### PR TITLE
Revert remapping on shutdown in idx view

### DIFF
--- a/src/libdrakvuf/vmi.c
+++ b/src/libdrakvuf/vmi.c
@@ -1032,6 +1032,7 @@ void close_vmi(drakvuf_t drakvuf) {
         xen_pfn_t *key;
         struct remapped_gfn *remapped_gfn = NULL;
         ghashtable_foreach(drakvuf->remapped_gfns, i, key, remapped_gfn) {
+            xc_altp2m_change_gfn(drakvuf->xen->xc, drakvuf->domID, drakvuf->altp2m_idx, remapped_gfn->o, ~0);
             xc_domain_decrease_reservation_exact(drakvuf->xen->xc, drakvuf->domID, 1, 0, &remapped_gfn->r);
         }
         g_hash_table_destroy(drakvuf->remapped_gfns);


### PR DESCRIPTION
Apparently altp2m view destroy doesn't actually free the tables in Xen, just deactivates them. On subsequent creation of the altp2m tables, the same remappings are active as before. So, if we do two DRAKVUF runs with different plugins, we might end up getting the following errors:

`Ignoring old breakpoint event found in the queue`

This error comes from the re-activated remappings of old DRAKVUF traps that now have no subscribers. By reverting all remappings on shutdown we can avoid running into this issue.