### PR TITLE
Convert main and plugins to C++

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -110,7 +110,8 @@ AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIR([m4])
 
 AC_PROG_CC_STDC
-AC_PROG_CXX
+AC_PROG_CXX(clang++)
+AX_CXX_COMPILE_STDCXX_11
 
 ######################################################
 

--- a/m4/ax_cxx_compile_stdcxx.m4
+++ b/m4/ax_cxx_compile_stdcxx.m4
@@ -1,0 +1,559 @@
+# ===========================================================================
+#   http://www.gnu.org/software/autoconf-archive/ax_cxx_compile_stdcxx.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_CXX_COMPILE_STDCXX(VERSION, [ext|noext], [mandatory|optional])
+#
+# DESCRIPTION
+#
+#   Check for baseline language coverage in the compiler for the specified
+#   version of the C++ standard.  If necessary, add switches to CXXFLAGS to
+#   enable support.  VERSION may be '11' (for the C++11 standard) or '14'
+#   (for the C++14 standard).
+#
+#   The second argument, if specified, indicates whether you insist on an
+#   extended mode (e.g. -std=gnu++11) or a strict conformance mode (e.g.
+#   -std=c++11).  If neither is specified, you get whatever works, with
+#   preference for an extended mode.
+#
+#   The third argument, if specified 'mandatory' or if left unspecified,
+#   indicates that baseline support for the specified C++ standard is
+#   required and that the macro should error out if no mode with that
+#   support is found.  If specified 'optional', then configuration proceeds
+#   regardless, after defining HAVE_CXX${VERSION} if and only if a
+#   supporting mode is found.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Benjamin Kosnik <bkoz@redhat.com>
+#   Copyright (c) 2012 Zack Weinberg <zackw@panix.com>
+#   Copyright (c) 2013 Roy Stogner <roystgnr@ices.utexas.edu>
+#   Copyright (c) 2014, 2015 Google Inc.; contributed by Alexey Sokolov <sokolov@google.com>
+#   Copyright (c) 2015 Paul Norman <penorman@mac.com>
+#   Copyright (c) 2015 Moritz Klammler <moritz@klammler.eu>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved.  This file is offered as-is, without any
+#   warranty.
+
+#serial 1
+
+dnl  This macro is based on the code from the AX_CXX_COMPILE_STDCXX_11 macro
+dnl  (serial version number 13).
+
+AC_DEFUN([AX_CXX_COMPILE_STDCXX], [dnl
+  m4_if([$1], [11], [],
+        [$1], [14], [],
+        [$1], [17], [m4_fatal([support for C++17 not yet implemented in AX_CXX_COMPILE_STDCXX])],
+        [m4_fatal([invalid first argument `$1' to AX_CXX_COMPILE_STDCXX])])dnl
+  m4_if([$2], [], [],
+        [$2], [ext], [],
+        [$2], [noext], [],
+        [m4_fatal([invalid second argument `$2' to AX_CXX_COMPILE_STDCXX])])dnl
+  m4_if([$3], [], [ax_cxx_compile_cxx$1_required=true],
+        [$3], [mandatory], [ax_cxx_compile_cxx$1_required=true],
+        [$3], [optional], [ax_cxx_compile_cxx$1_required=false],
+        [m4_fatal([invalid third argument `$3' to AX_CXX_COMPILE_STDCXX])])
+  AC_LANG_PUSH([C++])dnl
+  ac_success=no
+  AC_CACHE_CHECK(whether $CXX supports C++$1 features by default,
+  ax_cv_cxx_compile_cxx$1,
+  [AC_COMPILE_IFELSE([AC_LANG_SOURCE([_AX_CXX_COMPILE_STDCXX_testbody_$1])],
+    [ax_cv_cxx_compile_cxx$1=yes],
+    [ax_cv_cxx_compile_cxx$1=no])])
+  if test x$ax_cv_cxx_compile_cxx$1 = xyes; then
+    ac_success=yes
+  fi
+
+  m4_if([$2], [noext], [], [dnl
+  if test x$ac_success = xno; then
+    for switch in -std=gnu++$1 -std=gnu++0x; do
+      cachevar=AS_TR_SH([ax_cv_cxx_compile_cxx$1_$switch])
+      AC_CACHE_CHECK(whether $CXX supports C++$1 features with $switch,
+                     $cachevar,
+        [ac_save_CXXFLAGS="$CXXFLAGS"
+         CXXFLAGS="$CXXFLAGS $switch"
+         AC_COMPILE_IFELSE([AC_LANG_SOURCE([_AX_CXX_COMPILE_STDCXX_testbody_$1])],
+          [eval $cachevar=yes],
+          [eval $cachevar=no])
+         CXXFLAGS="$ac_save_CXXFLAGS"])
+      if eval test x\$$cachevar = xyes; then
+        CXXFLAGS="$CXXFLAGS $switch"
+        ac_success=yes
+        break
+      fi
+    done
+  fi])
+
+  m4_if([$2], [ext], [], [dnl
+  if test x$ac_success = xno; then
+    dnl HP's aCC needs +std=c++11 according to:
+    dnl http://h21007.www2.hp.com/portal/download/files/unprot/aCxx/PDF_Release_Notes/769149-001.pdf
+    dnl Cray's crayCC needs "-h std=c++11"
+    for switch in -std=c++$1 -std=c++0x +std=c++$1 "-h std=c++$1"; do
+      cachevar=AS_TR_SH([ax_cv_cxx_compile_cxx$1_$switch])
+      AC_CACHE_CHECK(whether $CXX supports C++$1 features with $switch,
+                     $cachevar,
+        [ac_save_CXXFLAGS="$CXXFLAGS"
+         CXXFLAGS="$CXXFLAGS $switch"
+         AC_COMPILE_IFELSE([AC_LANG_SOURCE([_AX_CXX_COMPILE_STDCXX_testbody_$1])],
+          [eval $cachevar=yes],
+          [eval $cachevar=no])
+         CXXFLAGS="$ac_save_CXXFLAGS"])
+      if eval test x\$$cachevar = xyes; then
+        CXXFLAGS="$CXXFLAGS $switch"
+        ac_success=yes
+        break
+      fi
+    done
+  fi])
+  AC_LANG_POP([C++])
+  if test x$ax_cxx_compile_cxx$1_required = xtrue; then
+    if test x$ac_success = xno; then
+      AC_MSG_ERROR([*** A compiler with support for C++$1 language features is required.])
+    fi
+  else
+    if test x$ac_success = xno; then
+      HAVE_CXX$1=0
+      AC_MSG_NOTICE([No compiler with C++$1 support was found])
+    else
+      HAVE_CXX$1=1
+      AC_DEFINE(HAVE_CXX$1,1,
+                [define if the compiler supports basic C++$1 syntax])
+    fi
+
+    AC_SUBST(HAVE_CXX$1)
+  fi
+])
+
+
+dnl  Test body for checking C++11 support
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_11],
+  _AX_CXX_COMPILE_STDCXX_testbody_new_in_11
+)
+
+
+dnl  Test body for checking C++14 support
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_14],
+  _AX_CXX_COMPILE_STDCXX_testbody_new_in_11
+  _AX_CXX_COMPILE_STDCXX_testbody_new_in_14
+)
+
+
+dnl  Tests for new features in C++11
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_new_in_11], [[
+
+// If the compiler admits that it is not ready for C++11, why torture it?
+// Hopefully, this will speed up the test.
+
+#ifndef __cplusplus
+
+#error "This is not a C++ compiler"
+
+#elif __cplusplus < 201103L
+
+#error "This is not a C++11 compiler"
+
+#else
+
+namespace cxx11
+{
+
+  namespace test_static_assert
+  {
+
+    template <typename T>
+    struct check
+    {
+      static_assert(sizeof(int) <= sizeof(T), "not big enough");
+    };
+
+  }
+
+  namespace test_final_override
+  {
+
+    struct Base
+    {
+      virtual void f() {}
+    };
+
+    struct Derived : public Base
+    {
+      virtual void f() override {}
+    };
+
+  }
+
+  namespace test_double_right_angle_brackets
+  {
+
+    template < typename T >
+    struct check {};
+
+    typedef check<void> single_type;
+    typedef check<check<void>> double_type;
+    typedef check<check<check<void>>> triple_type;
+    typedef check<check<check<check<void>>>> quadruple_type;
+
+  }
+
+  namespace test_decltype
+  {
+
+    int
+    f()
+    {
+      int a = 1;
+      decltype(a) b = 2;
+      return a + b;
+    }
+
+  }
+
+  namespace test_type_deduction
+  {
+
+    template < typename T1, typename T2 >
+    struct is_same
+    {
+      static const bool value = false;
+    };
+
+    template < typename T >
+    struct is_same<T, T>
+    {
+      static const bool value = true;
+    };
+
+    template < typename T1, typename T2 >
+    auto
+    add(T1 a1, T2 a2) -> decltype(a1 + a2)
+    {
+      return a1 + a2;
+    }
+
+    int
+    test(const int c, volatile int v)
+    {
+      static_assert(is_same<int, decltype(0)>::value == true, "");
+      static_assert(is_same<int, decltype(c)>::value == false, "");
+      static_assert(is_same<int, decltype(v)>::value == false, "");
+      auto ac = c;
+      auto av = v;
+      auto sumi = ac + av + 'x';
+      auto sumf = ac + av + 1.0;
+      static_assert(is_same<int, decltype(ac)>::value == true, "");
+      static_assert(is_same<int, decltype(av)>::value == true, "");
+      static_assert(is_same<int, decltype(sumi)>::value == true, "");
+      static_assert(is_same<int, decltype(sumf)>::value == false, "");
+      static_assert(is_same<int, decltype(add(c, v))>::value == true, "");
+      return (sumf > 0.0) ? sumi : add(c, v);
+    }
+
+  }
+
+  namespace test_noexcept
+  {
+
+    int f() { return 0; }
+    int g() noexcept { return 0; }
+
+    static_assert(noexcept(f()) == false, "");
+    static_assert(noexcept(g()) == true, "");
+
+  }
+
+  namespace test_constexpr
+  {
+
+    template < typename CharT >
+    unsigned long constexpr
+    strlen_c_r(const CharT *const s, const unsigned long acc) noexcept
+    {
+      return *s ? strlen_c_r(s + 1, acc + 1) : acc;
+    }
+
+    template < typename CharT >
+    unsigned long constexpr
+    strlen_c(const CharT *const s) noexcept
+    {
+      return strlen_c_r(s, 0UL);
+    }
+
+    static_assert(strlen_c("") == 0UL, "");
+    static_assert(strlen_c("1") == 1UL, "");
+    static_assert(strlen_c("example") == 7UL, "");
+    static_assert(strlen_c("another\0example") == 7UL, "");
+
+  }
+
+  namespace test_rvalue_references
+  {
+
+    template < int N >
+    struct answer
+    {
+      static constexpr int value = N;
+    };
+
+    answer<1> f(int&)       { return answer<1>(); }
+    answer<2> f(const int&) { return answer<2>(); }
+    answer<3> f(int&&)      { return answer<3>(); }
+
+    void
+    test()
+    {
+      int i = 0;
+      const int c = 0;
+      static_assert(decltype(f(i))::value == 1, "");
+      static_assert(decltype(f(c))::value == 2, "");
+      static_assert(decltype(f(0))::value == 3, "");
+    }
+
+  }
+
+  namespace test_uniform_initialization
+  {
+
+    struct test
+    {
+      static const int zero {};
+      static const int one {1};
+    };
+
+    static_assert(test::zero == 0, "");
+    static_assert(test::one == 1, "");
+
+  }
+
+  namespace test_lambdas
+  {
+
+    void
+    test1()
+    {
+      auto lambda1 = [](){};
+      auto lambda2 = lambda1;
+      lambda1();
+      lambda2();
+    }
+
+    int
+    test2()
+    {
+      auto a = [](int i, int j){ return i + j; }(1, 2);
+      auto b = []() -> int { return '0'; }();
+      auto c = [=](){ return a + b; }();
+      auto d = [&](){ return c; }();
+      auto e = [a, &b](int x) mutable {
+        const auto identity = [](int y){ return y; };
+        for (auto i = 0; i < a; ++i)
+          a += b--;
+        return x + identity(a + b);
+      }(0);
+      return a + b + c + d + e;
+    }
+
+    int
+    test3()
+    {
+      const auto nullary = [](){ return 0; };
+      const auto unary = [](int x){ return x; };
+      using nullary_t = decltype(nullary);
+      using unary_t = decltype(unary);
+      const auto higher1st = [](nullary_t f){ return f(); };
+      const auto higher2nd = [unary](nullary_t f1){
+        return [unary, f1](unary_t f2){ return f2(unary(f1())); };
+      };
+      return higher1st(nullary) + higher2nd(nullary)(unary);
+    }
+
+  }
+
+  namespace test_variadic_templates
+  {
+
+    template <int...>
+    struct sum;
+
+    template <int N0, int... N1toN>
+    struct sum<N0, N1toN...>
+    {
+      static constexpr auto value = N0 + sum<N1toN...>::value;
+    };
+
+    template <>
+    struct sum<>
+    {
+      static constexpr auto value = 0;
+    };
+
+    static_assert(sum<>::value == 0, "");
+    static_assert(sum<1>::value == 1, "");
+    static_assert(sum<23>::value == 23, "");
+    static_assert(sum<1, 2>::value == 3, "");
+    static_assert(sum<5, 5, 11>::value == 21, "");
+    static_assert(sum<2, 3, 5, 7, 11, 13>::value == 41, "");
+
+  }
+
+  // http://stackoverflow.com/questions/13728184/template-aliases-and-sfinae
+  // Clang 3.1 fails with headers of libstd++ 4.8.3 when using std::function
+  // because of this.
+  namespace test_template_alias_sfinae
+  {
+
+    struct foo {};
+
+    template<typename T>
+    using member = typename T::member_type;
+
+    template<typename T>
+    void func(...) {}
+
+    template<typename T>
+    void func(member<T>*) {}
+
+    void test();
+
+    void test() { func<foo>(0); }
+
+  }
+
+}  // namespace cxx11
+
+#endif  // __cplusplus >= 201103L
+
+]])
+
+
+dnl  Tests for new features in C++14
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_new_in_14], [[
+
+// If the compiler admits that it is not ready for C++14, why torture it?
+// Hopefully, this will speed up the test.
+
+#ifndef __cplusplus
+
+#error "This is not a C++ compiler"
+
+#elif __cplusplus < 201402L
+
+#error "This is not a C++14 compiler"
+
+#else
+
+namespace cxx14
+{
+
+  namespace test_polymorphic_lambdas
+  {
+
+    int
+    test()
+    {
+      const auto lambda = [](auto&&... args){
+        const auto istiny = [](auto x){
+          return (sizeof(x) == 1UL) ? 1 : 0;
+        };
+        const int aretiny[] = { istiny(args)... };
+        return aretiny[0];
+      };
+      return lambda(1, 1L, 1.0f, '1');
+    }
+
+  }
+
+  namespace test_binary_literals
+  {
+
+    constexpr auto ivii = 0b0000000000101010;
+    static_assert(ivii == 42, "wrong value");
+
+  }
+
+  namespace test_generalized_constexpr
+  {
+
+    template < typename CharT >
+    constexpr unsigned long
+    strlen_c(const CharT *const s) noexcept
+    {
+      auto length = 0UL;
+      for (auto p = s; *p; ++p)
+        ++length;
+      return length;
+    }
+
+    static_assert(strlen_c("") == 0UL, "");
+    static_assert(strlen_c("x") == 1UL, "");
+    static_assert(strlen_c("test") == 4UL, "");
+    static_assert(strlen_c("another\0test") == 7UL, "");
+
+  }
+
+  namespace test_lambda_init_capture
+  {
+
+    int
+    test()
+    {
+      auto x = 0;
+      const auto lambda1 = [a = x](int b){ return a + b; };
+      const auto lambda2 = [a = lambda1(x)](){ return a; };
+      return lambda2();
+    }
+
+  }
+
+  namespace test_digit_seperators
+  {
+
+    constexpr auto ten_million = 100'000'000;
+    static_assert(ten_million == 100000000, "");
+
+  }
+
+  namespace test_return_type_deduction
+  {
+
+    auto f(int& x) { return x; }
+    decltype(auto) g(int& x) { return x; }
+
+    template < typename T1, typename T2 >
+    struct is_same
+    {
+      static constexpr auto value = false;
+    };
+
+    template < typename T >
+    struct is_same<T, T>
+    {
+      static constexpr auto value = true;
+    };
+
+    int
+    test()
+    {
+      auto x = 0;
+      static_assert(is_same<int, decltype(f(x))>::value, "");
+      static_assert(is_same<int&, decltype(g(x))>::value, "");
+      return x;
+    }
+
+  }
+
+}  // namespace cxx14
+
+#endif  // __cplusplus >= 201402L
+
+]])
+

--- a/m4/ax_cxx_compile_stdcxx_11.m4
+++ b/m4/ax_cxx_compile_stdcxx_11.m4
@@ -1,0 +1,40 @@
+# ============================================================================
+#  http://www.gnu.org/software/autoconf-archive/ax_cxx_compile_stdcxx_11.html
+# ============================================================================
+#
+# SYNOPSIS
+#
+#   AX_CXX_COMPILE_STDCXX_11([ext|noext], [mandatory|optional])
+#
+# DESCRIPTION
+#
+#   Check for baseline language coverage in the compiler for the C++11
+#   standard; if necessary, add switches to CXXFLAGS to enable support.
+#
+#   This macro is a convenience alias for calling the AX_CXX_COMPILE_STDCXX
+#   macro with the version set to C++11.  The two optional arguments are
+#   forwarded literally as the second and third argument respectively.
+#   Please see the documentation for the AX_CXX_COMPILE_STDCXX macro for
+#   more information.  If you want to use this macro, you also need to
+#   download the ax_cxx_compile_stdcxx.m4 file.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Benjamin Kosnik <bkoz@redhat.com>
+#   Copyright (c) 2012 Zack Weinberg <zackw@panix.com>
+#   Copyright (c) 2013 Roy Stogner <roystgnr@ices.utexas.edu>
+#   Copyright (c) 2014, 2015 Google Inc.; contributed by Alexey Sokolov <sokolov@google.com>
+#   Copyright (c) 2015 Paul Norman <penorman@mac.com>
+#   Copyright (c) 2015 Moritz Klammler <moritz@klammler.eu>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 14
+
+include([ax_cxx_compile_stdcxx.m4])
+
+AC_DEFUN([AX_CXX_COMPILE_STDCXX_11], [AX_CXX_COMPILE_STDCXX([11], [$1], [$2])])
+

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -106,24 +106,34 @@ bin_PROGRAMS = drakvuf xen_memclone injector
 
 SUBDIRS = xen_helper libdrakvuf plugins dirwatch
 
-drakvuf_SOURCES = drakvuf.c
+drakvuf_SOURCES = main.cpp drakvuf.cpp
 xen_memclone_SOURCES  = xen_memclone.c
 injector_SOURCES = injector.c
 
 AM_CFLAGS = $(CFLAGS)
 AM_CFLAGS += $(VMI_CFLAGS)
 AM_CFLAGS += $(GLIB_CFLAGS)
+AM_CFLAGS += -I$(top_srcdir) -I$(srcdir)
+
+AM_CPPFLAGS = $(CPPFLAGS)
+AM_CPPFLAGS += $(VMI_CFLAGS)
+AM_CPPFLAGS += $(GLIB_CFLAGS)
+AM_CPPFLAGS += -I$(top_srcdir) -I$(srcdir)
 
 if HARDENING
 AM_CFLAGS += $(HARDEN_CFLAGS) -DHARDENING
+AM_CPPFLAGS += $(HARDEN_CFLAGS) -DHARDENING
 endif
 
 # Note that -pg is incompatible with HARDENING
 if DEBUG
 AM_CFLAGS += -DDRAKVUF_DEBUG -Wall -Wextra -Wno-override-init -Wno-strict-aliasing -g -ggdb3
 AM_CFLAGS += -Wno-unused-parameter -Wno-unused-but-set-variable -Wno-unused-variable
+AM_CPPFLAGS += -DDRAKVUF_DEBUG -Wall -Wextra -Wno-strict-aliasing -g -ggdb3
+AM_CPPFLAGS += -Wno-unused-parameter -Wno-unused-variable
 if !HARDENING
 AM_CFLAGS += -pg
+AM_CPPFLAGS += -pg
 endif
 endif
 

--- a/src/drakvuf.h
+++ b/src/drakvuf.h
@@ -102,235 +102,48 @@
  *                                                                         *
  ***************************************************************************/
 
-#include <glib.h>
+#ifndef DRAKVUF_H
+#define DRAKVUF_H
+
 #include <config.h>
-#include "../plugins.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <inttypes.h>
+#include <stdbool.h>
+#include <string.h>
+#include <unistd.h>
+#include <glib.h>
 
-#define FILE_DISPOSITION_INFORMATION 13
+#include <libdrakvuf/libdrakvuf.h>
+#include "plugins/plugins.h"
 
-static const char *dump_folder;
-static output_format_t format;
-static event_response_t cb(drakvuf_t drakvuf, drakvuf_trap_info_t *info);
-static page_mode_t pm;
-static uint32_t domid;
+class drakvuf_c {
+    private:
+        int initialized;
+        drakvuf_t drakvuf;
+        drakvuf_plugins* plugins;
+        GThread *timeout_thread;
+        const char *rekall_profile;
 
-enum offset {
-    FILE_OBJECT_FILENAME,
-    HANDLE_TABLE_HANDLECOUNT,
-    OBJECT_HEADER_TYPEINDEX,
-    OBJECT_HEADER_BODY,
-    UNICODE_STRING_LENGTH,
-    UNICODE_STRING_BUFFER,
-    __OFFSET_MAX
+        int start_plugins(const char *dump_folder);
+
+    public:
+        int timeout;
+        int interrupted;
+
+        drakvuf_c(const char* domain,
+                  const char *rekall_profile,
+                  output_format_t output,
+                  int timeout,
+                  const char* dump_folder);
+        ~drakvuf_c();
+
+        int is_initialized();
+        void interrupt(int signal);
+        void loop();
+        void pause();
+        void resume();
+        int inject_cmd(vmi_pid_t injection_pid, const char *inject_cmd);
 };
 
-static const char *offset_names[__OFFSET_MAX][2] = {
-    [FILE_OBJECT_FILENAME] = {"_FILE_OBJECT", "FileName"},
-    [HANDLE_TABLE_HANDLECOUNT] = {"_HANDLE_TABLE", "HandleCount" },
-    [OBJECT_HEADER_TYPEINDEX] = { "_OBJECT_HEADER", "TypeIndex" },
-    [OBJECT_HEADER_BODY] = { "_OBJECT_HEADER", "Body" },
-    [UNICODE_STRING_LENGTH] = {"_UNICODE_STRING", "Length" },
-    [UNICODE_STRING_BUFFER] = {"_UNICODE_STRING", "Buffer" },
-};
-
-#define WIN7_TYPEINDEX_LAST 44
-#define VOL_DUMPFILES "%s %s -l vmi://domid/%u --profile=%s -Q 0x%lx -D %s -n dumpfiles 2>&1"
-#define PROFILE32 "Win7SP1x86"
-#define PROFILE64 "Win7SP1x64"
-
-static size_t offsets[__OFFSET_MAX];
-
-static drakvuf_trap_t traps[4] = {
-    [0 ... 3] = { .lookup_type = LOOKUP_PID,
-                  .u.pid = 4,
-                  .addr_type = ADDR_RVA,
-                  .type = BREAKPOINT,
-                  .module = "ntoskrnl.exe" }
-};
-
-void volatility_extract_file(drakvuf_t drakvuf, addr_t file_object) {
-
-    const char* profile = NULL;
-    if (pm == VMI_PM_IA32E)
-        profile = PROFILE64;
-    else
-        profile = PROFILE32;
-
-    char *command = g_malloc0(
-            snprintf(NULL, 0, VOL_DUMPFILES, PYTHON, VOLATILITY, domid,
-                     profile, file_object, dump_folder
-                    )+ 1);
-    sprintf(command, VOL_DUMPFILES, PYTHON, VOLATILITY, domid, profile,
-            file_object, dump_folder);
-
-    g_spawn_command_line_sync(command, NULL, NULL, NULL, NULL);
-    free(command);
-}
-
-/*
- * The approach where the system process list es enumerated looking for
- * the matching cr3 value in each _EPROCESS struct is not going to work
- * if a DKOM attack unhooks the _EPROCESS struct.
- *
- * We can access the _EPROCESS structure by reading the FS_BASE register on x86
- * or the GS_BASE register on x64, which contains the _KPCR.
- *
- * FS/GS -> _KPCR._KPRCB.CurrentThread -> _ETHREAD._KTHREAD.Process = _EPROCESS
- *
- * Also see: http://www.csee.umbc.edu/~stephens/SECURITY/491M/HiddenProcesses.ppt
- */
-static void grab_file_by_handle(drakvuf_t drakvuf, uint32_t vcpu_id, vmi_instance_t vmi,
-                                page_mode_t pm,
-                                drakvuf_trap_info_t *info, addr_t handle)
-{
-    uint8_t type_index = 0;
-    addr_t process=drakvuf_get_current_process(drakvuf,vcpu_id);
-
-    // TODO: verify that the dtb in the _EPROCESS is the same as the cr3?
-
-    if (!process)
-        return;
-
-    addr_t obj = drakvuf_get_obj_by_handle(drakvuf, process, handle);
-
-    if (!obj)
-        return;
-
-    access_context_t ctx = {
-        .translate_mechanism = VMI_TM_PROCESS_DTB,
-        .addr = obj + offsets[OBJECT_HEADER_TYPEINDEX],
-        .dtb = info->regs->cr3
-    };
-
-    if (VMI_FAILURE == vmi_read_8(vmi, &ctx, &type_index))
-        return;
-
-    if (type_index >= WIN7_TYPEINDEX_LAST || type_index != 28)
-        return;
-
-    addr_t file = obj + offsets[OBJECT_HEADER_BODY];
-    addr_t file_pa = vmi_pagetable_lookup(vmi, info->regs->cr3, file);
-    addr_t filename = file + offsets[FILE_OBJECT_FILENAME];
-
-    uint16_t length = 0;
-    addr_t buffer = 0;
-
-    ctx.addr = filename + offsets[UNICODE_STRING_BUFFER];
-    vmi_read_addr(vmi, &ctx, &buffer);
-
-    ctx.addr = filename + offsets[UNICODE_STRING_LENGTH];
-    vmi_read_16(vmi, &ctx, &length);
-
-    if (length && buffer) {
-
-        unicode_string_t str = { .contents = NULL };
-        str.length = length;
-        str.encoding = "UTF-16";
-        str.contents = malloc(length);
-
-        ctx.addr = buffer;
-        vmi_read(vmi, &ctx, str.contents, length);
-
-        unicode_string_t str2 = { .contents = NULL };
-        status_t rc = vmi_convert_str_encoding(&str, &str2, "UTF-8");
-        if (rc == VMI_SUCCESS) {
-            //printf("\tExtracting file: %s\n", str2.contents);
-
-            volatility_extract_file(drakvuf, file_pa);
-
-            free(str2.contents);
-        }
-
-        free(str.contents);
-    }
-}
-
-static event_response_t setinformation(drakvuf_t drakvuf, drakvuf_trap_info_t *info) {
-
-    vmi_instance_t vmi = drakvuf_lock_and_get_vmi(drakvuf);
-
-    access_context_t ctx = {
-        .translate_mechanism = VMI_TM_PROCESS_DTB,
-        .dtb = info->regs->cr3
-    };
-
-    uint32_t fileinfoclass = 0;
-    reg_t handle = 0, fileinfo = 0, length = 0;
-
-    if (pm == VMI_PM_IA32E) {
-        handle = info->regs->rcx;
-        fileinfo = info->regs->r8;
-        length = info->regs->r9;
-
-        ctx.addr = info->regs->rsp + 5 * sizeof(addr_t); // addr of fileinfoclass
-        vmi_read_32(vmi, &ctx, &fileinfoclass);
-    } else {
-        ctx.addr = info->regs->rsp + sizeof(uint32_t);
-        vmi_read_32(vmi, &ctx, (uint32_t*) &handle);
-        ctx.addr += 2 * sizeof(uint32_t);
-        vmi_read_32(vmi, &ctx, (uint32_t*) &fileinfo);
-        ctx.addr += sizeof(uint32_t);
-        vmi_read_32(vmi, &ctx, (uint32_t*) &length);
-        ctx.addr += sizeof(uint32_t);
-        vmi_read_32(vmi, &ctx, &fileinfoclass);
-    }
-
-    if (fileinfoclass == FILE_DISPOSITION_INFORMATION && length == 1) {
-        uint8_t del = 0;
-        ctx.addr = fileinfo;
-        vmi_read_8(vmi, &ctx, &del);
-        if (del) {
-            //printf("DELETE FILE _FILE_OBJECT Handle: 0x%lx.\n", handle);
-            grab_file_by_handle(drakvuf, info->vcpu, vmi, pm, info, handle);
-        }
-    }
-
-    drakvuf_release_vmi(drakvuf);
-    return 0;
-}
-
-int plugin_filedelete_start(drakvuf_t drakvuf,
-                            const struct filedelete_config *c)
-{
-    vmi_instance_t vmi = drakvuf_lock_and_get_vmi(drakvuf);
-    pm = vmi_get_page_mode(vmi);
-    domid = vmi_get_vmid(vmi);
-    drakvuf_release_vmi(drakvuf);
-
-    dump_folder = c->dump_folder ? c->dump_folder : "/tmp";
-    format = drakvuf_get_output_format(drakvuf);
-
-    if(VMI_FAILURE == drakvuf_get_function_rva(c->rekall_profile, "NtSetInformationFile", &traps[0].u2.rva))
-        return 0;
-    if(VMI_FAILURE == drakvuf_get_function_rva(c->rekall_profile, "ZwSetInformationFile", &traps[1].u2.rva))
-        return 0;
-
-    traps[0].name = "NtSetInformationFile";
-    traps[0].cb = setinformation;
-    traps[1].name = "ZwSetInformationFile";
-    traps[1].cb = setinformation;
-    /* TODO
-    traps[2].u2.rva = drakvuf_get_function_rva(c->rekall_profile, "NtDeleteFile");
-    traps[2].name = "NtDeleteFile";
-    traps[3].u2.rva = drakvuf_get_function_rva(c->rekall_profile, "ZwDeleteFile");
-    traps[3].name = "ZwDeleteFile";*/
-
-    int i;
-    for(i=0;i<__OFFSET_MAX;i++) {
-        if(VMI_FAILURE == drakvuf_get_struct_member_rva(c->rekall_profile,
-                                                        offset_names[i][0], offset_names[i][1],
-                                                        &offsets[i]))
-            return 0;
-    }
-
-    drakvuf_add_trap(drakvuf, &traps[0]);
-    //drakvuf_add_trap(drakvuf, &traps[1]);
-    //drakvuf_add_trap(drakvuf, &traps[2]);
-    //drakvuf_add_trap(drakvuf, &traps[3]);
-
-    return 1;
-}
-
-int plugin_filedelete_stop(drakvuf_t drakvuf) {
-    return 1;
-}
+#endif

--- a/src/injector.c
+++ b/src/injector.c
@@ -106,7 +106,7 @@
 #include <stdlib.h>
 #include <libvmi/libvmi.h>
 
-#include "libdrakvuf/drakvuf.h"
+#include "libdrakvuf/libdrakvuf.h"
 
 static drakvuf_t drakvuf;
 

--- a/src/libdrakvuf/Makefile.am
+++ b/src/libdrakvuf/Makefile.am
@@ -102,7 +102,7 @@
  #                                                                         #
  #*************************************************************************# 
 
-h_sources = drakvuf.h
+h_sources = libdrakvuf.h
 c_sources = drakvuf.c injector.c win-exports.c vmi.c win-symbols.c win-handles.c win-processes.c
 
 AM_CFLAGS = -I$(top_srcdir)

--- a/src/libdrakvuf/drakvuf.c
+++ b/src/libdrakvuf/drakvuf.c
@@ -105,7 +105,7 @@
 #include <glib.h>
 #include "../xen_helper/xen_helper.h"
 
-#include "drakvuf.h"
+#include "libdrakvuf.h"
 #include "private.h"
 #include "vmi.h"
 #include "win-symbols.h"

--- a/src/libdrakvuf/injector.h
+++ b/src/libdrakvuf/injector.h
@@ -105,7 +105,7 @@
 #ifndef INJECTOR_H
 #define INJECTOR_H
 
-#include "drakvuf.h"
+#include "libdrakvuf.h"
 
 int start_app(drakvuf_t drakvuf, vmi_pid_t pid, const char *app);
 

--- a/src/libdrakvuf/private.h
+++ b/src/libdrakvuf/private.h
@@ -115,7 +115,7 @@
 #include <libvmi/libvmi.h>
 #include <libvmi/events.h>
 
-#include "drakvuf.h"
+#include "libdrakvuf.h"
 #include "../xen_helper/xen_helper.h"
 
 #ifdef DRAKVUF_DEBUG

--- a/src/libdrakvuf/vmi.c
+++ b/src/libdrakvuf/vmi.c
@@ -119,7 +119,7 @@
 
 #include "../xen_helper/xen_helper.h"
 
-#include "drakvuf.h"
+#include "libdrakvuf.h"
 #include "win-symbols.h"
 #include "vmi.h"
 #include "rdtsc.h"
@@ -554,7 +554,7 @@ void inject_trap_pa(drakvuf_t drakvuf,
 
         rc = xc_domain_increase_reservation_exact(drakvuf->xen->xc, drakvuf->domID, 1, 0, 0, &remapped_gfn->r);
         if (!rc)
-            PRINT_DEBUG("Reservation increased? %u with new gfn: 0x%lx\n", rc, remapped_gfn);
+            PRINT_DEBUG("Reservation increased? %u with new gfn: 0x%lx\n", rc, remapped_gfn->r);
         else
             return;
 
@@ -637,9 +637,8 @@ void inject_trap_pa(drakvuf_t drakvuf,
         else return;
     }
 
-    if (VMI_FAILURE == vmi_write_8_pa(vmi,
-                                      (remapped_gfn->r<<12) + (container->breakpoint.pa & VMI_BIT_MASK(0,11)),
-                                      &bp))
+    addr_t rpa = (remapped_gfn->r<<12) + (container->breakpoint.pa & VMI_BIT_MASK(0,11));
+    if (VMI_FAILURE == vmi_write_8_pa(vmi, rpa, &bp))
     {
         PRINT_DEBUG("FAILED TO INJECT TRAP @ 0x%lx !\n", container->breakpoint.pa);
         return;
@@ -659,10 +658,8 @@ void inject_trap_pa(drakvuf_t drakvuf,
     g_hash_table_insert(drakvuf->breakpoint_lookup_trap, g_memdup(&trap, sizeof(void*)),
                         container);
 
-    PRINT_DEBUG("\t\tTrap added @ PA 0x%lx RPA 0x%lx Page %lu for %s. \n",
-                container->breakpoint.pa,
-                (remapped_gfn->r<<12) + (container->breakpoint.pa & VMI_BIT_MASK(0,11)),
-                pa >> 12, trap->name);
+    PRINT_DEBUG("\t\tTrap added @ PA 0x%" PRIx64 " RPA 0x%" PRIx64 " Page %" PRIu64 " for %s. \n",
+                container->breakpoint.pa, rpa, pa >> 12, trap->name);
 }
 
 void inject_trap(drakvuf_t drakvuf,
@@ -725,7 +722,7 @@ void inject_traps_modules(drakvuf_t drakvuf,
         unicode_string_t out = { .contents = NULL };
 
         if (us && VMI_SUCCESS == vmi_convert_str_encoding(us, &out, "UTF-8")) {
-            PRINT_DEBUG("\t%s @ 0x%lx\n", out.contents, dllbase);
+            PRINT_DEBUG("\t%s @ 0x%" PRIx64 "\n", out.contents, dllbase);
         } // if
         if (us)
             vmi_free_unicode_str(us);

--- a/src/libdrakvuf/win-handles.h
+++ b/src/libdrakvuf/win-handles.h
@@ -106,7 +106,7 @@
 #define WIN_HANDLES_H
 
 #include <libvmi/libvmi.h>
-#include "drakvuf.h"
+#include "libdrakvuf.h"
 
 addr_t drakvuf_get_obj_by_handle(drakvuf_t drakvuf,
                                  uint64_t vcpu_id,

--- a/src/libdrakvuf/win-symbols.c
+++ b/src/libdrakvuf/win-symbols.c
@@ -111,7 +111,7 @@
 #include <jansson.h>
 #include <glib.h>
 
-#include "drakvuf.h"
+#include "libdrakvuf.h"
 #include "private.h"
 
 status_t windows_system_map_lookup(

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -102,87 +102,107 @@
  *                                                                         *
  ***************************************************************************/
 
-#include <glib.h>
+#include <config.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include <inttypes.h>
-#include "../plugins.h"
+#include <stdbool.h>
+#include <string.h>
+#include <unistd.h>
+#include <glib.h>
 
-static GSList *traps;
-static output_format_t format;
+#include "drakvuf.h"
 
-static event_response_t cb(drakvuf_t drakvuf, drakvuf_trap_info_t *info) {
+static drakvuf_c* drakvuf;
 
-    switch(format) {
-    case OUTPUT_CSV:
-        printf("syscall,0x%"PRIx64",%s,%s\n", info->regs->cr3, info->trap->module, info->trap->name);
+void close_handler(int signal) {
+    drakvuf->interrupt(signal);
+}
+
+int main(int argc, char** argv) {
+    int c, i, rc = 0, timeout = 0;
+    char *inject_cmd = NULL;
+    char *domain = NULL;
+    char *rekall_profile = NULL;
+    char *dump_folder = NULL;
+    vmi_pid_t injection_pid = -1;
+    struct sigaction act;
+    GThread *timeout_thread = NULL;
+    output_format_t output = OUTPUT_DEFAULT;
+
+    fprintf(stderr, "%s v%s\n", PACKAGE_NAME, PACKAGE_VERSION);
+
+    if ( __DRAKVUF_PLUGIN_LIST_MAX == 0 ) {
+        fprintf(stderr, "No plugins have been enabled, nothing to do!\n");
+        return rc;
+    }
+
+    if (argc < 4) {
+        fprintf(stderr, "Required input:\n"
+               "\t -r <rekall profile>       The Rekall profile of the Windows kernel\n"
+               "\t -d <domain ID or name>    The domain's ID or name\n"
+               "Optional inputs:\n"
+               "\t -i <injection pid>        The PID of the process to hijack for injection\n"
+               "\t -e <inject_exe>           The executable to start with injection\n"
+               "\t -t <timeout>              Timeout (in seconds)\n"
+               "\t -D <file dump folder>     Folder where extracted files should be stored at\n"
+               "\t -o <format>               Output format (default or csv)\n"
+               "\t -v                        Turn on verbose (debug) output\n"
+        );
+        return rc;
+    }
+
+    while ((c = getopt (argc, argv, "r:d:i:e:t:D:o:v")) != -1)
+    switch (c)
+    {
+    case 'r':
+        rekall_profile = optarg;
+        break;
+    case 'd':
+        domain = optarg;
+        break;
+    case 'i':
+        injection_pid = atoi(optarg);
+        break;
+    case 'e':
+        inject_cmd = optarg;
+        break;
+    case 't':
+        timeout = atoi(optarg);
+        break;
+    case 'D':
+        dump_folder = optarg;
+        break;
+    case 'o':
+        if(!strncmp(optarg,"csv",3))
+            output = OUTPUT_CSV;
+        break;
+    case 'v':
+//        verbose = 1;
         break;
     default:
-    case OUTPUT_DEFAULT:
-        printf("[SYSCALL] CR3:0x%"PRIx64" %s!%s\n", info->regs->cr3, info->trap->module, info->trap->name);
-        break;
+        fprintf(stderr, "Unrecognized option: %c\n", c);
+        return rc;
     }
 
-    return 0;
-}
+    drakvuf = new drakvuf_c(domain, rekall_profile, output, timeout, dump_folder);
+    if( !drakvuf->is_initialized() )
+        goto exit;
 
-static GSList *create_trap_config(symbols_t *symbols) {
+    /* for a clean exit */
+    act.sa_handler = close_handler;
+    act.sa_flags = 0;
+    sigemptyset(&act.sa_mask);
+    sigaction(SIGHUP, &act, NULL);
+    sigaction(SIGTERM, &act, NULL);
+    sigaction(SIGINT, &act, NULL);
+    sigaction(SIGALRM, &act, NULL);
 
-    GSList *ret = NULL;
-    unsigned long i;
-    for (i=0; i < symbols->count; i++) {
+    /* Start the event listener */
+    drakvuf->loop();
+    rc = 1;
 
-        const struct symbol *symbol = &symbols->symbols[i];
-
-        if (strncmp(symbol->name, "Nt", 2))
-            continue;
-        //if (strcmp(symbol->name, "NtCallbackReturn"))
-        //    continue;
-
-        drakvuf_trap_t *trap = g_malloc0(sizeof(drakvuf_trap_t));
-        trap->lookup_type = LOOKUP_PID;
-        trap->u.pid = 4;
-        trap->addr_type = ADDR_RVA;
-        trap->u2.rva = symbol->rva;
-        trap->name = g_strdup(symbol->name);
-        trap->module = "ntoskrnl.exe";
-        trap->type = BREAKPOINT;
-        trap->cb = cb;
-
-        ret = g_slist_prepend(ret, trap);
-    }
-
-    return ret;
-}
-
-int plugin_syscall_start(drakvuf_t drakvuf, const char *rekall_profile) {
-
-    symbols_t *symbols = drakvuf_get_symbols_from_rekall(rekall_profile);
-    if (!symbols)
-    {
-        fprintf(stderr, "Failed to parse Rekall profile at %s\n", rekall_profile);
-        return 0;
-    }
-
-    traps = create_trap_config(symbols);
-
-    drakvuf_free_symbols(symbols);
-    format = drakvuf_get_output_format(drakvuf);
-
-    drakvuf_add_traps(drakvuf, traps);
-
-    return 1;
-}
-
-int plugin_syscall_stop(drakvuf_t drakvuf) {
-    GSList *loop = traps;
-    while(loop) {
-        drakvuf_trap_t *trap = loop->data;
-        free((char*)trap->name);
-        free(loop->data);
-        loop = loop->next;
-    }
-
-    g_slist_free(traps);
-    traps = NULL;
-
-    return 1;
+exit:
+    delete drakvuf;
+    return rc;
 }

--- a/src/plugins/Makefile.am
+++ b/src/plugins/Makefile.am
@@ -107,48 +107,49 @@ sources =
 ###############################################################################
 
 if PLUGIN_SYSCALLS
-sources += syscalls/syscalls.c
+sources += syscalls/syscalls.cpp
 endif
 
 if PLUGIN_POOLMON
-sources += poolmon/poolmon.c
+sources += poolmon/poolmon.cpp
 endif
 
 if PLUGIN_FILETRACER
-sources += filetracer/filetracer.c
+sources += filetracer/filetracer.cpp
 endif
 
 if PLUGIN_FILEDELETE
-sources += filedelete/filedelete.c
+sources += filedelete/filedelete.cpp
 endif
 
 if PLUGIN_OBJMON
-sources += objmon/objmon.c
+sources += objmon/objmon.cpp
 endif
 
 if PLUGIN_EXMON
-sources += exmon/exmon.c
+sources += exmon/exmon.cpp
 endif
 
 
 ###############################################################################
-sources += plugins.c plugins.h
+sources += plugins.cpp plugins.h
 
-AM_CFLAGS = -I$(top_srcdir)
-AM_CFLAGS += $(CFLAGS)
-AM_CFLAGS += $(VMI_CFLAGS)
-AM_CFLAGS += $(GLIB_CFLAGS)
+AM_CPPFLAGS = -I$(top_srcdir) -I$(top_srcdir)/src -I$(srcdir)
+AM_CPPFLAGS += $(CPPFLAGS)
+AM_CPPFLAGS += $(CXXFLAGS)
+AM_CPPFLAGS += $(VMI_CFLAGS)
+AM_CPPFLAGS += $(GLIB_CFLAGS)
 
-if HARDENING
-AM_CFLAGS += $(HARDEN_CFLAGS) -DHARDENING
-endif
+#if HARDENING
+AM_CPPFLAGS += $(HARDEN_CFLAGS) -DHARDENING
+#endif
 
 # Note that -pg is incompatible with HARDENING
 if DEBUG
-AM_CFLAGS += -DDRAKVUF_DEBUG -Wall -Wextra -Wno-override-init -Wno-strict-aliasing -g -ggdb3
-AM_CFLAGS += -Wno-unused-parameter -Wno-unused-but-set-variable -Wno-unused-variable
+AM_CPPFLAGS += -DDRAKVUF_DEBUG -Wall -Wextra -Wno-strict-aliasing -g -ggdb3
+AM_CPPFLAGS += -Wno-unused-parameter -Wno-unused-variable
 if !HARDENING
-AM_CFLAGS += -pg
+AM_CPPFLAGS += -pg
 endif
 endif
 

--- a/src/plugins/exmon/exmon.cpp
+++ b/src/plugins/exmon/exmon.cpp
@@ -104,13 +104,9 @@
 
 #include <glib.h>
 #include <libvmi/libvmi.h>
-#include "private.h"
 #include "../plugins.h"
-
-
-// In case we'll need more APIs hooked, we keep a list handy
-static GSList *traps;
-static output_format_t format;
+#include "private.h"
+#include "exmon.h"
 
 enum offset {
     KTRAP_FRAME_EIP,
@@ -138,7 +134,7 @@ enum offset {
     EPROCESS_PID,
     EPROCESS_NAME,
     EPROCESS_PPID,
-   __OFFSET_MAX
+    __OFFSET_MAX
 };
 
 static const char *offset_names[__OFFSET_MAX][2] = {
@@ -169,31 +165,27 @@ static const char *offset_names[__OFFSET_MAX][2] = {
     [EPROCESS_PPID] = {"_EPROCESS", "InheritedFromUniqueProcessId"}
 };
 
-static size_t offsets[__OFFSET_MAX];
-
-size_t ktrap_frame_size=0;
-
 static event_response_t cb(drakvuf_t drakvuf, drakvuf_trap_info_t *info) {
+    exmon *e = (exmon*)info->trap->data;
     vmi_instance_t vmi = drakvuf_lock_and_get_vmi(drakvuf);
-    char *str_format;
-    char *user_format;
+    const char *str_format;
+    const char *user_format;
     page_mode_t pm = vmi_get_page_mode(vmi);
     uint8_t index = ~0;
     uint32_t first_chance;
-    char* trap_frame=malloc(ktrap_frame_size);  // Generic pointer that allows addressing byte-aligned offests
+    char* trap_frame=(char*)g_malloc0(e->ktrap_frame_size);  // Generic pointer that allows addressing byte-aligned offests
 
     if (!trap_frame){
-        printf("[EXMON] Memory allocation failed!\n");    
+        printf("[EXMON] Memory allocation failed!\n");
         drakvuf_release_vmi(drakvuf);
         return 0;
     }
 
-    access_context_t ctx = {
-        .translate_mechanism = VMI_TM_PROCESS_DTB,
-        .dtb = info->regs->cr3,
-    };
+    access_context_t ctx;
+    ctx.translate_mechanism = VMI_TM_PROCESS_DTB;
+    ctx.dtb = info->regs->cr3;
 
-    if(pm != VMI_PM_IA32E){
+    if(e->pm != VMI_PM_IA32E){
         reg_t exception_record, ptrap_frame, exception_code;
         uint8_t previous_mode;
 
@@ -206,11 +198,11 @@ static event_response_t cb(drakvuf_t drakvuf, drakvuf_trap_info_t *info) {
         ctx.addr = info->regs->rsp+20;
         vmi_read_32(vmi, &ctx, (uint32_t*)&first_chance);
         ctx.addr = ptrap_frame;
-        vmi_read(vmi,&ctx, trap_frame, ktrap_frame_size);
+        vmi_read(vmi,&ctx, trap_frame, e->ktrap_frame_size);
         ctx.addr = exception_record;
         vmi_read_32(vmi, &ctx, (uint32_t*)&exception_code);
 
-        switch(format) {
+        switch(e->format) {
         case OUTPUT_CSV:
             str_format=CSV_FORMAT32;
             user_format=CSV_FORMAT_USER;
@@ -223,45 +215,45 @@ static event_response_t cb(drakvuf_t drakvuf, drakvuf_trap_info_t *info) {
         }
 
         printf(str_format, \
-        (uint32_t)info->regs->rsp, 
-        (uint32_t)exception_record, 
+        (uint32_t)info->regs->rsp,
+        (uint32_t)exception_record,
         (uint32_t)exception_code,
         (uint32_t)first_chance,
-        *(uint32_t*)(trap_frame+offsets[KTRAP_FRAME_EIP]), 
-        *(uint32_t*)(trap_frame+offsets[KTRAP_FRAME_EAX]), 
-        *(uint32_t*)(trap_frame+offsets[KTRAP_FRAME_EBX]), 
-        *(uint32_t*)(trap_frame+offsets[KTRAP_FRAME_ECX]), 
-        *(uint32_t*)(trap_frame+offsets[KTRAP_FRAME_EDX]), 
-        *(uint32_t*)(trap_frame+offsets[KTRAP_FRAME_EDI]), 
-        *(uint32_t*)(trap_frame+offsets[KTRAP_FRAME_ESI]), 
-        *(uint32_t*)(trap_frame+offsets[KTRAP_FRAME_EBP]), 
-        *(uint32_t*)(trap_frame+offsets[KTRAP_FRAME_HWESP])); 
-        
+        *(uint32_t*)(trap_frame+e->offsets[KTRAP_FRAME_EIP]),
+        *(uint32_t*)(trap_frame+e->offsets[KTRAP_FRAME_EAX]),
+        *(uint32_t*)(trap_frame+e->offsets[KTRAP_FRAME_EBX]),
+        *(uint32_t*)(trap_frame+e->offsets[KTRAP_FRAME_ECX]),
+        *(uint32_t*)(trap_frame+e->offsets[KTRAP_FRAME_EDX]),
+        *(uint32_t*)(trap_frame+e->offsets[KTRAP_FRAME_EDI]),
+        *(uint32_t*)(trap_frame+e->offsets[KTRAP_FRAME_ESI]),
+        *(uint32_t*)(trap_frame+e->offsets[KTRAP_FRAME_EBP]),
+        *(uint32_t*)(trap_frame+e->offsets[KTRAP_FRAME_HWESP]));
+
         if (previous_mode == 1){
             addr_t process = drakvuf_get_current_process(drakvuf, info->vcpu);
             if (process){
                 uint32_t pid,ppid;
                 char* name;
-                vmi_read_32_va(vmi, process + offsets[EPROCESS_PID], 0, (uint32_t*)&pid);
-                vmi_read_32_va(vmi, process + offsets[EPROCESS_PPID], 0, (uint32_t*)&ppid);
-                name = vmi_read_str_va(vmi, process + offsets[EPROCESS_NAME], 0);
+                vmi_read_32_va(vmi, process + e->offsets[EPROCESS_PID], 0, (uint32_t*)&pid);
+                vmi_read_32_va(vmi, process + e->offsets[EPROCESS_PPID], 0, (uint32_t*)&ppid);
+                name = vmi_read_str_va(vmi, process + e->offsets[EPROCESS_NAME], 0);
                 printf(user_format,pid,ppid,name);
                 free(name);
             } else printf(user_format,0,"NOPROC");
         }else{
-            printf("\n");    
+            printf("\n");
         }
     }else{
         reg_t exception_code;
 
         ctx.addr = info->regs->r8;
-        vmi_read(vmi,&ctx, trap_frame,ktrap_frame_size);
+        vmi_read(vmi,&ctx, trap_frame, e->ktrap_frame_size);
         ctx.addr = info->regs->rcx;
         vmi_read_32(vmi, &ctx, (uint32_t*)&exception_code);
         ctx.addr = info->regs->rsp+40; // Return address + 32 byte shadow space
         vmi_read_32(vmi, &ctx, (uint32_t*)&first_chance);
 
-        switch(format) {
+        switch(e->format) {
         case OUTPUT_CSV:
             str_format=CSV_FORMAT64;
             user_format=CSV_FORMAT_USER;
@@ -274,33 +266,33 @@ static event_response_t cb(drakvuf_t drakvuf, drakvuf_trap_info_t *info) {
         }
         printf(str_format, \
         info->regs->rcx, exception_code, first_chance & 1,
-        *(uint64_t*)(trap_frame+offsets[KTRAP_FRAME_RIP]), 
-        *(uint64_t*)(trap_frame+offsets[KTRAP_FRAME_RAX]), 
-        *(uint64_t*)(trap_frame+offsets[KTRAP_FRAME_RBX]), 
-        *(uint64_t*)(trap_frame+offsets[KTRAP_FRAME_RCX]), 
-        *(uint64_t*)(trap_frame+offsets[KTRAP_FRAME_RDX]), 
-        *(uint64_t*)(trap_frame+offsets[KTRAP_FRAME_RSP]), 
-        *(uint64_t*)(trap_frame+offsets[KTRAP_FRAME_RBP]), 
-        *(uint64_t*)(trap_frame+offsets[KTRAP_FRAME_RSI]), 
-        *(uint64_t*)(trap_frame+offsets[KTRAP_FRAME_RDI]), 
-        *(uint64_t*)(trap_frame+offsets[KTRAP_FRAME_R8]), 
-        *(uint64_t*)(trap_frame+offsets[KTRAP_FRAME_R9]), 
-        *(uint64_t*)(trap_frame+offsets[KTRAP_FRAME_R10]), 
-        *(uint64_t*)(trap_frame+offsets[KTRAP_FRAME_R11])); 
+        *(uint64_t*)(trap_frame+e->offsets[KTRAP_FRAME_RIP]),
+        *(uint64_t*)(trap_frame+e->offsets[KTRAP_FRAME_RAX]),
+        *(uint64_t*)(trap_frame+e->offsets[KTRAP_FRAME_RBX]),
+        *(uint64_t*)(trap_frame+e->offsets[KTRAP_FRAME_RCX]),
+        *(uint64_t*)(trap_frame+e->offsets[KTRAP_FRAME_RDX]),
+        *(uint64_t*)(trap_frame+e->offsets[KTRAP_FRAME_RSP]),
+        *(uint64_t*)(trap_frame+e->offsets[KTRAP_FRAME_RBP]),
+        *(uint64_t*)(trap_frame+e->offsets[KTRAP_FRAME_RSI]),
+        *(uint64_t*)(trap_frame+e->offsets[KTRAP_FRAME_RDI]),
+        *(uint64_t*)(trap_frame+e->offsets[KTRAP_FRAME_R8]),
+        *(uint64_t*)(trap_frame+e->offsets[KTRAP_FRAME_R9]),
+        *(uint64_t*)(trap_frame+e->offsets[KTRAP_FRAME_R10]),
+        *(uint64_t*)(trap_frame+e->offsets[KTRAP_FRAME_R11]));
 
         if ((uint8_t)(info->regs->r9) == 1){
             addr_t process = drakvuf_get_current_process(drakvuf, info->vcpu);
             if (process){
                 uint32_t pid,ppid;
                 char* name;
-                vmi_read_32_va(vmi, process + offsets[EPROCESS_PID], 0, (uint32_t*)&pid);
-                vmi_read_32_va(vmi, process + offsets[EPROCESS_PPID], 0, (uint32_t*)&ppid);
-                name = vmi_read_str_va(vmi, process + offsets[EPROCESS_NAME], 0);
+                vmi_read_32_va(vmi, process + e->offsets[EPROCESS_PID], 0, (uint32_t*)&pid);
+                vmi_read_32_va(vmi, process + e->offsets[EPROCESS_PPID], 0, (uint32_t*)&ppid);
+                name = vmi_read_str_va(vmi, process + e->offsets[EPROCESS_NAME], 0);
                 printf(user_format,pid,ppid,name);
                 free(name);
             } else printf(user_format,0,"NOPROC");
-        }else{
-            printf("\n");    
+        } else {
+            printf("\n");
         }
     }
 
@@ -309,46 +301,28 @@ static event_response_t cb(drakvuf_t drakvuf, drakvuf_trap_info_t *info) {
     return 0;
 }
 
-int plugin_exmon_start(drakvuf_t drakvuf, const char *rekall_profile) {
+exmon::exmon(drakvuf_t drakvuf, const void *config) {
+    const char *rekall_profile =(const char *)config;
 
-    drakvuf_trap_t *trap = g_malloc0(sizeof(drakvuf_trap_t));
-    trap->lookup_type = LOOKUP_PID;
-    trap->u.pid = 4;
-    trap->addr_type = ADDR_RVA;
+    if(VMI_FAILURE == drakvuf_get_function_rva(rekall_profile, "KiDispatchException", &this->trap.u2.rva))
+        return;
 
-    if(VMI_FAILURE == drakvuf_get_function_rva(rekall_profile, "KiDispatchException", &trap->u2.rva))
-        return 0;
-
-    trap->name = "KiDispatchException";
-    trap->module = "ntoskrnl.exe";
-    trap->type = BREAKPOINT;
-    trap->cb = cb;
-
-    traps = g_slist_prepend(traps, trap);
-    format = drakvuf_get_output_format(drakvuf);
+    this->trap.cb = cb;
+    this->trap.data = (void*)this;
+    this->format = drakvuf_get_output_format(drakvuf);
+    this->offsets = (size_t*)g_malloc0(__OFFSET_MAX*sizeof(size_t));
 
     int i;
     for(i=0;i<__OFFSET_MAX;i++) {
         drakvuf_get_struct_member_rva(rekall_profile, offset_names[i][0], offset_names[i][1],
-                                        &offsets[i]);
+                                      &this->offsets[i]);
     }
 
-    drakvuf_get_struct_size(rekall_profile, "_KTRAP_FRAME", &ktrap_frame_size);
+    drakvuf_get_struct_size(rekall_profile, "_KTRAP_FRAME", &this->ktrap_frame_size);
 
-    drakvuf_add_traps(drakvuf,traps);
-    return 1;
+    drakvuf_add_trap(drakvuf,&this->trap);
 }
 
-int plugin_exmon_stop(drakvuf_t drakvuf) {
-    GSList *loop = traps;
-    while(loop) {
-        free(loop->data);
-        loop = loop->next;
-    }
-
-    g_slist_free(traps);
-    traps = NULL;
-
-    return 1;
+exmon::~exmon() {
+    free(this->offsets);
 }
-

--- a/src/plugins/exmon/exmon.h
+++ b/src/plugins/exmon/exmon.h
@@ -105,20 +105,25 @@
 #ifndef EXMON_H
 #define EXMON_H
 
-#ifdef ENABLE_PLUGIN_EXMON
+#include "plugins/plugins.h"
 
-int plugin_exmon_start(drakvuf_t drakvuf, const void *config);
-int plugin_exmon_stop(drakvuf_t drakvuf);
+class exmon: public plugin {
+    public:
+        drakvuf_trap_t trap = {
+            .lookup_type = LOOKUP_PID,
+            .u.pid = 4,
+            .addr_type = ADDR_RVA,
+            .name = "KiDispatchException",
+            .module = "ntoskrnl.exe",
+            .type = BREAKPOINT
+        };
+        output_format_t format;
+        page_mode_t pm;
+        size_t *offsets;
+        size_t ktrap_frame_size;
 
-#else
-
-static int plugin_exmon_start(drakvuf_t drakvuf, const void *config) {
-    return 1;
-}
-static int plugin_exmon_stop(drakvuf_t drakvuf) {
-    return 1;
-}
-
-#endif
+        exmon(drakvuf_t drakvuf, const void *config);
+        ~exmon();
+};
 
 #endif

--- a/src/plugins/filedelete/filedelete.h
+++ b/src/plugins/filedelete/filedelete.h
@@ -105,20 +105,28 @@
 #ifndef FILEDELETE_H
 #define FILEDELETE_H
 
-#ifdef ENABLE_PLUGIN_FILEDELETE
+#include "plugins/plugins.h"
 
-int plugin_filedelete_start(drakvuf_t drakvuf, const void *config);
-int plugin_filedelete_stop(drakvuf_t drakvuf);
+class filedelete: public plugin {
+    public:
+        drakvuf_trap_t traps[4] = {
+            [0 ... 3] = {
+                .lookup_type = LOOKUP_PID,
+                .u.pid = 4,
+                .addr_type = ADDR_RVA,
+                .type = BREAKPOINT,
+                .module = "ntoskrnl.exe",
+                .data = (void*)this
+            }
+        };
+        size_t* offsets;
 
-#else
-
-static int plugin_filedelete_start(drakvuf_t drakvuf, const void *config) {
-    return 1;
-}
-static int plugin_filedelete_stop(drakvuf_t drakvuf) {
-    return 1;
-}
-
-#endif
+        const char *dump_folder;
+        page_mode_t pm;
+        uint32_t domid;
+        output_format_t format;
+        filedelete(drakvuf_t drakvuf, const void *config);
+        ~filedelete();
+};
 
 #endif

--- a/src/plugins/filetracer/filetracer.cpp
+++ b/src/plugins/filetracer/filetracer.cpp
@@ -1,0 +1,394 @@
+/*********************IMPORTANT DRAKVUF LICENSE TERMS***********************
+ *                                                                         *
+ * DRAKVUF Dynamic Malware Analysis System (C) 2014-2015 Tamas K Lengyel.  *
+ * Tamas K Lengyel is hereinafter referred to as the author.               *
+ * This program is free software; you may redistribute and/or modify it    *
+ * under the terms of the GNU General Public License as published by the   *
+ * Free Software Foundation; Version 2 ("GPL"), BUT ONLY WITH ALL OF THE   *
+ * CLARIFICATIONS AND EXCEPTIONS DESCRIBED HEREIN.  This guarantees your   *
+ * right to use, modify, and redistribute this software under certain      *
+ * conditions.  If you wish to embed DRAKVUF technology into proprietary   *
+ * software, alternative licenses can be aquired from the author.          *
+ *                                                                         *
+ * Note that the GPL places important restrictions on "derivative works",  *
+ * yet it does not provide a detailed definition of that term.  To avoid   *
+ * misunderstandings, we interpret that term as broadly as copyright law   *
+ * allows.  For example, we consider an application to constitute a        *
+ * derivative work for the purpose of this license if it does any of the   *
+ * following with any software or content covered by this license          *
+ * ("Covered Software"):                                                   *
+ *                                                                         *
+ * o Integrates source code from Covered Software.                         *
+ *                                                                         *
+ * o Reads or includes copyrighted data files.                             *
+ *                                                                         *
+ * o Is designed specifically to execute Covered Software and parse the    *
+ * results (as opposed to typical shell or execution-menu apps, which will *
+ * execute anything you tell them to).                                     *
+ *                                                                         *
+ * o Includes Covered Software in a proprietary executable installer.  The *
+ * installers produced by InstallShield are an example of this.  Including *
+ * DRAKVUF with other software in compressed or archival form does not     *
+ * trigger this provision, provided appropriate open source decompression  *
+ * or de-archiving software is widely available for no charge.  For the    *
+ * purposes of this license, an installer is considered to include Covered *
+ * Software even if it actually retrieves a copy of Covered Software from  *
+ * another source during runtime (such as by downloading it from the       *
+ * Internet).                                                              *
+ *                                                                         *
+ * o Links (statically or dynamically) to a library which does any of the  *
+ * above.                                                                  *
+ *                                                                         *
+ * o Executes a helper program, module, or script to do any of the above.  *
+ *                                                                         *
+ * This list is not exclusive, but is meant to clarify our interpretation  *
+ * of derived works with some common examples.  Other people may interpret *
+ * the plain GPL differently, so we consider this a special exception to   *
+ * the GPL that we apply to Covered Software.  Works which meet any of     *
+ * these conditions must conform to all of the terms of this license,      *
+ * particularly including the GPL Section 3 requirements of providing      *
+ * source code and allowing free redistribution of the work as a whole.    *
+ *                                                                         *
+ * Any redistribution of Covered Software, including any derived works,    *
+ * must obey and carry forward all of the terms of this license, including *
+ * obeying all GPL rules and restrictions.  For example, source code of    *
+ * the whole work must be provided and free redistribution must be         *
+ * allowed.  All GPL references to "this License", are to be treated as    *
+ * including the terms and conditions of this license text as well.        *
+ *                                                                         *
+ * Because this license imposes special exceptions to the GPL, Covered     *
+ * Work may not be combined (even as part of a larger work) with plain GPL *
+ * software.  The terms, conditions, and exceptions of this license must   *
+ * be included as well.  This license is incompatible with some other open *
+ * source licenses as well.  In some cases we can relicense portions of    *
+ * DRAKVUF or grant special permissions to use it in other open source     *
+ * software.  Please contact tamas.k.lengyel@gmail.com with any such       *
+ * requests.  Similarly, we don't incorporate incompatible open source     *
+ * software into Covered Software without special permission from the      *
+ * copyright holders.                                                      *
+ *                                                                         *
+ * If you have any questions about the licensing restrictions on using     *
+ * DRAKVUF in other works, are happy to help.  As mentioned above,         *
+ * alternative license can be requested from the author to integrate       *
+ * DRAKVUF into proprietary applications and appliances.  Please email     *
+ * tamas.k.lengyel@gmail.com for further information.                      *
+ *                                                                         *
+ * If you have received a written license agreement or contract for        *
+ * Covered Software stating terms other than these, you may choose to use  *
+ * and redistribute Covered Software under those terms instead of these.   *
+ *                                                                         *
+ * Source is provided to this software because we believe users have a     *
+ * right to know exactly what a program is going to do before they run it. *
+ * This also allows you to audit the software for security holes.          *
+ *                                                                         *
+ * Source code also allows you to port DRAKVUF to new platforms, fix bugs, *
+ * and add new features.  You are highly encouraged to submit your changes *
+ * on https://github.com/tklengyel/drakvuf, or by other methods.           *
+ * By sending these changes, it is understood (unless you specify          *
+ * otherwise) that you are offering unlimited, non-exclusive right to      *
+ * reuse, modify, and relicense the code.  DRAKVUF will always be          *
+ * available Open Source, but this is important because the inability to   *
+ * relicense code has caused devastating problems for other Free Software  *
+ * projects (such as KDE and NASM).                                        *
+ * To specify special license conditions of your contributions, just say   *
+ * so when you send them.                                                  *
+ *                                                                         *
+ * This program is distributed in the hope that it will be useful, but     *
+ * WITHOUT ANY WARRANTY; without even the implied warranty of              *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the DRAKVUF   *
+ * license file for more details (it's in a COPYING file included with     *
+ * DRAKVUF, and also available from                                        *
+ * https://github.com/tklengyel/drakvuf/COPYING)                           *
+ *                                                                         *
+ ***************************************************************************/
+
+/*
+ * 1) ExAllocatePoolWithTag: is it a FILE?
+ *   - YES: breakpoint RSP
+ * 2) RSP: RAX -> _FILE_OBJECT
+ *    - MEMTRAP W location
+ * 3) MEMTRAP: is it at FileName string buffer?
+ *    - YES: read string and remove trap
+ */
+
+#include <config.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/prctl.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <dirent.h>
+#include <glib.h>
+#include <err.h>
+
+#include <libvmi/libvmi.h>
+#include "plugins/plugins.h"
+#include "private.h"
+#include "filetracer.h"
+
+#define POOLTAG_FILE "Fil\xe5"
+#define ALIGN_SIZE(alignment, size) \
+    ( (size % alignment) ? (alignment - (size % alignment)) : 0 )
+
+struct rettrap_struct {
+    filetracer *f;
+    drakvuf_trap_t *trap;
+    long counter;
+};
+
+struct file_watch {
+    filetracer *f;
+    addr_t file_name_buffer;
+    addr_t file_name_length;
+};
+
+void free_writetrap(drakvuf_trap_t *trap) {
+    //printf("Freeing writetrap @ %p\n", trap);
+    filetracer *f = (filetracer *)trap->data;
+    f->writetraps = g_slist_remove(f->writetraps, trap);
+    free(trap);
+}
+
+static event_response_t file_name_cb(drakvuf_t drakvuf, drakvuf_trap_info_t *info) {
+    vmi_instance_t vmi = drakvuf_lock_and_get_vmi(drakvuf);
+    struct file_watch *watch = (struct file_watch*)info->trap->data;
+    filetracer *f = watch->f;
+
+    if (info->trap_pa == watch->file_name_buffer)
+    {
+        addr_t file_name = 0;
+        uint16_t length = 0;
+        vmi_read_addr_pa(vmi, watch->file_name_buffer, &file_name);
+        vmi_read_16_pa(vmi, watch->file_name_length, &length);
+
+        //printf("File name @ 0x%lx. Length: %u\n", file_name, length);
+
+        if (file_name && length > 0 && length < VMI_PS_4KB) {
+            unicode_string_t str = { .contents = NULL };
+            str.length = length;
+            str.encoding = "UTF-16";
+            str.contents = (unsigned char *)g_malloc0(length);
+            vmi_read_va(vmi, file_name, 0, str.contents, length);
+            unicode_string_t str2 = { .contents = NULL };
+            status_t rc = vmi_convert_str_encoding(&str, &str2, "UTF-8");
+
+            if (VMI_SUCCESS == rc) {
+
+                switch(f->format) {
+                case OUTPUT_CSV:
+                    printf("filetracer,%u,%s\n", info->vcpu, str2.contents);
+                    break;
+                default:
+                case OUTPUT_DEFAULT:
+                    printf("[FILETRACER] VCPU:%u %s\n", info->vcpu, str2.contents);
+                    break;
+                };
+
+                g_free(str2.contents);
+            }
+
+            free(str.contents);
+            //printf("Requesting to free writetrap @ %p\n", info->trap);
+            info->trap->data=f;
+            drakvuf_remove_trap(drakvuf, info->trap, free_writetrap);
+        }
+    }
+
+    drakvuf_release_vmi(drakvuf);
+    return 0;
+}
+
+/* This will be hit for all sorts of heap alloc returns */
+static event_response_t pool_alloc_return(drakvuf_t drakvuf, drakvuf_trap_info_t *info) {
+    vmi_instance_t vmi = drakvuf_lock_and_get_vmi(drakvuf);
+    struct rettrap_struct *s = (struct rettrap_struct *)info->trap->data;
+    filetracer *f = s->f;
+    addr_t obj_pa = vmi_pagetable_lookup(vmi, info->regs->cr3, info->regs->rax);
+    bool file_alloc = 0;
+    addr_t ph_base = 0, thread = 0;
+    uint32_t block_size = 0;
+    uint32_t tag;
+    uint32_t aligned_file_size = f->file_object_size;
+
+    if ( f->pm == VMI_PM_IA32E ) {
+        struct pool_header_x64 ph;
+        memset(&ph, 0, sizeof(struct pool_header_x64));
+        ph_base = obj_pa - sizeof(struct pool_header_x64);
+        vmi_read_pa(vmi, ph_base, &ph, sizeof(struct pool_header_x64));
+        block_size = ph.block_size * 0x10; // align it
+        if(!memcmp(&ph.pool_tag, &POOLTAG_FILE, 4))
+            file_alloc = 1;
+    } else {
+        struct pool_header_x86 ph;
+        memset(&ph, 0, sizeof(struct pool_header_x86));
+        ph_base = obj_pa - sizeof(struct pool_header_x86);
+        vmi_read_pa(vmi, ph_base, &ph, sizeof(struct pool_header_x86));
+        block_size = ph.block_size * 0x8; // align it
+        if(!memcmp(&ph.pool_tag, &POOLTAG_FILE, 4))
+            file_alloc = 1;
+    }
+
+    if (!file_alloc) {
+        drakvuf_release_vmi(drakvuf);
+        return 0;
+    }
+
+    // We will need to catch when the file string buffer pointer is updated
+    addr_t file_base = ph_base + block_size - f->file_object_size; // addr of "_FILE_OBJECT"
+    addr_t file_name = file_base + f->file_name_offset; // addr of "_UNICODE_STRING"
+
+    struct file_watch *watch = (struct file_watch *)g_malloc0(sizeof(struct file_watch));
+    watch->f = f;
+    watch->file_name_buffer = file_name + f->string_buffer_offset;
+    watch->file_name_length = file_name + f->string_length_offset;
+
+    //printf("PH 0x%lx. Block size: %u\n", ph_base, block_size);
+    //printf("File size: 0x%lx File base: 0x%lx. Unicode string @ 0x%lx. Last write @ 0x%lx\n",
+    //       file_object_size, file_base, file_name-file_base, watch->file_name_buffer-file_base);
+
+    drakvuf_trap_t *writetrap = (drakvuf_trap_t*)g_malloc0(sizeof(drakvuf_trap_t));
+    //printf("Made a writetrap @ %p\n", writetrap);
+    writetrap->lookup_type = LOOKUP_NONE;
+    writetrap->addr_type = ADDR_PA;
+    writetrap->type = MEMACCESS_W;
+    writetrap->memaccess_type = POST;
+    writetrap->cb = file_name_cb;
+    writetrap->u2.addr = watch->file_name_buffer;
+    writetrap->data = watch;
+
+    f->writetraps = g_slist_prepend(f->writetraps, writetrap);
+
+    drakvuf_add_trap(drakvuf, writetrap);
+
+    s->counter--;
+
+    /*
+    if(s->counter == 0) {
+        drakvuf_remove_trap(drakvuf, info->trap, free);
+        g_hash_table_remove(rettraps, &s->trap->u2.addr);
+        free(s);
+    }*/
+
+    drakvuf_release_vmi(drakvuf);
+    return 0;
+}
+
+static event_response_t cb(drakvuf_t drakvuf, drakvuf_trap_info_t *info) {
+
+    filetracer *f = (filetracer*)info->trap->data;
+    vmi_instance_t vmi = drakvuf_lock_and_get_vmi(drakvuf);
+    reg_t tag = 0, size = 0;
+
+    access_context_t ctx;
+    ctx.translate_mechanism = VMI_TM_PROCESS_DTB;
+    ctx.dtb = info->regs->cr3;
+
+    if (f->pm == VMI_PM_IA32E) {
+        size = info->regs->rdx;
+        tag = info->regs->r8;
+    } else {
+        ctx.addr = info->regs->rsp+8;
+        vmi_read_32(vmi, &ctx, (uint32_t*)&size);
+        ctx.addr = info->regs->rsp+12;
+        vmi_read_32(vmi, &ctx, (uint32_t*)&tag);
+    }
+
+    /*printf("Got a heap alloc request for tag %c%c%c%c!\n",
+           ((uint8_t*)&tag)[0],
+           ((uint8_t*)&tag)[1],
+           ((uint8_t*)&tag)[2],
+           ((uint8_t*)&tag)[3]
+    );*/
+
+    if(!memcmp(&tag, &POOLTAG_FILE, 4)) {
+
+        addr_t ret, ret_pa;
+        ctx.addr = info->regs->rsp;
+        vmi_read_addr(vmi, &ctx, &ret);
+        ret_pa = vmi_pagetable_lookup(vmi, info->regs->cr3, ret);
+
+        struct rettrap_struct *s = (struct rettrap_struct*)g_hash_table_lookup(f->rettraps, &ret_pa);
+        if (s) {
+            s->counter++;
+        } else {
+            drakvuf_trap_t *rettrap = (drakvuf_trap_t*)g_malloc0(sizeof(drakvuf_trap_t));
+            s = (struct rettrap_struct*)g_malloc0(sizeof(struct rettrap_struct));
+            s->trap = rettrap;
+            s->counter = 1;
+            s->f = f;
+
+            rettrap->lookup_type = LOOKUP_NONE;
+            rettrap->addr_type = ADDR_PA;
+            rettrap->type = BREAKPOINT;
+            rettrap->name = "HeapRetTrap";
+            rettrap->cb = pool_alloc_return;
+            rettrap->u2.addr = ret_pa;
+            rettrap->data = s;
+
+            drakvuf_add_trap(drakvuf, rettrap);
+            g_hash_table_insert(f->rettraps, &rettrap->u2.addr, s);
+        }
+
+        //printf("File alloc request on vCPU %u. Ret: 0x%lx. Counter: %u\n",
+        //         info->vcpu, ret_pa, s->counter);
+    }
+
+    drakvuf_release_vmi(drakvuf);
+    return 0;
+}
+
+/* ----------------------------------------------------- */
+
+filetracer::filetracer(drakvuf_t drakvuf, const void* config) {
+    const char *rekall_profile = (const char *)config;
+    vmi_instance_t vmi = drakvuf_lock_and_get_vmi(drakvuf);
+    this->pm = vmi_get_page_mode(vmi);
+    drakvuf_release_vmi(drakvuf);
+    this->rettraps = g_hash_table_new(g_int64_hash, g_int64_equal);
+    this->format = drakvuf_get_output_format(drakvuf);
+
+    this->poolalloc.lookup_type = LOOKUP_PID;
+    this->poolalloc.u.pid = 4;
+    this->poolalloc.addr_type = ADDR_RVA;
+    this->poolalloc.name = "ExAllocatePoolWithTag";
+    this->poolalloc.module = "ntoskrnl.exe";
+    this->poolalloc.type = BREAKPOINT;
+    this->poolalloc.cb = cb;
+    this->poolalloc.data = (void*)this;
+
+    if (VMI_FAILURE == drakvuf_get_function_rva(rekall_profile, "ExAllocatePoolWithTag", &this->poolalloc.u2.rva))
+        return;
+    if (VMI_FAILURE == drakvuf_get_struct_member_rva(rekall_profile, "_FILE_OBJECT", "FileName", &this->file_name_offset))
+        return;
+    if (VMI_FAILURE == drakvuf_get_struct_member_rva(rekall_profile, "_UNICODE_STRING", "Buffer", &this->string_buffer_offset))
+        return;
+    if (VMI_FAILURE == drakvuf_get_struct_member_rva(rekall_profile, "_UNICODE_STRING", "Length", &this->string_length_offset))
+        return;
+    if (VMI_FAILURE == drakvuf_get_struct_size(rekall_profile, "_FILE_OBJECT", &this->file_object_size))
+        return;
+
+    if (this->pm == VMI_PM_IA32E)
+        this->file_object_size += ALIGN_SIZE(16, this->file_object_size);
+    else
+        this->file_object_size += ALIGN_SIZE(8, this->file_object_size);
+
+    drakvuf_add_trap(drakvuf, &this->poolalloc);
+}
+
+filetracer::~filetracer() {
+
+    GSList *loop = this->writetraps;
+    while(loop) {
+        free(loop->data);
+        loop=loop->next;
+    }
+    g_slist_free(this->writetraps);
+
+    if ( this->rettraps )
+        g_hash_table_destroy(this->rettraps);
+}

--- a/src/plugins/filetracer/filetracer.h
+++ b/src/plugins/filetracer/filetracer.h
@@ -105,20 +105,20 @@
 #ifndef FILETRACER_H
 #define FILETRACER_H
 
-#ifdef ENABLE_PLUGIN_FILETRACER
+#include "plugins/plugins.h"
 
-int plugin_filetracer_start(drakvuf_t drakvuf, const void *config);
-int plugin_filetracer_stop(drakvuf_t drakvuf);
+class filetracer: public plugin {
+    public:
+        page_mode_t pm;
+        output_format_t format;
+        drakvuf_trap_t poolalloc;
+        GSList *writetraps;
+        GHashTable *rettraps;
+        addr_t file_object_size, file_name_offset,
+              string_buffer_offset, string_length_offset;
 
-#else
-
-static int plugin_filetracer_start(drakvuf_t drakvuf, const void *config) {
-    return 1;
-}
-static int plugin_filetracer_stop(drakvuf_t drakvuf) {
-    return 1;
-}
-
-#endif
+        filetracer(drakvuf_t drakvuf, const void *config);
+        ~filetracer();
+};
 
 #endif

--- a/src/plugins/objmon/objmon.cpp
+++ b/src/plugins/objmon/objmon.cpp
@@ -102,36 +102,88 @@
  *                                                                         *
  ***************************************************************************/
 
-#include <stdarg.h>
-#include "plugins.h"
-#include "private.h"
+#include <config.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/prctl.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <dirent.h>
+#include <glib.h>
+#include <err.h>
 
-int drakvuf_plugin_start(drakvuf_t drakvuf,
-                        drakvuf_plugin_t plugin,
-                        const void *config)
-{
-    if ( __DRAKVUF_PLUGIN_LIST_MAX != 0 &&
-         plugin < __DRAKVUF_PLUGIN_LIST_MAX)
+#include <libvmi/libvmi.h>
+#include "private.h"
+#include "objmon.h"
+
+/*
+ NTKERNELAPI
+ NTSTATUS
+ ObCreateObject (
+ IN KPROCESSOR_MODE ObjectAttributesAccessMode OPTIONAL,
+ IN POBJECT_TYPE ObjectType,
+ IN POBJECT_ATTRIBUTES ObjectAttributes OPTIONAL,
+ IN KPROCESSOR_MODE AccessMode,
+ IN PVOID Reserved,
+ IN ULONG ObjectSizeToAllocate,
+ IN ULONG PagedPoolCharge OPTIONAL,
+ IN ULONG NonPagedPoolCharge OPTIONAL,
+ OUT PVOID *Object
+ );
+ */
+static event_response_t cb(drakvuf_t drakvuf, drakvuf_trap_info_t *info) {
+
+    objmon *o = (objmon *)info->trap->data;
+    vmi_instance_t vmi = drakvuf_lock_and_get_vmi(drakvuf);
+    page_mode_t pm = vmi_get_page_mode(vmi);
+    uint8_t index = ~0;
+
+    access_context_t ctx;
+    ctx.translate_mechanism = VMI_TM_PROCESS_DTB;
+    ctx.dtb = info->regs->cr3;
+    ctx.addr = info->regs->rdx + o->typeindex_offset;
+
+    vmi_read_8(vmi, &ctx, &index);
+
+    if(index < WIN7_TYPEINDEX_LAST)
     {
-        return plugins[plugin].start(drakvuf, config);
+        switch(o->format) {
+        case OUTPUT_CSV:
+        {
+            printf("objmon,%s", win7_typeindex[index]);
+            break;
+        }
+        default:
+        case OUTPUT_DEFAULT:
+            printf("[OBJMON] %s", win7_typeindex[index]);
+            break;
+        };
+
+        printf("\n");
     }
 
+    drakvuf_release_vmi(drakvuf);
     return 0;
 }
 
-int drakvuf_plugins_stop(drakvuf_t drakvuf)
-{
-    int i;
-    int ret = 0;
+/* ----------------------------------------------------- */
 
-    if (__DRAKVUF_PLUGIN_LIST_MAX == 0)
-        return ret;
+objmon::objmon(drakvuf_t drakvuf, const void *config) {
+    const char *rekall_profile = (const char *)config;
 
-    for(i=0;i<__DRAKVUF_PLUGIN_LIST_MAX;i++) {
-        ret = plugins[i].stop(drakvuf);
-        if (!ret)
-            break;
-    }
+    if(VMI_FAILURE == drakvuf_get_function_rva(rekall_profile, "ObCreateObject", &this->trap.u2.rva))
+        return;
+    if (VMI_FAILURE==drakvuf_get_struct_member_rva(rekall_profile, "_OBJECT_HEADER", "TypeIndex", &this->typeindex_offset))
+        return;
 
-    return ret;
+    this->trap.cb = cb;
+    this->trap.data = (void*)this;
+
+    this->format = drakvuf_get_output_format(drakvuf);
+    drakvuf_add_trap(drakvuf, &this->trap);
 }

--- a/src/plugins/objmon/objmon.h
+++ b/src/plugins/objmon/objmon.h
@@ -105,20 +105,23 @@
 #ifndef OBJMON_H
 #define OBJMON_H
 
-#ifdef ENABLE_PLUGIN_OBJMON
+#include "plugins/plugins.h"
 
-int plugin_objmon_start(drakvuf_t drakvuf, const void *config);
-int plugin_objmon_stop(drakvuf_t drakvuf);
+class objmon: public plugin {
+    public:
+        output_format_t format;
+        drakvuf_trap_t trap = {
+            .lookup_type = LOOKUP_PID,
+            .u.pid = 4,
+            .addr_type = ADDR_RVA,
+            .name = "ObCreateObject",
+            .module = "ntoskrnl.exe",
+            .type = BREAKPOINT
+        };
+        addr_t typeindex_offset;
 
-#else
-
-static int plugin_objmon_start(drakvuf_t drakvuf, const void *config) {
-    return 1;
-}
-static int plugin_objmon_stop(drakvuf_t drakvuf) {
-    return 1;
-}
-
-#endif
+        objmon(drakvuf_t drakvuf, const void *config);
+        ~objmon();
+};
 
 #endif

--- a/src/plugins/plugins.h
+++ b/src/plugins/plugins.h
@@ -107,7 +107,17 @@
 
 #include <config.h>
 #include <stdlib.h>
-#include "../libdrakvuf/drakvuf.h"
+#include <libdrakvuf/libdrakvuf.h>
+
+/***************************************************************************/
+
+/* Plugin-specific configuration input */
+struct filedelete_config {
+    const char *rekall_profile;
+    const char *dump_folder;
+};
+
+/***************************************************************************/
 
 typedef enum drakvuf_plugin {
     PLUGIN_SYSCALLS,
@@ -119,15 +129,19 @@ typedef enum drakvuf_plugin {
     __DRAKVUF_PLUGIN_LIST_MAX
 } drakvuf_plugin_t;
 
-int drakvuf_plugin_start(drakvuf_t drakvuf,
-                        drakvuf_plugin_t plugin,
-                        const void *config);
-int drakvuf_plugins_stop(drakvuf_t drakvuf);
+class plugin {};
+class drakvuf_plugins
+{
+    private:
+        drakvuf_t drakvuf;
+        plugin* plugins[__DRAKVUF_PLUGIN_LIST_MAX] = { [0 ... __DRAKVUF_PLUGIN_LIST_MAX-1] = NULL };
 
-/* Plugin-specific configuration input */
-struct filedelete_config {
-    const char *rekall_profile;
-    const char *dump_folder;
+    public:
+        drakvuf_plugins(drakvuf_t drakvuf);
+        ~drakvuf_plugins();
+        int start(drakvuf_plugin_t plugin, const void* config);
 };
+
+/***************************************************************************/
 
 #endif

--- a/src/plugins/poolmon/poolmon.cpp
+++ b/src/plugins/poolmon/poolmon.cpp
@@ -102,15 +102,6 @@
  *                                                                         *
  ***************************************************************************/
 
-/*
- * 1) ExAllocatePoolWithTag: is it a FILE?
- *   - YES: breakpoint RSP
- * 2) RSP: RAX -> _FILE_OBJECT
- *    - MEMTRAP W location
- * 3) MEMTRAP: is it at FileName string buffer?
- *    - YES: read string and remove trap
- */
-
 #include <config.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -129,265 +120,112 @@
 #include <libvmi/libvmi.h>
 #include "../plugins.h"
 #include "private.h"
+#include "poolmon.h"
 
-#define POOLTAG_FILE "Fil\xe5"
-#define ALIGN_SIZE(alignment, size) \
-    ( (size % alignment) ? (alignment - (size % alignment)) : 0 )
+static GTree* pooltag_build_tree() {
+    GTree *pooltags = g_tree_new((GCompareFunc) strcmp);
 
-static drakvuf_trap_t poolalloc;
-static GSList *writetraps;
-static GHashTable *rettraps;
-static addr_t file_object_size, file_name_offset,
-              string_buffer_offset, string_length_offset;
-static page_mode_t pm;
-static output_format_t format;
-
-struct rettrap_struct {
-    drakvuf_trap_t *trap;
-    long counter;
-};
-
-struct file_watch {
-    addr_t file_name_buffer;
-    addr_t file_name_length;
-};
-
-void free_writetrap(drakvuf_trap_t *trap) {
-    //printf("Freeing writetrap @ %p\n", trap);
-    writetraps = g_slist_remove(writetraps, trap);
-    free(trap);
-}
-
-static event_response_t file_name_cb(drakvuf_t drakvuf, drakvuf_trap_info_t *info) {
-    vmi_instance_t vmi = drakvuf_lock_and_get_vmi(drakvuf);
-    struct file_watch *watch = info->trap->data;
-
-    if (info->trap_pa == watch->file_name_buffer)
-    {
-        addr_t file_name = 0;
-        uint16_t length = 0;
-        vmi_read_addr_pa(vmi, watch->file_name_buffer, &file_name);
-        vmi_read_16_pa(vmi, watch->file_name_length, &length);
-
-        //printf("File name @ 0x%lx. Length: %u\n", file_name, length);
-
-        if (file_name && length > 0 && length < VMI_PS_4KB) {
-            unicode_string_t str = { .contents = NULL };
-            str.length = length;
-            str.encoding = "UTF-16";
-            str.contents = malloc(length);
-            vmi_read_va(vmi, file_name, 0, str.contents, length);
-            unicode_string_t str2 = { .contents = NULL };
-            status_t rc = vmi_convert_str_encoding(&str, &str2, "UTF-8");
-
-            if (VMI_SUCCESS == rc) {
-
-                switch(format) {
-                case OUTPUT_CSV:
-                    printf("filetracer,%u,%s\n", info->vcpu, str2.contents);
-                    break;
-                default:
-                case OUTPUT_DEFAULT:
-                    printf("[FILETRACER] VCPU:%u %s\n", info->vcpu, str2.contents);
-                    break;
-                };
-
-                g_free(str2.contents);
-            }
-
-            free(str.contents);
-            //printf("Requesting to free writetrap @ %p\n", info->trap);
-            drakvuf_remove_trap(drakvuf, info->trap, free_writetrap);
-        }
+    uint32_t i = 0;
+    for (; i < TAG_COUNT; i++) {
+        g_tree_insert(pooltags, (char*) tags[i].tag,
+                (char*) &tags[i]);
     }
 
-    drakvuf_release_vmi(drakvuf);
-    return 0;
-}
-
-/* This will be hit for all sorts of heap alloc returns */
-static event_response_t pool_alloc_return(drakvuf_t drakvuf, drakvuf_trap_info_t *info) {
-    vmi_instance_t vmi = drakvuf_lock_and_get_vmi(drakvuf);
-    struct rettrap_struct *s = info->trap->data;
-    addr_t obj_pa = vmi_pagetable_lookup(vmi, info->regs->cr3, info->regs->rax);
-    bool file_alloc = 0;
-    addr_t ph_base = 0, thread = 0;
-    uint32_t block_size = 0;
-    uint32_t tag;
-    uint32_t aligned_file_size = file_object_size;
-
-    if ( pm == VMI_PM_IA32E ) {
-        struct pool_header_x64 ph;
-        memset(&ph, 0, sizeof(struct pool_header_x64));
-        ph_base = obj_pa - sizeof(struct pool_header_x64);
-        vmi_read_pa(vmi, ph_base, &ph, sizeof(struct pool_header_x64));
-        block_size = ph.block_size * 0x10; // align it
-        if(!memcmp(&ph.pool_tag, &POOLTAG_FILE, 4))
-            file_alloc = 1;
-    } else {
-        struct pool_header_x86 ph;
-        memset(&ph, 0, sizeof(struct pool_header_x86));
-        ph_base = obj_pa - sizeof(struct pool_header_x86);
-        vmi_read_pa(vmi, ph_base, &ph, sizeof(struct pool_header_x86));
-        block_size = ph.block_size * 0x8; // align it
-        if(!memcmp(&ph.pool_tag, &POOLTAG_FILE, 4))
-            file_alloc = 1;
-    }
-
-    if (!file_alloc) goto done;
-
-    // We will need to catch when the file string buffer pointer is updated
-    addr_t file_base = ph_base + block_size - file_object_size; // addr of "_FILE_OBJECT"
-    addr_t file_name = file_base + file_name_offset; // addr of "_UNICODE_STRING"
-
-    struct file_watch *watch = g_malloc0(sizeof(struct file_watch));
-    watch->file_name_buffer = file_name + string_buffer_offset;
-    watch->file_name_length = file_name + string_length_offset;
-
-    //printf("PH 0x%lx. Block size: %u\n", ph_base, block_size);
-    //printf("File size: 0x%lx File base: 0x%lx. Unicode string @ 0x%lx. Last write @ 0x%lx\n",
-    //       file_object_size, file_base, file_name-file_base, watch->file_name_buffer-file_base);
-
-    drakvuf_trap_t *writetrap = g_malloc0(sizeof(drakvuf_trap_t));
-    //printf("Made a writetrap @ %p\n", writetrap);
-    writetrap->lookup_type = LOOKUP_NONE;
-    writetrap->addr_type = ADDR_PA;
-    writetrap->type = MEMACCESS_W;
-    writetrap->memaccess_type = POST;
-    writetrap->cb = file_name_cb;
-    writetrap->u2.addr = watch->file_name_buffer;
-    writetrap->data = watch;
-
-    writetraps = g_slist_prepend(writetraps, writetrap);
-
-    drakvuf_add_trap(drakvuf, writetrap);
-
-    s->counter--;
-
-    /*
-    if(s->counter == 0) {
-        drakvuf_remove_trap(drakvuf, info->trap, free);
-        g_hash_table_remove(rettraps, &s->trap->u2.addr);
-        free(s);
-    }*/
-
-done:
-    drakvuf_release_vmi(drakvuf);
-    return 0;
+    return pooltags;
 }
 
 static event_response_t cb(drakvuf_t drakvuf, drakvuf_trap_info_t *info) {
-
+    poolmon *p = (poolmon*)info->trap->data;
     vmi_instance_t vmi = drakvuf_lock_and_get_vmi(drakvuf);
-    reg_t tag = 0, size = 0;
+    page_mode_t pm = vmi_get_page_mode(vmi);
+    reg_t pool_type, size;
+    char tag[5] = { [0 ... 4] = '\0' };
 
-    access_context_t ctx = {
-        .translate_mechanism = VMI_TM_PROCESS_DTB,
-        .dtb = info->regs->cr3,
-    };
+    access_context_t ctx;
+    ctx.translate_mechanism = VMI_TM_PROCESS_DTB;
+    ctx.dtb = info->regs->cr3;
 
     if (pm == VMI_PM_IA32E) {
+        pool_type = info->regs->rcx;
         size = info->regs->rdx;
-        tag = info->regs->r8;
+        *(reg_t*)tag = info->regs->r8;
     } else {
+        ctx.addr = info->regs->rsp+12;
+        vmi_read_32(vmi, &ctx, (uint32_t*)tag);
         ctx.addr = info->regs->rsp+8;
         vmi_read_32(vmi, &ctx, (uint32_t*)&size);
-        ctx.addr = info->regs->rsp+12;
-        vmi_read_32(vmi, &ctx, (uint32_t*)&tag);
+        ctx.addr = info->regs->rsp+4;
+        vmi_read_32(vmi, &ctx, (uint32_t*)&pool_type);
     }
 
-    /*printf("Got a heap alloc request for tag %c%c%c%c!\n",
-           ((uint8_t*)&tag)[0],
-           ((uint8_t*)&tag)[1],
-           ((uint8_t*)&tag)[2],
-           ((uint8_t*)&tag)[3]
-    );*/
+    struct pooltag *s = (struct pooltag*)g_tree_lookup(p->pooltag_tree, tag);
 
-    if(!memcmp(&tag, &POOLTAG_FILE, 4)) {
-
-        addr_t ret, ret_pa;
-        ctx.addr = info->regs->rsp;
-        vmi_read_addr(vmi, &ctx, &ret);
-        ret_pa = vmi_pagetable_lookup(vmi, info->regs->cr3, ret);
-
-        struct rettrap_struct *s = g_hash_table_lookup(rettraps, &ret_pa);
-        if (s) {
-            s->counter++;
-        } else {
-            drakvuf_trap_t *rettrap = g_malloc0(sizeof(drakvuf_trap_t));
-            s = g_malloc0(sizeof(struct rettrap_struct));
-            s->trap = rettrap;
-            s->counter = 1;
-
-            rettrap->lookup_type = LOOKUP_NONE;
-            rettrap->addr_type = ADDR_PA;
-            rettrap->type = BREAKPOINT;
-            rettrap->name = "HeapRetTrap";
-            rettrap->cb = pool_alloc_return;
-            rettrap->u2.addr = ret_pa;
-            rettrap->data = s;
-
-            drakvuf_add_trap(drakvuf, rettrap);
-            g_hash_table_insert(rettraps, &rettrap->u2.addr, s);
-        }
-
-        //printf("File alloc request on vCPU %u. Ret: 0x%lx. Counter: %u\n",
-        //         info->vcpu, ret_pa, s->counter);
+    switch(p->format) {
+    case OUTPUT_CSV:
+    {
+        printf("poolmon,%s,%s,%zu", tag,
+               pool_type<MaxPoolType ? pool_types[pool_type] : "unknown_pool_type", (size_t)size);
+        if (s)
+            printf(",%s,%s", s->source, s->description);
+        break;
     }
+    default:
+    case OUTPUT_DEFAULT:
+        printf("[POOLMON] %s (type: %s, size: %zu)", tag,
+               pool_type<MaxPoolType ? pool_types[pool_type] : "unknown_pool_type", (size_t)size);
+        if (s)
+            printf(": %s,%s", s->source, s->description);
+
+        break;
+    };
+
+    printf("\n");
 
     drakvuf_release_vmi(drakvuf);
     return 0;
 }
 
+/*void pool_tracker_free(vmi_instance_t vmi, vmi_event_t *event) {
+    // TODO: 32-bit inputs are on the stack
+    reg_t rcx, rdx;
+    drakvuf_t *drakvuf = event->data;
+
+    vmi_get_vcpureg(vmi, &rcx, RCX, event->vcpu_id);
+    vmi_get_vcpureg(vmi, &rdx, RDX, event->vcpu_id);
+
+    char ctag[5] = { [0 ... 4] = '\0' };
+    memcpy(ctag, &rdx, 4);
+
+    PRINT(drakvuf, HEAPFREE_STRING, rcx, ctag);
+}*/
+
 /* ----------------------------------------------------- */
 
-int plugin_filetracer_start(drakvuf_t drakvuf, const char *rekall_profile) {
-    vmi_instance_t vmi = drakvuf_lock_and_get_vmi(drakvuf);
-    pm = vmi_get_page_mode(vmi);
-    drakvuf_release_vmi(drakvuf);
-    rettraps = g_hash_table_new(g_int64_hash, g_int64_equal);
-    format = drakvuf_get_output_format(drakvuf);
+poolmon::poolmon(drakvuf_t drakvuf, const void *config) {
+    const char *rekall_profile = (const char*)config;
+    this->pooltag_tree = pooltag_build_tree();
 
-    poolalloc.lookup_type = LOOKUP_PID;
-    poolalloc.u.pid = 4;
-    poolalloc.addr_type = ADDR_RVA;
-    poolalloc.name = "ExAllocatePoolWithTag";
-    poolalloc.module = "ntoskrnl.exe";
-    poolalloc.type = BREAKPOINT;
-    poolalloc.cb = cb;
+    this->trap.lookup_type = LOOKUP_PID;
+    this->trap.u.pid = 4;
+    this->trap.addr_type = ADDR_RVA;
+    if (VMI_FAILURE == drakvuf_get_function_rva(rekall_profile,
+                                                "ExAllocatePoolWithTag",
+                                                &this->trap.u2.rva))
+    {
+        return;
+    }
 
-    if (VMI_FAILURE == drakvuf_get_function_rva(rekall_profile, "ExAllocatePoolWithTag", &poolalloc.u2.rva))
-        return 0;
-    if (VMI_FAILURE == drakvuf_get_struct_member_rva(rekall_profile, "_FILE_OBJECT", "FileName", &file_name_offset))
-        return 0;
-    if (VMI_FAILURE == drakvuf_get_struct_member_rva(rekall_profile, "_UNICODE_STRING", "Buffer", &string_buffer_offset))
-        return 0;
-    if (VMI_FAILURE == drakvuf_get_struct_member_rva(rekall_profile, "_UNICODE_STRING", "Length", &string_length_offset))
-        return 0;
-    if (VMI_FAILURE == drakvuf_get_struct_size(rekall_profile, "_FILE_OBJECT", &file_object_size))
-        return 0;
+    this->trap.name = "ExAllocatePoolWithTag";
+    this->trap.module = "ntoskrnl.exe";
+    this->trap.type = BREAKPOINT;
+    this->trap.cb = cb;
+    this->trap.data = (void*)this;
+    this->format = drakvuf_get_output_format(drakvuf);
 
-    if (pm == VMI_PM_IA32E)
-        file_object_size += ALIGN_SIZE(16, file_object_size);
-    else
-        file_object_size += ALIGN_SIZE(8, file_object_size);
-
-    drakvuf_add_trap(drakvuf, &poolalloc);
-
-    return 1;
+    drakvuf_add_trap(drakvuf, &this->trap);
 }
 
-int plugin_filetracer_stop(drakvuf_t drakvuf) {
-
-    GSList *loop = writetraps;
-    while(loop) {
-        free(loop->data);
-        loop=loop->next;
-    }
-    g_slist_free(writetraps);
-
-    if ( rettraps )
-        g_hash_table_destroy(rettraps);
-
-    return 1;
+poolmon::~poolmon() {
+    if(this->pooltag_tree)
+        g_tree_destroy(this->pooltag_tree);
 }

--- a/src/plugins/poolmon/poolmon.h
+++ b/src/plugins/poolmon/poolmon.h
@@ -105,20 +105,16 @@
 #ifndef POOLMON_H
 #define POOLMON_H
 
-#ifdef ENABLE_PLUGIN_POOLMON
+#include "plugins/plugins.h"
 
-int plugin_poolmon_start(drakvuf_t drakvuf, const void *config);
-int plugin_poolmon_stop(drakvuf_t drakvuf);
+class poolmon: public plugin {
+    public:
+        output_format_t format;
+        GTree *pooltag_tree;
+        drakvuf_trap_t trap;
 
-#else
-
-static int plugin_poolmon_start(drakvuf_t drakvuf, const void *config) {
-    return 1;
-}
-static int plugin_poolmon_stop(drakvuf_t drakvuf) {
-    return 1;
-}
-
-#endif
+        poolmon(drakvuf_t drakvuf, const void *config);
+        ~poolmon();
+};
 
 #endif

--- a/src/plugins/poolmon/private.h
+++ b/src/plugins/poolmon/private.h
@@ -134,10 +134,8 @@ enum pool_type {
     NonPagedPoolSessionNx                 = NonPagedPoolNx + 32
 };
 
-static const char *pool_types[] = {
-    [0 ... MaxPoolType]                     = NULL,
+static const char *pool_types[MaxPoolType] = {
     [NonPagedPool]                          = "NonPagedPool",
-    [NonPagedPoolExecute]                   = "NonPagedPoolExecute",
     [PagedPool]                             = "PagedPool",
     [NonPagedPoolMustSucceed]               = "NonPagedPoolMustSucceed",
     [DontUseThisType]                       = "DontUseThisType",
@@ -147,9 +145,9 @@ static const char *pool_types[] = {
 };
 
 struct pooltag {
-    char* tag;
-    char* source;
-    char* description;
+    const char* tag;
+    const char* source;
+    const char* description;
 };
 
 #define TAG_COUNT 2254

--- a/src/plugins/syscalls/syscalls.h
+++ b/src/plugins/syscalls/syscalls.h
@@ -105,20 +105,17 @@
 #ifndef SYSCALLS_H
 #define SYSCALLS_H
 
-#ifdef ENABLE_PLUGIN_SYSCALLS
+#include "plugins/plugins.h"
 
-int plugin_syscall_start(drakvuf_t drakvuf, const void *config);
-int plugin_syscall_stop(drakvuf_t drakvuf);
+class syscalls: public plugin {
 
-#else
+    private:
+        GSList *traps;
 
-static int plugin_syscall_start(drakvuf_t drakvuf, const void *config) {
-    return 1;
-}
-static int plugin_syscall_stop(drakvuf_t drakvuf) {
-    return 1;
-}
-
-#endif
+    public:
+        output_format_t format;
+        syscalls(drakvuf_t drakvuf, const void *config);
+        ~syscalls();
+};
 
 #endif


### PR DESCRIPTION
While libdrakvuf maintains its own state and thus multiple can be used in a single
program, the plugins have largely assumed that only one instance will be active
at any given time. While the plugin state could be maintained in pure C structs as well,
this adds considerably more work and is less intuitive then maintaing C++ classes.