### PR TITLE
Fix vmi_write_pa return value

### DIFF
--- a/src/libdrakvuf/vmi.c
+++ b/src/libdrakvuf/vmi.c
@@ -947,7 +947,7 @@ bool inject_trap_pa(drakvuf_t drakvuf,
             return 0;
         }
 
-        if ( VMI_FAILURE == vmi_write_pa(drakvuf->vmi, remapped_gfn->r << 12, VMI_PS_4KB, &backup, NULL) )
+        if ( VMI_SUCCESS == vmi_write_pa(drakvuf->vmi, remapped_gfn->r << 12, VMI_PS_4KB, &backup, NULL) )
             PRINT_DEBUG("Copied trapped page to new location\n");
         else {
             // TODO cleanup


### PR DESCRIPTION
If writing with the `vmi_write_pa` call has succeded return value will be VMI_SUCCESS