### PR TITLE
Added routines for helping with win32ksys hooking

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,6 +1,6 @@
 /*********************IMPORTANT DRAKVUF LICENSE TERMS***********************
  *                                                                         *
- * DRAKVUF Dynamic Malware Analysis System (C) 2014-2015 Tamas K Lengyel.  *
+ * DRAKVUF Dynamic Malware Analysis System (C) 2014-2016 Tamas K Lengyel.  *
  * Tamas K Lengyel is hereinafter referred to as the author.               *
  * This program is free software; you may redistribute and/or modify it    *
  * under the terms of the GNU General Public License as published by the   *

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 /*********************IMPORTANT DRAKVUF LICENSE TERMS***********************
  *                                                                         *
- * DRAKVUF Dynamic Malware Analysis System (C) 2014-2015 Tamas K Lengyel.  *
+ * DRAKVUF Dynamic Malware Analysis System (C) 2014-2016 Tamas K Lengyel.  *
  * Tamas K Lengyel is hereinafter referred to as the author.               *
  * This program is free software; you may redistribute and/or modify it    *
  * under the terms of the GNU General Public License as published by the   *

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,106 +1,106 @@
- #********************IMPORTANT DRAKVUF LICENSE TERMS**********************#
- #                                                                         #
- # DRAKVUF Dynamic Malware Analysis System (C) 2014-2015 Tamas K Lengyel.  #
- # Tamas K Lengyel is hereinafter referred to as the author.               #
- # This program is free software; you may redistribute and/or modify it    #
- # under the terms of the GNU General Public License as published by the   #
- # Free Software Foundation; Version 2 ("GPL"), BUT ONLY WITH ALL OF THE   #
- # CLARIFICATIONS AND EXCEPTIONS DESCRIBED HEREIN.  This guarantees your   # 
- # right to use, modify, and redistribute this software under certain      # 
- # conditions.  If you wish to embed DRAKVUF technology into proprietary   #
- # software, alternative licenses can be aquired from the author.          #
- #                                                                         #
- # Note that the GPL places important restrictions on "derivative works",  #
- # yet it does not provide a detailed definition of that term.  To avoid   #
- # misunderstandings, we interpret that term as broadly as copyright law   #
- # allows.  For example, we consider an application to constitute a        #
- # derivative work for the purpose of this license if it does any of the   #
- # following with any software or content covered by this license          #
- # ("Covered Software"):                                                   #
- #                                                                         #
- # o Integrates source code from Covered Software.                         #
- #                                                                         #
- # o Reads or includes copyrighted data files.                             #
- #                                                                         #
- # o Is designed specifically to execute Covered Software and parse the    #
- # results (as opposed to typical shell or execution-menu apps, which will #
- # execute anything you tell them to).                                     #
- #                                                                         #
- # o Includes Covered Software in a proprietary executable installer.  The #
- # installers produced by InstallShield are an example of this.  Including #
- # DRAKVUF with other software in compressed or archival form does not     #
- # trigger this provision, provided appropriate open source decompression  #
- # or de-archiving software is widely available for no charge.  For the    #
- # purposes of this license, an installer is considered to include Covered #
- # Software even if it actually retrieves a copy of Covered Software from  #
- # another source during runtime (such as by downloading it from the       #
- # Internet).                                                              #
- #                                                                         #
- # o Links (statically or dynamically) to a library which does any of the  #
- # above.                                                                  #
- #                                                                         #
- # o Executes a helper program, module, or script to do any of the above.  #
- #                                                                         #
- # This list is not exclusive, but is meant to clarify our interpretation  #
- # of derived works with some common examples.  Other people may interpret #
- # the plain GPL differently, so we consider this a special exception to   #
- # the GPL that we apply to Covered Software.  Works which meet any of     #
- # these conditions must conform to all of the terms of this license,      #
- # particularly including the GPL Section 3 requirements of providing      #
- # source code and allowing free redistribution of the work as a whole.    #
- #                                                                         #
- # Any redistribution of Covered Software, including any derived works,    #
- # must obey and carry forward all of the terms of this license, including #
- # obeying all GPL rules and restrictions.  For example, source code of    #
- # the whole work must be provided and free redistribution must be         #
- # allowed.  All GPL references to "this License", are to be treated as    #
- # including the terms and conditions of this license text as well.        #
- #                                                                         #
- # Because this license imposes special exceptions to the GPL, Covered     #
- # Work may not be combined (even as part of a larger work) with plain GPL #
- # software.  The terms, conditions, and exceptions of this license must   #
- # be included as well.  This license is incompatible with some other open #
- # source licenses as well.  In some cases we can relicense portions of    #
- # DRAKVUF or grant special permissions to use it in other open source     #
- # software.  Please contact tamas.k.lengyel@gmail.com with any such       #
- # requests.  Similarly, we don't incorporate incompatible open source     #
- # software into Covered Software without special permission from the      #
- # copyright holders.                                                      #
- #                                                                         #
- # If you have any questions about the licensing restrictions on using     #
- # DRAKVUF in other works, are happy to help.  As mentioned above,         #
- # alternative license can be requested from the author to integrate       #
- # DRAKVUF into proprietary applications and appliances.  Please email     #
- # tamas.k.lengyel@gmail.com for further information.                      #
- #                                                                         #
- # If you have received a written license agreement or contract for        #
- # Covered Software stating terms other than these, you may choose to use  #
- # and redistribute Covered Software under those terms instead of these.   #
- #                                                                         #
- # Source is provided to this software because we believe users have a     #
- # right to know exactly what a program is going to do before they run it. #
- # This also allows you to audit the software for security holes.          #
- #                                                                         #
- # Source code also allows you to port DRAKVUF to new platforms, fix bugs, #
- # and add new features.  You are highly encouraged to submit your changes #
- # on https://github.com/tklengyel/drakvuf, or by other methods.           #
- # By sending these changes, it is understood (unless you specify          #
- # otherwise) that you are offering unlimited, non-exclusive right to      #
- # reuse, modify, and relicense the code.  DRAKVUF will always be          #
- # available Open Source, but this is important because the inability to   #
- # relicense code has caused devastating problems for other Free Software  #
- # projects (such as KDE and NASM).                                        #
- # To specify special license conditions of your contributions, just say   #
- # so when you send them.                                                  #
- #                                                                         #
- # This program is distributed in the hope that it will be useful, but     #
- # WITHOUT ANY WARRANTY; without even the implied warranty of              #
- # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the DRAKVUF   #
- # license file for more details (it's in a COPYING file included with     #
- # DRAKVUF, and also available from                                        #
- # https://github.com/tklengyel/drakvuf/COPYING)                           #
- #                                                                         #
- #*************************************************************************#
+#********************IMPORTANT DRAKVUF LICENSE TERMS**********************#
+#                                                                         #
+# DRAKVUF Dynamic Malware Analysis System (C) 2014-2016 Tamas K Lengyel.  #
+# Tamas K Lengyel is hereinafter referred to as the author.               #
+# This program is free software; you may redistribute and/or modify it    #
+# under the terms of the GNU General Public License as published by the   #
+# Free Software Foundation; Version 2 ("GPL"), BUT ONLY WITH ALL OF THE   #
+# CLARIFICATIONS AND EXCEPTIONS DESCRIBED HEREIN.  This guarantees your   # 
+# right to use, modify, and redistribute this software under certain      # 
+# conditions.  If you wish to embed DRAKVUF technology into proprietary   #
+# software, alternative licenses can be aquired from the author.          #
+#                                                                         #
+# Note that the GPL places important restrictions on "derivative works",  #
+# yet it does not provide a detailed definition of that term.  To avoid   #
+# misunderstandings, we interpret that term as broadly as copyright law   #
+# allows.  For example, we consider an application to constitute a        #
+# derivative work for the purpose of this license if it does any of the   #
+# following with any software or content covered by this license          #
+# ("Covered Software"):                                                   #
+#                                                                         #
+# o Integrates source code from Covered Software.                         #
+#                                                                         #
+# o Reads or includes copyrighted data files.                             #
+#                                                                         #
+# o Is designed specifically to execute Covered Software and parse the    #
+# results (as opposed to typical shell or execution-menu apps, which will #
+# execute anything you tell them to).                                     #
+#                                                                         #
+# o Includes Covered Software in a proprietary executable installer.  The #
+# installers produced by InstallShield are an example of this.  Including #
+# DRAKVUF with other software in compressed or archival form does not     #
+# trigger this provision, provided appropriate open source decompression  #
+# or de-archiving software is widely available for no charge.  For the    #
+# purposes of this license, an installer is considered to include Covered #
+# Software even if it actually retrieves a copy of Covered Software from  #
+# another source during runtime (such as by downloading it from the       #
+# Internet).                                                              #
+#                                                                         #
+# o Links (statically or dynamically) to a library which does any of the  #
+# above.                                                                  #
+#                                                                         #
+# o Executes a helper program, module, or script to do any of the above.  #
+#                                                                         #
+# This list is not exclusive, but is meant to clarify our interpretation  #
+# of derived works with some common examples.  Other people may interpret #
+# the plain GPL differently, so we consider this a special exception to   #
+# the GPL that we apply to Covered Software.  Works which meet any of     #
+# these conditions must conform to all of the terms of this license,      #
+# particularly including the GPL Section 3 requirements of providing      #
+# source code and allowing free redistribution of the work as a whole.    #
+#                                                                         #
+# Any redistribution of Covered Software, including any derived works,    #
+# must obey and carry forward all of the terms of this license, including #
+# obeying all GPL rules and restrictions.  For example, source code of    #
+# the whole work must be provided and free redistribution must be         #
+# allowed.  All GPL references to "this License", are to be treated as    #
+# including the terms and conditions of this license text as well.        #
+#                                                                         #
+# Because this license imposes special exceptions to the GPL, Covered     #
+# Work may not be combined (even as part of a larger work) with plain GPL #
+# software.  The terms, conditions, and exceptions of this license must   #
+# be included as well.  This license is incompatible with some other open #
+# source licenses as well.  In some cases we can relicense portions of    #
+# DRAKVUF or grant special permissions to use it in other open source     #
+# software.  Please contact tamas.k.lengyel@gmail.com with any such       #
+# requests.  Similarly, we don't incorporate incompatible open source     #
+# software into Covered Software without special permission from the      #
+# copyright holders.                                                      #
+#                                                                         #
+# If you have any questions about the licensing restrictions on using     #
+# DRAKVUF in other works, are happy to help.  As mentioned above,         #
+# alternative license can be requested from the author to integrate       #
+# DRAKVUF into proprietary applications and appliances.  Please email     #
+# tamas.k.lengyel@gmail.com for further information.                      #
+#                                                                         #
+# If you have received a written license agreement or contract for        #
+# Covered Software stating terms other than these, you may choose to use  #
+# and redistribute Covered Software under those terms instead of these.   #
+#                                                                         #
+# Source is provided to this software because we believe users have a     #
+# right to know exactly what a program is going to do before they run it. #
+# This also allows you to audit the software for security holes.          #
+#                                                                         #
+# Source code also allows you to port DRAKVUF to new platforms, fix bugs, #
+# and add new features.  You are highly encouraged to submit your changes #
+# on https://github.com/tklengyel/drakvuf, or by other methods.           #
+# By sending these changes, it is understood (unless you specify          #
+# otherwise) that you are offering unlimited, non-exclusive right to      #
+# reuse, modify, and relicense the code.  DRAKVUF will always be          #
+# available Open Source, but this is important because the inability to   #
+# relicense code has caused devastating problems for other Free Software  #
+# projects (such as KDE and NASM).                                        #
+# To specify special license conditions of your contributions, just say   #
+# so when you send them.                                                  #
+#                                                                         #
+# This program is distributed in the hope that it will be useful, but     #
+# WITHOUT ANY WARRANTY; without even the implied warranty of              #
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the DRAKVUF   #
+# license file for more details (it's in a COPYING file included with     #
+# DRAKVUF, and also available from                                        #
+# https://github.com/tklengyel/drakvuf/COPYING)                           #
+#                                                                         #
+#*************************************************************************#
 
 ACLOCAL_AMFLAGS = --install -I m4
 SUBDIRS = src

--- a/configure.ac
+++ b/configure.ac
@@ -1,106 +1,106 @@
- #********************IMPORTANT DRAKVUF LICENSE TERMS**********************#
- #                                                                         #
- # DRAKVUF Dynamic Malware Analysis System (C) 2014-2015 Tamas K Lengyel.  #
- # Tamas K Lengyel is hereinafter referred to as the author.               #
- # This program is free software; you may redistribute and/or modify it    #
- # under the terms of the GNU General Public License as published by the   #
- # Free Software Foundation; Version 2 ("GPL"), BUT ONLY WITH ALL OF THE   #
- # CLARIFICATIONS AND EXCEPTIONS DESCRIBED HEREIN.  This guarantees your   # 
- # right to use, modify, and redistribute this software under certain      # 
- # conditions.  If you wish to embed DRAKVUF technology into proprietary   #
- # software, alternative licenses can be aquired from the author.          #
- #                                                                         #
- # Note that the GPL places important restrictions on "derivative works",  #
- # yet it does not provide a detailed definition of that term.  To avoid   #
- # misunderstandings, we interpret that term as broadly as copyright law   #
- # allows.  For example, we consider an application to constitute a        #
- # derivative work for the purpose of this license if it does any of the   #
- # following with any software or content covered by this license          #
- # ("Covered Software"):                                                   #
- #                                                                         #
- # o Integrates source code from Covered Software.                         #
- #                                                                         #
- # o Reads or includes copyrighted data files.                             #
- #                                                                         #
- # o Is designed specifically to execute Covered Software and parse the    #
- # results (as opposed to typical shell or execution-menu apps, which will #
- # execute anything you tell them to).                                     #
- #                                                                         #
- # o Includes Covered Software in a proprietary executable installer.  The #
- # installers produced by InstallShield are an example of this.  Including #
- # DRAKVUF with other software in compressed or archival form does not     #
- # trigger this provision, provided appropriate open source decompression  #
- # or de-archiving software is widely available for no charge.  For the    #
- # purposes of this license, an installer is considered to include Covered #
- # Software even if it actually retrieves a copy of Covered Software from  #
- # another source during runtime (such as by downloading it from the       #
- # Internet).                                                              #
- #                                                                         #
- # o Links (statically or dynamically) to a library which does any of the  #
- # above.                                                                  #
- #                                                                         #
- # o Executes a helper program, module, or script to do any of the above.  #
- #                                                                         #
- # This list is not exclusive, but is meant to clarify our interpretation  #
- # of derived works with some common examples.  Other people may interpret #
- # the plain GPL differently, so we consider this a special exception to   #
- # the GPL that we apply to Covered Software.  Works which meet any of     #
- # these conditions must conform to all of the terms of this license,      #
- # particularly including the GPL Section 3 requirements of providing      #
- # source code and allowing free redistribution of the work as a whole.    #
- #                                                                         #
- # Any redistribution of Covered Software, including any derived works,    #
- # must obey and carry forward all of the terms of this license, including #
- # obeying all GPL rules and restrictions.  For example, source code of    #
- # the whole work must be provided and free redistribution must be         #
- # allowed.  All GPL references to "this License", are to be treated as    #
- # including the terms and conditions of this license text as well.        #
- #                                                                         #
- # Because this license imposes special exceptions to the GPL, Covered     #
- # Work may not be combined (even as part of a larger work) with plain GPL #
- # software.  The terms, conditions, and exceptions of this license must   #
- # be included as well.  This license is incompatible with some other open #
- # source licenses as well.  In some cases we can relicense portions of    #
- # DRAKVUF or grant special permissions to use it in other open source     #
- # software.  Please contact tamas.k.lengyel@gmail.com with any such       #
- # requests.  Similarly, we don't incorporate incompatible open source     #
- # software into Covered Software without special permission from the      #
- # copyright holders.                                                      #
- #                                                                         #
- # If you have any questions about the licensing restrictions on using     #
- # DRAKVUF in other works, are happy to help.  As mentioned above,         #
- # alternative license can be requested from the author to integrate       #
- # DRAKVUF into proprietary applications and appliances.  Please email     #
- # tamas.k.lengyel@gmail.com for further information.                      #
- #                                                                         #
- # If you have received a written license agreement or contract for        #
- # Covered Software stating terms other than these, you may choose to use  #
- # and redistribute Covered Software under those terms instead of these.   #
- #                                                                         #
- # Source is provided to this software because we believe users have a     #
- # right to know exactly what a program is going to do before they run it. #
- # This also allows you to audit the software for security holes.          #
- #                                                                         #
- # Source code also allows you to port DRAKVUF to new platforms, fix bugs, #
- # and add new features.  You are highly encouraged to submit your changes #
- # on https://github.com/tklengyel/drakvuf, or by other methods.           #
- # By sending these changes, it is understood (unless you specify          #
- # otherwise) that you are offering unlimited, non-exclusive right to      #
- # reuse, modify, and relicense the code.  DRAKVUF will always be          #
- # available Open Source, but this is important because the inability to   #
- # relicense code has caused devastating problems for other Free Software  #
- # projects (such as KDE and NASM).                                        #
- # To specify special license conditions of your contributions, just say   #
- # so when you send them.                                                  #
- #                                                                         #
- # This program is distributed in the hope that it will be useful, but     #
- # WITHOUT ANY WARRANTY; without even the implied warranty of              #
- # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the DRAKVUF   #
- # license file for more details (it's in a COPYING file included with     #
- # DRAKVUF, and also available from                                        #
- # https://github.com/tklengyel/drakvuf/COPYING)                           #
- #                                                                         #
- #*************************************************************************#
+#********************IMPORTANT DRAKVUF LICENSE TERMS**********************#
+#                                                                         #
+# DRAKVUF Dynamic Malware Analysis System (C) 2014-2016 Tamas K Lengyel.  #
+# Tamas K Lengyel is hereinafter referred to as the author.               #
+# This program is free software; you may redistribute and/or modify it    #
+# under the terms of the GNU General Public License as published by the   #
+# Free Software Foundation; Version 2 ("GPL"), BUT ONLY WITH ALL OF THE   #
+# CLARIFICATIONS AND EXCEPTIONS DESCRIBED HEREIN.  This guarantees your   # 
+# right to use, modify, and redistribute this software under certain      # 
+# conditions.  If you wish to embed DRAKVUF technology into proprietary   #
+# software, alternative licenses can be aquired from the author.          #
+#                                                                         #
+# Note that the GPL places important restrictions on "derivative works",  #
+# yet it does not provide a detailed definition of that term.  To avoid   #
+# misunderstandings, we interpret that term as broadly as copyright law   #
+# allows.  For example, we consider an application to constitute a        #
+# derivative work for the purpose of this license if it does any of the   #
+# following with any software or content covered by this license          #
+# ("Covered Software"):                                                   #
+#                                                                         #
+# o Integrates source code from Covered Software.                         #
+#                                                                         #
+# o Reads or includes copyrighted data files.                             #
+#                                                                         #
+# o Is designed specifically to execute Covered Software and parse the    #
+# results (as opposed to typical shell or execution-menu apps, which will #
+# execute anything you tell them to).                                     #
+#                                                                         #
+# o Includes Covered Software in a proprietary executable installer.  The #
+# installers produced by InstallShield are an example of this.  Including #
+# DRAKVUF with other software in compressed or archival form does not     #
+# trigger this provision, provided appropriate open source decompression  #
+# or de-archiving software is widely available for no charge.  For the    #
+# purposes of this license, an installer is considered to include Covered #
+# Software even if it actually retrieves a copy of Covered Software from  #
+# another source during runtime (such as by downloading it from the       #
+# Internet).                                                              #
+#                                                                         #
+# o Links (statically or dynamically) to a library which does any of the  #
+# above.                                                                  #
+#                                                                         #
+# o Executes a helper program, module, or script to do any of the above.  #
+#                                                                         #
+# This list is not exclusive, but is meant to clarify our interpretation  #
+# of derived works with some common examples.  Other people may interpret #
+# the plain GPL differently, so we consider this a special exception to   #
+# the GPL that we apply to Covered Software.  Works which meet any of     #
+# these conditions must conform to all of the terms of this license,      #
+# particularly including the GPL Section 3 requirements of providing      #
+# source code and allowing free redistribution of the work as a whole.    #
+#                                                                         #
+# Any redistribution of Covered Software, including any derived works,    #
+# must obey and carry forward all of the terms of this license, including #
+# obeying all GPL rules and restrictions.  For example, source code of    #
+# the whole work must be provided and free redistribution must be         #
+# allowed.  All GPL references to "this License", are to be treated as    #
+# including the terms and conditions of this license text as well.        #
+#                                                                         #
+# Because this license imposes special exceptions to the GPL, Covered     #
+# Work may not be combined (even as part of a larger work) with plain GPL #
+# software.  The terms, conditions, and exceptions of this license must   #
+# be included as well.  This license is incompatible with some other open #
+# source licenses as well.  In some cases we can relicense portions of    #
+# DRAKVUF or grant special permissions to use it in other open source     #
+# software.  Please contact tamas.k.lengyel@gmail.com with any such       #
+# requests.  Similarly, we don't incorporate incompatible open source     #
+# software into Covered Software without special permission from the      #
+# copyright holders.                                                      #
+#                                                                         #
+# If you have any questions about the licensing restrictions on using     #
+# DRAKVUF in other works, are happy to help.  As mentioned above,         #
+# alternative license can be requested from the author to integrate       #
+# DRAKVUF into proprietary applications and appliances.  Please email     #
+# tamas.k.lengyel@gmail.com for further information.                      #
+#                                                                         #
+# If you have received a written license agreement or contract for        #
+# Covered Software stating terms other than these, you may choose to use  #
+# and redistribute Covered Software under those terms instead of these.   #
+#                                                                         #
+# Source is provided to this software because we believe users have a     #
+# right to know exactly what a program is going to do before they run it. #
+# This also allows you to audit the software for security holes.          #
+#                                                                         #
+# Source code also allows you to port DRAKVUF to new platforms, fix bugs, #
+# and add new features.  You are highly encouraged to submit your changes #
+# on https://github.com/tklengyel/drakvuf, or by other methods.           #
+# By sending these changes, it is understood (unless you specify          #
+# otherwise) that you are offering unlimited, non-exclusive right to      #
+# reuse, modify, and relicense the code.  DRAKVUF will always be          #
+# available Open Source, but this is important because the inability to   #
+# relicense code has caused devastating problems for other Free Software  #
+# projects (such as KDE and NASM).                                        #
+# To specify special license conditions of your contributions, just say   #
+# so when you send them.                                                  #
+#                                                                         #
+# This program is distributed in the hope that it will be useful, but     #
+# WITHOUT ANY WARRANTY; without even the implied warranty of              #
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the DRAKVUF   #
+# license file for more details (it's in a COPYING file included with     #
+# DRAKVUF, and also available from                                        #
+# https://github.com/tklengyel/drakvuf/COPYING)                           #
+#                                                                         #
+#*************************************************************************#
 
 AC_PREREQ([2.60])
 AC_INIT([DRAKVUF], [0.3], [tamas@tklengyel.com], [], [http://drakvuf.com])

--- a/configure.ac
+++ b/configure.ac
@@ -103,7 +103,7 @@
  #*************************************************************************#
 
 AC_PREREQ([2.60])
-AC_INIT([DRAKVUF], [0.2], [tamas@tklengyel.com], [], [http://drakvuf.com])
+AC_INIT([DRAKVUF], [0.3], [tamas@tklengyel.com], [], [http://drakvuf.com])
 AM_INIT_AUTOMAKE([1.10 no-define foreign subdir-objects])
 LT_INIT
 AC_CONFIG_HEADERS([config.h])

--- a/configure.ac
+++ b/configure.ac
@@ -103,7 +103,7 @@
 #*************************************************************************#
 
 AC_PREREQ([2.60])
-AC_INIT([DRAKVUF], [0.3], [tamas@tklengyel.com], [], [http://drakvuf.com])
+AC_INIT([DRAKVUF], [0.3-m4_esyscmd_s([git describe --always])], [tamas@tklengyel.com], [], [http://drakvuf.com])
 AM_INIT_AUTOMAKE([1.10 no-define foreign subdir-objects])
 LT_INIT
 AC_CONFIG_HEADERS([config.h])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,106 +1,106 @@
- #********************IMPORTANT DRAKVUF LICENSE TERMS**********************#
- #                                                                         #
- # DRAKVUF Dynamic Malware Analysis System (C) 2014-2015 Tamas K Lengyel.  #
- # Tamas K Lengyel is hereinafter referred to as the author.               #
- # This program is free software; you may redistribute and/or modify it    #
- # under the terms of the GNU General Public License as published by the   #
- # Free Software Foundation; Version 2 ("GPL"), BUT ONLY WITH ALL OF THE   #
- # CLARIFICATIONS AND EXCEPTIONS DESCRIBED HEREIN.  This guarantees your   #
- # right to use, modify, and redistribute this software under certain      #
- # conditions.  If you wish to embed DRAKVUF technology into proprietary   #
- # software, alternative licenses can be aquired from the author.          #
- #                                                                         #
- # Note that the GPL places important restrictions on "derivative works",  #
- # yet it does not provide a detailed definition of that term.  To avoid   #
- # misunderstandings, we interpret that term as broadly as copyright law   #
- # allows.  For example, we consider an application to constitute a        #
- # derivative work for the purpose of this license if it does any of the   #
- # following with any software or content covered by this license          #
- # ("Covered Software"):                                                   #
- #                                                                         #
- # o Integrates source code from Covered Software.                         #
- #                                                                         #
- # o Reads or includes copyrighted data files.                             #
- #                                                                         #
- # o Is designed specifically to execute Covered Software and parse the    #
- # results (as opposed to typical shell or execution-menu apps, which will #
- # execute anything you tell them to).                                     #
- #                                                                         #
- # o Includes Covered Software in a proprietary executable installer.  The #
- # installers produced by InstallShield are an example of this.  Including #
- # DRAKVUF with other software in compressed or archival form does not     #
- # trigger this provision, provided appropriate open source decompression  #
- # or de-archiving software is widely available for no charge.  For the    #
- # purposes of this license, an installer is considered to include Covered #
- # Software even if it actually retrieves a copy of Covered Software from  #
- # another source during runtime (such as by downloading it from the       #
- # Internet).                                                              #
- #                                                                         #
- # o Links (statically or dynamically) to a library which does any of the  #
- # above.                                                                  #
- #                                                                         #
- # o Executes a helper program, module, or script to do any of the above.  #
- #                                                                         #
- # This list is not exclusive, but is meant to clarify our interpretation  #
- # of derived works with some common examples.  Other people may interpret #
- # the plain GPL differently, so we consider this a special exception to   #
- # the GPL that we apply to Covered Software.  Works which meet any of     #
- # these conditions must conform to all of the terms of this license,      #
- # particularly including the GPL Section 3 requirements of providing      #
- # source code and allowing free redistribution of the work as a whole.    #
- #                                                                         #
- # Any redistribution of Covered Software, including any derived works,    #
- # must obey and carry forward all of the terms of this license, including #
- # obeying all GPL rules and restrictions.  For example, source code of    #
- # the whole work must be provided and free redistribution must be         #
- # allowed.  All GPL references to "this License", are to be treated as    #
- # including the terms and conditions of this license text as well.        #
- #                                                                         #
- # Because this license imposes special exceptions to the GPL, Covered     #
- # Work may not be combined (even as part of a larger work) with plain GPL #
- # software.  The terms, conditions, and exceptions of this license must   #
- # be included as well.  This license is incompatible with some other open #
- # source licenses as well.  In some cases we can relicense portions of    #
- # DRAKVUF or grant special permissions to use it in other open source     #
- # software.  Please contact tamas.k.lengyel@gmail.com with any such       #
- # requests.  Similarly, we don't incorporate incompatible open source     #
- # software into Covered Software without special permission from the      #
- # copyright holders.                                                      #
- #                                                                         #
- # If you have any questions about the licensing restrictions on using     #
- # DRAKVUF in other works, are happy to help.  As mentioned above,         #
- # alternative license can be requested from the author to integrate       #
- # DRAKVUF into proprietary applications and appliances.  Please email     #
- # tamas.k.lengyel@gmail.com for further information.                      #
- #                                                                         #
- # If you have received a written license agreement or contract for        #
- # Covered Software stating terms other than these, you may choose to use  #
- # and redistribute Covered Software under those terms instead of these.   #
- #                                                                         #
- # Source is provided to this software because we believe users have a     #
- # right to know exactly what a program is going to do before they run it. #
- # This also allows you to audit the software for security holes.          #
- #                                                                         #
- # Source code also allows you to port DRAKVUF to new platforms, fix bugs, #
- # and add new features.  You are highly encouraged to submit your changes #
- # on https://github.com/tklengyel/drakvuf, or by other methods.           #
- # By sending these changes, it is understood (unless you specify          #
- # otherwise) that you are offering unlimited, non-exclusive right to      #
- # reuse, modify, and relicense the code.  DRAKVUF will always be          #
- # available Open Source, but this is important because the inability to   #
- # relicense code has caused devastating problems for other Free Software  #
- # projects (such as KDE and NASM).                                        #
- # To specify special license conditions of your contributions, just say   #
- # so when you send them.                                                  #
- #                                                                         #
- # This program is distributed in the hope that it will be useful, but     #
- # WITHOUT ANY WARRANTY; without even the implied warranty of              #
- # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the DRAKVUF   #
- # license file for more details (it's in a COPYING file included with     #
- # DRAKVUF, and also available from                                        #
- # https://github.com/tklengyel/drakvuf/COPYING)                           #
- #                                                                         #
- #*************************************************************************# 
+#********************IMPORTANT DRAKVUF LICENSE TERMS**********************#
+#                                                                         #
+# DRAKVUF Dynamic Malware Analysis System (C) 2014-2016 Tamas K Lengyel.  #
+# Tamas K Lengyel is hereinafter referred to as the author.               #
+# This program is free software; you may redistribute and/or modify it    #
+# under the terms of the GNU General Public License as published by the   #
+# Free Software Foundation; Version 2 ("GPL"), BUT ONLY WITH ALL OF THE   #
+# CLARIFICATIONS AND EXCEPTIONS DESCRIBED HEREIN.  This guarantees your   #
+# right to use, modify, and redistribute this software under certain      #
+# conditions.  If you wish to embed DRAKVUF technology into proprietary   #
+# software, alternative licenses can be aquired from the author.          #
+#                                                                         #
+# Note that the GPL places important restrictions on "derivative works",  #
+# yet it does not provide a detailed definition of that term.  To avoid   #
+# misunderstandings, we interpret that term as broadly as copyright law   #
+# allows.  For example, we consider an application to constitute a        #
+# derivative work for the purpose of this license if it does any of the   #
+# following with any software or content covered by this license          #
+# ("Covered Software"):                                                   #
+#                                                                         #
+# o Integrates source code from Covered Software.                         #
+#                                                                         #
+# o Reads or includes copyrighted data files.                             #
+#                                                                         #
+# o Is designed specifically to execute Covered Software and parse the    #
+# results (as opposed to typical shell or execution-menu apps, which will #
+# execute anything you tell them to).                                     #
+#                                                                         #
+# o Includes Covered Software in a proprietary executable installer.  The #
+# installers produced by InstallShield are an example of this.  Including #
+# DRAKVUF with other software in compressed or archival form does not     #
+# trigger this provision, provided appropriate open source decompression  #
+# or de-archiving software is widely available for no charge.  For the    #
+# purposes of this license, an installer is considered to include Covered #
+# Software even if it actually retrieves a copy of Covered Software from  #
+# another source during runtime (such as by downloading it from the       #
+# Internet).                                                              #
+#                                                                         #
+# o Links (statically or dynamically) to a library which does any of the  #
+# above.                                                                  #
+#                                                                         #
+# o Executes a helper program, module, or script to do any of the above.  #
+#                                                                         #
+# This list is not exclusive, but is meant to clarify our interpretation  #
+# of derived works with some common examples.  Other people may interpret #
+# the plain GPL differently, so we consider this a special exception to   #
+# the GPL that we apply to Covered Software.  Works which meet any of     #
+# these conditions must conform to all of the terms of this license,      #
+# particularly including the GPL Section 3 requirements of providing      #
+# source code and allowing free redistribution of the work as a whole.    #
+#                                                                         #
+# Any redistribution of Covered Software, including any derived works,    #
+# must obey and carry forward all of the terms of this license, including #
+# obeying all GPL rules and restrictions.  For example, source code of    #
+# the whole work must be provided and free redistribution must be         #
+# allowed.  All GPL references to "this License", are to be treated as    #
+# including the terms and conditions of this license text as well.        #
+#                                                                         #
+# Because this license imposes special exceptions to the GPL, Covered     #
+# Work may not be combined (even as part of a larger work) with plain GPL #
+# software.  The terms, conditions, and exceptions of this license must   #
+# be included as well.  This license is incompatible with some other open #
+# source licenses as well.  In some cases we can relicense portions of    #
+# DRAKVUF or grant special permissions to use it in other open source     #
+# software.  Please contact tamas.k.lengyel@gmail.com with any such       #
+# requests.  Similarly, we don't incorporate incompatible open source     #
+# software into Covered Software without special permission from the      #
+# copyright holders.                                                      #
+#                                                                         #
+# If you have any questions about the licensing restrictions on using     #
+# DRAKVUF in other works, are happy to help.  As mentioned above,         #
+# alternative license can be requested from the author to integrate       #
+# DRAKVUF into proprietary applications and appliances.  Please email     #
+# tamas.k.lengyel@gmail.com for further information.                      #
+#                                                                         #
+# If you have received a written license agreement or contract for        #
+# Covered Software stating terms other than these, you may choose to use  #
+# and redistribute Covered Software under those terms instead of these.   #
+#                                                                         #
+# Source is provided to this software because we believe users have a     #
+# right to know exactly what a program is going to do before they run it. #
+# This also allows you to audit the software for security holes.          #
+#                                                                         #
+# Source code also allows you to port DRAKVUF to new platforms, fix bugs, #
+# and add new features.  You are highly encouraged to submit your changes #
+# on https://github.com/tklengyel/drakvuf, or by other methods.           #
+# By sending these changes, it is understood (unless you specify          #
+# otherwise) that you are offering unlimited, non-exclusive right to      #
+# reuse, modify, and relicense the code.  DRAKVUF will always be          #
+# available Open Source, but this is important because the inability to   #
+# relicense code has caused devastating problems for other Free Software  #
+# projects (such as KDE and NASM).                                        #
+# To specify special license conditions of your contributions, just say   #
+# so when you send them.                                                  #
+#                                                                         #
+# This program is distributed in the hope that it will be useful, but     #
+# WITHOUT ANY WARRANTY; without even the implied warranty of              #
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the DRAKVUF   #
+# license file for more details (it's in a COPYING file included with     #
+# DRAKVUF, and also available from                                        #
+# https://github.com/tklengyel/drakvuf/COPYING)                           #
+#                                                                         #
+#*************************************************************************# 
 
 bin_PROGRAMS = drakvuf xen_memclone injector
 

--- a/src/dirwatch/Makefile.am
+++ b/src/dirwatch/Makefile.am
@@ -1,106 +1,106 @@
- #********************IMPORTANT DRAKVUF LICENSE TERMS**********************#
- #                                                                         #
- # DRAKVUF Dynamic Malware Analysis System (C) 2014-2016 Tamas K Lengyel.  #
- # Tamas K Lengyel is hereinafter referred to as the author.               #
- # This program is free software; you may redistribute and/or modify it    #
- # under the terms of the GNU General Public License as published by the   #
- # Free Software Foundation; Version 2 ("GPL"), BUT ONLY WITH ALL OF THE   #
- # CLARIFICATIONS AND EXCEPTIONS DESCRIBED HEREIN.  This guarantees your   #
- # right to use, modify, and redistribute this software under certain      #
- # conditions.  If you wish to embed DRAKVUF technology into proprietary   #
- # software, alternative licenses can be aquired from the author.          #
- #                                                                         #
- # Note that the GPL places important restrictions on "derivative works",  #
- # yet it does not provide a detailed definition of that term.  To avoid   #
- # misunderstandings, we interpret that term as broadly as copyright law   #
- # allows.  For example, we consider an application to constitute a        #
- # derivative work for the purpose of this license if it does any of the   #
- # following with any software or content covered by this license          #
- # ("Covered Software"):                                                   #
- #                                                                         #
- # o Integrates source code from Covered Software.                         #
- #                                                                         #
- # o Reads or includes copyrighted data files.                             #
- #                                                                         #
- # o Is designed specifically to execute Covered Software and parse the    #
- # results (as opposed to typical shell or execution-menu apps, which will #
- # execute anything you tell them to).                                     #
- #                                                                         #
- # o Includes Covered Software in a proprietary executable installer.  The #
- # installers produced by InstallShield are an example of this.  Including #
- # DRAKVUF with other software in compressed or archival form does not     #
- # trigger this provision, provided appropriate open source decompression  #
- # or de-archiving software is widely available for no charge.  For the    #
- # purposes of this license, an installer is considered to include Covered #
- # Software even if it actually retrieves a copy of Covered Software from  #
- # another source during runtime (such as by downloading it from the       #
- # Internet).                                                              #
- #                                                                         #
- # o Links (statically or dynamically) to a library which does any of the  #
- # above.                                                                  #
- #                                                                         #
- # o Executes a helper program, module, or script to do any of the above.  #
- #                                                                         #
- # This list is not exclusive, but is meant to clarify our interpretation  #
- # of derived works with some common examples.  Other people may interpret #
- # the plain GPL differently, so we consider this a special exception to   #
- # the GPL that we apply to Covered Software.  Works which meet any of     #
- # these conditions must conform to all of the terms of this license,      #
- # particularly including the GPL Section 3 requirements of providing      #
- # source code and allowing free redistribution of the work as a whole.    #
- #                                                                         #
- # Any redistribution of Covered Software, including any derived works,    #
- # must obey and carry forward all of the terms of this license, including #
- # obeying all GPL rules and restrictions.  For example, source code of    #
- # the whole work must be provided and free redistribution must be         #
- # allowed.  All GPL references to "this License", are to be treated as    #
- # including the terms and conditions of this license text as well.        #
- #                                                                         #
- # Because this license imposes special exceptions to the GPL, Covered     #
- # Work may not be combined (even as part of a larger work) with plain GPL #
- # software.  The terms, conditions, and exceptions of this license must   #
- # be included as well.  This license is incompatible with some other open #
- # source licenses as well.  In some cases we can relicense portions of    #
- # DRAKVUF or grant special permissions to use it in other open source     #
- # software.  Please contact tamas.k.lengyel@gmail.com with any such       #
- # requests.  Similarly, we don't incorporate incompatible open source     #
- # software into Covered Software without special permission from the      #
- # copyright holders.                                                      #
- #                                                                         #
- # If you have any questions about the licensing restrictions on using     #
- # DRAKVUF in other works, are happy to help.  As mentioned above,         #
- # alternative license can be requested from the author to integrate       #
- # DRAKVUF into proprietary applications and appliances.  Please email     #
- # tamas.k.lengyel@gmail.com for further information.                      #
- #                                                                         #
- # If you have received a written license agreement or contract for        #
- # Covered Software stating terms other than these, you may choose to use  #
- # and redistribute Covered Software under those terms instead of these.   #
- #                                                                         #
- # Source is provided to this software because we believe users have a     #
- # right to know exactly what a program is going to do before they run it. #
- # This also allows you to audit the software for security holes.          #
- #                                                                         #
- # Source code also allows you to port DRAKVUF to new platforms, fix bugs, #
- # and add new features.  You are highly encouraged to submit your changes #
- # on https://github.com/tklengyel/drakvuf, or by other methods.           #
- # By sending these changes, it is understood (unless you specify          #
- # otherwise) that you are offering unlimited, non-exclusive right to      #
- # reuse, modify, and relicense the code.  DRAKVUF will always be          #
- # available Open Source, but this is important because the inability to   #
- # relicense code has caused devastating problems for other Free Software  #
- # projects (such as KDE and NASM).                                        #
- # To specify special license conditions of your contributions, just say   #
- # so when you send them.                                                  #
- #                                                                         #
- # This program is distributed in the hope that it will be useful, but     #
- # WITHOUT ANY WARRANTY; without even the implied warranty of              #
- # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the DRAKVUF   #
- # license file for more details (it's in a COPYING file included with     #
- # DRAKVUF, and also available from                                        #
- # https://github.com/tklengyel/drakvuf/COPYING)                           #
- #                                                                         #
- #*************************************************************************# 
+#********************IMPORTANT DRAKVUF LICENSE TERMS**********************#
+#                                                                         #
+# DRAKVUF Dynamic Malware Analysis System (C) 2014-2016 Tamas K Lengyel.  #
+# Tamas K Lengyel is hereinafter referred to as the author.               #
+# This program is free software; you may redistribute and/or modify it    #
+# under the terms of the GNU General Public License as published by the   #
+# Free Software Foundation; Version 2 ("GPL"), BUT ONLY WITH ALL OF THE   #
+# CLARIFICATIONS AND EXCEPTIONS DESCRIBED HEREIN.  This guarantees your   #
+# right to use, modify, and redistribute this software under certain      #
+# conditions.  If you wish to embed DRAKVUF technology into proprietary   #
+# software, alternative licenses can be aquired from the author.          #
+#                                                                         #
+# Note that the GPL places important restrictions on "derivative works",  #
+# yet it does not provide a detailed definition of that term.  To avoid   #
+# misunderstandings, we interpret that term as broadly as copyright law   #
+# allows.  For example, we consider an application to constitute a        #
+# derivative work for the purpose of this license if it does any of the   #
+# following with any software or content covered by this license          #
+# ("Covered Software"):                                                   #
+#                                                                         #
+# o Integrates source code from Covered Software.                         #
+#                                                                         #
+# o Reads or includes copyrighted data files.                             #
+#                                                                         #
+# o Is designed specifically to execute Covered Software and parse the    #
+# results (as opposed to typical shell or execution-menu apps, which will #
+# execute anything you tell them to).                                     #
+#                                                                         #
+# o Includes Covered Software in a proprietary executable installer.  The #
+# installers produced by InstallShield are an example of this.  Including #
+# DRAKVUF with other software in compressed or archival form does not     #
+# trigger this provision, provided appropriate open source decompression  #
+# or de-archiving software is widely available for no charge.  For the    #
+# purposes of this license, an installer is considered to include Covered #
+# Software even if it actually retrieves a copy of Covered Software from  #
+# another source during runtime (such as by downloading it from the       #
+# Internet).                                                              #
+#                                                                         #
+# o Links (statically or dynamically) to a library which does any of the  #
+# above.                                                                  #
+#                                                                         #
+# o Executes a helper program, module, or script to do any of the above.  #
+#                                                                         #
+# This list is not exclusive, but is meant to clarify our interpretation  #
+# of derived works with some common examples.  Other people may interpret #
+# the plain GPL differently, so we consider this a special exception to   #
+# the GPL that we apply to Covered Software.  Works which meet any of     #
+# these conditions must conform to all of the terms of this license,      #
+# particularly including the GPL Section 3 requirements of providing      #
+# source code and allowing free redistribution of the work as a whole.    #
+#                                                                         #
+# Any redistribution of Covered Software, including any derived works,    #
+# must obey and carry forward all of the terms of this license, including #
+# obeying all GPL rules and restrictions.  For example, source code of    #
+# the whole work must be provided and free redistribution must be         #
+# allowed.  All GPL references to "this License", are to be treated as    #
+# including the terms and conditions of this license text as well.        #
+#                                                                         #
+# Because this license imposes special exceptions to the GPL, Covered     #
+# Work may not be combined (even as part of a larger work) with plain GPL #
+# software.  The terms, conditions, and exceptions of this license must   #
+# be included as well.  This license is incompatible with some other open #
+# source licenses as well.  In some cases we can relicense portions of    #
+# DRAKVUF or grant special permissions to use it in other open source     #
+# software.  Please contact tamas.k.lengyel@gmail.com with any such       #
+# requests.  Similarly, we don't incorporate incompatible open source     #
+# software into Covered Software without special permission from the      #
+# copyright holders.                                                      #
+#                                                                         #
+# If you have any questions about the licensing restrictions on using     #
+# DRAKVUF in other works, are happy to help.  As mentioned above,         #
+# alternative license can be requested from the author to integrate       #
+# DRAKVUF into proprietary applications and appliances.  Please email     #
+# tamas.k.lengyel@gmail.com for further information.                      #
+#                                                                         #
+# If you have received a written license agreement or contract for        #
+# Covered Software stating terms other than these, you may choose to use  #
+# and redistribute Covered Software under those terms instead of these.   #
+#                                                                         #
+# Source is provided to this software because we believe users have a     #
+# right to know exactly what a program is going to do before they run it. #
+# This also allows you to audit the software for security holes.          #
+#                                                                         #
+# Source code also allows you to port DRAKVUF to new platforms, fix bugs, #
+# and add new features.  You are highly encouraged to submit your changes #
+# on https://github.com/tklengyel/drakvuf, or by other methods.           #
+# By sending these changes, it is understood (unless you specify          #
+# otherwise) that you are offering unlimited, non-exclusive right to      #
+# reuse, modify, and relicense the code.  DRAKVUF will always be          #
+# available Open Source, but this is important because the inability to   #
+# relicense code has caused devastating problems for other Free Software  #
+# projects (such as KDE and NASM).                                        #
+# To specify special license conditions of your contributions, just say   #
+# so when you send them.                                                  #
+#                                                                         #
+# This program is distributed in the hope that it will be useful, but     #
+# WITHOUT ANY WARRANTY; without even the implied warranty of              #
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the DRAKVUF   #
+# license file for more details (it's in a COPYING file included with     #
+# DRAKVUF, and also available from                                        #
+# https://github.com/tklengyel/drakvuf/COPYING)                           #
+#                                                                         #
+#*************************************************************************# 
 
 bin_PROGRAMS = dirwatch
 

--- a/src/drakvuf.cpp
+++ b/src/drakvuf.cpp
@@ -1,6 +1,6 @@
 /*********************IMPORTANT DRAKVUF LICENSE TERMS***********************
  *                                                                         *
- * DRAKVUF Dynamic Malware Analysis System (C) 2014-2015 Tamas K Lengyel.  *
+ * DRAKVUF Dynamic Malware Analysis System (C) 2014-2016 Tamas K Lengyel.  *
  * Tamas K Lengyel is hereinafter referred to as the author.               *
  * This program is free software; you may redistribute and/or modify it    *
  * under the terms of the GNU General Public License as published by the   *

--- a/src/drakvuf.h
+++ b/src/drakvuf.h
@@ -1,6 +1,6 @@
 /*********************IMPORTANT DRAKVUF LICENSE TERMS***********************
  *                                                                         *
- * DRAKVUF Dynamic Malware Analysis System (C) 2014-2015 Tamas K Lengyel.  *
+ * DRAKVUF Dynamic Malware Analysis System (C) 2014-2016 Tamas K Lengyel.  *
  * Tamas K Lengyel is hereinafter referred to as the author.               *
  * This program is free software; you may redistribute and/or modify it    *
  * under the terms of the GNU General Public License as published by the   *

--- a/src/injector.c
+++ b/src/injector.c
@@ -1,6 +1,6 @@
 /*********************IMPORTANT DRAKVUF LICENSE TERMS***********************
  *                                                                         *
- * DRAKVUF Dynamic Malware Analysis System (C) 2014-2015 Tamas K Lengyel.  *
+ * DRAKVUF Dynamic Malware Analysis System (C) 2014-2016 Tamas K Lengyel.  *
  * Tamas K Lengyel is hereinafter referred to as the author.               *
  * This program is free software; you may redistribute and/or modify it    *
  * under the terms of the GNU General Public License as published by the   *

--- a/src/libdrakvuf/Makefile.am
+++ b/src/libdrakvuf/Makefile.am
@@ -1,106 +1,106 @@
- #********************IMPORTANT DRAKVUF LICENSE TERMS**********************#
- #                                                                         #
- # DRAKVUF Dynamic Malware Analysis System (C) 2014-2015 Tamas K Lengyel.  #
- # Tamas K Lengyel is hereinafter referred to as the author.               #
- # This program is free software; you may redistribute and/or modify it    #
- # under the terms of the GNU General Public License as published by the   #
- # Free Software Foundation; Version 2 ("GPL"), BUT ONLY WITH ALL OF THE   #
- # CLARIFICATIONS AND EXCEPTIONS DESCRIBED HEREIN.  This guarantees your   #
- # right to use, modify, and redistribute this software under certain      #
- # conditions.  If you wish to embed DRAKVUF technology into proprietary   #
- # software, alternative licenses can be aquired from the author.          #
- #                                                                         #
- # Note that the GPL places important restrictions on "derivative works",  #
- # yet it does not provide a detailed definition of that term.  To avoid   #
- # misunderstandings, we interpret that term as broadly as copyright law   #
- # allows.  For example, we consider an application to constitute a        #
- # derivative work for the purpose of this license if it does any of the   #
- # following with any software or content covered by this license          #
- # ("Covered Software"):                                                   #
- #                                                                         #
- # o Integrates source code from Covered Software.                         #
- #                                                                         #
- # o Reads or includes copyrighted data files.                             #
- #                                                                         #
- # o Is designed specifically to execute Covered Software and parse the    #
- # results (as opposed to typical shell or execution-menu apps, which will #
- # execute anything you tell them to).                                     #
- #                                                                         #
- # o Includes Covered Software in a proprietary executable installer.  The #
- # installers produced by InstallShield are an example of this.  Including #
- # DRAKVUF with other software in compressed or archival form does not     #
- # trigger this provision, provided appropriate open source decompression  #
- # or de-archiving software is widely available for no charge.  For the    #
- # purposes of this license, an installer is considered to include Covered #
- # Software even if it actually retrieves a copy of Covered Software from  #
- # another source during runtime (such as by downloading it from the       #
- # Internet).                                                              #
- #                                                                         #
- # o Links (statically or dynamically) to a library which does any of the  #
- # above.                                                                  #
- #                                                                         #
- # o Executes a helper program, module, or script to do any of the above.  #
- #                                                                         #
- # This list is not exclusive, but is meant to clarify our interpretation  #
- # of derived works with some common examples.  Other people may interpret #
- # the plain GPL differently, so we consider this a special exception to   #
- # the GPL that we apply to Covered Software.  Works which meet any of     #
- # these conditions must conform to all of the terms of this license,      #
- # particularly including the GPL Section 3 requirements of providing      #
- # source code and allowing free redistribution of the work as a whole.    #
- #                                                                         #
- # Any redistribution of Covered Software, including any derived works,    #
- # must obey and carry forward all of the terms of this license, including #
- # obeying all GPL rules and restrictions.  For example, source code of    #
- # the whole work must be provided and free redistribution must be         #
- # allowed.  All GPL references to "this License", are to be treated as    #
- # including the terms and conditions of this license text as well.        #
- #                                                                         #
- # Because this license imposes special exceptions to the GPL, Covered     #
- # Work may not be combined (even as part of a larger work) with plain GPL #
- # software.  The terms, conditions, and exceptions of this license must   #
- # be included as well.  This license is incompatible with some other open #
- # source licenses as well.  In some cases we can relicense portions of    #
- # DRAKVUF or grant special permissions to use it in other open source     #
- # software.  Please contact tamas.k.lengyel@gmail.com with any such       #
- # requests.  Similarly, we don't incorporate incompatible open source     #
- # software into Covered Software without special permission from the      #
- # copyright holders.                                                      #
- #                                                                         #
- # If you have any questions about the licensing restrictions on using     #
- # DRAKVUF in other works, are happy to help.  As mentioned above,         #
- # alternative license can be requested from the author to integrate       #
- # DRAKVUF into proprietary applications and appliances.  Please email     #
- # tamas.k.lengyel@gmail.com for further information.                      #
- #                                                                         #
- # If you have received a written license agreement or contract for        #
- # Covered Software stating terms other than these, you may choose to use  #
- # and redistribute Covered Software under those terms instead of these.   #
- #                                                                         #
- # Source is provided to this software because we believe users have a     #
- # right to know exactly what a program is going to do before they run it. #
- # This also allows you to audit the software for security holes.          #
- #                                                                         #
- # Source code also allows you to port DRAKVUF to new platforms, fix bugs, #
- # and add new features.  You are highly encouraged to submit your changes #
- # on https://github.com/tklengyel/drakvuf, or by other methods.           #
- # By sending these changes, it is understood (unless you specify          #
- # otherwise) that you are offering unlimited, non-exclusive right to      #
- # reuse, modify, and relicense the code.  DRAKVUF will always be          #
- # available Open Source, but this is important because the inability to   #
- # relicense code has caused devastating problems for other Free Software  #
- # projects (such as KDE and NASM).                                        #
- # To specify special license conditions of your contributions, just say   #
- # so when you send them.                                                  #
- #                                                                         #
- # This program is distributed in the hope that it will be useful, but     #
- # WITHOUT ANY WARRANTY; without even the implied warranty of              #
- # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the DRAKVUF   #
- # license file for more details (it's in a COPYING file included with     #
- # DRAKVUF, and also available from                                        #
- # https://github.com/tklengyel/drakvuf/COPYING)                           #
- #                                                                         #
- #*************************************************************************# 
+#********************IMPORTANT DRAKVUF LICENSE TERMS**********************#
+#                                                                         #
+# DRAKVUF Dynamic Malware Analysis System (C) 2014-2016 Tamas K Lengyel.  #
+# Tamas K Lengyel is hereinafter referred to as the author.               #
+# This program is free software; you may redistribute and/or modify it    #
+# under the terms of the GNU General Public License as published by the   #
+# Free Software Foundation; Version 2 ("GPL"), BUT ONLY WITH ALL OF THE   #
+# CLARIFICATIONS AND EXCEPTIONS DESCRIBED HEREIN.  This guarantees your   #
+# right to use, modify, and redistribute this software under certain      #
+# conditions.  If you wish to embed DRAKVUF technology into proprietary   #
+# software, alternative licenses can be aquired from the author.          #
+#                                                                         #
+# Note that the GPL places important restrictions on "derivative works",  #
+# yet it does not provide a detailed definition of that term.  To avoid   #
+# misunderstandings, we interpret that term as broadly as copyright law   #
+# allows.  For example, we consider an application to constitute a        #
+# derivative work for the purpose of this license if it does any of the   #
+# following with any software or content covered by this license          #
+# ("Covered Software"):                                                   #
+#                                                                         #
+# o Integrates source code from Covered Software.                         #
+#                                                                         #
+# o Reads or includes copyrighted data files.                             #
+#                                                                         #
+# o Is designed specifically to execute Covered Software and parse the    #
+# results (as opposed to typical shell or execution-menu apps, which will #
+# execute anything you tell them to).                                     #
+#                                                                         #
+# o Includes Covered Software in a proprietary executable installer.  The #
+# installers produced by InstallShield are an example of this.  Including #
+# DRAKVUF with other software in compressed or archival form does not     #
+# trigger this provision, provided appropriate open source decompression  #
+# or de-archiving software is widely available for no charge.  For the    #
+# purposes of this license, an installer is considered to include Covered #
+# Software even if it actually retrieves a copy of Covered Software from  #
+# another source during runtime (such as by downloading it from the       #
+# Internet).                                                              #
+#                                                                         #
+# o Links (statically or dynamically) to a library which does any of the  #
+# above.                                                                  #
+#                                                                         #
+# o Executes a helper program, module, or script to do any of the above.  #
+#                                                                         #
+# This list is not exclusive, but is meant to clarify our interpretation  #
+# of derived works with some common examples.  Other people may interpret #
+# the plain GPL differently, so we consider this a special exception to   #
+# the GPL that we apply to Covered Software.  Works which meet any of     #
+# these conditions must conform to all of the terms of this license,      #
+# particularly including the GPL Section 3 requirements of providing      #
+# source code and allowing free redistribution of the work as a whole.    #
+#                                                                         #
+# Any redistribution of Covered Software, including any derived works,    #
+# must obey and carry forward all of the terms of this license, including #
+# obeying all GPL rules and restrictions.  For example, source code of    #
+# the whole work must be provided and free redistribution must be         #
+# allowed.  All GPL references to "this License", are to be treated as    #
+# including the terms and conditions of this license text as well.        #
+#                                                                         #
+# Because this license imposes special exceptions to the GPL, Covered     #
+# Work may not be combined (even as part of a larger work) with plain GPL #
+# software.  The terms, conditions, and exceptions of this license must   #
+# be included as well.  This license is incompatible with some other open #
+# source licenses as well.  In some cases we can relicense portions of    #
+# DRAKVUF or grant special permissions to use it in other open source     #
+# software.  Please contact tamas.k.lengyel@gmail.com with any such       #
+# requests.  Similarly, we don't incorporate incompatible open source     #
+# software into Covered Software without special permission from the      #
+# copyright holders.                                                      #
+#                                                                         #
+# If you have any questions about the licensing restrictions on using     #
+# DRAKVUF in other works, are happy to help.  As mentioned above,         #
+# alternative license can be requested from the author to integrate       #
+# DRAKVUF into proprietary applications and appliances.  Please email     #
+# tamas.k.lengyel@gmail.com for further information.                      #
+#                                                                         #
+# If you have received a written license agreement or contract for        #
+# Covered Software stating terms other than these, you may choose to use  #
+# and redistribute Covered Software under those terms instead of these.   #
+#                                                                         #
+# Source is provided to this software because we believe users have a     #
+# right to know exactly what a program is going to do before they run it. #
+# This also allows you to audit the software for security holes.          #
+#                                                                         #
+# Source code also allows you to port DRAKVUF to new platforms, fix bugs, #
+# and add new features.  You are highly encouraged to submit your changes #
+# on https://github.com/tklengyel/drakvuf, or by other methods.           #
+# By sending these changes, it is understood (unless you specify          #
+# otherwise) that you are offering unlimited, non-exclusive right to      #
+# reuse, modify, and relicense the code.  DRAKVUF will always be          #
+# available Open Source, but this is important because the inability to   #
+# relicense code has caused devastating problems for other Free Software  #
+# projects (such as KDE and NASM).                                        #
+# To specify special license conditions of your contributions, just say   #
+# so when you send them.                                                  #
+#                                                                         #
+# This program is distributed in the hope that it will be useful, but     #
+# WITHOUT ANY WARRANTY; without even the implied warranty of              #
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the DRAKVUF   #
+# license file for more details (it's in a COPYING file included with     #
+# DRAKVUF, and also available from                                        #
+# https://github.com/tklengyel/drakvuf/COPYING)                           #
+#                                                                         #
+#*************************************************************************# 
 
 h_sources = libdrakvuf.h
 c_sources = drakvuf.c injector.c win-exports.c vmi.c win-symbols.c win-handles.c win-processes.c

--- a/src/libdrakvuf/drakvuf.c
+++ b/src/libdrakvuf/drakvuf.c
@@ -306,3 +306,52 @@ status_t drakvuf_get_struct_member_rva(const char *rekall_profile,
                 rva,
                 NULL);
 }
+
+bool drakvuf_get_module_base_addr( drakvuf_t drakvuf, addr_t *module_list_head, char *module_name, addr_t *base_addr )
+{
+    size_t name_len = strlen( module_name );
+    vmi_instance_t vmi = drakvuf->vmi;
+    addr_t next_module = *module_list_head;
+
+    while( 1 )
+    {
+        addr_t tmp_next = 0;
+
+        if ( vmi_read_addr_va( vmi, next_module, 4, &tmp_next ) != VMI_SUCCESS )
+            break;
+
+        if ( *module_list_head == tmp_next )
+            break;
+
+        *base_addr = 0 ;
+
+        vmi_read_addr_va( vmi, next_module + offsets[LDR_DATA_TABLE_ENTRY_DLLBASE], 4, base_addr );
+
+        if ( ! *base_addr )
+            break;
+
+        unicode_string_t *us = vmi_read_unicode_str_va( vmi, next_module + offsets[LDR_DATA_TABLE_ENTRY_BASEDLLNAME], 4 );
+
+        if ( us )
+        {
+            unicode_string_t out = { 0 };
+            if ( vmi_convert_str_encoding( us, &out, "UTF-8" ) == VMI_SUCCESS  )
+            {
+                if ( ! strncasecmp( (char *)out.contents, module_name, name_len ) )
+                {
+                    free( out.contents );
+                    vmi_free_unicode_str( us );
+                    return true ;
+                }
+
+                if ( out.contents ) 
+                    free( out.contents );
+            }
+            vmi_free_unicode_str( us );
+        }
+
+        next_module = tmp_next ;
+    }
+
+    return false ;
+}

--- a/src/libdrakvuf/drakvuf.c
+++ b/src/libdrakvuf/drakvuf.c
@@ -1,6 +1,6 @@
 /*********************IMPORTANT DRAKVUF LICENSE TERMS***********************
  *                                                                         *
- * DRAKVUF Dynamic Malware Analysis System (C) 2014-2015 Tamas K Lengyel.  *
+ * DRAKVUF Dynamic Malware Analysis System (C) 2014-2016 Tamas K Lengyel.  *
  * Tamas K Lengyel is hereinafter referred to as the author.               *
  * This program is free software; you may redistribute and/or modify it    *
  * under the terms of the GNU General Public License as published by the   *

--- a/src/libdrakvuf/injector.c
+++ b/src/libdrakvuf/injector.c
@@ -1,6 +1,6 @@
  /*********************IMPORTANT DRAKVUF LICENSE TERMS***********************
  *                                                                         *
- * DRAKVUF Dynamic Malware Analysis System (C) 2014-2015 Tamas K Lengyel.  *
+ * DRAKVUF Dynamic Malware Analysis System (C) 2014-2016 Tamas K Lengyel.  *
  * Tamas K Lengyel is hereinafter referred to as the author.               *
  * This program is free software; you may redistribute and/or modify it    *
  * under the terms of the GNU General Public License as published by the   *

--- a/src/libdrakvuf/injector.h
+++ b/src/libdrakvuf/injector.h
@@ -1,6 +1,6 @@
 /*********************IMPORTANT DRAKVUF LICENSE TERMS***********************
  *                                                                         *
- * DRAKVUF Dynamic Malware Analysis System (C) 2014-2015 Tamas K Lengyel.  *
+ * DRAKVUF Dynamic Malware Analysis System (C) 2014-2016 Tamas K Lengyel.  *
  * Tamas K Lengyel is hereinafter referred to as the author.               *
  * This program is free software; you may redistribute and/or modify it    *
  * under the terms of the GNU General Public License as published by the   *

--- a/src/libdrakvuf/libdrakvuf.h
+++ b/src/libdrakvuf/libdrakvuf.h
@@ -322,6 +322,11 @@ bool drakvuf_obj_ref_by_handle(drakvuf_t drakvuf,
                                object_manager_object_t obj_type_arg,
                                addr_t *obj_body_addr);
 
+bool drakvuf_get_module_base_addr( drakvuf_t drakvuf,
+                                   addr_t *module_list_head, 
+                                   char *module_name, 
+                                   addr_t *base_addr );
+
 #pragma GCC visibility pop
 
 #ifdef __cplusplus

--- a/src/libdrakvuf/libdrakvuf.h
+++ b/src/libdrakvuf/libdrakvuf.h
@@ -1,6 +1,6 @@
 /*********************IMPORTANT DRAKVUF LICENSE TERMS***********************
  *                                                                         *
- * DRAKVUF Dynamic Malware Analysis System (C) 2014-2015 Tamas K Lengyel.  *
+ * DRAKVUF Dynamic Malware Analysis System (C) 2014-2016 Tamas K Lengyel.  *
  * Tamas K Lengyel is hereinafter referred to as the author.               *
  * This program is free software; you may redistribute and/or modify it    *
  * under the terms of the GNU General Public License as published by the   *

--- a/src/libdrakvuf/libdrakvuf.h
+++ b/src/libdrakvuf/libdrakvuf.h
@@ -324,7 +324,7 @@ bool drakvuf_obj_ref_by_handle(drakvuf_t drakvuf,
 
 bool drakvuf_get_module_base_addr( drakvuf_t drakvuf,
                                    addr_t *module_list_head, 
-                                   char *module_name, 
+                                   const char *module_name, 
                                    addr_t *base_addr );
 
 #pragma GCC visibility pop

--- a/src/libdrakvuf/private.h
+++ b/src/libdrakvuf/private.h
@@ -1,6 +1,6 @@
 /*********************IMPORTANT DRAKVUF LICENSE TERMS***********************
  *                                                                         *
- * DRAKVUF Dynamic Malware Analysis System (C) 2014-2015 Tamas K Lengyel.  *
+ * DRAKVUF Dynamic Malware Analysis System (C) 2014-2016 Tamas K Lengyel.  *
  * Tamas K Lengyel is hereinafter referred to as the author.               *
  * This program is free software; you may redistribute and/or modify it    *
  * under the terms of the GNU General Public License as published by the   *

--- a/src/libdrakvuf/vmi.c
+++ b/src/libdrakvuf/vmi.c
@@ -1,6 +1,6 @@
 /*********************IMPORTANT DRAKVUF LICENSE TERMS***********************
  *                                                                         *
- * DRAKVUF Dynamic Malware Analysis System (C) 2014-2015 Tamas K Lengyel.  *
+ * DRAKVUF Dynamic Malware Analysis System (C) 2014-2016 Tamas K Lengyel.  *
  * Tamas K Lengyel is hereinafter referred to as the author.               *
  * This program is free software; you may redistribute and/or modify it    *
  * under the terms of the GNU General Public License as published by the   *

--- a/src/libdrakvuf/vmi.c
+++ b/src/libdrakvuf/vmi.c
@@ -824,6 +824,10 @@ bool init_vmi(drakvuf_t drakvuf) {
         g_hash_table_new_full(g_int64_hash, g_int64_equal, free, free);
     drakvuf->memaccess_lookup_trap =
         g_hash_table_new_full(g_int64_hash, g_int64_equal, free, NULL);
+    drakvuf->remapped_gfns =
+        g_hash_table_new_full(g_int64_hash, g_int64_equal, NULL, free);
+    drakvuf->remove_traps =
+        g_hash_table_new_full(g_int64_hash, g_int64_equal, free, NULL);
 
     // Get the offsets from the Rekall profile
     unsigned int i;
@@ -856,10 +860,18 @@ bool init_vmi(drakvuf_t drakvuf) {
         drakvuf->step_event[i] = g_malloc0(sizeof(vmi_event_t));
         SETUP_SINGLESTEP_EVENT(drakvuf->step_event[i], 1u << i, vmi_reset_trap, 0);
         drakvuf->step_event[i]->data = drakvuf;
-        vmi_register_event(drakvuf->vmi, drakvuf->step_event[i]);
+        if (VMI_FAILURE == vmi_register_event(drakvuf->vmi, drakvuf->step_event[i])) {
+            fprintf(stderr, "Failed to register singlestep for vCPU %u\n", i);
+            return 0;
+        }
     }
 
     rc = xc_domain_setmaxmem(drakvuf->xen->xc, drakvuf->domID, drakvuf->memsize+VMI_PS_4KB);
+    if ( rc ) {
+        fprintf(stderr, "Failed to increase max memory\n");
+        return 0;
+    }
+
     drakvuf->memsize+=VMI_PS_4KB;
 
     rc = xc_domain_increase_reservation_exact(drakvuf->xen->xc, drakvuf->domID, 1, 0, 0, &drakvuf->zero_page_gfn);
@@ -910,11 +922,6 @@ bool init_vmi(drakvuf_t drakvuf) {
 
     PRINT_DEBUG("Xen altp2m view created with idx: %u idr: %u\n", drakvuf->altp2m_idx, drakvuf->altp2m_idr);
 
-    drakvuf->remapped_gfns =
-        g_hash_table_new_full(g_int64_hash, g_int64_equal, NULL, free);
-    drakvuf->remove_traps =
-        g_hash_table_new_full(g_int64_hash, g_int64_equal, free, NULL);
-
     return 1;
 }
 
@@ -927,15 +934,16 @@ void close_vmi(drakvuf_t drakvuf) {
         drakvuf->vmi = NULL;
     }
 
-    do {
+    if(drakvuf->breakpoint_lookup_pa) {
         GHashTableIter i;
         addr_t *key = NULL;
         struct wrapper *s = NULL;
         ghashtable_foreach(drakvuf->breakpoint_lookup_pa, i, key, s)
             g_slist_free(s->traps);
-    } while (0);
+        g_hash_table_destroy(drakvuf->breakpoint_lookup_pa);
+    }
 
-    do {
+    if(drakvuf->guards) {
         GHashTableIter i;
         addr_t *key = NULL;
         vmi_event_t *guard = NULL;
@@ -945,14 +953,10 @@ void close_vmi(drakvuf_t drakvuf) {
             }
             free(guard);
         }
-    } while (0);
+        g_hash_table_destroy(drakvuf->guards);
+    }
 
-    g_hash_table_destroy(drakvuf->guards);
-    g_hash_table_destroy(drakvuf->guards2);
-    g_hash_table_destroy(drakvuf->breakpoint_lookup_pa);
-    g_hash_table_destroy(drakvuf->breakpoint_lookup_trap);
-
-    do {
+    if(drakvuf->memaccess_lookup_gfn) {
         GHashTableIter i;
         addr_t *key = NULL;
         struct wrapper *s = NULL;
@@ -961,32 +965,41 @@ void close_vmi(drakvuf_t drakvuf) {
             free(s->memaccess.memtrap);
             g_slist_free(s->traps);
         }
-    } while (0);
-
-    g_hash_table_destroy(drakvuf->memaccess_lookup_gfn);
-
-    unsigned int i3;
-    for (i3 = 0; i3 < drakvuf->vcpus; i3++) {
-        free(drakvuf->step_event[i3]);
+        g_hash_table_destroy(drakvuf->memaccess_lookup_gfn);
     }
 
-    do {
+    if(drakvuf->remapped_gfns) {
         GHashTableIter i;
         xen_pfn_t *key;
         struct remapped_gfn *remapped_gfn = NULL;
         ghashtable_foreach(drakvuf->remapped_gfns, i, key, remapped_gfn) {
             xc_domain_decrease_reservation_exact(drakvuf->xen->xc, drakvuf->domID, 1, 0, &remapped_gfn->r);
         }
-    } while (0);
+        g_hash_table_destroy(drakvuf->remapped_gfns);
+    };
+
+    if(drakvuf->guards2)
+        g_hash_table_destroy(drakvuf->guards2);
+    if(drakvuf->breakpoint_lookup_trap)
+        g_hash_table_destroy(drakvuf->breakpoint_lookup_trap);
+    if(drakvuf->remove_traps)
+        g_hash_table_destroy(drakvuf->remove_traps);
+
+    unsigned int i3;
+    for (i3 = 0; i3 < drakvuf->vcpus; i3++) {
+        free(drakvuf->step_event[i3]);
+    }
 
     xc_altp2m_switch_to_view(drakvuf->xen->xc, drakvuf->domID, 0);
-    xc_altp2m_destroy_view(drakvuf->xen->xc, drakvuf->domID, drakvuf->altp2m_idx);
-    xc_altp2m_destroy_view(drakvuf->xen->xc, drakvuf->domID, drakvuf->altp2m_idr);
+    if(drakvuf->altp2m_idx)
+        xc_altp2m_destroy_view(drakvuf->xen->xc, drakvuf->domID, drakvuf->altp2m_idx);
+    if(drakvuf->altp2m_idr)
+        xc_altp2m_destroy_view(drakvuf->xen->xc, drakvuf->domID, drakvuf->altp2m_idr);
     xc_altp2m_set_domain_state(drakvuf->xen->xc, drakvuf->domID, 0);
-    xc_domain_decrease_reservation_exact(drakvuf->xen->xc, drakvuf->domID, 1, 0, &drakvuf->zero_page_gfn);
+
+    if(drakvuf->zero_page_gfn)
+        xc_domain_decrease_reservation_exact(drakvuf->xen->xc, drakvuf->domID, 1, 0, &drakvuf->zero_page_gfn);
     xc_domain_setmaxmem(drakvuf->xen->xc, drakvuf->domID, drakvuf->init_memsize);
-    g_hash_table_destroy(drakvuf->remapped_gfns);
-    g_hash_table_destroy(drakvuf->remove_traps);
 
     PRINT_DEBUG("close_vmi_drakvuf finished\n");
 }

--- a/src/libdrakvuf/vmi.h
+++ b/src/libdrakvuf/vmi.h
@@ -1,6 +1,6 @@
 /*********************IMPORTANT DRAKVUF LICENSE TERMS***********************
  *                                                                         *
- * DRAKVUF Dynamic Malware Analysis System (C) 2014-2015 Tamas K Lengyel.  *
+ * DRAKVUF Dynamic Malware Analysis System (C) 2014-2016 Tamas K Lengyel.  *
  * Tamas K Lengyel is hereinafter referred to as the author.               *
  * This program is free software; you may redistribute and/or modify it    *
  * under the terms of the GNU General Public License as published by the   *

--- a/src/libdrakvuf/win-exports.c
+++ b/src/libdrakvuf/win-exports.c
@@ -1,6 +1,6 @@
 /*********************IMPORTANT DRAKVUF LICENSE TERMS***********************
  *                                                                         *
- * DRAKVUF Dynamic Malware Analysis System (C) 2014-2015 Tamas K Lengyel.  *
+ * DRAKVUF Dynamic Malware Analysis System (C) 2014-2016 Tamas K Lengyel.  *
  * Tamas K Lengyel is hereinafter referred to as the author.               *
  * This program is free software; you may redistribute and/or modify it    *
  * under the terms of the GNU General Public License as published by the   *

--- a/src/libdrakvuf/win-exports.h
+++ b/src/libdrakvuf/win-exports.h
@@ -1,6 +1,6 @@
 /*********************IMPORTANT DRAKVUF LICENSE TERMS***********************
  *                                                                         *
- * DRAKVUF Dynamic Malware Analysis System (C) 2014-2015 Tamas K Lengyel.  *
+ * DRAKVUF Dynamic Malware Analysis System (C) 2014-2016 Tamas K Lengyel.  *
  * Tamas K Lengyel is hereinafter referred to as the author.               *
  * This program is free software; you may redistribute and/or modify it    *
  * under the terms of the GNU General Public License as published by the   *

--- a/src/libdrakvuf/win-handles.c
+++ b/src/libdrakvuf/win-handles.c
@@ -1,6 +1,6 @@
 /*********************IMPORTANT DRAKVUF LICENSE TERMS***********************
  *                                                                         *
- * DRAKVUF Dynamic Malware Analysis System (C) 2014-2015 Tamas K Lengyel.  *
+ * DRAKVUF Dynamic Malware Analysis System (C) 2014-2016 Tamas K Lengyel.  *
  * Tamas K Lengyel is hereinafter referred to as the author.               *
  * This program is free software; you may redistribute and/or modify it    *
  * under the terms of the GNU General Public License as published by the   *

--- a/src/libdrakvuf/win-handles.h
+++ b/src/libdrakvuf/win-handles.h
@@ -1,6 +1,6 @@
 /*********************IMPORTANT DRAKVUF LICENSE TERMS***********************
  *                                                                         *
- * DRAKVUF Dynamic Malware Analysis System (C) 2014-2015 Tamas K Lengyel.  *
+ * DRAKVUF Dynamic Malware Analysis System (C) 2014-2016 Tamas K Lengyel.  *
  * Tamas K Lengyel is hereinafter referred to as the author.               *
  * This program is free software; you may redistribute and/or modify it    *
  * under the terms of the GNU General Public License as published by the   *

--- a/src/libdrakvuf/win-processes.c
+++ b/src/libdrakvuf/win-processes.c
@@ -1,6 +1,6 @@
 /*********************IMPORTANT DRAKVUF LICENSE TERMS***********************
  *                                                                         *
- * DRAKVUF Dynamic Malware Analysis System (C) 2014-2015 Tamas K Lengyel.  *
+ * DRAKVUF Dynamic Malware Analysis System (C) 2014-2016 Tamas K Lengyel.  *
  * Tamas K Lengyel is hereinafter referred to as the author.               *
  * This program is free software; you may redistribute and/or modify it    *
  * under the terms of the GNU General Public License as published by the   *

--- a/src/libdrakvuf/win-symbols.c
+++ b/src/libdrakvuf/win-symbols.c
@@ -1,6 +1,6 @@
 /*********************IMPORTANT DRAKVUF LICENSE TERMS***********************
  *                                                                         *
- * DRAKVUF Dynamic Malware Analysis System (C) 2014-2015 Tamas K Lengyel.  *
+ * DRAKVUF Dynamic Malware Analysis System (C) 2014-2016 Tamas K Lengyel.  *
  * Tamas K Lengyel is hereinafter referred to as the author.               *
  * This program is free software; you may redistribute and/or modify it    *
  * under the terms of the GNU General Public License as published by the   *

--- a/src/libdrakvuf/win-symbols.h
+++ b/src/libdrakvuf/win-symbols.h
@@ -1,6 +1,6 @@
 /*********************IMPORTANT DRAKVUF LICENSE TERMS***********************
  *                                                                         *
- * DRAKVUF Dynamic Malware Analysis System (C) 2014-2015 Tamas K Lengyel.  *
+ * DRAKVUF Dynamic Malware Analysis System (C) 2014-2016 Tamas K Lengyel.  *
  * Tamas K Lengyel is hereinafter referred to as the author.               *
  * This program is free software; you may redistribute and/or modify it    *
  * under the terms of the GNU General Public License as published by the   *

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,6 @@
 /*********************IMPORTANT DRAKVUF LICENSE TERMS***********************
  *                                                                         *
- * DRAKVUF Dynamic Malware Analysis System (C) 2014-2015 Tamas K Lengyel.  *
+ * DRAKVUF Dynamic Malware Analysis System (C) 2014-2016 Tamas K Lengyel.  *
  * Tamas K Lengyel is hereinafter referred to as the author.               *
  * This program is free software; you may redistribute and/or modify it    *
  * under the terms of the GNU General Public License as published by the   *

--- a/src/plugins/Makefile.am
+++ b/src/plugins/Makefile.am
@@ -1,106 +1,106 @@
 #********************IMPORTANT DRAKVUF LICENSE TERMS**********************#
- #                                                                         #
- # DRAKVUF Dynamic Malware Analysis System (C) 2014-2015 Tamas K Lengyel.  #
- # Tamas K Lengyel is hereinafter referred to as the author.               #
- # This program is free software; you may redistribute and/or modify it    #
- # under the terms of the GNU General Public License as published by the   #
- # Free Software Foundation; Version 2 ("GPL"), BUT ONLY WITH ALL OF THE   #
- # CLARIFICATIONS AND EXCEPTIONS DESCRIBED HEREIN.  This guarantees your   #
- # right to use, modify, and redistribute this software under certain      #
- # conditions.  If you wish to embed DRAKVUF technology into proprietary   #
- # software, alternative licenses can be aquired from the author.          #
- #                                                                         #
- # Note that the GPL places important restrictions on "derivative works",  #
- # yet it does not provide a detailed definition of that term.  To avoid   #
- # misunderstandings, we interpret that term as broadly as copyright law   #
- # allows.  For example, we consider an application to constitute a        #
- # derivative work for the purpose of this license if it does any of the   #
- # following with any software or content covered by this license          #
- # ("Covered Software"):                                                   #
- #                                                                         #
- # o Integrates source code from Covered Software.                         #
- #                                                                         #
- # o Reads or includes copyrighted data files.                             #
- #                                                                         #
- # o Is designed specifically to execute Covered Software and parse the    #
- # results (as opposed to typical shell or execution-menu apps, which will #
- # execute anything you tell them to).                                     #
- #                                                                         #
- # o Includes Covered Software in a proprietary executable installer.  The #
- # installers produced by InstallShield are an example of this.  Including #
- # DRAKVUF with other software in compressed or archival form does not     #
- # trigger this provision, provided appropriate open source decompression  #
- # or de-archiving software is widely available for no charge.  For the    #
- # purposes of this license, an installer is considered to include Covered #
- # Software even if it actually retrieves a copy of Covered Software from  #
- # another source during runtime (such as by downloading it from the       #
- # Internet).                                                              #
- #                                                                         #
- # o Links (statically or dynamically) to a library which does any of the  #
- # above.                                                                  #
- #                                                                         #
- # o Executes a helper program, module, or script to do any of the above.  #
- #                                                                         #
- # This list is not exclusive, but is meant to clarify our interpretation  #
- # of derived works with some common examples.  Other people may interpret #
- # the plain GPL differently, so we consider this a special exception to   #
- # the GPL that we apply to Covered Software.  Works which meet any of     #
- # these conditions must conform to all of the terms of this license,      #
- # particularly including the GPL Section 3 requirements of providing      #
- # source code and allowing free redistribution of the work as a whole.    #
- #                                                                         #
- # Any redistribution of Covered Software, including any derived works,    #
- # must obey and carry forward all of the terms of this license, including #
- # obeying all GPL rules and restrictions.  For example, source code of    #
- # the whole work must be provided and free redistribution must be         #
- # allowed.  All GPL references to "this License", are to be treated as    #
- # including the terms and conditions of this license text as well.        #
- #                                                                         #
- # Because this license imposes special exceptions to the GPL, Covered     #
- # Work may not be combined (even as part of a larger work) with plain GPL #
- # software.  The terms, conditions, and exceptions of this license must   #
- # be included as well.  This license is incompatible with some other open #
- # source licenses as well.  In some cases we can relicense portions of    #
- # DRAKVUF or grant special permissions to use it in other open source     #
- # software.  Please contact tamas.k.lengyel@gmail.com with any such       #
- # requests.  Similarly, we don't incorporate incompatible open source     #
- # software into Covered Software without special permission from the      #
- # copyright holders.                                                      #
- #                                                                         #
- # If you have any questions about the licensing restrictions on using     #
- # DRAKVUF in other works, are happy to help.  As mentioned above,         #
- # alternative license can be requested from the author to integrate       #
- # DRAKVUF into proprietary applications and appliances.  Please email     #
- # tamas.k.lengyel@gmail.com for further information.                      #
- #                                                                         #
- # If you have received a written license agreement or contract for        #
- # Covered Software stating terms other than these, you may choose to use  #
- # and redistribute Covered Software under those terms instead of these.   #
- #                                                                         #
- # Source is provided to this software because we believe users have a     #
- # right to know exactly what a program is going to do before they run it. #
- # This also allows you to audit the software for security holes.          #
- #                                                                         #
- # Source code also allows you to port DRAKVUF to new platforms, fix bugs, #
- # and add new features.  You are highly encouraged to submit your changes #
- # on https://github.com/tklengyel/drakvuf, or by other methods.           #
- # By sending these changes, it is understood (unless you specify          #
- # otherwise) that you are offering unlimited, non-exclusive right to      #
- # reuse, modify, and relicense the code.  DRAKVUF will always be          #
- # available Open Source, but this is important because the inability to   #
- # relicense code has caused devastating problems for other Free Software  #
- # projects (such as KDE and NASM).                                        #
- # To specify special license conditions of your contributions, just say   #
- # so when you send them.                                                  #
- #                                                                         #
- # This program is distributed in the hope that it will be useful, but     #
- # WITHOUT ANY WARRANTY; without even the implied warranty of              #
- # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the DRAKVUF   #
- # license file for more details (it's in a COPYING file included with     #
- # DRAKVUF, and also available from                                        #
- # https://github.com/tklengyel/drakvuf/COPYING)                           #
- #                                                                         #
- #*************************************************************************# 
+#                                                                         #
+# DRAKVUF Dynamic Malware Analysis System (C) 2014-2016 Tamas K Lengyel.  #
+# Tamas K Lengyel is hereinafter referred to as the author.               #
+# This program is free software; you may redistribute and/or modify it    #
+# under the terms of the GNU General Public License as published by the   #
+# Free Software Foundation; Version 2 ("GPL"), BUT ONLY WITH ALL OF THE   #
+# CLARIFICATIONS AND EXCEPTIONS DESCRIBED HEREIN.  This guarantees your   #
+# right to use, modify, and redistribute this software under certain      #
+# conditions.  If you wish to embed DRAKVUF technology into proprietary   #
+# software, alternative licenses can be aquired from the author.          #
+#                                                                         #
+# Note that the GPL places important restrictions on "derivative works",  #
+# yet it does not provide a detailed definition of that term.  To avoid   #
+# misunderstandings, we interpret that term as broadly as copyright law   #
+# allows.  For example, we consider an application to constitute a        #
+# derivative work for the purpose of this license if it does any of the   #
+# following with any software or content covered by this license          #
+# ("Covered Software"):                                                   #
+#                                                                         #
+# o Integrates source code from Covered Software.                         #
+#                                                                         #
+# o Reads or includes copyrighted data files.                             #
+#                                                                         #
+# o Is designed specifically to execute Covered Software and parse the    #
+# results (as opposed to typical shell or execution-menu apps, which will #
+# execute anything you tell them to).                                     #
+#                                                                         #
+# o Includes Covered Software in a proprietary executable installer.  The #
+# installers produced by InstallShield are an example of this.  Including #
+# DRAKVUF with other software in compressed or archival form does not     #
+# trigger this provision, provided appropriate open source decompression  #
+# or de-archiving software is widely available for no charge.  For the    #
+# purposes of this license, an installer is considered to include Covered #
+# Software even if it actually retrieves a copy of Covered Software from  #
+# another source during runtime (such as by downloading it from the       #
+# Internet).                                                              #
+#                                                                         #
+# o Links (statically or dynamically) to a library which does any of the  #
+# above.                                                                  #
+#                                                                         #
+# o Executes a helper program, module, or script to do any of the above.  #
+#                                                                         #
+# This list is not exclusive, but is meant to clarify our interpretation  #
+# of derived works with some common examples.  Other people may interpret #
+# the plain GPL differently, so we consider this a special exception to   #
+# the GPL that we apply to Covered Software.  Works which meet any of     #
+# these conditions must conform to all of the terms of this license,      #
+# particularly including the GPL Section 3 requirements of providing      #
+# source code and allowing free redistribution of the work as a whole.    #
+#                                                                         #
+# Any redistribution of Covered Software, including any derived works,    #
+# must obey and carry forward all of the terms of this license, including #
+# obeying all GPL rules and restrictions.  For example, source code of    #
+# the whole work must be provided and free redistribution must be         #
+# allowed.  All GPL references to "this License", are to be treated as    #
+# including the terms and conditions of this license text as well.        #
+#                                                                         #
+# Because this license imposes special exceptions to the GPL, Covered     #
+# Work may not be combined (even as part of a larger work) with plain GPL #
+# software.  The terms, conditions, and exceptions of this license must   #
+# be included as well.  This license is incompatible with some other open #
+# source licenses as well.  In some cases we can relicense portions of    #
+# DRAKVUF or grant special permissions to use it in other open source     #
+# software.  Please contact tamas.k.lengyel@gmail.com with any such       #
+# requests.  Similarly, we don't incorporate incompatible open source     #
+# software into Covered Software without special permission from the      #
+# copyright holders.                                                      #
+#                                                                         #
+# If you have any questions about the licensing restrictions on using     #
+# DRAKVUF in other works, are happy to help.  As mentioned above,         #
+# alternative license can be requested from the author to integrate       #
+# DRAKVUF into proprietary applications and appliances.  Please email     #
+# tamas.k.lengyel@gmail.com for further information.                      #
+#                                                                         #
+# If you have received a written license agreement or contract for        #
+# Covered Software stating terms other than these, you may choose to use  #
+# and redistribute Covered Software under those terms instead of these.   #
+#                                                                         #
+# Source is provided to this software because we believe users have a     #
+# right to know exactly what a program is going to do before they run it. #
+# This also allows you to audit the software for security holes.          #
+#                                                                         #
+# Source code also allows you to port DRAKVUF to new platforms, fix bugs, #
+# and add new features.  You are highly encouraged to submit your changes #
+# on https://github.com/tklengyel/drakvuf, or by other methods.           #
+# By sending these changes, it is understood (unless you specify          #
+# otherwise) that you are offering unlimited, non-exclusive right to      #
+# reuse, modify, and relicense the code.  DRAKVUF will always be          #
+# available Open Source, but this is important because the inability to   #
+# relicense code has caused devastating problems for other Free Software  #
+# projects (such as KDE and NASM).                                        #
+# To specify special license conditions of your contributions, just say   #
+# so when you send them.                                                  #
+#                                                                         #
+# This program is distributed in the hope that it will be useful, but     #
+# WITHOUT ANY WARRANTY; without even the implied warranty of              #
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the DRAKVUF   #
+# license file for more details (it's in a COPYING file included with     #
+# DRAKVUF, and also available from                                        #
+# https://github.com/tklengyel/drakvuf/COPYING)                           #
+#                                                                         #
+#*************************************************************************# 
 
 sources =
 

--- a/src/plugins/exmon/exmon.cpp
+++ b/src/plugins/exmon/exmon.cpp
@@ -1,6 +1,6 @@
 /*********************IMPORTANT DRAKVUF LICENSE TERMS***********************
  *                                                                         *
- * DRAKVUF Dynamic Malware Analysis System (C) 2014-2015 Tamas K Lengyel.  *
+ * DRAKVUF Dynamic Malware Analysis System (C) 2014-2016 Tamas K Lengyel.  *
  * Tamas K Lengyel is hereinafter referred to as the author.               *
  * This program is free software; you may redistribute and/or modify it    *
  * under the terms of the GNU General Public License as published by the   *

--- a/src/plugins/exmon/exmon.h
+++ b/src/plugins/exmon/exmon.h
@@ -1,6 +1,6 @@
 /*********************IMPORTANT DRAKVUF LICENSE TERMS***********************
  *                                                                         *
- * DRAKVUF Dynamic Malware Analysis System (C) 2014-2015 Tamas K Lengyel.  *
+ * DRAKVUF Dynamic Malware Analysis System (C) 2014-2016 Tamas K Lengyel.  *
  * Tamas K Lengyel is hereinafter referred to as the author.               *
  * This program is free software; you may redistribute and/or modify it    *
  * under the terms of the GNU General Public License as published by the   *

--- a/src/plugins/exmon/private.h
+++ b/src/plugins/exmon/private.h
@@ -1,6 +1,6 @@
 /*********************IMPORTANT DRAKVUF LICENSE TERMS***********************
  *                                                                         *
- * DRAKVUF Dynamic Malware Analysis System (C) 2014-2015 Tamas K Lengyel.  *
+ * DRAKVUF Dynamic Malware Analysis System (C) 2014-2016 Tamas K Lengyel.  *
  * Tamas K Lengyel is hereinafter referred to as the author.               *
  * This program is free software; you may redistribute and/or modify it    *
  * under the terms of the GNU General Public License as published by the   *

--- a/src/plugins/filedelete/filedelete.cpp
+++ b/src/plugins/filedelete/filedelete.cpp
@@ -1,6 +1,6 @@
 /*********************IMPORTANT DRAKVUF LICENSE TERMS***********************
  *                                                                         *
- * DRAKVUF Dynamic Malware Analysis System (C) 2014-2015 Tamas K Lengyel.  *
+ * DRAKVUF Dynamic Malware Analysis System (C) 2014-2016 Tamas K Lengyel.  *
  * Tamas K Lengyel is hereinafter referred to as the author.               *
  * This program is free software; you may redistribute and/or modify it    *
  * under the terms of the GNU General Public License as published by the   *

--- a/src/plugins/filedelete/filedelete.h
+++ b/src/plugins/filedelete/filedelete.h
@@ -1,6 +1,6 @@
 /*********************IMPORTANT DRAKVUF LICENSE TERMS***********************
  *                                                                         *
- * DRAKVUF Dynamic Malware Analysis System (C) 2014-2015 Tamas K Lengyel.  *
+ * DRAKVUF Dynamic Malware Analysis System (C) 2014-2016 Tamas K Lengyel.  *
  * Tamas K Lengyel is hereinafter referred to as the author.               *
  * This program is free software; you may redistribute and/or modify it    *
  * under the terms of the GNU General Public License as published by the   *

--- a/src/plugins/filetracer/filetracer.cpp
+++ b/src/plugins/filetracer/filetracer.cpp
@@ -1,6 +1,6 @@
 /*********************IMPORTANT DRAKVUF LICENSE TERMS***********************
  *                                                                         *
- * DRAKVUF Dynamic Malware Analysis System (C) 2014-2015 Tamas K Lengyel.  *
+ * DRAKVUF Dynamic Malware Analysis System (C) 2014-2016 Tamas K Lengyel.  *
  * Tamas K Lengyel is hereinafter referred to as the author.               *
  * This program is free software; you may redistribute and/or modify it    *
  * under the terms of the GNU General Public License as published by the   *

--- a/src/plugins/filetracer/filetracer.h
+++ b/src/plugins/filetracer/filetracer.h
@@ -1,6 +1,6 @@
 /*********************IMPORTANT DRAKVUF LICENSE TERMS***********************
  *                                                                         *
- * DRAKVUF Dynamic Malware Analysis System (C) 2014-2015 Tamas K Lengyel.  *
+ * DRAKVUF Dynamic Malware Analysis System (C) 2014-2016 Tamas K Lengyel.  *
  * Tamas K Lengyel is hereinafter referred to as the author.               *
  * This program is free software; you may redistribute and/or modify it    *
  * under the terms of the GNU General Public License as published by the   *

--- a/src/plugins/filetracer/private.h
+++ b/src/plugins/filetracer/private.h
@@ -1,6 +1,6 @@
 /*********************IMPORTANT DRAKVUF LICENSE TERMS***********************
  *                                                                         *
- * DRAKVUF Dynamic Malware Analysis System (C) 2014-2015 Tamas K Lengyel.  *
+ * DRAKVUF Dynamic Malware Analysis System (C) 2014-2016 Tamas K Lengyel.  *
  * Tamas K Lengyel is hereinafter referred to as the author.               *
  * This program is free software; you may redistribute and/or modify it    *
  * under the terms of the GNU General Public License as published by the   *

--- a/src/plugins/objmon/objmon.cpp
+++ b/src/plugins/objmon/objmon.cpp
@@ -1,6 +1,6 @@
 /*********************IMPORTANT DRAKVUF LICENSE TERMS***********************
  *                                                                         *
- * DRAKVUF Dynamic Malware Analysis System (C) 2014-2015 Tamas K Lengyel.  *
+ * DRAKVUF Dynamic Malware Analysis System (C) 2014-2016 Tamas K Lengyel.  *
  * Tamas K Lengyel is hereinafter referred to as the author.               *
  * This program is free software; you may redistribute and/or modify it    *
  * under the terms of the GNU General Public License as published by the   *

--- a/src/plugins/objmon/objmon.h
+++ b/src/plugins/objmon/objmon.h
@@ -1,6 +1,6 @@
 /*********************IMPORTANT DRAKVUF LICENSE TERMS***********************
  *                                                                         *
- * DRAKVUF Dynamic Malware Analysis System (C) 2014-2015 Tamas K Lengyel.  *
+ * DRAKVUF Dynamic Malware Analysis System (C) 2014-2016 Tamas K Lengyel.  *
  * Tamas K Lengyel is hereinafter referred to as the author.               *
  * This program is free software; you may redistribute and/or modify it    *
  * under the terms of the GNU General Public License as published by the   *

--- a/src/plugins/objmon/private.h
+++ b/src/plugins/objmon/private.h
@@ -1,6 +1,6 @@
 /*********************IMPORTANT DRAKVUF LICENSE TERMS***********************
  *                                                                         *
- * DRAKVUF Dynamic Malware Analysis System (C) 2014-2015 Tamas K Lengyel.  *
+ * DRAKVUF Dynamic Malware Analysis System (C) 2014-2016 Tamas K Lengyel.  *
  * Tamas K Lengyel is hereinafter referred to as the author.               *
  * This program is free software; you may redistribute and/or modify it    *
  * under the terms of the GNU General Public License as published by the   *

--- a/src/plugins/plugins.cpp
+++ b/src/plugins/plugins.cpp
@@ -1,6 +1,6 @@
 /*********************IMPORTANT DRAKVUF LICENSE TERMS***********************
  *                                                                         *
- * DRAKVUF Dynamic Malware Analysis System (C) 2014-2015 Tamas K Lengyel.  *
+ * DRAKVUF Dynamic Malware Analysis System (C) 2014-2016 Tamas K Lengyel.  *
  * Tamas K Lengyel is hereinafter referred to as the author.               *
  * This program is free software; you may redistribute and/or modify it    *
  * under the terms of the GNU General Public License as published by the   *

--- a/src/plugins/plugins.h
+++ b/src/plugins/plugins.h
@@ -1,6 +1,6 @@
 /*********************IMPORTANT DRAKVUF LICENSE TERMS***********************
  *                                                                         *
- * DRAKVUF Dynamic Malware Analysis System (C) 2014-2015 Tamas K Lengyel.  *
+ * DRAKVUF Dynamic Malware Analysis System (C) 2014-2016 Tamas K Lengyel.  *
  * Tamas K Lengyel is hereinafter referred to as the author.               *
  * This program is free software; you may redistribute and/or modify it    *
  * under the terms of the GNU General Public License as published by the   *

--- a/src/plugins/poolmon/poolmon.cpp
+++ b/src/plugins/poolmon/poolmon.cpp
@@ -1,6 +1,6 @@
 /*********************IMPORTANT DRAKVUF LICENSE TERMS***********************
  *                                                                         *
- * DRAKVUF Dynamic Malware Analysis System (C) 2014-2015 Tamas K Lengyel.  *
+ * DRAKVUF Dynamic Malware Analysis System (C) 2014-2016 Tamas K Lengyel.  *
  * Tamas K Lengyel is hereinafter referred to as the author.               *
  * This program is free software; you may redistribute and/or modify it    *
  * under the terms of the GNU General Public License as published by the   *

--- a/src/plugins/poolmon/poolmon.h
+++ b/src/plugins/poolmon/poolmon.h
@@ -1,6 +1,6 @@
 /*********************IMPORTANT DRAKVUF LICENSE TERMS***********************
  *                                                                         *
- * DRAKVUF Dynamic Malware Analysis System (C) 2014-2015 Tamas K Lengyel.  *
+ * DRAKVUF Dynamic Malware Analysis System (C) 2014-2016 Tamas K Lengyel.  *
  * Tamas K Lengyel is hereinafter referred to as the author.               *
  * This program is free software; you may redistribute and/or modify it    *
  * under the terms of the GNU General Public License as published by the   *

--- a/src/plugins/poolmon/private.h
+++ b/src/plugins/poolmon/private.h
@@ -1,6 +1,6 @@
 /*********************IMPORTANT DRAKVUF LICENSE TERMS***********************
  *                                                                         *
- * DRAKVUF Dynamic Malware Analysis System (C) 2014-2015 Tamas K Lengyel.  *
+ * DRAKVUF Dynamic Malware Analysis System (C) 2014-2016 Tamas K Lengyel.  *
  * Tamas K Lengyel is hereinafter referred to as the author.               *
  * This program is free software; you may redistribute and/or modify it    *
  * under the terms of the GNU General Public License as published by the   *

--- a/src/plugins/syscalls/scproto.h
+++ b/src/plugins/syscalls/scproto.h
@@ -1,6 +1,6 @@
 /*********************IMPORTANT DRAKVUF LICENSE TERMS***********************
  *                                                                         *
- * DRAKVUF Dynamic Malware Analysis System (C) 2014-2015 Tamas K Lengyel.  *
+ * DRAKVUF Dynamic Malware Analysis System (C) 2014-2016 Tamas K Lengyel.  *
  * Tamas K Lengyel is hereinafter referred to as the author.               *
  * This program is free software; you may redistribute and/or modify it    *
  * under the terms of the GNU General Public License as published by the   *

--- a/src/plugins/syscalls/syscalls.cpp
+++ b/src/plugins/syscalls/syscalls.cpp
@@ -1,6 +1,6 @@
 /*********************IMPORTANT DRAKVUF LICENSE TERMS***********************
  *                                                                         *
- * DRAKVUF Dynamic Malware Analysis System (C) 2014-2015 Tamas K Lengyel.  *
+ * DRAKVUF Dynamic Malware Analysis System (C) 2014-2016 Tamas K Lengyel.  *
  * Tamas K Lengyel is hereinafter referred to as the author.               *
  * This program is free software; you may redistribute and/or modify it    *
  * under the terms of the GNU General Public License as published by the   *

--- a/src/plugins/syscalls/syscalls.h
+++ b/src/plugins/syscalls/syscalls.h
@@ -1,6 +1,6 @@
 /*********************IMPORTANT DRAKVUF LICENSE TERMS***********************
  *                                                                         *
- * DRAKVUF Dynamic Malware Analysis System (C) 2014-2015 Tamas K Lengyel.  *
+ * DRAKVUF Dynamic Malware Analysis System (C) 2014-2016 Tamas K Lengyel.  *
  * Tamas K Lengyel is hereinafter referred to as the author.               *
  * This program is free software; you may redistribute and/or modify it    *
  * under the terms of the GNU General Public License as published by the   *

--- a/src/xen_helper/Makefile.am
+++ b/src/xen_helper/Makefile.am
@@ -1,106 +1,106 @@
- #********************IMPORTANT DRAKVUF LICENSE TERMS**********************#
- #                                                                         #
- # DRAKVUF Dynamic Malware Analysis System (C) 2014-2015 Tamas K Lengyel.  #
- # Tamas K Lengyel is hereinafter referred to as the author.               #
- # This program is free software; you may redistribute and/or modify it    #
- # under the terms of the GNU General Public License as published by the   #
- # Free Software Foundation; Version 2 ("GPL"), BUT ONLY WITH ALL OF THE   #
- # CLARIFICATIONS AND EXCEPTIONS DESCRIBED HEREIN.  This guarantees your   #
- # right to use, modify, and redistribute this software under certain      #
- # conditions.  If you wish to embed DRAKVUF technology into proprietary   #
- # software, alternative licenses can be aquired from the author.          #
- #                                                                         #
- # Note that the GPL places important restrictions on "derivative works",  #
- # yet it does not provide a detailed definition of that term.  To avoid   #
- # misunderstandings, we interpret that term as broadly as copyright law   #
- # allows.  For example, we consider an application to constitute a        #
- # derivative work for the purpose of this license if it does any of the   #
- # following with any software or content covered by this license          #
- # ("Covered Software"):                                                   #
- #                                                                         #
- # o Integrates source code from Covered Software.                         #
- #                                                                         #
- # o Reads or includes copyrighted data files.                             #
- #                                                                         #
- # o Is designed specifically to execute Covered Software and parse the    #
- # results (as opposed to typical shell or execution-menu apps, which will #
- # execute anything you tell them to).                                     #
- #                                                                         #
- # o Includes Covered Software in a proprietary executable installer.  The #
- # installers produced by InstallShield are an example of this.  Including #
- # DRAKVUF with other software in compressed or archival form does not     #
- # trigger this provision, provided appropriate open source decompression  #
- # or de-archiving software is widely available for no charge.  For the    #
- # purposes of this license, an installer is considered to include Covered #
- # Software even if it actually retrieves a copy of Covered Software from  #
- # another source during runtime (such as by downloading it from the       #
- # Internet).                                                              #
- #                                                                         #
- # o Links (statically or dynamically) to a library which does any of the  #
- # above.                                                                  #
- #                                                                         #
- # o Executes a helper program, module, or script to do any of the above.  #
- #                                                                         #
- # This list is not exclusive, but is meant to clarify our interpretation  #
- # of derived works with some common examples.  Other people may interpret #
- # the plain GPL differently, so we consider this a special exception to   #
- # the GPL that we apply to Covered Software.  Works which meet any of     #
- # these conditions must conform to all of the terms of this license,      #
- # particularly including the GPL Section 3 requirements of providing      #
- # source code and allowing free redistribution of the work as a whole.    #
- #                                                                         #
- # Any redistribution of Covered Software, including any derived works,    #
- # must obey and carry forward all of the terms of this license, including #
- # obeying all GPL rules and restrictions.  For example, source code of    #
- # the whole work must be provided and free redistribution must be         #
- # allowed.  All GPL references to "this License", are to be treated as    #
- # including the terms and conditions of this license text as well.        #
- #                                                                         #
- # Because this license imposes special exceptions to the GPL, Covered     #
- # Work may not be combined (even as part of a larger work) with plain GPL #
- # software.  The terms, conditions, and exceptions of this license must   #
- # be included as well.  This license is incompatible with some other open #
- # source licenses as well.  In some cases we can relicense portions of    #
- # DRAKVUF or grant special permissions to use it in other open source     #
- # software.  Please contact tamas.k.lengyel@gmail.com with any such       #
- # requests.  Similarly, we don't incorporate incompatible open source     #
- # software into Covered Software without special permission from the      #
- # copyright holders.                                                      #
- #                                                                         #
- # If you have any questions about the licensing restrictions on using     #
- # DRAKVUF in other works, are happy to help.  As mentioned above,         #
- # alternative license can be requested from the author to integrate       #
- # DRAKVUF into proprietary applications and appliances.  Please email     #
- # tamas.k.lengyel@gmail.com for further information.                      #
- #                                                                         #
- # If you have received a written license agreement or contract for        #
- # Covered Software stating terms other than these, you may choose to use  #
- # and redistribute Covered Software under those terms instead of these.   #
- #                                                                         #
- # Source is provided to this software because we believe users have a     #
- # right to know exactly what a program is going to do before they run it. #
- # This also allows you to audit the software for security holes.          #
- #                                                                         #
- # Source code also allows you to port DRAKVUF to new platforms, fix bugs, #
- # and add new features.  You are highly encouraged to submit your changes #
- # on https://github.com/tklengyel/drakvuf, or by other methods.           #
- # By sending these changes, it is understood (unless you specify          #
- # otherwise) that you are offering unlimited, non-exclusive right to      #
- # reuse, modify, and relicense the code.  DRAKVUF will always be          #
- # available Open Source, but this is important because the inability to   #
- # relicense code has caused devastating problems for other Free Software  #
- # projects (such as KDE and NASM).                                        #
- # To specify special license conditions of your contributions, just say   #
- # so when you send them.                                                  #
- #                                                                         #
- # This program is distributed in the hope that it will be useful, but     #
- # WITHOUT ANY WARRANTY; without even the implied warranty of              #
- # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the DRAKVUF   #
- # license file for more details (it's in a COPYING file included with     #
- # DRAKVUF, and also available from                                        #
- # https://github.com/tklengyel/drakvuf/COPYING)                           #
- #                                                                         #
- #*************************************************************************# 
+#********************IMPORTANT DRAKVUF LICENSE TERMS**********************#
+#                                                                         #
+# DRAKVUF Dynamic Malware Analysis System (C) 2014-2016 Tamas K Lengyel.  #
+# Tamas K Lengyel is hereinafter referred to as the author.               #
+# This program is free software; you may redistribute and/or modify it    #
+# under the terms of the GNU General Public License as published by the   #
+# Free Software Foundation; Version 2 ("GPL"), BUT ONLY WITH ALL OF THE   #
+# CLARIFICATIONS AND EXCEPTIONS DESCRIBED HEREIN.  This guarantees your   #
+# right to use, modify, and redistribute this software under certain      #
+# conditions.  If you wish to embed DRAKVUF technology into proprietary   #
+# software, alternative licenses can be aquired from the author.          #
+#                                                                         #
+# Note that the GPL places important restrictions on "derivative works",  #
+# yet it does not provide a detailed definition of that term.  To avoid   #
+# misunderstandings, we interpret that term as broadly as copyright law   #
+# allows.  For example, we consider an application to constitute a        #
+# derivative work for the purpose of this license if it does any of the   #
+# following with any software or content covered by this license          #
+# ("Covered Software"):                                                   #
+#                                                                         #
+# o Integrates source code from Covered Software.                         #
+#                                                                         #
+# o Reads or includes copyrighted data files.                             #
+#                                                                         #
+# o Is designed specifically to execute Covered Software and parse the    #
+# results (as opposed to typical shell or execution-menu apps, which will #
+# execute anything you tell them to).                                     #
+#                                                                         #
+# o Includes Covered Software in a proprietary executable installer.  The #
+# installers produced by InstallShield are an example of this.  Including #
+# DRAKVUF with other software in compressed or archival form does not     #
+# trigger this provision, provided appropriate open source decompression  #
+# or de-archiving software is widely available for no charge.  For the    #
+# purposes of this license, an installer is considered to include Covered #
+# Software even if it actually retrieves a copy of Covered Software from  #
+# another source during runtime (such as by downloading it from the       #
+# Internet).                                                              #
+#                                                                         #
+# o Links (statically or dynamically) to a library which does any of the  #
+# above.                                                                  #
+#                                                                         #
+# o Executes a helper program, module, or script to do any of the above.  #
+#                                                                         #
+# This list is not exclusive, but is meant to clarify our interpretation  #
+# of derived works with some common examples.  Other people may interpret #
+# the plain GPL differently, so we consider this a special exception to   #
+# the GPL that we apply to Covered Software.  Works which meet any of     #
+# these conditions must conform to all of the terms of this license,      #
+# particularly including the GPL Section 3 requirements of providing      #
+# source code and allowing free redistribution of the work as a whole.    #
+#                                                                         #
+# Any redistribution of Covered Software, including any derived works,    #
+# must obey and carry forward all of the terms of this license, including #
+# obeying all GPL rules and restrictions.  For example, source code of    #
+# the whole work must be provided and free redistribution must be         #
+# allowed.  All GPL references to "this License", are to be treated as    #
+# including the terms and conditions of this license text as well.        #
+#                                                                         #
+# Because this license imposes special exceptions to the GPL, Covered     #
+# Work may not be combined (even as part of a larger work) with plain GPL #
+# software.  The terms, conditions, and exceptions of this license must   #
+# be included as well.  This license is incompatible with some other open #
+# source licenses as well.  In some cases we can relicense portions of    #
+# DRAKVUF or grant special permissions to use it in other open source     #
+# software.  Please contact tamas.k.lengyel@gmail.com with any such       #
+# requests.  Similarly, we don't incorporate incompatible open source     #
+# software into Covered Software without special permission from the      #
+# copyright holders.                                                      #
+#                                                                         #
+# If you have any questions about the licensing restrictions on using     #
+# DRAKVUF in other works, are happy to help.  As mentioned above,         #
+# alternative license can be requested from the author to integrate       #
+# DRAKVUF into proprietary applications and appliances.  Please email     #
+# tamas.k.lengyel@gmail.com for further information.                      #
+#                                                                         #
+# If you have received a written license agreement or contract for        #
+# Covered Software stating terms other than these, you may choose to use  #
+# and redistribute Covered Software under those terms instead of these.   #
+#                                                                         #
+# Source is provided to this software because we believe users have a     #
+# right to know exactly what a program is going to do before they run it. #
+# This also allows you to audit the software for security holes.          #
+#                                                                         #
+# Source code also allows you to port DRAKVUF to new platforms, fix bugs, #
+# and add new features.  You are highly encouraged to submit your changes #
+# on https://github.com/tklengyel/drakvuf, or by other methods.           #
+# By sending these changes, it is understood (unless you specify          #
+# otherwise) that you are offering unlimited, non-exclusive right to      #
+# reuse, modify, and relicense the code.  DRAKVUF will always be          #
+# available Open Source, but this is important because the inability to   #
+# relicense code has caused devastating problems for other Free Software  #
+# projects (such as KDE and NASM).                                        #
+# To specify special license conditions of your contributions, just say   #
+# so when you send them.                                                  #
+#                                                                         #
+# This program is distributed in the hope that it will be useful, but     #
+# WITHOUT ANY WARRANTY; without even the implied warranty of              #
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the DRAKVUF   #
+# license file for more details (it's in a COPYING file included with     #
+# DRAKVUF, and also available from                                        #
+# https://github.com/tklengyel/drakvuf/COPYING)                           #
+#                                                                         #
+#*************************************************************************# 
 
 h_sources = xen_helper.h
 c_sources = xen_helper.c

--- a/src/xen_helper/xen_helper.c
+++ b/src/xen_helper/xen_helper.c
@@ -1,6 +1,6 @@
 /*********************IMPORTANT DRAKVUF LICENSE TERMS***********************
  *                                                                         *
- * DRAKVUF Dynamic Malware Analysis System (C) 2014-2015 Tamas K Lengyel.  *
+ * DRAKVUF Dynamic Malware Analysis System (C) 2014-2016 Tamas K Lengyel.  *
  * Tamas K Lengyel is hereinafter referred to as the author.               *
  * This program is free software; you may redistribute and/or modify it    *
  * under the terms of the GNU General Public License as published by the   *

--- a/src/xen_helper/xen_helper.h
+++ b/src/xen_helper/xen_helper.h
@@ -1,6 +1,6 @@
 /*********************IMPORTANT DRAKVUF LICENSE TERMS***********************
  *                                                                         *
- * DRAKVUF Dynamic Malware Analysis System (C) 2014-2015 Tamas K Lengyel.  *
+ * DRAKVUF Dynamic Malware Analysis System (C) 2014-2016 Tamas K Lengyel.  *
  * Tamas K Lengyel is hereinafter referred to as the author.               *
  * This program is free software; you may redistribute and/or modify it    *
  * under the terms of the GNU General Public License as published by the   *

--- a/src/xen_memclone.c
+++ b/src/xen_memclone.c
@@ -1,6 +1,6 @@
 /*********************IMPORTANT DRAKVUF LICENSE TERMS***********************
  *                                                                         *
- * DRAKVUF Dynamic Malware Analysis System (C) 2014-2015 Tamas K Lengyel.  *
+ * DRAKVUF Dynamic Malware Analysis System (C) 2014-2016 Tamas K Lengyel.  *
  * Tamas K Lengyel is hereinafter referred to as the author.               *
  * This program is free software; you may redistribute and/or modify it    *
  * under the terms of the GNU General Public License as published by the   *

--- a/tools/clone.pl
+++ b/tools/clone.pl
@@ -2,7 +2,7 @@
 #
 #********************IMPORTANT DRAKVUF LICENSE TERMS*********************#
 #                                                                        #
-# DRAKVUF Dynamic Malware Analysis System (C) 2014-2015 Tamas K Lengyel. #
+# DRAKVUF Dynamic Malware Analysis System (C) 2014-2016 Tamas K Lengyel. #
 # Tamas K Lengyel is hereinafter referred to as the author.              #
 # This program is free software; you may redistribute and/or modify it   #
 # under the terms of the GNU General Public License as published by the  #


### PR DESCRIPTION
Win32ksys is a especial case because is treated as a DLL, trap is made using the CSRSS pid.

Routines added:

- drakvuf_get_kern_module_base_addr(). Return the kernel module base address
- drakvuf_add_trap_dll(). Add trap using provided pid and base address.

Skeleton usage example:
```
drakvuf_get_kern_module_base_addr( drakvuf, "win32k.sys", win32k_base_addr );

trap->name   = "NtUserSetWindowsHookEx" ;
trap->module = "win32k.sys";

drakvuf_get_function_rva( win32ksys_rekall_profile, trap_name, &trap->u2.rva );

drakvuf_add_trap_dll( drakvuf, trap, win32k_base_addr, csrss_pid );
```

Regards,

Alfredo