### PR TITLE
Added useful Windows routines...

### DIFF
--- a/src/libdrakvuf/libdrakvuf.h
+++ b/src/libdrakvuf/libdrakvuf.h
@@ -223,6 +223,28 @@ struct drakvuf_trap {
     void *data;
 };
 
+
+////////////////////////////////////////////////////////////////////////////
+
+// IMHO these definitions must be placed within another file, named
+// libdrakvuf-windows.h or something similar
+
+// For get_previous_mode...
+typedef enum privilege_mode {
+    KERNEL_MODE,
+    USER_MODE,
+    MAXIMUM_MODE
+} privilege_mode_t ;
+
+// Confirmed only on Win7 SP1...
+typedef enum object_manager_object {
+    OBJ_MANAGER_PROCESS_OBJECT = 7,
+    OBJ_MANAGER_THREAD_OBJECT  = 8
+} object_manager_object_t ;
+
+////////////////////////////////////////////////////////////////////////////
+
+
 bool drakvuf_init (drakvuf_t *drakvuf,
                    const char *domain,
                    const char *rekall_profile);
@@ -273,6 +295,38 @@ char *drakvuf_get_process_name(drakvuf_t drakvuf,
 char *drakvuf_get_current_process_name(drakvuf_t drakvuf,
                                        uint64_t vcpu_id,
                                        x86_registers_t *regs);
+
+
+bool drakvuf_get_current_thread_id( drakvuf_t drakvuf, 
+                                    uint64_t vcpu_id, 
+                                    x86_registers_t *regs,
+                                    uint32_t *thread_id );
+
+// Microsoft PreviousMode KTHREAD explanation:
+// https://msdn.microsoft.com/en-us/library/windows/hardware/ff559860(v=vs.85).aspx
+bool drakvuf_get_current_thread_previous_mode( drakvuf_t drakvuf, 
+                                               drakvuf_trap_info_t *info, 
+                                               privilege_mode_t *previous_mode );
+
+bool drakvuf_get_thread_previous_mode( drakvuf_t drakvuf, 
+                                       addr_t kthread, 
+                                       privilege_mode_t *previous_mode );
+
+bool drakvuf_is_ethread( drakvuf_t drakvuf, 
+                         drakvuf_trap_info_t *info, 
+                         addr_t ethread_addr );
+
+bool drakvuf_is_eprocess( drakvuf_t drakvuf, 
+                          drakvuf_trap_info_t *info, 
+                          addr_t eprocess_addr );
+
+// ObReferenceObjectByHandle
+bool drakvuf_obj_ref_by_handle( drakvuf_t drakvuf, 
+                                drakvuf_trap_info_t *info, 
+                                addr_t current_eprocess,
+                                addr_t handle, 
+                                object_manager_object_t obj_type_arg, 
+                                addr_t *obj_body_addr );
 
 #pragma GCC visibility pop
 

--- a/src/libdrakvuf/vmi.h
+++ b/src/libdrakvuf/vmi.h
@@ -136,6 +136,9 @@ enum offset {
     EPROCESS_TASKS,
     EPROCESS_PEB,
     EPROCESS_OBJECTTABLE,
+    EPROCESS_PCB,
+
+    KPROCESS_HEADER,
 
     PEB_IMAGEBASADDRESS,
     PEB_LDR,
@@ -164,6 +167,8 @@ enum offset {
     KTHREAD_APCSTATE,
     KTHREAD_TRAPFRAME,
     KTHREAD_APCQUEUEABLE,
+    KTHREAD_PREVIOUSMODE,
+    KTHREAD_HEADER,
 
     KTRAP_FRAME_RIP,
 
@@ -173,6 +178,7 @@ enum offset {
     NT_TIB_STACKLIMIT,
 
     ETHREAD_CID,
+    ETHREAD_TCB,
     CLIENT_ID_UNIQUETHREAD,
 
     OBJECT_HEADER_TYPEINDEX,
@@ -184,6 +190,8 @@ enum offset {
     POOL_HEADER_BLOCKSIZE,
     POOL_HEADER_POOLTYPE,
     POOL_HEADER_POOLTAG,
+
+    DISPATCHER_TYPE,
 
     OFFSET_MAX
 };
@@ -198,6 +206,8 @@ static const char *offset_names[OFFSET_MAX][2] = {
     [EPROCESS_TASKS] = { "_EPROCESS", "ActiveProcessLinks" },
     [EPROCESS_PEB] = { "_EPROCESS", "Peb" },
     [EPROCESS_OBJECTTABLE] = {"_EPROCESS", "ObjectTable" },
+    [EPROCESS_PCB] = { "_EPROCESS", "Pcb" },
+    [KPROCESS_HEADER] = { "_KPROCESS", "Header" },
     [PEB_IMAGEBASADDRESS] = { "_PEB", "ImageBaseAddress" },
     [PEB_LDR] = { "_PEB", "Ldr" },
     [PEB_LDR_DATA_INLOADORDERMODULELIST] = {"_PEB_LDR_DATA", "InLoadOrderModuleList" },
@@ -219,11 +229,14 @@ static const char *offset_names[OFFSET_MAX][2] = {
     [KTHREAD_TRAPFRAME] = {"_KTHREAD", "TrapFrame" },
     [KTHREAD_APCSTATE] = {"_KTHREAD", "ApcState" },
     [KTHREAD_APCQUEUEABLE] = {"_KTHREAD", "ApcQueueable"},
+    [KTHREAD_PREVIOUSMODE] = { "_KTHREAD", "PreviousMode" },
+    [KTHREAD_HEADER] = { "_KTHREAD", "Header" },
     [KAPC_APCLISTENTRY] = {"_KAPC", "ApcListEntry" },
     [KTRAP_FRAME_RIP] = {"_KTRAP_FRAME", "Rip" },
     [NT_TIB_STACKBASE] = { "_NT_TIB", "StackBase" },
     [NT_TIB_STACKLIMIT] = { "_NT_TIB", "StackLimit" },
     [ETHREAD_CID] = {"_ETHREAD", "Cid" },
+    [ETHREAD_TCB] = { "_ETHREAD", "Tcb" },
     [CLIENT_ID_UNIQUETHREAD] = {"_CLIENT_ID", "UniqueThread" },
     [OBJECT_HEADER_TYPEINDEX] = { "_OBJECT_HEADER", "TypeIndex" },
     [OBJECT_HEADER_BODY] = { "_OBJECT_HEADER", "Body" },
@@ -232,6 +245,7 @@ static const char *offset_names[OFFSET_MAX][2] = {
     [POOL_HEADER_BLOCKSIZE] = {"_POOL_HEADER", "BlockSize" },
     [POOL_HEADER_POOLTYPE] = {"_POOL_HEADER", "PoolType" },
     [POOL_HEADER_POOLTAG] = {"_POOL_HEADER", "PoolTag" },
+    [DISPATCHER_TYPE] = { "_DISPATCHER_HEADER",  "Type" },
 };
 
 size_t offsets[OFFSET_MAX];


### PR DESCRIPTION
...for use within the hooks:
- drakvuf_get_current_thread_id(): Get the current thread id
- drakvuf_get_previous_mode(): Return the thread PreviousMode (see libdrakvuf.h)
- drakvuf_is_ethread(): Check if the address argument is an _ETHREAD
- drakvuf_is_eprocess(): Check if the adress argument is an _EPROCESS
- drakvuf_obj_ref_by_handle(): Returns the Object body address from a HANDLE cheking its validity

This PR replaces #96 
