### PR TITLE
Migrate DRAKVUF to Xen 4.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,21 +7,16 @@ before_install:
   - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib:/usr/local/lib
   - sudo add-apt-repository "deb mirror://mirrors.ubuntu.com/mirrors.txt trusty main restricted universe multiverse" -y
   - sudo apt-get update -qq
-  - sudo apt-get install -y bison flex check libjansson-dev libxen-dev uuid-dev libfuse-dev
-  - git clone https://github.com/bdpayne/libvmi
-  - cd libvmi
-  - ./autogen.sh
-  - ./configure --enable-xen --enable-xen-events
-  - make
-  - sudo make install
-  - cd tools/pyvmi
-  - python setup.py build
-  - sudo python setup.py install
+  - sudo apt-get install -y bison flex check libjansson-dev uuid-dev libfuse-dev
+  - sudo apt-get build-dep libxen-dev
+  - sudo dpkg -i test-packages/xen-4.6.0-tools_amd64.deb
+  - git clone -b drakvuf https://github.com/tklengyel/libvmi
+  - cd libvmi && ./autogen.sh && ./configure --enable-xen --enable-xen-events
+  - make && sudo make install
+  - cd tools/pyvmi && python setup.py build && sudo python setup.py install
   - cd ../../..
   - git clone https://github.com/volatilityfoundation/volatility
-  - cd volatility
-  - python setup.py build
-  - sudo python setup.py install
+  - cd volatility && python setup.py build && sudo python setup.py install
   - cd ..
 
 script: "./autogen.sh; ./configure; make clean; make"

--- a/configure.ac
+++ b/configure.ac
@@ -103,7 +103,7 @@
  #*************************************************************************#
 
 AC_PREREQ([2.60])
-AC_INIT([DRAKVUF], [0.1], [tamas.k.lengyel@gmail.com], [], [http://github.com/tklengyel/drakvuf])
+AC_INIT([DRAKVUF], [0.2], [tamas.k.lengyel@gmail.com], [], [http://github.com/tklengyel/drakvuf])
 AM_INIT_AUTOMAKE([1.10 no-define foreign])
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIR([m4])

--- a/src/file_extractor.c
+++ b/src/file_extractor.c
@@ -292,7 +292,7 @@ void grab_file_before_delete(vmi_instance_t vmi, vmi_event_t *event, reg_t cr3,
 }
 
 // post-write
-void file_name_post_cb(vmi_instance_t vmi, vmi_event_t *event) {
+event_response_t file_name_post_cb(vmi_instance_t vmi, vmi_event_t *event) {
 
     struct memevent *container = event->data;
     struct file_watch *watch = &container->file;
@@ -338,10 +338,12 @@ void file_name_post_cb(vmi_instance_t vmi, vmi_event_t *event) {
 
     if (VMI_FAILURE == rc)
         vmi_step_event(vmi, event, event->vcpu_id, 1, NULL);
+
+    return 0;
 }
 
 // pre-write
-void file_name_pre_cb(vmi_instance_t vmi, vmi_event_t *event) {
+event_response_t file_name_pre_cb(vmi_instance_t vmi, vmi_event_t *event) {
     vmi_clear_event(vmi, event);
     addr_t pa = (event->mem_event.gfn << 12) + event->mem_event.offset;
 
@@ -350,6 +352,7 @@ void file_name_pre_cb(vmi_instance_t vmi, vmi_event_t *event) {
     } else {
         vmi_step_event(vmi, event, event->vcpu_id, 1, NULL);
     }
+    return 0;
 }
 
 // Create mem event to catch when the memory space of the struct gets written to

--- a/src/vmi.c
+++ b/src/vmi.c
@@ -129,7 +129,7 @@
 static uint64_t read_count, write_count, x_count;
 
 // This is the callback when an int3 or a read event happens
-void vmi_reset_trap(vmi_instance_t vmi, vmi_event_t *event) {
+event_response_t vmi_reset_trap(vmi_instance_t vmi, vmi_event_t *event) {
 
     /*reg_t tsc, deltatsc;
      deltatsc = rdtsc();
@@ -163,10 +163,11 @@ void vmi_reset_trap(vmi_instance_t vmi, vmi_event_t *event) {
     }
 
     //vmi_set_vcpureg(vmi, tsc+(rdtsc()-deltatsc), TSC, event->vcpu_id);
+    return 0;
 }
 
 // This is the callback when an write event happens
-void vmi_save_and_reset_trap(vmi_instance_t vmi, vmi_event_t *event) {
+event_response_t vmi_save_and_reset_trap(vmi_instance_t vmi, vmi_event_t *event) {
 
     vmi_register_event(vmi, event);
     uint8_t trap = TRAP;
@@ -186,9 +187,10 @@ void vmi_save_and_reset_trap(vmi_instance_t vmi, vmi_event_t *event) {
             }
         }
     }
+    return 0;
 }
 
-void trap_guard(vmi_instance_t vmi, vmi_event_t *event) {
+event_response_t trap_guard(vmi_instance_t vmi, vmi_event_t *event) {
 
     /*reg_t tsc, deltatsc;
      deltatsc = rdtsc();
@@ -259,9 +261,10 @@ void trap_guard(vmi_instance_t vmi, vmi_event_t *event) {
     }
 
     //vmi_set_vcpureg(vmi, tsc+(rdtsc()-deltatsc), TSC, event->vcpu_id);
+    return 0;
 }
 
-void int3_cb(vmi_instance_t vmi, vmi_event_t *event) {
+event_response_t int3_cb(vmi_instance_t vmi, vmi_event_t *event) {
 
     /*reg_t tsc, deltatsc;
      deltatsc = rdtsc();
@@ -341,6 +344,7 @@ void int3_cb(vmi_instance_t vmi, vmi_event_t *event) {
 
     g_free(ts);
     //vmi_set_vcpureg(vmi, tsc+(rdtsc()-deltatsc), TSC, event->vcpu_id);
+    return 0;
 }
 
 void inject_traps_pe(honeymon_clone_t *clone, addr_t vaddr, uint32_t pid, struct sym_config *sym_config) {

--- a/src/vmi.c
+++ b/src/vmi.c
@@ -267,8 +267,7 @@ void int3_cb(vmi_instance_t vmi, vmi_event_t *event) {
      deltatsc = rdtsc();
      vmi_get_vcpureg(vmi, &tsc, TSC, event->vcpu_id);*/
 
-    reg_t cr3;
-    vmi_get_vcpureg(vmi, &cr3, CR3, event->vcpu_id);
+    reg_t cr3 = event->regs.x86->cr3;
 
     char *ts;
     NOW(&ts);

--- a/src/vmi.h
+++ b/src/vmi.h
@@ -249,9 +249,9 @@ void *clone_vmi_thread(void *input);
 void clone_vmi_init(honeymon_clone_t *clone);
 void close_vmi_clone(honeymon_clone_t *clone);
 
-void trap_guard(vmi_instance_t vmi, vmi_event_t *event);
-void vmi_reset_trap(vmi_instance_t vmi, vmi_event_t *event);
-void vmi_save_and_reset_trap(vmi_instance_t vmi, vmi_event_t *event);
+event_response_t trap_guard(vmi_instance_t vmi, vmi_event_t *event);
+event_response_t vmi_reset_trap(vmi_instance_t vmi, vmi_event_t *event);
+event_response_t vmi_save_and_reset_trap(vmi_instance_t vmi, vmi_event_t *event);
 
 void free_guid_lookup(gpointer s);
 void free_symbolwrap(gpointer z);

--- a/src/xen_helper.c
+++ b/src/xen_helper.c
@@ -173,13 +173,6 @@ int get_dom_info(xen_interface_t *xen, const char *input, uint32_t *domID,
     } else {
         //printf("Converting domid %u to name\n", _domID);
         _name = libxl_domid_to_name(xen->xl_ctx, _domID);
-        if (_name == NULL) {
-            printf(
-                    "Failed to get domain name from ID, is the domain running?\n");
-            return -1;
-        } else {
-            //printf("Got name from domID: %s\n", _name);
-        }
     }
 
     *name = _name;


### PR DESCRIPTION
With Xen 4.6 now officially released, moving DRAKVUF to this new version will enable taking advantage of some of the newest features as well.