### PR TITLE
Include config.h from syscalls.cpp

### DIFF
--- a/src/plugins/syscalls/syscalls.cpp
+++ b/src/plugins/syscalls/syscalls.cpp
@@ -102,6 +102,7 @@
  *                                                                         *
  ***************************************************************************/
 
+#include <config.h>
 #include <glib.h>
 #include <inttypes.h>
 #include "syscalls.h"


### PR DESCRIPTION
This will ensure that macros such as `PRIu32` etc. will be defined correctly, as `config.h` will define `__STDC_FORMAT_MACROS` if necessary