### PR TITLE
Libinjector

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -334,6 +334,7 @@ fi
 
 AC_CONFIG_FILES([Makefile src/Makefile
                  src/libdrakvuf/Makefile
+                 src/libinjector/Makefile
                  src/xen_helper/Makefile
                  src/plugins/Makefile
                  src/dirwatch/Makefile

--- a/src/drakvuf.cpp
+++ b/src/drakvuf.cpp
@@ -181,6 +181,9 @@ drakvuf_c::drakvuf_c(const char* domain,
 
 void drakvuf_c::close()
 {
+    this->interrupted = -1;
+    g_mutex_trylock(&this->loop_signal);
+    g_mutex_unlock(&this->loop_signal);
     g_mutex_clear(&this->loop_signal);
 
     if (this->plugins)
@@ -228,7 +231,7 @@ void drakvuf_c::resume()
 
 int drakvuf_c::inject_cmd(vmi_pid_t injection_pid, const char *inject_cmd)
 {
-    int rc = drakvuf_inject_cmd(this->drakvuf, injection_pid, inject_cmd);
+    int rc = injector_start_app(this->drakvuf, injection_pid, inject_cmd);
     if (!rc)
         fprintf(stderr, "Process startup failed\n");
     return rc;

--- a/src/drakvuf.h
+++ b/src/drakvuf.h
@@ -115,7 +115,8 @@
 #include <glib.h>
 
 #include <libdrakvuf/libdrakvuf.h>
-#include "plugins/plugins.h"
+#include <plugins/plugins.h>
+#include <libinjector/libinjector.h>
 
 class drakvuf_c {
     private:

--- a/src/libdrakvuf/Makefile.am
+++ b/src/libdrakvuf/Makefile.am
@@ -103,7 +103,7 @@
 #*************************************************************************# 
 
 h_sources = libdrakvuf.h
-c_sources = drakvuf.c injector.c win-exports.c vmi.c win-symbols.c win-handles.c win-processes.c
+c_sources = drakvuf.c win-exports.c vmi.c win-symbols.c win-handles.c win-processes.c
 
 AM_CFLAGS = -I$(top_srcdir)
 AM_CFLAGS += $(CFLAGS)

--- a/src/libdrakvuf/libdrakvuf.h
+++ b/src/libdrakvuf/libdrakvuf.h
@@ -261,9 +261,6 @@ void drakvuf_remove_trap (drakvuf_t drakvuf,
 void drakvuf_loop (drakvuf_t drakvuf);
 void drakvuf_interrupt (drakvuf_t drakvuf,
                         int sig);
-int drakvuf_inject_cmd (drakvuf_t drakvuf,
-                        vmi_pid_t pid,
-                        const char *cmd);
 void drakvuf_pause (drakvuf_t drakvuf);
 void drakvuf_resume (drakvuf_t drakvuf);
 
@@ -273,6 +270,8 @@ void drakvuf_release_vmi(drakvuf_t drakvuf);
 addr_t drakvuf_get_obj_by_handle(drakvuf_t drakvuf,
                                  addr_t process,
                                  uint64_t handle);
+
+const char *drakvuf_get_rekall_profile(drakvuf_t drakvuf);
 
 /*
  * Specify either vcpu_id and/or regs. If regs don't have the required info
@@ -297,6 +296,9 @@ bool drakvuf_get_current_thread_id(drakvuf_t drakvuf,
                                     uint64_t vcpu_id,
                                     const x86_registers_t *regs,
                                     uint32_t *thread_id);
+
+addr_t drakvuf_exportsym_to_va(drakvuf_t drakvuf, addr_t eprocess_addr,
+                               const char *module, const char *sym);
 
 // Microsoft PreviousMode KTHREAD explanation:
 // https://msdn.microsoft.com/en-us/library/windows/hardware/ff559860(v=vs.85).aspx

--- a/src/libdrakvuf/private.h
+++ b/src/libdrakvuf/private.h
@@ -116,6 +116,7 @@
 #include <libvmi/events.h>
 
 #include "libdrakvuf.h"
+#include "vmi.h"
 #include "../xen_helper/xen_helper.h"
 
 #ifdef DRAKVUF_DEBUG
@@ -146,7 +147,11 @@ struct drakvuf {
     GMutex vmi_lock;
     vmi_instance_t vmi;
 
+    vmi_event_t cr3_event;
+    vmi_event_t interrupt_event;
     vmi_event_t *step_event[16];
+
+    size_t offsets[OFFSET_MAX];
 
     // Processing trap removals in trap callbacks
     // is problematic so we save all such requests

--- a/src/libdrakvuf/vmi.h
+++ b/src/libdrakvuf/vmi.h
@@ -105,13 +105,15 @@
 #ifndef VMI_H
 #define VMI_H
 
-#include "private.h"
-
 #define BIT32 0
 #define BIT64 1
 #define PM2BIT(pm) ((pm == VMI_PM_IA32E) ? BIT64 : BIT32)
 
 #define TRAP 0xCC
+
+#include <glib.h>
+#include <stdbool.h>
+#include "libdrakvuf.h"
 
 #define ghashtable_foreach(table, i, key, val) \
       g_hash_table_iter_init(&i, table); \
@@ -247,27 +249,6 @@ static const char *offset_names[OFFSET_MAX][2] = {
     [POOL_HEADER_POOLTAG] = {"_POOL_HEADER", "PoolTag" },
     [DISPATCHER_TYPE] = { "_DISPATCHER_HEADER",  "Type" },
 };
-
-size_t offsets[OFFSET_MAX];
-
-enum size {
-    FILE_OBJECT,
-    //OBJECT_ATTRIBUTES,
-    //OBJECT_HEADER,
-    POOL_HEADER,
-
-    SIZE_LIST_MAX
-};
-
-static const char *size_names[SIZE_LIST_MAX] = {
-        [FILE_OBJECT] = "_FILE_OBJECT",
-        //[OBJECT_ATTRIBUTES] = "_OBJECT_ATTRIBUTES", // May be useful TODO
-        //[OBJECT_HEADER] = "_OBJECT_HEADER",
-        [POOL_HEADER] = "_POOL_HEADER",
-};
-
-// Aligned object sizes
-size_t struct_sizes[SIZE_LIST_MAX];
 
 bool init_vmi(drakvuf_t drakvuf);
 void close_vmi(drakvuf_t drakvuf);

--- a/src/libdrakvuf/win-exports.c
+++ b/src/libdrakvuf/win-exports.c
@@ -116,43 +116,50 @@
 #include <libvmi/libvmi.h>
 #include <libvmi/peparse.h>
 
-#include "vmi.h"
+#include "private.h"
 #include "win-exports.h"
 
 #define MAX_HEADER_SIZE 1024
 
 // search for the given module+symbol in the given module list
-status_t modlist_sym2va(vmi_instance_t vmi, addr_t list_head, uint32_t pid,
-        const char *mod_name, const char *symbol, addr_t *va) {
+static status_t
+modlist_sym2va(drakvuf_t drakvuf, addr_t list_head, access_context_t *ctx,
+               const char *mod_name, const char *symbol, addr_t *va) {
 
+    vmi_instance_t vmi = drakvuf->vmi;
     addr_t next_module = list_head;
     /* walk the module list */
     while (1) {
 
         /* follow the next pointer */
         addr_t tmp_next = 0;
-        vmi_read_addr_va(vmi, next_module, pid, &tmp_next);
+
+        ctx->addr = next_module;
+        if(VMI_FAILURE==vmi_read_addr(vmi, ctx, &tmp_next))
+            break;
 
         /* if we are back at the list head, we are done */
         if (list_head == tmp_next || !tmp_next) {
             break;
         }
-        unicode_string_t *us = vmi_read_unicode_str_va(vmi,
-                next_module + offsets[LDR_DATA_TABLE_ENTRY_BASEDLLNAME], pid);
+
+        ctx->addr = next_module + drakvuf->offsets[LDR_DATA_TABLE_ENTRY_BASEDLLNAME];
+        unicode_string_t *us = vmi_read_unicode_str(vmi, ctx);
         unicode_string_t out = { .contents = NULL };
 
         if (us && VMI_SUCCESS == vmi_convert_str_encoding(us, &out, "UTF-8")) {
 
-            PRINT_DEBUG("Found module in PID %u: %s\n", pid, out.contents);
+            PRINT_DEBUG("Found module %s\n", out.contents);
 
             if (!strcasecmp((char*) out.contents, mod_name)) {
 
                 addr_t dllbase;
-                vmi_read_addr_va(vmi,
-                        next_module + offsets[LDR_DATA_TABLE_ENTRY_DLLBASE],
-                        pid, &dllbase);
 
-                *va = vmi_translate_sym2v(vmi, dllbase, pid, (char *) symbol);
+                ctx->addr = next_module + drakvuf->offsets[LDR_DATA_TABLE_ENTRY_DLLBASE];
+                vmi_read_addr(vmi, ctx, &dllbase);
+
+                ctx->addr = dllbase;
+                *va = vmi_translate_sym2v(vmi, ctx, (char *) symbol);
 
                 PRINT_DEBUG("\t%s @ 0x%lx\n", symbol, *va);
 
@@ -173,8 +180,34 @@ status_t modlist_sym2va(vmi_instance_t vmi, addr_t list_head, uint32_t pid,
     return VMI_FAILURE;
 }
 
-addr_t sym2va(vmi_instance_t vmi, vmi_pid_t target_pid, const char *mod_name,
-        const char *symbol) {
+addr_t eprocess_sym2va (drakvuf_t drakvuf, addr_t eprocess_base, const char *mod_name, const char *symbol) {
+    addr_t peb, ldr, inloadorder, dtb, ret = 0;
+    access_context_t ctx = {
+        .translate_mechanism = VMI_TM_PROCESS_DTB,
+    };
+
+    if(VMI_FAILURE==vmi_read_addr_va(drakvuf->vmi, eprocess_base + drakvuf->offsets[EPROCESS_PDBASE], 0, &ctx.dtb))
+        return 0;
+    if(VMI_FAILURE==vmi_read_addr_va(drakvuf->vmi, eprocess_base + drakvuf->offsets[EPROCESS_PEB], 0, &peb))
+        return 0;
+
+    ctx.addr = peb + drakvuf->offsets[PEB_LDR];
+    if(VMI_FAILURE==vmi_read_addr(drakvuf->vmi, &ctx, &ldr))
+        return 0;
+
+    ctx.addr = ldr + drakvuf->offsets[PEB_LDR_DATA_INLOADORDERMODULELIST];
+    if(VMI_FAILURE==vmi_read_addr(drakvuf->vmi, &ctx, &inloadorder))
+        return 0;
+
+    PRINT_DEBUG("Found PEB @ 0x%lx. LDR @ 0x%lx. INLOADORDER @ 0x%lx.\n",
+                peb, ldr, inloadorder);
+
+    modlist_sym2va(drakvuf, inloadorder, &ctx, mod_name, symbol, &ret);
+    return ret;
+}
+
+addr_t sym2va(drakvuf_t drakvuf, vmi_pid_t target_pid, const char *mod_name, const char *symbol) {
+    vmi_instance_t vmi = drakvuf->vmi;
     addr_t ret = 0;
     addr_t list_head;
     status_t status;
@@ -202,27 +235,11 @@ addr_t sym2va(vmi_instance_t vmi, vmi_pid_t target_pid, const char *mod_name,
 
         /* follow the next pointer */
 
-        addr_t peb, ldr, inloadorder;
-        vmi_pid_t pid;
+        vmi_pid_t pid = -1;
         vmi_read_32_va(vmi, current_process + pid_offset, 0, (uint32_t*)&pid);
 
         if (pid == target_pid) {
-
-            vmi_read_addr_va(vmi, current_process + offsets[EPROCESS_PEB], 0,
-                    &peb);
-            vmi_read_addr_va(vmi, peb + offsets[PEB_LDR], pid, &ldr);
-            vmi_read_addr_va(vmi,
-                    ldr + offsets[PEB_LDR_DATA_INLOADORDERMODULELIST], pid,
-                    &inloadorder);
-
-            PRINT_DEBUG("Found target pid of %u. PEB @ 0x%lx. LDR @ 0x%lx. INLOADORDER @ 0x%lx.\n",
-                        target_pid, peb, ldr, inloadorder);
-
-            if (VMI_SUCCESS
-                    == modlist_sym2va(vmi, inloadorder, pid, mod_name, symbol,
-                            &ret)) {
-                return ret;
-            }
+            return eprocess_sym2va(drakvuf, current_process, mod_name, symbol);
         }
 
         status = vmi_read_addr_va(vmi, current_list_entry, 0, &next_list_entry);
@@ -237,32 +254,42 @@ addr_t sym2va(vmi_instance_t vmi, vmi_pid_t target_pid, const char *mod_name,
 }
 
 // search for the given module+symbol in the given module list
-status_t modlist_va2sym(vmi_instance_t vmi, addr_t list_head, addr_t va,
-        vmi_pid_t pid, char **out_mod, char **out_sym) {
+static status_t
+modlist_va2sym(drakvuf_t drakvuf, addr_t list_head, addr_t va,
+               access_context_t *ctx, char **out_mod, char **out_sym) {
 
+    vmi_instance_t vmi = drakvuf->vmi;
     addr_t next_module = list_head;
+
     /* walk the module list */
     while (1) {
 
         /* follow the next pointer */
         addr_t tmp_next = 0;
-        vmi_read_addr_va(vmi, next_module, pid, &tmp_next);
+        ctx->addr = next_module;
+        if(VMI_FAILURE == vmi_read_addr(vmi, ctx, &tmp_next))
+            break;
 
         /* if we are back at the list head, we are done */
         if (list_head == tmp_next || !tmp_next) {
             break;
         }
-        unicode_string_t *us = vmi_read_unicode_str_va(vmi,
-                next_module + offsets[LDR_DATA_TABLE_ENTRY_BASEDLLNAME], pid);
+
+        ctx->addr = next_module + drakvuf->offsets[LDR_DATA_TABLE_ENTRY_BASEDLLNAME];
+        unicode_string_t *us = vmi_read_unicode_str(vmi, ctx);
         unicode_string_t out = { .contents = NULL };
 
         if (us && VMI_SUCCESS == vmi_convert_str_encoding(us, &out, "UTF-8")) {
             addr_t dllbase;
-            vmi_read_addr_va(vmi,
-                    next_module + offsets[LDR_DATA_TABLE_ENTRY_DLLBASE], pid,
-                    &dllbase);
+            ctx->addr = next_module + drakvuf->offsets[LDR_DATA_TABLE_ENTRY_DLLBASE];
+            if(VMI_FAILURE == vmi_read_addr(vmi, ctx, &dllbase)) {
+                free(us);
+                break;
+            }
 
-            const char *sym = vmi_translate_v2sym(vmi, dllbase, pid, va);
+            ctx->addr = dllbase;
+            const char *sym = vmi_translate_v2sym(vmi, ctx, va);
+
             if (sym) {
                 *out_mod = g_strdup((char*)out.contents);
                 *out_sym = (char*) sym;
@@ -283,9 +310,10 @@ status_t modlist_va2sym(vmi_instance_t vmi, addr_t list_head, addr_t va,
     return VMI_FAILURE;
 }
 
-status_t va2sym(vmi_instance_t vmi, addr_t va, vmi_pid_t target_pid,
+status_t va2sym(drakvuf_t drakvuf, addr_t va, vmi_pid_t target_pid,
         char **out_mod, char **out_sym) {
 
+    vmi_instance_t vmi = drakvuf->vmi;
     addr_t list_head;
 
     size_t pid_offset = vmi_get_offset(vmi, "win_pid");
@@ -298,10 +326,9 @@ status_t va2sym(vmi_instance_t vmi, addr_t va, vmi_pid_t target_pid,
     list_head = current_process + tasks_offset;
     current_list_entry = list_head;
 
-    if (VMI_FAILURE
-            == vmi_read_addr_va(vmi, current_list_entry, 0, &next_list_entry)) {
+    if (VMI_FAILURE == vmi_read_addr_va(vmi, current_list_entry, 0, &next_list_entry)) {
         PRINT_DEBUG("Failed to read next pointer at 0x%lx before entering loop\n",
-                current_list_entry);
+                    current_list_entry);
         return VMI_FAILURE;
     }
 
@@ -317,18 +344,18 @@ status_t va2sym(vmi_instance_t vmi, addr_t va, vmi_pid_t target_pid,
 
         if (pid == target_pid) {
 
-            vmi_read_addr_va(vmi, current_process + offsets[EPROCESS_PEB], 0,
-                    &peb);
-            vmi_read_addr_va(vmi, peb + offsets[PEB_LDR], pid, &ldr);
+            vmi_read_addr_va(vmi, current_process + drakvuf->offsets[EPROCESS_PEB], 0, &peb);
+            vmi_read_addr_va(vmi, peb + drakvuf->offsets[PEB_LDR], pid, &ldr);
             vmi_read_addr_va(vmi,
-                    ldr + offsets[PEB_LDR_DATA_INLOADORDERMODULELIST], pid,
+                    ldr + drakvuf->offsets[PEB_LDR_DATA_INLOADORDERMODULELIST], pid,
                     &inloadorder);
 
-            if (VMI_SUCCESS
-                    == modlist_va2sym(vmi, inloadorder, va, pid, out_mod,
-                            out_sym)) {
-                return VMI_SUCCESS;
-            }
+            access_context_t ctx = {
+                .translate_mechanism = VMI_TM_PROCESS_PID,
+                .pid = pid,
+            };
+
+            return modlist_va2sym(drakvuf, inloadorder, va, &ctx, out_mod, out_sym);
         }
 
         if (VMI_FAILURE

--- a/src/libdrakvuf/win-exports.h
+++ b/src/libdrakvuf/win-exports.h
@@ -107,8 +107,9 @@
 
 #include <libvmi/libvmi.h>
 
-addr_t sym2va(vmi_instance_t vmi, vmi_pid_t cr3, const char *mod_name, const char *sym);
-const char *rva2sym(vmi_instance_t vmi, const char *mod_name, addr_t base_vaddr, vmi_pid_t pid, addr_t rva);
-status_t va2sym(vmi_instance_t vmi, addr_t va, vmi_pid_t pid, char **mod, char **sym);
+addr_t sym2va(drakvuf_t drakvuf, vmi_pid_t pid, const char *mod_name, const char *sym);
+addr_t eprocess_sym2va(drakvuf_t drakvuf, addr_t eprocess_base, const char *mod_name, const char *sym);
+const char *rva2sym(drakvuf_t drakvuf, const char *mod_name, addr_t base_vaddr, vmi_pid_t pid, addr_t rva);
+status_t va2sym(drakvuf_t drakvuf, addr_t va, vmi_pid_t pid, char **mod, char **sym);
 
 #endif

--- a/src/libinjector/Makefile.am
+++ b/src/libinjector/Makefile.am
@@ -102,51 +102,28 @@
 #                                                                         #
 #*************************************************************************# 
 
-bin_PROGRAMS = drakvuf xen_memclone injector
+h_sources = libinjector.h private.h
+c_sources = injector.c
 
-SUBDIRS = xen_helper libdrakvuf libinjector plugins dirwatch
-
-drakvuf_SOURCES = main.cpp drakvuf.cpp
-xen_memclone_SOURCES  = xen_memclone.c
-injector_SOURCES = injector.c
-
-AM_CFLAGS = $(CFLAGS)
+AM_CFLAGS = -I$(top_srcdir) -I$(top_srcdir)/src -I$(srcdir)
+AM_CFLAGS += $(CFLAGS)
 AM_CFLAGS += $(VMI_CFLAGS)
 AM_CFLAGS += $(GLIB_CFLAGS)
-AM_CFLAGS += -I$(top_srcdir) -I$(srcdir)
-
-AM_CPPFLAGS = $(CPPFLAGS)
-AM_CPPFLAGS += $(VMI_CFLAGS)
-AM_CPPFLAGS += $(GLIB_CFLAGS)
-AM_CPPFLAGS += -I$(top_srcdir) -I$(srcdir)
 
 if HARDENING
 AM_CFLAGS += $(HARDEN_CFLAGS) -DHARDENING
-AM_CPPFLAGS += $(HARDEN_CFLAGS) -DHARDENING
 endif
 
 # Note that -pg is incompatible with HARDENING
 if DEBUG
 AM_CFLAGS += -DDRAKVUF_DEBUG -Wall -Wextra -Wno-override-init -Wno-strict-aliasing -g -ggdb3
 AM_CFLAGS += -Wno-unused-parameter -Wno-unused-but-set-variable -Wno-unused-variable
-AM_CPPFLAGS += -DDRAKVUF_DEBUG -Wall -Wextra -Wno-strict-aliasing -g -ggdb3
-AM_CPPFLAGS += -Wno-unused-parameter -Wno-unused-variable
 if !HARDENING
 AM_CFLAGS += -pg
-AM_CPPFLAGS += -pg
 endif
 endif
 
-drakvuf_LDADD = libdrakvuf/libdrakvuf.la
-drakvuf_LDADD += xen_helper/libxenhelper.la
-drakvuf_LDADD += plugins/libdrakvufplugins.la
-drakvuf_LDADD += libinjector/libinjector.la
-
-if HARDENING
-drakvuf_LDADD += $(HARDEN_LDFLAGS)
-endif
-
-injector_LDADD = libdrakvuf/libdrakvuf.la
-injector_LDADD += libinjector/libinjector.la
-
-xen_memclone_LDADD = xen_helper/libxenhelper.la
+noinst_LTLIBRARIES= libinjector.la
+libinjector_la_SOURCES= $(h_sources) $(c_sources)
+libinjector_la_LIBADD= ../xen_helper/libxenhelper.la
+libinjector_la_LIBADD+= ../libdrakvuf/libdrakvuf.la

--- a/src/libinjector/libinjector.h
+++ b/src/libinjector/libinjector.h
@@ -102,11 +102,23 @@
  *                                                                         *
  ***************************************************************************/
 
-#ifndef INJECTOR_H
-#define INJECTOR_H
+#ifndef LIBINJECTOR_H
+#define LIBINJECTOR_H
 
-#include "libdrakvuf.h"
-
-int start_app(drakvuf_t drakvuf, vmi_pid_t pid, const char *app);
-
+#ifdef __cplusplus
+extern "C" {
 #endif
+
+#pragma GCC visibility push(default)
+
+#include <libdrakvuf/libdrakvuf.h>
+
+int injector_start_app(drakvuf_t drakvuf, vmi_pid_t pid, const char *app);
+
+#pragma GCC visibility pop
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // LIBINJECTOR_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -228,7 +228,7 @@ int main(int argc, char** argv) {
     sigaction(SIGINT, &act, NULL);
     sigaction(SIGALRM, &act, NULL);
 
-    if ( injection_pid && inject_cmd ) {
+    if ( injection_pid > 0 && inject_cmd ) {
         rc = drakvuf->inject_cmd(injection_pid, inject_cmd);
         if (!rc)
             goto exit;


### PR DESCRIPTION
Relocate injector codebase from libdrakvuf to its own separate library and convert all traps to use DRAKVUF traps instead of manual LibVMI traps. On x86 Windows use new method of trapping userspace entry as the APC injection method is unreliable on multi-vCPU guests.

Fixes #148 