### PR TITLE
(Windows platform): Use case insensitive comparison for processes names...

### DIFF
--- a/src/libdrakvuf/win-processes.c
+++ b/src/libdrakvuf/win-processes.c
@@ -363,7 +363,8 @@ bool win_find_eprocess(drakvuf_t drakvuf, vmi_pid_t find_pid, const char *find_p
 
         if((find_pid != ~0 && pid == find_pid) || (find_procname && procname && !strcasecmp(procname, find_procname))) {
             *eprocess_addr = current_process;
-            free(procname);
+            if ( procname )
+                free(procname);
             return true;
         }
 

--- a/src/libdrakvuf/win-processes.c
+++ b/src/libdrakvuf/win-processes.c
@@ -361,7 +361,7 @@ bool win_find_eprocess(drakvuf_t drakvuf, vmi_pid_t find_pid, const char *find_p
 
         char *procname = vmi_read_str_va(vmi, current_process + drakvuf->offsets[EPROCESS_PNAME], 0);
 
-        if((find_pid != ~0 && pid == find_pid) || (find_procname && procname && !strcmp(procname, find_procname))) {
+        if((find_pid != ~0 && pid == find_pid) || (find_procname && procname && !strcasecmp(procname, find_procname))) {
             *eprocess_addr = current_process;
             free(procname);
             return true;


### PR DESCRIPTION
- When looking for a process name we don't have guaranteed its name case so use _strcasecmp_ instead of _strcmp_.

- Currently the  code checks for null before freeing the memory for the process name (allocated by the _vmi_read_str_va()_ call) only when the user is looking for process name and not when looking for pid.
I agree is high unlikely but IMHO could happen so I'd prefere to check before diving into that swimming pool.  :)

