### PR TITLE
Don't pack internal structures

### DIFF
--- a/src/libdrakvuf/private.h
+++ b/src/libdrakvuf/private.h
@@ -204,14 +204,13 @@ struct breakpoint
     addr_t pa;
     drakvuf_trap_t guard, guard2;
     bool doubletrap;
-} __attribute__ ((packed));
-
+};
 struct memaccess
 {
     addr_t gfn;
     bool guard2;
     vmi_mem_access_t access;
-} __attribute__ ((packed));
+};
 
 struct wrapper
 {
@@ -223,7 +222,7 @@ struct wrapper
         struct memaccess memaccess;
         struct breakpoint breakpoint;
     };
-} __attribute__ ((packed));
+};
 
 struct free_trap_wrapper
 {


### PR DESCRIPTION
clang complains:
`
vmi.c:768:39: error: taking address of packed member 'guard' of class or structure 'breakpoint' may result in an unaligned pointer value [-Werror,-Waddress-of-packed-member]
                remove_trap(drakvuf, &container->breakpoint.guard);
                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~`