### PR TITLE
Created drakvuf_get_current_process API in libdrakvuf

### DIFF
--- a/src/libdrakvuf/Makefile.am
+++ b/src/libdrakvuf/Makefile.am
@@ -103,7 +103,7 @@
  #*************************************************************************# 
 
 h_sources = drakvuf.h
-c_sources = drakvuf.c injector.c win-exports.c vmi.c win-symbols.c win-handles.c
+c_sources = drakvuf.c injector.c win-exports.c vmi.c win-symbols.c win-handles.c win-processes.c
 
 AM_CFLAGS = -I$(top_srcdir)
 AM_CFLAGS += $(CFLAGS)

--- a/src/libdrakvuf/drakvuf.h
+++ b/src/libdrakvuf/drakvuf.h
@@ -243,4 +243,9 @@ addr_t drakvuf_get_obj_by_handle(drakvuf_t drakvuf,
                                  addr_t process,
                                  uint64_t handle);
 
+addr_t drakvuf_get_current_process(drakvuf_t drakvuf,
+                                   uint64_t vcpu_id);
+addr_t drakvuf_get_current_thread(drakvuf_t drakvuf,
+                                   uint64_t vcpu_id);
+
 #endif

--- a/src/libdrakvuf/win-processes.c
+++ b/src/libdrakvuf/win-processes.c
@@ -102,232 +102,50 @@
  *                                                                         *
  ***************************************************************************/
 
+#include <libvmi/libvmi.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <sys/mman.h>
+#include <stdio.h>
 #include <glib.h>
-#include <config.h>
-#include "../plugins.h"
 
-#define FILE_DISPOSITION_INFORMATION 13
+#include "vmi.h"
 
-static const char *dump_folder;
-static output_format_t format;
-static event_response_t cb(drakvuf_t drakvuf, drakvuf_trap_info_t *info);
-static page_mode_t pm;
-static uint32_t domid;
+addr_t drakvuf_get_current_thread(drakvuf_t drakvuf, uint64_t vcpu_id){
+    vmi_instance_t vmi = drakvuf->vmi;
+    addr_t thread;
 
-enum offset {
-    FILE_OBJECT_FILENAME,
-    HANDLE_TABLE_HANDLECOUNT,
-    OBJECT_HEADER_TYPEINDEX,
-    OBJECT_HEADER_BODY,
-    UNICODE_STRING_LENGTH,
-    UNICODE_STRING_BUFFER,
-    __OFFSET_MAX
-};
+    addr_t prcb;
 
-static const char *offset_names[__OFFSET_MAX][2] = {
-    [FILE_OBJECT_FILENAME] = {"_FILE_OBJECT", "FileName"},
-    [HANDLE_TABLE_HANDLECOUNT] = {"_HANDLE_TABLE", "HandleCount" },
-    [OBJECT_HEADER_TYPEINDEX] = { "_OBJECT_HEADER", "TypeIndex" },
-    [OBJECT_HEADER_BODY] = { "_OBJECT_HEADER", "Body" },
-    [UNICODE_STRING_LENGTH] = {"_UNICODE_STRING", "Length" },
-    [UNICODE_STRING_BUFFER] = {"_UNICODE_STRING", "Buffer" },
-};
-
-#define WIN7_TYPEINDEX_LAST 44
-#define VOL_DUMPFILES "%s %s -l vmi://domid/%u --profile=%s -Q 0x%lx -D %s -n dumpfiles 2>&1"
-#define PROFILE32 "Win7SP1x86"
-#define PROFILE64 "Win7SP1x64"
-
-static size_t offsets[__OFFSET_MAX];
-
-static drakvuf_trap_t traps[4] = {
-    [0 ... 3] = { .lookup_type = LOOKUP_PID,
-                  .u.pid = 4,
-                  .addr_type = ADDR_RVA,
-                  .type = BREAKPOINT,
-                  .module = "ntoskrnl.exe" }
-};
-
-void volatility_extract_file(drakvuf_t drakvuf, addr_t file_object) {
-
-    const char* profile = NULL;
-    if (pm == VMI_PM_IA32E)
-        profile = PROFILE64;
-    else
-        profile = PROFILE32;
-
-    char *command = g_malloc0(
-            snprintf(NULL, 0, VOL_DUMPFILES, PYTHON, VOLATILITY, domid,
-                     profile, file_object, dump_folder
-                    )+ 1);
-    sprintf(command, VOL_DUMPFILES, PYTHON, VOLATILITY, domid, profile,
-            file_object, dump_folder);
-
-    g_spawn_command_line_sync(command, NULL, NULL, NULL, NULL);
-    free(command);
-}
-
-/*
- * The approach where the system process list es enumerated looking for
- * the matching cr3 value in each _EPROCESS struct is not going to work
- * if a DKOM attack unhooks the _EPROCESS struct.
- *
- * We can access the _EPROCESS structure by reading the FS_BASE register on x86
- * or the GS_BASE register on x64, which contains the _KPCR.
- *
- * FS/GS -> _KPCR._KPRCB.CurrentThread -> _ETHREAD._KTHREAD.Process = _EPROCESS
- *
- * Also see: http://www.csee.umbc.edu/~stephens/SECURITY/491M/HiddenProcesses.ppt
- */
-static void grab_file_by_handle(drakvuf_t drakvuf, uint32_t vcpu_id, vmi_instance_t vmi,
-                                page_mode_t pm,
-                                drakvuf_trap_info_t *info, addr_t handle)
-{
-    uint8_t type_index = 0;
-    addr_t process=drakvuf_get_current_process(drakvuf,vcpu_id);
-
-    // TODO: verify that the dtb in the _EPROCESS is the same as the cr3?
-
-    if (!process)
-        return;
-
-    addr_t obj = drakvuf_get_obj_by_handle(drakvuf, process, handle);
-
-    if (!obj)
-        return;
-
-    access_context_t ctx = {
-        .translate_mechanism = VMI_TM_PROCESS_DTB,
-        .addr = obj + offsets[OBJECT_HEADER_TYPEINDEX],
-        .dtb = info->regs->cr3
-    };
-
-    if (VMI_FAILURE == vmi_read_8(vmi, &ctx, &type_index))
-        return;
-
-    if (type_index >= WIN7_TYPEINDEX_LAST || type_index != 28)
-        return;
-
-    addr_t file = obj + offsets[OBJECT_HEADER_BODY];
-    addr_t file_pa = vmi_pagetable_lookup(vmi, info->regs->cr3, file);
-    addr_t filename = file + offsets[FILE_OBJECT_FILENAME];
-
-    uint16_t length = 0;
-    addr_t buffer = 0;
-
-    ctx.addr = filename + offsets[UNICODE_STRING_BUFFER];
-    vmi_read_addr(vmi, &ctx, &buffer);
-
-    ctx.addr = filename + offsets[UNICODE_STRING_LENGTH];
-    vmi_read_16(vmi, &ctx, &length);
-
-    if (length && buffer) {
-
-        unicode_string_t str = { .contents = NULL };
-        str.length = length;
-        str.encoding = "UTF-16";
-        str.contents = malloc(length);
-
-        ctx.addr = buffer;
-        vmi_read(vmi, &ctx, str.contents, length);
-
-        unicode_string_t str2 = { .contents = NULL };
-        status_t rc = vmi_convert_str_encoding(&str, &str2, "UTF-8");
-        if (rc == VMI_SUCCESS) {
-            //printf("\tExtracting file: %s\n", str2.contents);
-
-            volatility_extract_file(drakvuf, file_pa);
-
-            free(str2.contents);
-        }
-
-        free(str.contents);
-    }
-}
-
-static event_response_t setinformation(drakvuf_t drakvuf, drakvuf_trap_info_t *info) {
-
-    vmi_instance_t vmi = drakvuf_lock_and_get_vmi(drakvuf);
-
-    access_context_t ctx = {
-        .translate_mechanism = VMI_TM_PROCESS_DTB,
-        .dtb = info->regs->cr3
-    };
-
-    uint32_t fileinfoclass = 0;
-    reg_t handle = 0, fileinfo = 0, length = 0;
-
-    if (pm == VMI_PM_IA32E) {
-        handle = info->regs->rcx;
-        fileinfo = info->regs->r8;
-        length = info->regs->r9;
-
-        ctx.addr = info->regs->rsp + 5 * sizeof(addr_t); // addr of fileinfoclass
-        vmi_read_32(vmi, &ctx, &fileinfoclass);
+    /*
+     * fs_base/gs_base in the info->regs structure are not actually filled in
+     * by Xen for vm_events, so we need to manually ask for these each time
+     */
+    reg_t fsgs;
+    if(vmi_get_page_mode(vmi) == VMI_PM_IA32E)  {
+        vmi_get_vcpureg(vmi, &fsgs, GS_BASE, vcpu_id);
+        prcb=offsets[KPCR_PRCB];
     } else {
-        ctx.addr = info->regs->rsp + sizeof(uint32_t);
-        vmi_read_32(vmi, &ctx, (uint32_t*) &handle);
-        ctx.addr += 2 * sizeof(uint32_t);
-        vmi_read_32(vmi, &ctx, (uint32_t*) &info);
-        ctx.addr += sizeof(uint32_t);
-        vmi_read_32(vmi, &ctx, (uint32_t*) &length);
-        ctx.addr += sizeof(uint32_t);
-        vmi_read_32(vmi, &ctx, &fileinfoclass);
+        vmi_get_vcpureg(vmi, &fsgs, FS_BASE, vcpu_id);
+        prcb=offsets[KPCR_PRCBDATA];
     }
 
-    if (fileinfoclass == FILE_DISPOSITION_INFORMATION && length == 1) {
-        uint8_t del = 0;
-        ctx.addr = fileinfo;
-        vmi_read_8(vmi, &ctx, &del);
-        if (del) {
-            //printf("DELETE FILE _FILE_OBJECT Handle: 0x%lx.\n", handle);
-            grab_file_by_handle(drakvuf, info->vcpu, vmi, pm, info, handle);
-        }
+    if (VMI_SUCCESS != vmi_read_addr_va(vmi, fsgs + prcb + offsets[KPRCB_CURRENTTHREAD], 0, &thread)){
+        return 0;
     }
 
-    drakvuf_release_vmi(drakvuf);
-    return 0;
+    return thread;
 }
 
-int plugin_filedelete_init(drakvuf_t drakvuf,
-                           const struct filedelete_config *c)
-{
-    vmi_instance_t vmi = drakvuf_lock_and_get_vmi(drakvuf);
-    pm = vmi_get_page_mode(vmi);
-    domid = vmi_get_vmid(vmi);
-    drakvuf_release_vmi(drakvuf);
+addr_t drakvuf_get_current_process(drakvuf_t drakvuf, uint64_t vcpu_id) {
+    addr_t thread, process;
 
-    dump_folder = c->dump_folder ? c->dump_folder : "/tmp";
-    format = drakvuf_get_output_format(drakvuf);
-
-    traps[0].u2.rva = drakvuf_get_function_rva(c->rekall_profile, "NtSetInformationFile");
-    traps[0].name = "NtSetInformationFile";
-    traps[0].cb = setinformation;
-    traps[1].u2.rva = drakvuf_get_function_rva(c->rekall_profile, "ZwSetInformationFile");
-    traps[1].name = "ZwSetInformationFile";
-    traps[1].cb = setinformation;
-    /*traps[2].u2.rva = drakvuf_get_function_rva(c->rekall_profile, "NtDeleteFile");
-    traps[2].name = "NtDeleteFile";
-    traps[3].u2.rva = drakvuf_get_function_rva(c->rekall_profile, "ZwDeleteFile");
-    traps[3].name = "ZwDeleteFile";*/
-
-    int i;
-    for(i=0;i<__OFFSET_MAX;i++) {
-        windows_system_map_lookup( c->rekall_profile, offset_names[i][0], offset_names[i][1], 
-                                   &offsets[i], NULL);
+    thread=drakvuf_get_current_thread(drakvuf,vcpu_id); 
+    
+    if (thread == 0 || VMI_SUCCESS != vmi_read_addr_va(drakvuf->vmi, thread + offsets[KTHREAD_PROCESS], 0, &process)){
+        return 0;    
     }
 
-    return 1;
-}
-
-int plugin_filedelete_start(drakvuf_t drakvuf) {
-    drakvuf_add_trap(drakvuf, &traps[0]);
-    //drakvuf_add_trap(drakvuf, &traps[1]);
-    //drakvuf_add_trap(drakvuf, &traps[2]);
-    //drakvuf_add_trap(drakvuf, &traps[3]);
-    return 1;
-}
-
-int plugin_filedelete_close(drakvuf_t drakvuf) {
-    return 1;
+    return process;
 }


### PR DESCRIPTION
I updated the `filedelete` plugin to use the new API. Please test this carefully as I didn't manage to get `filedelete` to work properly in the `master` branch so I couldn't really test the modifications comprehensively. 

This is the output in case of 64-bit guest:

```
Volatility Foundation Volatility Framework 2.5
No suitable address space mapping found
Tried to open image as:
 MachOAddressSpace: mac: need base
 LimeAddressSpace: lime: need base
 WindowsHiberFileSpace32: No base Address Space
 WindowsCrashDumpSpace64BitMap: No base Address Space
 WindowsCrashDumpSpace64: No base Address Space
 HPAKAddressSpace: No base Address Space
 VirtualBoxCoreDumpElf64: No base Address Space
 VMWareMetaAddressSpace: No base Address Space
 VMWareAddressSpace: No base Address Space
 QemuCoreDumpElf: No base Address Space
 WindowsCrashDumpSpace32: No base Address Space
 AMD64PagedMemory: No base Address Space
 IA32PagedMemoryPae: No base Address Space
 IA32PagedMemory: No base Address Space
 OSXPmemELF: No base Address Space
 FileAddressSpace: Location is not of file scheme
 ArmAddressSpace: No base Address Space
```

In case of 32-bit guests neither the `master` nor my version give results.