### PR TITLE
Pause tweaking

### DIFF
--- a/src/drakvuf.cpp
+++ b/src/drakvuf.cpp
@@ -128,6 +128,7 @@ static gpointer timer(gpointer data)
 int drakvuf_c::start_plugins(const bool* plugin_list, const char *dump_folder)
 {
     int i, rc;
+
     for(i=0;i<__DRAKVUF_PLUGIN_LIST_MAX;i++)
     {
         if (plugin_list[i]) {

--- a/src/injector.c
+++ b/src/injector.c
@@ -149,8 +149,6 @@ int main(int argc, char** argv)
         return rc;
     }
 
-    drakvuf_pause(drakvuf);
-
     if (pid > 0 && app) {
         printf("Injector starting %s through PID %u\n", app, pid);
         rc = injector_start_app(drakvuf, pid, app);

--- a/src/libdrakvuf/private.h
+++ b/src/libdrakvuf/private.h
@@ -221,4 +221,6 @@ struct remapped_gfn {
     bool active;
 };
 
+void drakvuf_force_resume (drakvuf_t drakvuf);
+
 #endif

--- a/src/xen_helper/xen_helper.c
+++ b/src/xen_helper/xen_helper.c
@@ -250,15 +250,21 @@ void print_sharing_info(xen_interface_t *xen, domid_t domID) {
     printf("Shared memory pages: %lu\n", info.nr_shared_pages);
 }
 
-void xen_pause(xen_interface_t *xen, domid_t domID) {
-    xc_dominfo_t info = { 0 };
+/* Increments Xen's pause count if paused */
+bool xen_pause(xen_interface_t *xen, domid_t domID) {
+    int rc = xc_domain_pause(xen->xc, domID);
+    if ( rc < 0 )
+        return 0;
 
-    if (1 == xc_domain_getinfo(xen->xc, domID, 1, &info) && info.domid == domID && !info.paused)
-        xc_domain_pause(xen->xc, domID);
-
+   return 1;
 }
 
-void xen_unpause(xen_interface_t *xen, domid_t domID) {
+/* Decrements Xen's pause count and only resumes when it reaches 0 */
+void xen_resume(xen_interface_t *xen, domid_t domID) {
+    xc_domain_unpause(xen->xc, domID);
+}
+
+void xen_force_resume(xen_interface_t *xen, domid_t domID) {
     do {
         xc_dominfo_t info = { 0 };
 

--- a/src/xen_helper/xen_helper.h
+++ b/src/xen_helper/xen_helper.h
@@ -129,8 +129,9 @@ uint64_t xen_memshare(xen_interface_t *xen, domid_t domID, domid_t cloneID);
 
 void print_sharing_info(xen_interface_t *xen, domid_t domID);
 
-void xen_pause(xen_interface_t *xen, domid_t domID);
-void xen_unpause(xen_interface_t *xen, domid_t domID);
+bool xen_pause(xen_interface_t *xen, domid_t domID);
+void xen_resume(xen_interface_t *xen, domid_t domID);
+void xen_force_resume(xen_interface_t *xen, domid_t domID);
 
 
 #endif


### PR DESCRIPTION
The pause/unpause pairs have been out of whack since vmi_pause_vm no longer increments Xen's pause count. This resulted in the VM getting unpaused after every add_trap call.