### PR TITLE
Update libvmi

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -299,7 +299,8 @@ AC_CHECK_LIB(glib-2.0, [g_malloc0, g_tree_lookup], [], [AC_ERROR([glib-2.0 libra
 
 PKG_CHECK_MODULES([VMI], [libvmi >= 0.11], [], [AC_ERROR([LibVMI not found])])
 AC_CHECK_HEADERS([libvmi/events.h], [], [AC_ERROR([LibVMI doesn't have events support.])], [#include <libvmi/libvmi.h>])
-AC_CHECK_LIB(vmi, [vmi_register_event, vmi_step_event, vmi_read], [], [AC_ERROR([LibVMI doesn't have events support.])])
+AC_CHECK_LIB(vmi, [vmi_register_event], [], [AC_ERROR([LibVMI doesn't have required events support. Please update LibVMI!])])
+AC_CHECK_LIB(vmi, [vmi_events_version], [], [AC_ERROR([LibVMI doesn't have required events support. Please update LibVMI!])])
 
 AC_CHECK_LIB(json-c, json_object_get_int64,, [AC_ERROR([libjson-c-dev is missing])])
 AC_CHECK_HEADERS([json-c/json.h], [], [AC_ERROR([libjson-c-dev is missing])])

--- a/src/libdrakvuf/drakvuf.c
+++ b/src/libdrakvuf/drakvuf.c
@@ -420,3 +420,7 @@ addr_t drakvuf_exportsym_to_va(drakvuf_t drakvuf, addr_t eprocess_addr,
 {
     return eprocess_sym2va(drakvuf, eprocess_addr, module, sym);
 }
+
+addr_t drakvuf_get_kernel_base(drakvuf_t drakvuf) {
+    return drakvuf->kernbase;
+}

--- a/src/libdrakvuf/private.h
+++ b/src/libdrakvuf/private.h
@@ -149,6 +149,7 @@ struct drakvuf {
 
     vmi_event_t cr3_event;
     vmi_event_t interrupt_event;
+    vmi_event_t mem_event;
     vmi_event_t *step_event[16];
 
     size_t offsets[OFFSET_MAX];
@@ -194,7 +195,7 @@ struct memaccess {
     addr_t gfn;
     addr_t pa;
     bool guard2;
-    vmi_event_t *memtrap;
+    vmi_mem_access_t access;
 } __attribute__ ((packed));
 
 struct wrapper {

--- a/src/libdrakvuf/private.h
+++ b/src/libdrakvuf/private.h
@@ -166,6 +166,7 @@ struct drakvuf {
     unsigned int vcpus;
     unsigned int init_memsize;
     unsigned int memsize;
+    addr_t kernbase;
 
     GHashTable *remapped_gfns; // Key: gfn
                                // val: remapped gfn

--- a/src/libdrakvuf/vmi.c
+++ b/src/libdrakvuf/vmi.c
@@ -1069,6 +1069,21 @@ bool init_vmi(drakvuf_t drakvuf) {
         return 0;
     }
 
+    addr_t sysproc_rva;
+    addr_t sysproc = vmi_translate_ksym2v(drakvuf->vmi, "PsInitialSystemProcess");
+    if ( !sysproc ) {
+        printf("LibVMI failed to get us the VA of PsInitialSystemProcess!\n");
+        return 0;
+    }
+
+    if ( VMI_FAILURE == drakvuf_get_constant_rva(drakvuf->rekall_profile, "PsInitialSystemProcess", &sysproc_rva) ) {
+        fprintf(stderr, "Failed to get PsInitialSystemProcess RVA from Rekall profile!\n");
+        return 0;
+    }
+
+    drakvuf->kernbase = sysproc - sysproc_rva;
+    PRINT_DEBUG("Windows kernel base address is 0x%lx\n", drakvuf->kernbase);
+
     return 1;
 }
 

--- a/src/libdrakvuf/vmi.c
+++ b/src/libdrakvuf/vmi.c
@@ -132,8 +132,8 @@ static uint8_t bp = 0xCC;
  */
 event_response_t vmi_reset_trap(vmi_instance_t vmi, vmi_event_t *event) {
     drakvuf_t drakvuf = event->data;
-    PRINT_DEBUG("reset trap, switching %u->%u\n", event->vmm_pagetable_id, drakvuf->altp2m_idx);
-    event->vmm_pagetable_id = drakvuf->altp2m_idx;
+    PRINT_DEBUG("reset trap, switching %u->%u\n", event->slat_id, drakvuf->altp2m_idx);
+    event->slat_id = drakvuf->altp2m_idx;
     return (1u << VMI_EVENT_RESPONSE_TOGGLE_SINGLESTEP) | // Turn off singlestep
            (1u << VMI_EVENT_RESPONSE_VMM_PAGETABLE_ID);
 }
@@ -251,7 +251,7 @@ event_response_t post_mem_cb(vmi_instance_t vmi, vmi_event_t *event) {
 done:
     free(pass);
     /* We switch back to the altp2m view no matter what */
-    event->vmm_pagetable_id = drakvuf->altp2m_idx;
+    event->slat_id = drakvuf->altp2m_idx;
     drakvuf->step_event[event->vcpu_id]->callback = vmi_reset_trap;
     drakvuf->step_event[event->vcpu_id]->data = drakvuf;
     return (1u << VMI_EVENT_RESPONSE_TOGGLE_SINGLESTEP) | // Turn off singlestep
@@ -267,12 +267,12 @@ event_response_t pre_mem_cb(vmi_instance_t vmi, vmi_event_t *event) {
 
     if (!s) {
         PRINT_DEBUG("Event has been cleared for GFN 0x%lx but we are still in view %u\n",
-                    event->mem_event.gfn, event->vmm_pagetable_id);
+                    event->mem_event.gfn, event->slat_id);
         goto done;
     }
 
     PRINT_DEBUG("Pre mem cb with vCPU %u @ 0x%lx 0x%lx in view %u: %c%c%c\n",
-                event->vcpu_id, event->mem_event.gfn, event->mem_event.offset, event->vmm_pagetable_id,
+                event->vcpu_id, event->mem_event.gfn, event->mem_event.offset, event->slat_id,
                 (event->mem_event.out_access & VMI_MEMACCESS_R) ? 'r' : '-',
                 (event->mem_event.out_access & VMI_MEMACCESS_W) ? 'w' : '-',
                 (event->mem_event.out_access & VMI_MEMACCESS_X) ? 'x' : '-'
@@ -307,7 +307,7 @@ event_response_t pre_mem_cb(vmi_instance_t vmi, vmi_event_t *event) {
         
         if (sbp) {
             PRINT_DEBUG("Simulated INT3 event vCPU %u altp2m:%u CR3: 0x%"PRIx64" PA=0x%"PRIx64" RIP=0x%"PRIx64"\n",
-                event->vcpu_id, event->vmm_pagetable_id, event->regs.x86->cr3, s->memaccess.pa, event->regs.x86->rip);
+                event->vcpu_id, event->slat_id, event->regs.x86->cr3, s->memaccess.pa, event->regs.x86->rip);
 
             loop = sbp->traps;
             while(loop) {
@@ -344,7 +344,7 @@ event_response_t pre_mem_cb(vmi_instance_t vmi, vmi_event_t *event) {
         pass->gfn = event->mem_event.gfn;
         pass->access = event->mem_event.out_access;
         if(!s->memaccess.guard2) {
-            event->vmm_pagetable_id = 0;
+            event->slat_id = 0;
 
             /*
              * If this is a remapped gfn and the page is getting written, the remapped copy needs to be updated
@@ -355,7 +355,7 @@ event_response_t pre_mem_cb(vmi_instance_t vmi, vmi_event_t *event) {
                     pass->remapped_gfn = g_hash_table_lookup(drakvuf->remapped_gfns, &pass->gfn);
             }
         } else
-            event->vmm_pagetable_id = drakvuf->altp2m_idr;
+            event->slat_id = drakvuf->altp2m_idr;
         drakvuf->step_event[event->vcpu_id]->callback = post_mem_cb;
         drakvuf->step_event[event->vcpu_id]->data = pass;
         return (1u << VMI_EVENT_RESPONSE_TOGGLE_SINGLESTEP) | // Turn on singlestep
@@ -376,7 +376,7 @@ event_response_t int3_cb(vmi_instance_t vmi, vmi_event_t *event) {
     struct wrapper *s = g_hash_table_lookup(drakvuf->breakpoint_lookup_pa, &pa);
 
     PRINT_DEBUG("INT3 event vCPU %u altp2m:%u CR3: 0x%"PRIx64" PA=0x%"PRIx64" RIP=0x%"PRIx64". Insn_length: %u\n",
-                event->vcpu_id, event->vmm_pagetable_id, cr3, pa,
+                event->vcpu_id, event->slat_id, cr3, pa,
                 event->interrupt_event.gla, event->interrupt_event.insn_length);
 
     if (!s) {
@@ -427,7 +427,7 @@ event_response_t int3_cb(vmi_instance_t vmi, vmi_event_t *event) {
     // Check if we have traps still active on this breakpoint
     if ( g_hash_table_lookup(drakvuf->breakpoint_lookup_pa, &pa) ) {
         PRINT_DEBUG("Switching altp2m and to singlestep on vcpu %u\n", event->vcpu_id);
-        event->vmm_pagetable_id = 0;
+        event->slat_id = 0;
         drakvuf->step_event[event->vcpu_id]->callback = vmi_reset_trap;
         drakvuf->step_event[event->vcpu_id]->data = drakvuf;
         return (1u << VMI_EVENT_RESPONSE_TOGGLE_SINGLESTEP) | // Enable singlestep
@@ -473,13 +473,6 @@ event_response_t cr3_cb(vmi_instance_t vmi, vmi_event_t *event) {
     process_free_requests(drakvuf);
 
     return 0;
-}
-
-void clear_memtrap(vmi_event_t *event, status_t rc) {
-    drakvuf_t drakvuf = event->data;
-    xc_altp2m_change_gfn(drakvuf->xen->xc, drakvuf->domID,
-                         drakvuf->altp2m_idx, event->mem_event.gfn, ~0);
-    free(event);
 }
 
 void remove_trap(drakvuf_t drakvuf,
@@ -538,25 +531,22 @@ void remove_trap(drakvuf_t drakvuf,
     {
         struct wrapper *container =
             g_hash_table_lookup(drakvuf->memaccess_lookup_trap, &trap);
+        status_t ret;
 
         if ( !container ) {
             return;
         }
 
         container->traps = g_slist_remove(container->traps, trap);
-        vmi_event_t *event = container->memaccess.memtrap;
-        event->vmm_pagetable_id = drakvuf->altp2m_idx;
 
         if (!container->traps) {
-            PRINT_DEBUG("Removing memtrap for GFN 0x%lx, event @ %p\n",
-                        container->memaccess.gfn, container->memaccess.memtrap);
+            PRINT_DEBUG("Removing memtrap for GFN 0x%lx\n", container->memaccess.gfn);
 
             /*
              * This vmi_clear_event will be queued and removed when all events
              * are pulled from the ring.
              */
-            event->data = drakvuf;
-            vmi_clear_event(vmi, event, clear_memtrap);
+            vmi_set_mem_event(vmi, container->memaccess.gfn<<12, VMI_MEMACCESS_N, drakvuf->altp2m_idx);
             g_hash_table_remove(drakvuf->memaccess_lookup_trap, &trap);
             g_hash_table_remove(drakvuf->memaccess_lookup_gfn, &container->memaccess.gfn);
             return;
@@ -566,28 +556,25 @@ void remove_trap(drakvuf_t drakvuf,
          * If more subscriber are present make sure we only set the required access settings.
          */
         GSList *loop = container->traps;
-        event->vmm_pagetable_id = drakvuf->altp2m_idx;
-        vmi_event_t *update_event = g_memdup(event, sizeof(vmi_event_t));
-        update_event->mem_event.in_access = 0;
+        vmi_mem_access_t update_access = 0;
 
         while(loop) {
             drakvuf_trap_t *trap = loop->data;
-            update_event->mem_event.in_access |= trap->memaccess.access;
+            update_access |= trap->memaccess.access;
             loop=loop->next;
         }
 
-        if(VMI_SUCCESS == vmi_swap_events(vmi, event, update_event, (vmi_event_free_t)free)) {
-            PRINT_DEBUG("Successfully requested to swap events to permission %c%c%c on GFN 0x%lx!\n",
-                        (update_event->mem_event.in_access & VMI_MEMACCESS_R) ? 'r' : '-',
-                        (update_event->mem_event.in_access & VMI_MEMACCESS_W) ? 'w' : '-',
-                        (update_event->mem_event.in_access & VMI_MEMACCESS_X) ? 'x' : '-',
-                        (update_event->mem_event.physical_address >> 12)
+        ret = vmi_set_mem_event(vmi, container->memaccess.gfn<<12, update_access, drakvuf->altp2m_idx);
+        if(VMI_SUCCESS == ret) {
+            PRINT_DEBUG("Successfully set access to %c%c%c on GFN 0x%lx!\n",
+                        (update_access & VMI_MEMACCESS_R) ? 'r' : '-',
+                        (update_access & VMI_MEMACCESS_W) ? 'w' : '-',
+                        (update_access & VMI_MEMACCESS_X) ? 'x' : '-',
+                        container->memaccess.gfn
                         );
-            container->memaccess.memtrap = update_event;
-        } else {
-            PRINT_DEBUG("Failed to update memaccess trap settings!\n");
-            free(update_event);
-        }
+            container->memaccess.access = update_access;
+        } else
+            PRINT_DEBUG("Failed to update memaccess trap settings on GFN 0x%lx!\n", container->memaccess.gfn);
 
         break;
     }
@@ -624,26 +611,17 @@ bool inject_trap_mem(drakvuf_t drakvuf, drakvuf_trap_t *trap, bool guard2) {
          */
         s->memaccess.guard2 = guard2;
 
-        if ( s->memaccess.memtrap->mem_event.in_access != trap->memaccess.access ) {
+        if ( s->memaccess.access != trap->memaccess.access ) {
 
-            s->memaccess.memtrap->vmm_pagetable_id = drakvuf->altp2m_idx;
-            vmi_event_t *update_event = g_memdup(s->memaccess.memtrap, sizeof(vmi_event_t));
-            update_event->mem_event.in_access |= trap->memaccess.access;
+            vmi_mem_access_t update_access = (s->memaccess.access | trap->memaccess.access);
+            status_t ret = vmi_set_mem_event(drakvuf->vmi, trap->memaccess.gfn<<12, update_access, drakvuf->altp2m_idx);
 
-            if (VMI_FAILURE == vmi_swap_events(drakvuf->vmi, s->memaccess.memtrap, update_event, (vmi_event_free_t)free)) {
-                PRINT_DEBUG("*** FAILED TO SWAP MEMORY TRAP @ PAGE %lu ***\n",
-                            trap->memaccess.gfn);
-                free(update_event);
+            if ( ret == VMI_FAILURE ) {
+                PRINT_DEBUG("*** FAILED TO SET MEMORY TRAP @ PAGE %lu ***\n", trap->memaccess.gfn);
                 return 0;
-            } else {
-                PRINT_DEBUG("Successfully requested to swap events to permission %c%c%c on GFN 0x%lx!\n",
-                            (update_event->mem_event.in_access & VMI_MEMACCESS_R) ? 'r' : '-',
-                            (update_event->mem_event.in_access & VMI_MEMACCESS_W) ? 'w' : '-',
-                            (update_event->mem_event.in_access & VMI_MEMACCESS_X) ? 'x' : '-',
-                            (update_event->mem_event.physical_address >> 12)
-                            );
-                s->memaccess.memtrap = update_event;
             }
+
+            s->memaccess.access = update_access;
         }
 
         s->traps = g_slist_prepend(s->traps, trap);
@@ -651,28 +629,25 @@ bool inject_trap_mem(drakvuf_t drakvuf, drakvuf_trap_t *trap, bool guard2) {
         return 1;
     } else {
 
+        status_t ret;
         xen_unshare_gfn(drakvuf->xen, drakvuf->domID, trap->memaccess.gfn);
 
         s = g_malloc0(sizeof(struct wrapper));
         s->drakvuf = drakvuf;
         s->traps = g_slist_prepend(s->traps, trap);
         s->memaccess.gfn = trap->memaccess.gfn;
+        s->memaccess.access = trap->memaccess.access;
 
         /*
          * Guard2 types are protecting remapped gfns, thus when hit
          * these need to be swapped to the altp2m_idr view.
          */
         s->memaccess.guard2 = guard2;
-        s->memaccess.memtrap = g_malloc0(sizeof(vmi_event_t));
-        s->memaccess.memtrap->data = drakvuf;
-        SETUP_MEM_EVENT(s->memaccess.memtrap, trap->memaccess.gfn<<12,
-                        trap->memaccess.access, pre_mem_cb);
-        s->memaccess.memtrap->vmm_pagetable_id = drakvuf->altp2m_idx;
 
-        if (VMI_FAILURE == vmi_register_event(drakvuf->vmi, s->memaccess.memtrap)) {
-            PRINT_DEBUG("*** FAILED TO REGISTER MEMORY TRAP @ PAGE %lu ***\n",
+        ret = vmi_set_mem_event(drakvuf->vmi, trap->memaccess.gfn<<12, trap->memaccess.access, drakvuf->altp2m_idx);
+        if ( ret == VMI_FAILURE ) {
+            PRINT_DEBUG("*** FAILED TO SET MEMORY TRAP @ PAGE %lu ***\n",
                         trap->memaccess.gfn);
-            free(s->memaccess.memtrap);
             g_slist_free(s->traps);
             free(s);
             return 0;
@@ -711,7 +686,7 @@ bool inject_trap_pa(drakvuf_t drakvuf,
     vmi_mem_access_t old_access = VMI_MEMACCESS_INVALID;
 
     if (s)
-        old_access = s->memaccess.memtrap->mem_event.in_access;
+        old_access = s->memaccess.access;
 
     container = g_malloc0(sizeof(struct wrapper));
 
@@ -1077,6 +1052,14 @@ bool init_vmi(drakvuf_t drakvuf) {
         return 0;
     }
 
+    SETUP_MEM_EVENT(&drakvuf->mem_event, ~0, VMI_MEMACCESS_RWX, pre_mem_cb, 1);
+    drakvuf->mem_event.data = drakvuf;
+
+    if(VMI_FAILURE == vmi_register_event(drakvuf->vmi, &drakvuf->mem_event)) {
+        fprintf(stderr, "Failed to register generic mem event\n");
+        return 0;
+    }
+
     rc = xc_altp2m_switch_to_view(drakvuf->xen->xc, drakvuf->domID, drakvuf->altp2m_idx);
     if ( rc < 0 ) {
         fprintf(stderr, "Failed to switch to altp2m view %u\n", drakvuf->altp2m_idx);
@@ -1092,16 +1075,17 @@ void close_vmi(drakvuf_t drakvuf) {
 
     xen_pause(drakvuf->xen, drakvuf->domID);
 
-    /*
-     * Make sure all memaccess events are on altp2m_idx
-     * so that vmi_destroy can properly reset the permissions.
-     */
     if(drakvuf->memaccess_lookup_gfn) {
         GHashTableIter i;
         addr_t *key = NULL;
         struct wrapper *s = NULL;
         ghashtable_foreach(drakvuf->memaccess_lookup_gfn, i, key, s)
-            s->memaccess.memtrap->vmm_pagetable_id = drakvuf->altp2m_idx;
+        {
+            vmi_set_mem_event(drakvuf->vmi, s->memaccess.gfn<<12, VMI_MEMACCESS_N, drakvuf->altp2m_idx);
+            xc_altp2m_change_gfn(drakvuf->xen->xc, drakvuf->domID, drakvuf->altp2m_idx, s->memaccess.gfn, ~0);
+            g_slist_free(s->traps);
+        }
+        g_hash_table_destroy(drakvuf->memaccess_lookup_gfn);
     }
 
     if (drakvuf->vmi) {
@@ -1125,19 +1109,6 @@ void close_vmi(drakvuf_t drakvuf) {
         ghashtable_foreach(drakvuf->breakpoint_lookup_pa, i, key, s)
             g_slist_free(s->traps);
         g_hash_table_destroy(drakvuf->breakpoint_lookup_pa);
-    }
-
-    if(drakvuf->memaccess_lookup_gfn) {
-        GHashTableIter i;
-        addr_t *key = NULL;
-        struct wrapper *s = NULL;
-        ghashtable_foreach(drakvuf->memaccess_lookup_gfn, i, key, s)
-        {
-            xc_altp2m_change_gfn(drakvuf->xen->xc, drakvuf->domID, drakvuf->altp2m_idx, s->memaccess.gfn, ~0);
-            free(s->memaccess.memtrap);
-            g_slist_free(s->traps);
-        }
-        g_hash_table_destroy(drakvuf->memaccess_lookup_gfn);
     }
 
     if(drakvuf->remapped_gfns) {

--- a/src/libdrakvuf/win-processes.c
+++ b/src/libdrakvuf/win-processes.c
@@ -117,18 +117,6 @@ typedef enum dispatcher_object {
     DISPATCHER_THREAD_OBJECT  = 6
 } dispatcher_object_t ;
 
-addr_t drakvuf_get_kernel_base(drakvuf_t drakvuf) {
-    reg_t fsgs;
-
-    if(vmi_get_page_mode(drakvuf->vmi) == VMI_PM_IA32E)  {
-        vmi_get_vcpureg(drakvuf->vmi, &fsgs, GS_BASE, 0);
-    } else {
-        vmi_get_vcpureg(drakvuf->vmi, &fsgs, FS_BASE, 0);
-    }
-
-    return fsgs - drakvuf->offsets[KIINITIALPCR];
-}
-
 addr_t drakvuf_get_current_thread(drakvuf_t drakvuf, uint64_t vcpu_id, const x86_registers_t *regs){
     vmi_instance_t vmi = drakvuf->vmi;
     addr_t thread;

--- a/src/libinjector/injector.c
+++ b/src/libinjector/injector.c
@@ -711,19 +711,16 @@ event_response_t cr3_callback(drakvuf_t drakvuf, drakvuf_trap_info_t *info) {
         drakvuf_pause(drakvuf);
         while(loop) {
             page_info_t *page = loop->data;
-            if(page->vaddr < 0x80000000  && USER_SUPERVISOR(page->x86_pae.pte_value)) {
-                vmi_event_t *new_event = vmi_get_mem_event(injector->vmi, page->paddr);
-                if(!new_event) {
-                    drakvuf_trap_t *new_trap = g_malloc0(sizeof(drakvuf_trap_t));
-                    new_trap->type = MEMACCESS;
-                    new_trap->cb = mem_callback;
-                    new_trap->data = injector;
-                    new_trap->memaccess.access = VMI_MEMACCESS_X;
-                    new_trap->memaccess.type = POST;
-                    new_trap->memaccess.gfn = page->paddr >> 12;
-                    injector->memtraps = g_slist_prepend(injector->memtraps, new_trap);
-                    drakvuf_add_trap(injector->drakvuf, new_trap);
-                }
+            if(page->vaddr < 0x80000000 && USER_SUPERVISOR(page->x86_pae.pte_value)) {
+                drakvuf_trap_t *new_trap = g_malloc0(sizeof(drakvuf_trap_t));
+                new_trap->type = MEMACCESS;
+                new_trap->cb = mem_callback;
+                new_trap->data = injector;
+                new_trap->memaccess.access = VMI_MEMACCESS_X;
+                new_trap->memaccess.type = POST;
+                new_trap->memaccess.gfn = page->paddr >> 12;
+                injector->memtraps = g_slist_prepend(injector->memtraps, new_trap);
+                drakvuf_add_trap(injector->drakvuf, new_trap);
             }
             free(page);
             loop = loop->next;


### PR DESCRIPTION
Fixes #204 and also a hitherto lingering bug where the GFN remapping would overwrite the memaccess settings on breakpointed pages, potentially leading to bluescreens as the breakpoints would become visible during read-accesses.