### PR TITLE
Added useful Windows routines...

### DIFF
--- a/src/libdrakvuf/libdrakvuf.h
+++ b/src/libdrakvuf/libdrakvuf.h
@@ -321,12 +321,12 @@ bool drakvuf_is_eprocess( drakvuf_t drakvuf,
                           addr_t eprocess_addr );
 
 // ObReferenceObjectByHandle
-bool drakvuf_obj_ref_by_handleObjReferenceByHandle( drakvuf_t drakvuf, 
-                                                    drakvuf_trap_info_t *info, 
-                                                    addr_t current_eprocess,
-                                                    addr_t handle, 
-                                                    uint8_t obj_type_arg, 
-                                                    addr_t *obj_body_addr );
+bool drakvuf_obj_ref_by_handle( drakvuf_t drakvuf, 
+                                drakvuf_trap_info_t *info, 
+                                addr_t current_eprocess,
+                                addr_t handle, 
+                                uint8_t obj_type_arg, 
+                                addr_t *obj_body_addr );
 
 #pragma GCC visibility pop
 

--- a/src/libdrakvuf/libdrakvuf.h
+++ b/src/libdrakvuf/libdrakvuf.h
@@ -223,6 +223,34 @@ struct drakvuf_trap {
     void *data;
 };
 
+
+////////////////////////////////////////////////////////////////////////////
+
+// IMHO these definitions must be placed within another file, named
+// libdrakvuf-windows.h or something similar
+
+// For get_previous_mode...
+typedef enum _MODE {
+    KernelMode,
+    UserMode,
+    MaximumMode
+} MODE ;
+
+// Confirmed only on Win7 SP1...
+typedef enum _OBJECT_MANAGER_OBJECT_TYPE {
+    ObjManagerProcessObject = 7,
+    ObjManagerThreadObject  = 8
+} OBJECT_MANAGER_OBJECT_TYPE ;
+
+// Confirmed from Win2K to Win7, I don't know about Win8/Win10...
+typedef enum _DISPATCHER_OBJECT_TYPE {
+    DispatcherProcessObject = 3,
+    DispatcherThreadObject  = 6
+} DISPATCHER_OBJECT_TYPE ;
+
+////////////////////////////////////////////////////////////////////////////
+
+
 bool drakvuf_init (drakvuf_t *drakvuf,
                    const char *domain,
                    const char *rekall_profile);
@@ -273,6 +301,32 @@ char *drakvuf_get_process_name(drakvuf_t drakvuf,
 char *drakvuf_get_current_process_name(drakvuf_t drakvuf,
                                        uint64_t vcpu_id,
                                        x86_registers_t *regs);
+
+
+bool drakvuf_get_current_thread_id( drakvuf_t drakvuf, 
+                                    uint64_t vcpu_id, 
+                                    x86_registers_t *regs,
+                                    uint32_t *thread_id );
+
+bool drakvuf_get_previous_mode( drakvuf_t drakvuf, 
+                                drakvuf_trap_info_t *info, 
+                                uint8_t *previous_mode );
+
+bool drakvuf_is_ethread( drakvuf_t drakvuf, 
+                         drakvuf_trap_info_t *info, 
+                         addr_t ethread_addr );
+
+bool drakvuf_is_eprocess( drakvuf_t drakvuf, 
+                          drakvuf_trap_info_t *info, 
+                          addr_t eprocess_addr );
+
+// ObReferenceObjectByHandle
+bool drakvuf_obj_ref_by_handleObjReferenceByHandle( drakvuf_t drakvuf, 
+                                                    drakvuf_trap_info_t *info, 
+                                                    addr_t current_eprocess,
+                                                    addr_t handle, 
+                                                    uint8_t obj_type_arg, 
+                                                    addr_t *obj_body_addr );
 
 #pragma GCC visibility pop
 

--- a/src/libdrakvuf/vmi.h
+++ b/src/libdrakvuf/vmi.h
@@ -136,6 +136,9 @@ enum offset {
     EPROCESS_TASKS,
     EPROCESS_PEB,
     EPROCESS_OBJECTTABLE,
+    EPROCESS_PCB,
+
+    KPROCESS_HEADER,
 
     PEB_IMAGEBASADDRESS,
     PEB_LDR,
@@ -164,6 +167,8 @@ enum offset {
     KTHREAD_APCSTATE,
     KTHREAD_TRAPFRAME,
     KTHREAD_APCQUEUEABLE,
+    KTHREAD_PREVIOUSMODE,
+    KTHREAD_HEADER,
 
     KTRAP_FRAME_RIP,
 
@@ -173,6 +178,7 @@ enum offset {
     NT_TIB_STACKLIMIT,
 
     ETHREAD_CID,
+    ETHREAD_TCB,
     CLIENT_ID_UNIQUETHREAD,
 
     OBJECT_HEADER_TYPEINDEX,
@@ -184,6 +190,8 @@ enum offset {
     POOL_HEADER_BLOCKSIZE,
     POOL_HEADER_POOLTYPE,
     POOL_HEADER_POOLTAG,
+
+    DISPATCHER_TYPE,
 
     OFFSET_MAX
 };
@@ -198,6 +206,8 @@ static const char *offset_names[OFFSET_MAX][2] = {
     [EPROCESS_TASKS] = { "_EPROCESS", "ActiveProcessLinks" },
     [EPROCESS_PEB] = { "_EPROCESS", "Peb" },
     [EPROCESS_OBJECTTABLE] = {"_EPROCESS", "ObjectTable" },
+    [EPROCESS_PCB] = { "_EPROCESS", "Pcb" },
+    [KPROCESS_HEADER] = { "_KPROCESS", "Header" },
     [PEB_IMAGEBASADDRESS] = { "_PEB", "ImageBaseAddress" },
     [PEB_LDR] = { "_PEB", "Ldr" },
     [PEB_LDR_DATA_INLOADORDERMODULELIST] = {"_PEB_LDR_DATA", "InLoadOrderModuleList" },
@@ -219,11 +229,14 @@ static const char *offset_names[OFFSET_MAX][2] = {
     [KTHREAD_TRAPFRAME] = {"_KTHREAD", "TrapFrame" },
     [KTHREAD_APCSTATE] = {"_KTHREAD", "ApcState" },
     [KTHREAD_APCQUEUEABLE] = {"_KTHREAD", "ApcQueueable"},
+    [KTHREAD_PREVIOUSMODE] = { "_KTHREAD", "PreviousMode" },
+    [KTHREAD_HEADER] = { "_KTHREAD", "Header" },
     [KAPC_APCLISTENTRY] = {"_KAPC", "ApcListEntry" },
     [KTRAP_FRAME_RIP] = {"_KTRAP_FRAME", "Rip" },
     [NT_TIB_STACKBASE] = { "_NT_TIB", "StackBase" },
     [NT_TIB_STACKLIMIT] = { "_NT_TIB", "StackLimit" },
     [ETHREAD_CID] = {"_ETHREAD", "Cid" },
+    [ETHREAD_TCB] = { "_ETHREAD", "Tcb" },
     [CLIENT_ID_UNIQUETHREAD] = {"_CLIENT_ID", "UniqueThread" },
     [OBJECT_HEADER_TYPEINDEX] = { "_OBJECT_HEADER", "TypeIndex" },
     [OBJECT_HEADER_BODY] = { "_OBJECT_HEADER", "Body" },
@@ -232,6 +245,7 @@ static const char *offset_names[OFFSET_MAX][2] = {
     [POOL_HEADER_BLOCKSIZE] = {"_POOL_HEADER", "BlockSize" },
     [POOL_HEADER_POOLTYPE] = {"_POOL_HEADER", "PoolType" },
     [POOL_HEADER_POOLTAG] = {"_POOL_HEADER", "PoolTag" },
+    [DISPATCHER_TYPE] = { "_DISPATCHER_HEADER",  "Type" },
 };
 
 size_t offsets[OFFSET_MAX];

--- a/src/libdrakvuf/win-handles.c
+++ b/src/libdrakvuf/win-handles.c
@@ -227,8 +227,6 @@ bool drakvuf_obj_ref_by_handle( drakvuf_t drakvuf, drakvuf_trap_info_t *info, ad
     bool ret        = false ;
     addr_t obj_addr = 0 ;
 
-    *obj_body_addr = 0 ;
-
     obj_addr = drakvuf_get_obj_by_handle( drakvuf, current_eprocess, handle );
 
     if ( obj_addr )
@@ -257,7 +255,7 @@ bool drakvuf_obj_ref_by_handle( drakvuf_t drakvuf, drakvuf_trap_info_t *info, ad
                     // Object Body must be an _ETHREAD...
                     ret = drakvuf_is_ethread( drakvuf, info, obj_addr + offsets[ OBJECT_HEADER_BODY ] );
                 }
-                else // Resto de tipos...
+                else // Other object types...
                     ret = true ;
             }
         }

--- a/src/libdrakvuf/win-handles.c
+++ b/src/libdrakvuf/win-handles.c
@@ -216,3 +216,59 @@ addr_t drakvuf_get_obj_by_handle(drakvuf_t drakvuf, addr_t process, uint64_t han
     return handle_table_get_entry(PM2BIT(drakvuf->pm), vmi, table_base,
             table_levels, table_depth, &handlecount, handle);
 }
+
+
+/////////////////////////////////////////////////////////////////////////////////////////////
+
+
+bool drakvuf_obj_ref_by_handle( drakvuf_t drakvuf, drakvuf_trap_info_t *info, addr_t current_eprocess,
+                                addr_t handle, uint8_t obj_type_arg, addr_t *obj_body_addr )
+{
+    bool ret        = false ;
+    addr_t obj_addr = 0 ;
+
+    *obj_body_addr = 0 ;
+
+    obj_addr = drakvuf_get_obj_by_handle( drakvuf, current_eprocess, handle );
+
+    if ( obj_addr )
+    {
+        uint8_t object_type ;
+        access_context_t ctx = {
+            .translate_mechanism = VMI_TM_PROCESS_DTB,
+            .dtb = info->regs->cr3,
+        };
+
+        // Get TypeIndex from _OBJ_HEADER...
+        ctx.addr = obj_addr + offsets[ OBJECT_HEADER_TYPEINDEX ] ;
+
+        if ( vmi_read_8( drakvuf->vmi, &ctx, &object_type ) == VMI_SUCCESS )
+        {
+            if ( object_type == obj_type_arg )
+            {
+                if ( object_type == ObjManagerProcessObject )
+                {
+                    // Object Body must be an _EPROCESS...
+                    ret = drakvuf_is_eprocess( drakvuf, info, obj_addr + offsets[ OBJECT_HEADER_BODY ] );
+                }
+                else
+                if ( object_type == ObjManagerThreadObject )
+                {
+                    // Object Body must be an _ETHREAD...
+                    ret = drakvuf_is_ethread( drakvuf, info, obj_addr + offsets[ OBJECT_HEADER_BODY ] );
+                }
+                else // Resto de tipos...
+                    ret = true ;
+            }
+        }
+    }
+
+    if ( ret )
+    {
+        *obj_body_addr = obj_addr + offsets[ OBJECT_HEADER_BODY ];
+    }
+
+    return ret ;
+}
+
+

--- a/src/libdrakvuf/win-processes.c
+++ b/src/libdrakvuf/win-processes.c
@@ -164,3 +164,103 @@ char *drakvuf_get_process_name(drakvuf_t drakvuf, addr_t eprocess_base) {
 char *drakvuf_get_current_process_name(drakvuf_t drakvuf, uint64_t vcpu_id, x86_registers_t *regs) {
     return drakvuf_get_process_name(drakvuf, drakvuf_get_current_process(drakvuf, vcpu_id, regs));
 }
+
+/////////////////////////////////////////////////////////////////////////////////////////////
+
+
+bool drakvuf_get_current_thread_id( drakvuf_t drakvuf, uint64_t vcpu_id, x86_registers_t *regs,
+                                    uint32_t *thread_id )
+{
+    addr_t p_tid ;
+    addr_t ethread = drakvuf_get_current_thread( drakvuf, vcpu_id, regs );
+
+    if ( ethread )
+    {
+        if ( vmi_read_addr_va( drakvuf->vmi, ethread + offsets[ ETHREAD_CID ] + offsets[ CLIENT_ID_UNIQUETHREAD ],
+                               0,
+                               &p_tid ) == VMI_SUCCESS )
+        {
+            *thread_id = p_tid;
+
+            return true;
+        }
+    }
+
+    *thread_id = 0 ;
+
+    return false ;
+}
+
+
+/////////////////////////////////////////////////////////////////////////////////////////////
+
+
+bool drakvuf_get_previous_mode( drakvuf_t drakvuf, drakvuf_trap_info_t *info, uint8_t *previous_mode )
+{
+    addr_t kthread = drakvuf_get_current_thread( drakvuf, info->vcpu, info->regs );
+
+    if ( kthread )
+    {
+        if ( vmi_read_8_va( drakvuf->vmi, kthread + offsets[ KTHREAD_PREVIOUSMODE ], 0, previous_mode ) == VMI_SUCCESS )
+
+            return true ;
+    }
+
+    *previous_mode = -1 ;
+
+    return false ;
+}
+
+
+/////////////////////////////////////////////////////////////////////////////////////////////
+
+
+bool drakvuf_is_ethread( drakvuf_t drakvuf, drakvuf_trap_info_t *info, addr_t ethread_addr )
+{
+    uint8_t dispatcher_type = 0 ;
+    access_context_t ctx = {
+            .translate_mechanism = VMI_TM_PROCESS_DTB,
+            .dtb = info->regs->cr3,
+    };
+
+    ctx.addr = ethread_addr + offsets[ ETHREAD_TCB ] + offsets[ KTHREAD_HEADER ]
+                            + offsets[ DISPATCHER_TYPE ] ;
+
+    if ( vmi_read_8( drakvuf->vmi, &ctx, &dispatcher_type ) == VMI_SUCCESS )
+    {
+        if ( dispatcher_type == DispatcherThreadObject )
+
+            return true ;
+    }
+
+    return false ;
+}
+
+
+/////////////////////////////////////////////////////////////////////////////////////////////
+
+
+bool drakvuf_is_eprocess( drakvuf_t drakvuf, drakvuf_trap_info_t *info, addr_t eprocess_addr )
+{
+    uint8_t dispatcher_type = 0 ;
+    access_context_t ctx = {
+            .translate_mechanism = VMI_TM_PROCESS_DTB,
+            .dtb = info->regs->cr3,
+    };
+
+    ctx.addr = eprocess_addr + offsets[ EPROCESS_PCB ] + offsets[ KPROCESS_HEADER ]
+                             + offsets[ DISPATCHER_TYPE ] ;
+
+    if ( vmi_read_8( drakvuf->vmi, &ctx, &dispatcher_type ) == VMI_SUCCESS )
+    {
+        if ( dispatcher_type == DispatcherProcessObject )
+
+            return true ;
+    }
+
+    return false ;
+}
+
+
+
+

--- a/src/libdrakvuf/win-processes.c
+++ b/src/libdrakvuf/win-processes.c
@@ -186,8 +186,6 @@ bool drakvuf_get_current_thread_id( drakvuf_t drakvuf, uint64_t vcpu_id, x86_reg
         }
     }
 
-    *thread_id = 0 ;
-
     return false ;
 }
 
@@ -205,8 +203,6 @@ bool drakvuf_get_previous_mode( drakvuf_t drakvuf, drakvuf_trap_info_t *info, ui
 
             return true ;
     }
-
-    *previous_mode = -1 ;
 
     return false ;
 }

--- a/src/libdrakvuf/win-processes.c
+++ b/src/libdrakvuf/win-processes.c
@@ -256,7 +256,3 @@ bool drakvuf_is_eprocess( drakvuf_t drakvuf, drakvuf_trap_info_t *info, addr_t e
 
     return false ;
 }
-
-
-
-


### PR DESCRIPTION
...for use within the hooks:

- drakvuf_get_current_thread_id(): Get the current thread id
- drakvuf_get_previous_mode(): Return the PreviousMode (see libdrakvuf.h)
- drakvuf_is_ethread(): Check if the address argument is an _ETHREAD
- drakvuf_is_eprocess(): Check if the adress argument is an _EPROCESS
- drakvuf_obj_ref_by_handle(): Returns the Object body address from a HANDLE checking its validity