### PR TITLE
Log current time in seconds and microseconds.

### DIFF
--- a/src/plugins/cpuidmon/cpuidmon.cpp
+++ b/src/plugins/cpuidmon/cpuidmon.cpp
@@ -130,12 +130,12 @@ event_response_t cpuid_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
     switch (s->format)
     {
         case OUTPUT_CSV:
-            printf("[" FORMAT_TIMEVAL "] cpuidmon,%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64 "\n",
+            printf("cpuidmon," FORMAT_TIMEVAL ",%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64 "\n",
                    UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3, info->proc_data.name, info->proc_data.userid);
             break;
         default:
         case OUTPUT_DEFAULT:
-            printf("[" FORMAT_TIMEVAL "][CPUIDMON] VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64". "
+            printf("[CPUIDMON] TIME:" FORMAT_TIMEVAL " VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64". "
                    "Leaf: 0x%" PRIx32 ". Subleaf: 0x%" PRIx32". "
                    "RAX: 0x%" PRIx64 " RBX: 0x%" PRIx64 " RCX: 0x%" PRIx64 " RDX: 0x%" PRIx64 "\n",
                    UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3, info->proc_data.name,

--- a/src/plugins/cpuidmon/cpuidmon.cpp
+++ b/src/plugins/cpuidmon/cpuidmon.cpp
@@ -126,18 +126,19 @@ event_response_t cpuid_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 
     cpuidmon* s = (cpuidmon*)info->trap->data;
 
+    timeval t = get_time();
     switch (s->format)
     {
         case OUTPUT_CSV:
-            printf("cpuidmon,%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64 "\n",
-                   info->vcpu, info->regs->cr3, info->proc_data.name, info->proc_data.userid);
+            printf("[" FORMAT_TIMEVAL "] cpuidmon,%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64 "\n",
+                   UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3, info->proc_data.name, info->proc_data.userid);
             break;
         default:
         case OUTPUT_DEFAULT:
-            printf("[CPUIDMON] VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64". "
+            printf("[" FORMAT_TIMEVAL "][CPUIDMON] VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64". "
                    "Leaf: 0x%" PRIx32 ". Subleaf: 0x%" PRIx32". "
                    "RAX: 0x%" PRIx64 " RBX: 0x%" PRIx64 " RCX: 0x%" PRIx64 " RDX: 0x%" PRIx64 "\n",
-                   info->vcpu, info->regs->cr3, info->proc_data.name,
+                   UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3, info->proc_data.name,
                    USERIDSTR(drakvuf), info->proc_data.userid,
                    info->cpuid->leaf, info->cpuid->subleaf,
                    info->regs->rax, info->regs->rbx, info->regs->rcx, info->regs->rdx

--- a/src/plugins/debugmon/debugmon.cpp
+++ b/src/plugins/debugmon/debugmon.cpp
@@ -143,18 +143,19 @@ event_response_t debug_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 
     debugmon* s = (debugmon*)info->trap->data;
 
+    timeval t = get_time();
     switch (s->format)
     {
         case OUTPUT_CSV:
-            printf("debugmon,%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64 ",%" PRIx64 ",%" PRIi32 ",%s\n",
-                   info->vcpu, info->regs->cr3, info->proc_data.name, info->proc_data.userid,
+            printf("[" FORMAT_TIMEVAL "] debugmon,%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64 ",%" PRIx64 ",%" PRIi32 ",%s\n",
+                   UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3, info->proc_data.name, info->proc_data.userid,
                    info->regs->rip, info->debug->type, debug_type[info->debug->type]);
             break;
         default:
         case OUTPUT_DEFAULT:
-            printf("[DEBUGMON] VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64". "
+            printf("[" FORMAT_TIMEVAL "][DEBUGMON] VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64". "
                    "RIP: 0x%" PRIx64". Debug type: %" PRIi32 ",%s\n",
-                   info->vcpu, info->regs->cr3, info->proc_data.name,
+                   UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3, info->proc_data.name,
                    USERIDSTR(drakvuf), info->proc_data.userid,
                    info->regs->rip, info->debug->type, debug_type[info->debug->type]);
             break;

--- a/src/plugins/debugmon/debugmon.cpp
+++ b/src/plugins/debugmon/debugmon.cpp
@@ -147,13 +147,13 @@ event_response_t debug_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
     switch (s->format)
     {
         case OUTPUT_CSV:
-            printf("[" FORMAT_TIMEVAL "] debugmon,%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64 ",%" PRIx64 ",%" PRIi32 ",%s\n",
+            printf("debugmon," FORMAT_TIMEVAL ",%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64 ",%" PRIx64 ",%" PRIi32 ",%s\n",
                    UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3, info->proc_data.name, info->proc_data.userid,
                    info->regs->rip, info->debug->type, debug_type[info->debug->type]);
             break;
         default:
         case OUTPUT_DEFAULT:
-            printf("[" FORMAT_TIMEVAL "][DEBUGMON] VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64". "
+            printf("[DEBUGMON] TIME:" FORMAT_TIMEVAL " VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64". "
                    "RIP: 0x%" PRIx64". Debug type: %" PRIi32 ",%s\n",
                    UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3, info->proc_data.name,
                    USERIDSTR(drakvuf), info->proc_data.userid,

--- a/src/plugins/exmon/exmon.cpp
+++ b/src/plugins/exmon/exmon.cpp
@@ -216,20 +216,22 @@ static event_response_t cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
         if ( VMI_FAILURE == vmi_read_32(vmi, &ctx, (uint32_t*)&exception_code) )
             goto done;
 
+        timeval t = get_time();
         switch (e->format)
         {
             case OUTPUT_CSV:
-                str_format=CSV_FORMAT32;
-                user_format=CSV_FORMAT_USER;
+                str_format="[" FORMAT_TIMEVAL "] " CSV_FORMAT32;
+                user_format="[" FORMAT_TIMEVAL "] " CSV_FORMAT_USER;
                 break;
             default:
             case OUTPUT_DEFAULT:
-                str_format=DEFAULT_FORMAT32;
-                user_format=DEFAULT_FORMAT_USER;
+                str_format="[" FORMAT_TIMEVAL "]" DEFAULT_FORMAT32;
+                user_format="[" FORMAT_TIMEVAL "]" DEFAULT_FORMAT_USER;
                 break;
         }
 
         printf(str_format, \
+               UNPACK_TIMEVAL(t),
                (uint32_t)info->regs->rsp,
                (uint32_t)exception_record,
                (uint32_t)exception_code,
@@ -258,10 +260,10 @@ static event_response_t cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
                     goto done;
 
                 name = vmi_read_str_va(vmi, process + e->offsets[EPROCESS_NAME], 0);
-                printf(user_format,pid,ppid,name);
+                printf(user_format,UNPACK_TIMEVAL(t),pid,ppid,name);
                 free(name);
             }
-            else printf(user_format,0,"NOPROC");
+            else printf(user_format,UNPACK_TIMEVAL(t),0,"NOPROC");
         }
         else
         {
@@ -284,19 +286,21 @@ static event_response_t cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
         if ( VMI_FAILURE == vmi_read_32(vmi, &ctx, (uint32_t*)&first_chance) )
             goto done;
 
+        timeval t = get_time();
         switch (e->format)
         {
             case OUTPUT_CSV:
-                str_format=CSV_FORMAT64;
-                user_format=CSV_FORMAT_USER;
+                str_format="[" FORMAT_TIMEVAL "] " CSV_FORMAT64;
+                user_format="[" FORMAT_TIMEVAL "] " CSV_FORMAT_USER;
                 break;
             default:
             case OUTPUT_DEFAULT:
-                str_format=DEFAULT_FORMAT64;
-                user_format=DEFAULT_FORMAT_USER;
+                str_format="[" FORMAT_TIMEVAL "]" DEFAULT_FORMAT64;
+                user_format="[" FORMAT_TIMEVAL "]" DEFAULT_FORMAT_USER;
                 break;
         }
         printf(str_format, \
+               UNPACK_TIMEVAL(t),
                info->regs->rcx, exception_code, first_chance & 1,
                *(uint64_t*)(trap_frame+e->offsets[KTRAP_FRAME_RIP]),
                *(uint64_t*)(trap_frame+e->offsets[KTRAP_FRAME_RAX]),
@@ -327,10 +331,10 @@ static event_response_t cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
                     goto done;
 
                 name = vmi_read_str_va(vmi, process + e->offsets[EPROCESS_NAME], 0);
-                printf(user_format,pid,ppid,name);
+                printf(user_format,UNPACK_TIMEVAL(t),pid,ppid,name);
                 free(name);
             }
-            else printf(user_format,0,"NOPROC");
+            else printf(user_format,UNPACK_TIMEVAL(t),0,"NOPROC");
         }
         else
         {

--- a/src/plugins/exmon/exmon.cpp
+++ b/src/plugins/exmon/exmon.cpp
@@ -220,13 +220,13 @@ static event_response_t cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
         switch (e->format)
         {
             case OUTPUT_CSV:
-                str_format="[" FORMAT_TIMEVAL "] " CSV_FORMAT32;
-                user_format="[" FORMAT_TIMEVAL "] " CSV_FORMAT_USER;
+                str_format=CSV_FORMAT32;
+                user_format=CSV_FORMAT_USER;
                 break;
             default:
             case OUTPUT_DEFAULT:
-                str_format="[" FORMAT_TIMEVAL "]" DEFAULT_FORMAT32;
-                user_format="[" FORMAT_TIMEVAL "]" DEFAULT_FORMAT_USER;
+                str_format=DEFAULT_FORMAT32;
+                user_format=DEFAULT_FORMAT_USER;
                 break;
         }
 
@@ -260,10 +260,10 @@ static event_response_t cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
                     goto done;
 
                 name = vmi_read_str_va(vmi, process + e->offsets[EPROCESS_NAME], 0);
-                printf(user_format,UNPACK_TIMEVAL(t),pid,ppid,name);
+                printf(user_format,pid,ppid,name);
                 free(name);
             }
-            else printf(user_format,UNPACK_TIMEVAL(t),0,"NOPROC");
+            else printf(user_format,0,"NOPROC");
         }
         else
         {
@@ -290,13 +290,13 @@ static event_response_t cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
         switch (e->format)
         {
             case OUTPUT_CSV:
-                str_format="[" FORMAT_TIMEVAL "] " CSV_FORMAT64;
-                user_format="[" FORMAT_TIMEVAL "] " CSV_FORMAT_USER;
+                str_format=CSV_FORMAT64;
+                user_format=CSV_FORMAT_USER;
                 break;
             default:
             case OUTPUT_DEFAULT:
-                str_format="[" FORMAT_TIMEVAL "]" DEFAULT_FORMAT64;
-                user_format="[" FORMAT_TIMEVAL "]" DEFAULT_FORMAT_USER;
+                str_format=DEFAULT_FORMAT64;
+                user_format=DEFAULT_FORMAT_USER;
                 break;
         }
         printf(str_format, \
@@ -331,10 +331,10 @@ static event_response_t cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
                     goto done;
 
                 name = vmi_read_str_va(vmi, process + e->offsets[EPROCESS_NAME], 0);
-                printf(user_format,UNPACK_TIMEVAL(t),pid,ppid,name);
+                printf(user_format,pid,ppid,name);
                 free(name);
             }
-            else printf(user_format,UNPACK_TIMEVAL(t),0,"NOPROC");
+            else printf(user_format,0,"NOPROC");
         }
         else
         {

--- a/src/plugins/exmon/exmon.cpp
+++ b/src/plugins/exmon/exmon.cpp
@@ -263,7 +263,7 @@ static event_response_t cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
                 printf(user_format,pid,ppid,name);
                 free(name);
             }
-            else printf(user_format,0,"NOPROC");
+            else printf(user_format,0,0,"NOPROC");
         }
         else
         {
@@ -334,7 +334,7 @@ static event_response_t cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
                 printf(user_format,pid,ppid,name);
                 free(name);
             }
-            else printf(user_format,0,"NOPROC");
+            else printf(user_format,0,0,"NOPROC");
         }
         else
         {

--- a/src/plugins/exmon/private.h
+++ b/src/plugins/exmon/private.h
@@ -105,11 +105,13 @@
 #ifndef EXMON_PRIVATE_H
 #define EXMON_PRIVATE_H
 
-#define CSV_FORMAT32 "exmon,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x"
-#define CSV_FORMAT64 "exmon,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x"
+#include "plugins/plugins.h"
 
-#define DEFAULT_FORMAT32 "[EXMON] RSP: %x EXCEPTION_RECORD: %x EXCEPTION_CODE: %x FIRST_CHANCE: %x EIP: %x EAX: %x EBX: %x ECX: %x EDX: %x EDI: %x ESI: %x EBP: %x ESP: %x"
-#define DEFAULT_FORMAT64 "[EXMON] EXCEPTION_RECORD: %x EXCEPTION_CODE: %x FIRST_CHANCE: %x RIP: %x RAX: %x RBX: %x RCX: %x RDX: %x RSP: %x RBP: %x RSI: %x RDI: %x R8: %x R9: %x R10: %x R11:%x"
+#define CSV_FORMAT32 "exmon," FORMAT_TIMEVAL ",%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x"
+#define CSV_FORMAT64 "exmon," FORMAT_TIMEVAL ",%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x"
+
+#define DEFAULT_FORMAT32 "[EXMON] TIME:" FORMAT_TIMEVAL " RSP: %x EXCEPTION_RECORD: %x EXCEPTION_CODE: %x FIRST_CHANCE: %x EIP: %x EAX: %x EBX: %x ECX: %x EDX: %x EDI: %x ESI: %x EBP: %x ESP: %x"
+#define DEFAULT_FORMAT64 "[EXMON] TIME:" FORMAT_TIMEVAL " EXCEPTION_RECORD: %x EXCEPTION_CODE: %x FIRST_CHANCE: %x RIP: %x RAX: %x RBX: %x RCX: %x RDX: %x RSP: %x RBP: %x RSI: %x RDI: %x R8: %x R9: %x R10: %x R11:%x"
 
 #define CSV_FORMAT_USER ",%d,%d,%s\n"
 

--- a/src/plugins/filedelete/filedelete.cpp
+++ b/src/plugins/filedelete/filedelete.cpp
@@ -375,12 +375,12 @@ static void grab_file_by_handle(filedelete* f, drakvuf_t drakvuf,
         switch (f->format)
         {
             case OUTPUT_CSV:
-                printf("[" FORMAT_TIMEVAL "] filedelete,%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64 ",\"%s\"\n",
+                printf("filedelete," FORMAT_TIMEVAL ",%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64 ",\"%s\"\n",
                        UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3, info->proc_data.name, info->proc_data.userid, filename_us->contents);
                 break;
             default:
             case OUTPUT_DEFAULT:
-                printf("[" FORMAT_TIMEVAL "][FILEDELETE] VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64" \"%s\"\n",
+                printf("[FILEDELETE] TIME:" FORMAT_TIMEVAL " VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64" \"%s\"\n",
                        UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3, info->proc_data.name,
                        USERIDSTR(drakvuf), info->proc_data.userid, filename_us->contents);
                 break;

--- a/src/plugins/filedelete/filedelete.cpp
+++ b/src/plugins/filedelete/filedelete.cpp
@@ -369,18 +369,19 @@ static void grab_file_by_handle(filedelete* f, drakvuf_t drakvuf,
 
     unicode_string_t* filename_us = drakvuf_read_unicode(drakvuf, info, filename);
 
+    timeval t = get_time();
     if (filename_us)
     {
         switch (f->format)
         {
             case OUTPUT_CSV:
-                printf("filedelete,%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64 ",\"%s\"\n",
-                       info->vcpu, info->regs->cr3, info->proc_data.name, info->proc_data.userid, filename_us->contents);
+                printf("[" FORMAT_TIMEVAL "] filedelete,%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64 ",\"%s\"\n",
+                       UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3, info->proc_data.name, info->proc_data.userid, filename_us->contents);
                 break;
             default:
             case OUTPUT_DEFAULT:
-                printf("[FILEDELETE] VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64" \"%s\"\n",
-                       info->vcpu, info->regs->cr3, info->proc_data.name,
+                printf("[" FORMAT_TIMEVAL "][FILEDELETE] VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64" \"%s\"\n",
+                       UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3, info->proc_data.name,
                        USERIDSTR(drakvuf), info->proc_data.userid, filename_us->contents);
                 break;
         }

--- a/src/plugins/filetracer/filetracer.cpp
+++ b/src/plugins/filetracer/filetracer.cpp
@@ -235,17 +235,18 @@ static event_response_t objattr_read(drakvuf_t drakvuf, drakvuf_trap_info_t* inf
     const char* file_sep = file_root_us ? "\\" : "";
     const char* file_name = (const char*)file_name_us->contents;
 
+    timeval t = get_time();
     switch (f->format)
     {
         case OUTPUT_CSV:
-            printf("filetracer,%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64",%s,%s%s%s\n",
-                   info->vcpu, info->regs->cr3, info->proc_data.name, info->proc_data.userid, syscall_name, file_root, file_sep, file_name);
+            printf("[" FORMAT_TIMEVAL "] filetracer,%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64",%s,%s%s%s\n",
+                   UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3, info->proc_data.name, info->proc_data.userid, syscall_name, file_root, file_sep, file_name);
             break;
 
         default:
         case OUTPUT_DEFAULT:
-            printf("[FILETRACER] VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " %s,%s%s%s\n",
-                   info->vcpu, info->regs->cr3, info->proc_data.name,
+            printf("[" FORMAT_TIMEVAL "][FILETRACER] VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " %s,%s%s%s\n",
+                   UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3, info->proc_data.name,
                    USERIDSTR(drakvuf), info->proc_data.userid, syscall_name, file_root, file_sep, file_name);
             break;
     }
@@ -326,18 +327,19 @@ static void print_rename_file_info(vmi_instance_t vmi, drakvuf_t drakvuf, drakvu
     }
     vmi_free_unicode_str(dst_file_name_us);
 
+    timeval t = get_time();
     switch (f->format)
     {
         case OUTPUT_CSV:
-            printf("filetracer,%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64",%s,%s,%s,%s\n",
-                   info->vcpu, info->regs->cr3, info->proc_data.name, info->proc_data.userid,
+            printf("[" FORMAT_TIMEVAL "] filetracer,%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64",%s,%s,%s,%s\n",
+                   UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3, info->proc_data.name, info->proc_data.userid,
                    syscall_name, operation_name, src_file_us->contents, dst_file_p);
             break;
 
         default:
         case OUTPUT_DEFAULT:
-            printf("[FILETRACER] VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " %s,%s,%s,%s\n",
-                   info->vcpu, info->regs->cr3, info->proc_data.name, USERIDSTR(drakvuf), info->proc_data.userid,
+            printf("[" FORMAT_TIMEVAL "][FILETRACER] VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " %s,%s,%s,%s\n",
+                   UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3, info->proc_data.name, USERIDSTR(drakvuf), info->proc_data.userid,
                    syscall_name, operation_name, src_file_us->contents, dst_file_p);
             break;
     }

--- a/src/plugins/filetracer/filetracer.cpp
+++ b/src/plugins/filetracer/filetracer.cpp
@@ -239,13 +239,13 @@ static event_response_t objattr_read(drakvuf_t drakvuf, drakvuf_trap_info_t* inf
     switch (f->format)
     {
         case OUTPUT_CSV:
-            printf("[" FORMAT_TIMEVAL "] filetracer,%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64",%s,%s%s%s\n",
+            printf("filetracer," FORMAT_TIMEVAL ",%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64",%s,%s%s%s\n",
                    UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3, info->proc_data.name, info->proc_data.userid, syscall_name, file_root, file_sep, file_name);
             break;
 
         default:
         case OUTPUT_DEFAULT:
-            printf("[" FORMAT_TIMEVAL "][FILETRACER] VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " %s,%s%s%s\n",
+            printf("[FILETRACER] TIME:" FORMAT_TIMEVAL " VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " %s,%s%s%s\n",
                    UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3, info->proc_data.name,
                    USERIDSTR(drakvuf), info->proc_data.userid, syscall_name, file_root, file_sep, file_name);
             break;
@@ -331,14 +331,14 @@ static void print_rename_file_info(vmi_instance_t vmi, drakvuf_t drakvuf, drakvu
     switch (f->format)
     {
         case OUTPUT_CSV:
-            printf("[" FORMAT_TIMEVAL "] filetracer,%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64",%s,%s,%s,%s\n",
+            printf("filetracer," FORMAT_TIMEVAL ",%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64",%s,%s,%s,%s\n",
                    UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3, info->proc_data.name, info->proc_data.userid,
                    syscall_name, operation_name, src_file_us->contents, dst_file_p);
             break;
 
         default:
         case OUTPUT_DEFAULT:
-            printf("[" FORMAT_TIMEVAL "][FILETRACER] VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " %s,%s,%s,%s\n",
+            printf("[FILETRACER] TIME:" FORMAT_TIMEVAL " VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " %s,%s,%s,%s\n",
                    UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3, info->proc_data.name, USERIDSTR(drakvuf), info->proc_data.userid,
                    syscall_name, operation_name, src_file_us->contents, dst_file_p);
             break;

--- a/src/plugins/objmon/objmon.cpp
+++ b/src/plugins/objmon/objmon.cpp
@@ -175,14 +175,14 @@ static event_response_t cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
     {
         case OUTPUT_CSV:
         {
-            printf("[" FORMAT_TIMEVAL "] objmon,%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64 ",%c%c%c%c",
+            printf("objmon," FORMAT_TIMEVAL ",%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64 ",%c%c%c%c",
                    UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3, info->proc_data.name, info->proc_data.userid,
                    ckey._key[0], ckey._key[1], ckey._key[2], ckey._key[3]);
             break;
         }
         default:
         case OUTPUT_DEFAULT:
-            printf("[" FORMAT_TIMEVAL "][OBJMON] vCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64" '%c%c%c%c'",
+            printf("[OBJMON] TIME:" FORMAT_TIMEVAL " VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64" '%c%c%c%c'",
                    UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3, info->proc_data.name,
                    USERIDSTR(drakvuf), info->proc_data.userid,
                    ckey._key[0], ckey._key[1], ckey._key[2], ckey._key[3]);

--- a/src/plugins/objmon/objmon.cpp
+++ b/src/plugins/objmon/objmon.cpp
@@ -170,19 +170,20 @@ static event_response_t cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 
     vmi_read_32(vmi, &ctx, &ckey.key);
 
+    timeval t = get_time();
     switch (o->format)
     {
         case OUTPUT_CSV:
         {
-            printf("objmon,%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64 ",%c%c%c%c",
-                   info->vcpu, info->regs->cr3, info->proc_data.name, info->proc_data.userid,
+            printf("[" FORMAT_TIMEVAL "] objmon,%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64 ",%c%c%c%c",
+                    UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3, info->proc_data.name, info->proc_data.userid,
                    ckey._key[0], ckey._key[1], ckey._key[2], ckey._key[3]);
             break;
         }
         default:
         case OUTPUT_DEFAULT:
-            printf("[OBJMON] vCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64" '%c%c%c%c'",
-                   info->vcpu, info->regs->cr3, info->proc_data.name,
+            printf("[" FORMAT_TIMEVAL "][OBJMON] vCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64" '%c%c%c%c'",
+                   UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3, info->proc_data.name,
                    USERIDSTR(drakvuf), info->proc_data.userid,
                    ckey._key[0], ckey._key[1], ckey._key[2], ckey._key[3]);
             break;

--- a/src/plugins/objmon/objmon.cpp
+++ b/src/plugins/objmon/objmon.cpp
@@ -176,7 +176,7 @@ static event_response_t cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
         case OUTPUT_CSV:
         {
             printf("[" FORMAT_TIMEVAL "] objmon,%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64 ",%c%c%c%c",
-                    UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3, info->proc_data.name, info->proc_data.userid,
+                   UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3, info->proc_data.name, info->proc_data.userid,
                    ckey._key[0], ckey._key[1], ckey._key[2], ckey._key[3]);
             break;
         }

--- a/src/plugins/plugins.h
+++ b/src/plugins/plugins.h
@@ -211,7 +211,7 @@ public:
 // Retrieves system time in seconds and microseconds.
 inline timeval get_time()
 {
-    struct timeval now{};
+    struct timeval now {};
     gettimeofday(&now, nullptr);
     return now;
 }

--- a/src/plugins/plugins.h
+++ b/src/plugins/plugins.h
@@ -107,6 +107,8 @@
 
 #include <config.h>
 #include <stdlib.h>
+#include <inttypes.h>
+#include <sys/time.h>
 #include <libdrakvuf/libdrakvuf.h>
 
 /***************************************************************************/
@@ -180,7 +182,7 @@ static const bool drakvuf_plugin_os_support[__DRAKVUF_PLUGIN_LIST_MAX][VMI_OS_WI
     [PLUGIN_SSDTMON]    = { [VMI_OS_WINDOWS] = 1, [VMI_OS_LINUX] = 0 },
     [PLUGIN_DEBUGMON]   = { [VMI_OS_WINDOWS] = 1, [VMI_OS_LINUX] = 1 },
     [PLUGIN_CPUIDMON]   = { [VMI_OS_WINDOWS] = 1, [VMI_OS_LINUX] = 1 },
-    [PLUGIN_SOCKETMON]     = { [VMI_OS_WINDOWS] = 1, [VMI_OS_LINUX] = 0 },
+    [PLUGIN_SOCKETMON]  = { [VMI_OS_WINDOWS] = 1, [VMI_OS_LINUX] = 0 },
     [PLUGIN_REGMON]     = { [VMI_OS_WINDOWS] = 1, [VMI_OS_LINUX] = 0 },
 };
 
@@ -203,6 +205,20 @@ public:
     ~drakvuf_plugins();
     int start(drakvuf_plugin_t plugin, const void* config);
 };
+
+/***************************************************************************/
+
+// Retrieves system time in seconds and microseconds.
+inline timeval get_time()
+{
+    struct timeval now{};
+    gettimeofday(&now, nullptr);
+    return now;
+}
+
+// Printf helpers for timeval.
+#define FORMAT_TIMEVAL "%" PRId64 ".%06" PRId64
+#define UNPACK_TIMEVAL(t) (t).tv_sec, (t).tv_usec
 
 /***************************************************************************/
 

--- a/src/plugins/poolmon/poolmon.cpp
+++ b/src/plugins/poolmon/poolmon.cpp
@@ -178,7 +178,7 @@ static event_response_t cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
     {
         case OUTPUT_CSV:
         {
-            printf("[" FORMAT_TIMEVAL "] poolmon,%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64 ",%s,%s,%" PRIu64 "",
+            printf("poolmon," FORMAT_TIMEVAL ",%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64 ",%s,%s,%" PRIu64 "",
                    UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3, info->proc_data.name, info->proc_data.userid, tag,
                    pool_type<MaxPoolType ? pool_types[pool_type] : "unknown_pool_type", size);
             if (s)
@@ -187,7 +187,7 @@ static event_response_t cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
         }
         default:
         case OUTPUT_DEFAULT:
-            printf("[" FORMAT_TIMEVAL "][POOLMON] vCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " %s (type: %s, size: %" PRIu64 ")",
+            printf("[POOLMON] TIME:" FORMAT_TIMEVAL " VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " %s (type: %s, size: %" PRIu64 ")",
                    UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3, info->proc_data.name,
                    USERIDSTR(drakvuf), info->proc_data.userid, tag,
                    pool_type<MaxPoolType ? pool_types[pool_type] : "unknown_pool_type", size);

--- a/src/plugins/poolmon/poolmon.cpp
+++ b/src/plugins/poolmon/poolmon.cpp
@@ -144,6 +144,7 @@ static event_response_t cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
     reg_t pool_type, size;
     char tag[5] = { [0 ... 4] = '\0' };
     struct pooltag* s = NULL;
+    timeval t;
 
     access_context_t ctx;
     ctx.translate_mechanism = VMI_TM_PROCESS_DTB;
@@ -172,12 +173,13 @@ static event_response_t cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 
     s = (struct pooltag*)g_tree_lookup(p->pooltag_tree, tag);
 
+    t = get_time();
     switch (p->format)
     {
         case OUTPUT_CSV:
         {
-            printf("poolmon,%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64 ",%s,%s,%" PRIu64 "",
-                   info->vcpu, info->regs->cr3, info->proc_data.name, info->proc_data.userid, tag,
+            printf("[" FORMAT_TIMEVAL "] poolmon,%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64 ",%s,%s,%" PRIu64 "",
+                   UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3, info->proc_data.name, info->proc_data.userid, tag,
                    pool_type<MaxPoolType ? pool_types[pool_type] : "unknown_pool_type", size);
             if (s)
                 printf(",%s,%s", s->source, s->description);
@@ -185,13 +187,12 @@ static event_response_t cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
         }
         default:
         case OUTPUT_DEFAULT:
-            printf("[POOLMON] vCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " %s (type: %s, size: %" PRIu64 ")",
-                   info->vcpu, info->regs->cr3, info->proc_data.name,
+            printf("[" FORMAT_TIMEVAL "][POOLMON] vCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " %s (type: %s, size: %" PRIu64 ")",
+                   UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3, info->proc_data.name,
                    USERIDSTR(drakvuf), info->proc_data.userid, tag,
                    pool_type<MaxPoolType ? pool_types[pool_type] : "unknown_pool_type", size);
             if (s)
                 printf(": %s,%s", s->source, s->description);
-
             break;
     };
 

--- a/src/plugins/regmon/regmon.cpp
+++ b/src/plugins/regmon/regmon.cpp
@@ -132,7 +132,7 @@ static event_response_t log_reg_hook( drakvuf_t drakvuf, drakvuf_trap_info_t* in
             switch ( reg->format )
             {
                 case OUTPUT_CSV:
-                    printf("[" FORMAT_TIMEVAL "] regmon,%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64",%s,%s",
+                    printf("regmon," FORMAT_TIMEVAL ",%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64",%s,%s",
                            UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3, info->proc_data.name, info->proc_data.userid, syscall_name, key_path );
                     if (with_value_name)
                         printf(",%s", value_name);
@@ -141,7 +141,7 @@ static event_response_t log_reg_hook( drakvuf_t drakvuf, drakvuf_trap_info_t* in
 
                 default:
                 case OUTPUT_DEFAULT:
-                    printf("[" FORMAT_TIMEVAL "][REGMON] VCPU:%" PRIu32 " CR3:0x%" PRIx64 ", EPROCESS:0x%" PRIx64 ", PID:%d, PPID:%d, \"%s\" %s:%" PRIi64 " %s:%s",
+                    printf("[REGMON] TIME:" FORMAT_TIMEVAL " VCPU:%" PRIu32 " CR3:0x%" PRIx64 ", EPROCESS:0x%" PRIx64 ", PID:%d, PPID:%d, \"%s\" %s:%" PRIi64 " %s:%s",
                            UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3, info->proc_data.base_addr, info->proc_data.pid, info->proc_data.ppid, info->proc_data.name,
                            USERIDSTR(drakvuf), info->proc_data.userid, syscall_name, key_path );
                     if (with_value_name)
@@ -216,13 +216,13 @@ static event_response_t log_reg_objattr_hook(drakvuf_t drakvuf, drakvuf_trap_inf
         switch ( reg->format )
         {
             case OUTPUT_CSV:
-                printf("[" FORMAT_TIMEVAL "] regmon,%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64",%s,%s%s%s\n",
+                printf("regmon," FORMAT_TIMEVAL ",%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64",%s,%s%s%s\n",
                        UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3, info->proc_data.name, info->proc_data.userid, syscall_name, key_root, key_sep, key_name );
                 break;
 
             default:
             case OUTPUT_DEFAULT:
-                printf("[" FORMAT_TIMEVAL "][REGMON] VCPU:%" PRIu32 " CR3:0x%" PRIx64 ", EPROCESS:0x%" PRIx64 ", PID:%d, PPID:%d, \"%s\" %s:%" PRIi64 " %s:%s%s%s\n",
+                printf("[REGMON] TIME:" FORMAT_TIMEVAL " VCPU:%" PRIu32 " CR3:0x%" PRIx64 ", EPROCESS:0x%" PRIx64 ", PID:%d, PPID:%d, \"%s\" %s:%" PRIi64 " %s:%s%s%s\n",
                        UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3, info->proc_data.base_addr, info->proc_data.pid, info->proc_data.ppid, info->proc_data.name,
                        USERIDSTR(drakvuf), info->proc_data.userid, syscall_name, key_root, key_sep, key_name );
                 break;

--- a/src/plugins/regmon/regmon.cpp
+++ b/src/plugins/regmon/regmon.cpp
@@ -128,11 +128,12 @@ static event_response_t log_reg_hook( drakvuf_t drakvuf, drakvuf_trap_info_t* in
         {
             regmon* reg = (regmon*)info->trap->data;
 
+            timeval t = get_time();
             switch ( reg->format )
             {
                 case OUTPUT_CSV:
-                    printf("regmon,%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64",%s,%s",
-                           info->vcpu, info->regs->cr3, info->proc_data.name, info->proc_data.userid, syscall_name, key_path );
+                    printf("[" FORMAT_TIMEVAL "] regmon,%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64",%s,%s",
+                           UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3, info->proc_data.name, info->proc_data.userid, syscall_name, key_path );
                     if (with_value_name)
                         printf(",%s", value_name);
                     printf("\n");
@@ -140,8 +141,8 @@ static event_response_t log_reg_hook( drakvuf_t drakvuf, drakvuf_trap_info_t* in
 
                 default:
                 case OUTPUT_DEFAULT:
-                    printf("[REGMON] VCPU:%" PRIu32 " CR3:0x%" PRIx64 ", EPROCESS:0x%" PRIx64 ", PID:%d, PPID:%d, \"%s\" %s:%" PRIi64 " %s:%s",
-                           info->vcpu, info->regs->cr3, info->proc_data.base_addr, info->proc_data.pid, info->proc_data.ppid, info->proc_data.name,
+                    printf("[" FORMAT_TIMEVAL "][REGMON] VCPU:%" PRIu32 " CR3:0x%" PRIx64 ", EPROCESS:0x%" PRIx64 ", PID:%d, PPID:%d, \"%s\" %s:%" PRIi64 " %s:%s",
+                           UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3, info->proc_data.base_addr, info->proc_data.pid, info->proc_data.ppid, info->proc_data.name,
                            USERIDSTR(drakvuf), info->proc_data.userid, syscall_name, key_path );
                     if (with_value_name)
                         printf(",%s", value_name);
@@ -211,17 +212,18 @@ static event_response_t log_reg_objattr_hook(drakvuf_t drakvuf, drakvuf_trap_inf
         const char* key_name = (const char*)str2.contents ?: "";
         const char* key_sep = key_root_p ? "\\" : "";
 
+        timeval t = get_time();
         switch ( reg->format )
         {
             case OUTPUT_CSV:
-                printf("regmon,%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64",%s,%s%s%s\n",
-                       info->vcpu, info->regs->cr3, info->proc_data.name, info->proc_data.userid, syscall_name, key_root, key_sep, key_name );
+                printf("[" FORMAT_TIMEVAL "] regmon,%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64",%s,%s%s%s\n",
+                       UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3, info->proc_data.name, info->proc_data.userid, syscall_name, key_root, key_sep, key_name );
                 break;
 
             default:
             case OUTPUT_DEFAULT:
-                printf("[REGMON] VCPU:%" PRIu32 " CR3:0x%" PRIx64 ", EPROCESS:0x%" PRIx64 ", PID:%d, PPID:%d, \"%s\" %s:%" PRIi64 " %s:%s%s%s\n",
-                       info->vcpu, info->regs->cr3, info->proc_data.base_addr, info->proc_data.pid, info->proc_data.ppid, info->proc_data.name,
+                printf("[" FORMAT_TIMEVAL "][REGMON] VCPU:%" PRIu32 " CR3:0x%" PRIx64 ", EPROCESS:0x%" PRIx64 ", PID:%d, PPID:%d, \"%s\" %s:%" PRIi64 " %s:%s%s%s\n",
+                       UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3, info->proc_data.base_addr, info->proc_data.pid, info->proc_data.ppid, info->proc_data.name,
                        USERIDSTR(drakvuf), info->proc_data.userid, syscall_name, key_root, key_sep, key_name );
                 break;
         }

--- a/src/plugins/socketmon/socketmon.cpp
+++ b/src/plugins/socketmon/socketmon.cpp
@@ -190,6 +190,7 @@ static event_response_t udpa_x86_ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* 
     char* lip = NULL, *owner = NULL;
     struct wrapper* w = (struct wrapper*)info->trap->data;
     socketmon* s = w->s;
+    timeval t;
 
     struct udp_endpoint_x86 udpa;;
     struct inetaf_x86 inetaf;
@@ -254,11 +255,12 @@ static event_response_t udpa_x86_ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* 
     owner = drakvuf_get_process_name(drakvuf, udpa.owner);
     ownerid = drakvuf_get_process_userid(drakvuf, udpa.owner);
 
+    t = get_time();
     switch (s->format)
     {
         case OUTPUT_CSV:
-            printf("socketmon,%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64",%s,%" PRIi64 ",%s,%s,%u\n",
-                   info->vcpu, info->regs->cr3,
+            printf("[" FORMAT_TIMEVAL "] socketmon,%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64",%s,%" PRIi64 ",%s,%s,%u\n",
+                   UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3,
                    info->proc_data.name, info->proc_data.userid,
                    owner, ownerid,
                    (inetaf.addressfamily == AF_INET) ? "UDPv4" : "UDPv6",
@@ -266,8 +268,8 @@ static event_response_t udpa_x86_ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* 
             break;
         default:
         case OUTPUT_DEFAULT:
-            printf("[SOCKETMON] VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " Owner:%s %s:%" PRIi64 " %s %s:%u\n",
-                   info->vcpu, info->regs->cr3, info->proc_data.name,
+            printf("[" FORMAT_TIMEVAL "][SOCKETMON] VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " Owner:%s %s:%" PRIi64 " %s %s:%u\n",
+                   UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3, info->proc_data.name,
                    USERIDSTR(drakvuf), info->proc_data.userid,
                    owner, USERIDSTR(drakvuf), ownerid,
                    (inetaf.addressfamily == AF_INET) ? "UDPv4" : "UDPv6",
@@ -294,6 +296,7 @@ static event_response_t udpa_x64_ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* 
     char* lip = NULL, *owner = NULL;
     struct wrapper* w = (struct wrapper*)info->trap->data;
     socketmon* s = w->s;
+    timeval t;
 
     vmi_instance_t vmi = drakvuf_lock_and_get_vmi(drakvuf);
 
@@ -359,11 +362,12 @@ static event_response_t udpa_x64_ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* 
     owner = drakvuf_get_process_name(drakvuf, udpa.owner);
     ownerid = drakvuf_get_process_userid(drakvuf, udpa.owner);
 
+    t = get_time();
     switch (s->format)
     {
         case OUTPUT_CSV:
-            printf("socketmon,%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64",%s,%" PRIi64",%s,%s,%u\n",
-                   info->vcpu, info->regs->cr3,
+            printf("[" FORMAT_TIMEVAL "] socketmon,%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64",%s,%" PRIi64",%s,%s,%u\n",
+                   UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3,
                    info->proc_data.name, info->proc_data.userid,
                    owner, ownerid,
                    (inetaf.addressfamily == AF_INET) ? "UDPv4" : "UDPv6",
@@ -371,8 +375,8 @@ static event_response_t udpa_x64_ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* 
             break;
         default:
         case OUTPUT_DEFAULT:
-            printf("[SOCKETMON] VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " Owner:%s %s:%" PRIi64 " %s %s:%u\n",
-                   info->vcpu, info->regs->cr3, info->proc_data.name,
+            printf("[" FORMAT_TIMEVAL "][SOCKETMON] VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " Owner:%s %s:%" PRIi64 " %s %s:%u\n",
+                   UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3, info->proc_data.name,
                    USERIDSTR(drakvuf), info->proc_data.userid,
                    owner, USERIDSTR(drakvuf), ownerid,
                    (inetaf.addressfamily == AF_INET) ? "UDPv4" : "UDPv6",
@@ -399,6 +403,7 @@ static event_response_t udpa_win10_x64_ret_cb(drakvuf_t drakvuf, drakvuf_trap_in
     char* lip = NULL, *owner = NULL;
     struct wrapper* w = (struct wrapper*)info->trap->data;
     socketmon* s = w->s;
+    timeval t;
 
     vmi_instance_t vmi = drakvuf_lock_and_get_vmi(drakvuf);
 
@@ -465,11 +470,12 @@ static event_response_t udpa_win10_x64_ret_cb(drakvuf_t drakvuf, drakvuf_trap_in
     owner = drakvuf_get_process_name(drakvuf, udpa.owner);
     ownerid = drakvuf_get_process_userid(drakvuf, udpa.owner);
 
+    t = get_time();
     switch (s->format)
     {
         case OUTPUT_CSV:
-            printf("socketmon,%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64",%s,%" PRIi64",%s,%s,%u\n",
-                   info->vcpu, info->regs->cr3,
+            printf("[" FORMAT_TIMEVAL "] socketmon,%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64",%s,%" PRIi64",%s,%s,%u\n",
+                   UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3,
                    info->proc_data.name, info->proc_data.userid,
                    owner, ownerid,
                    (inetaf.addressfamily == AF_INET) ? "UDPv4" : "UDPv6",
@@ -477,8 +483,8 @@ static event_response_t udpa_win10_x64_ret_cb(drakvuf_t drakvuf, drakvuf_trap_in
             break;
         default:
         case OUTPUT_DEFAULT:
-            printf("[SOCKETMON] VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " Owner:%s %s:%" PRIi64 " %s %s:%u\n",
-                   info->vcpu, info->regs->cr3, info->proc_data.name,
+            printf("[" FORMAT_TIMEVAL "][SOCKETMON] VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " Owner:%s %s:%" PRIi64 " %s %s:%u\n",
+                   UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3, info->proc_data.name,
                    USERIDSTR(drakvuf), info->proc_data.userid,
                    owner, USERIDSTR(drakvuf), ownerid,
                    (inetaf.addressfamily == AF_INET) ? "UDPv4" : "UDPv6",
@@ -497,7 +503,8 @@ done:
 static event_response_t tcpe_x86_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 {
 
-    socketmon* s = (socketmon*)info->trap->data;;
+    socketmon* s = (socketmon*)info->trap->data;
+    timeval t;
 
     int64_t ownerid = -1;
     addr_t p1 = 0;
@@ -598,11 +605,12 @@ static event_response_t tcpe_x86_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info
     owner = drakvuf_get_process_name(drakvuf, tcpe.owner);
     ownerid = drakvuf_get_process_userid(drakvuf, tcpe.owner);
 
+    t = get_time();
     switch (s->format)
     {
         case OUTPUT_CSV:
-            printf("socketmon,%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64 ",%s,%" PRIi64 ",%s,%s,%s,%u,%s,%u\n",
-                   info->vcpu, info->regs->cr3,
+            printf("[" FORMAT_TIMEVAL "] socketmon,%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64 ",%s,%" PRIi64 ",%s,%s,%s,%u,%s,%u\n",
+                   UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3,
                    info->proc_data.name, info->proc_data.userid,
                    owner,ownerid,
                    (inetaf.addressfamily == AF_INET) ? "TCPv4" : "TCPv6",
@@ -611,8 +619,8 @@ static event_response_t tcpe_x86_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info
             break;
         default:
         case OUTPUT_DEFAULT:
-            printf("[SOCKETMON] VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " Owner:%s %s:%" PRIi64 " %s State:%s Local:%s:%u Remote:%s:%u\n",
-                   info->vcpu, info->regs->cr3,
+            printf("[" FORMAT_TIMEVAL "][SOCKETMON] VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " Owner:%s %s:%" PRIi64 " %s State:%s Local:%s:%u Remote:%s:%u\n",
+                   UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3,
                    info->proc_data.name, USERIDSTR(drakvuf), info->proc_data.userid,
                    owner, USERIDSTR(drakvuf), ownerid,
                    (inetaf.addressfamily == AF_INET) ? "TCPv4" : "TCPv6",
@@ -632,6 +640,7 @@ done:
 static event_response_t tcpe_x64_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 {
     socketmon* s = (socketmon*)info->trap->data;
+    timeval t;
 
     int64_t ownerid;
     addr_t p1 = 0;
@@ -714,11 +723,12 @@ static event_response_t tcpe_x64_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info
     owner = drakvuf_get_process_name(drakvuf, tcpe.owner);
     ownerid = drakvuf_get_process_userid(drakvuf, tcpe.owner);
 
+    t = get_time();
     switch (s->format)
     {
         case OUTPUT_CSV:
-            printf("socketmon,%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64 ",%s,%" PRIi64 ",%s,%s,%s,%u,%s,%u\n",
-                   info->vcpu, info->regs->cr3,
+            printf("[" FORMAT_TIMEVAL "] socketmon,%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64 ",%s,%" PRIi64 ",%s,%s,%s,%u,%s,%u\n",
+                   UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3,
                    info->proc_data.name, info->proc_data.userid,
                    owner,ownerid,
                    (inetaf.addressfamily == AF_INET) ? "TCPv4" : "TCPv6",
@@ -727,8 +737,8 @@ static event_response_t tcpe_x64_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info
             break;
         default:
         case OUTPUT_DEFAULT:
-            printf("[SOCKETMON] VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " Owner:%s %s:%" PRIi64 " %s State:%s Local:%s:%u Remote:%s:%u\n",
-                   info->vcpu, info->regs->cr3,
+            printf("[" FORMAT_TIMEVAL "][SOCKETMON] VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " Owner:%s %s:%" PRIi64 " %s State:%s Local:%s:%u Remote:%s:%u\n",
+                   UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3,
                    info->proc_data.name, USERIDSTR(drakvuf), info->proc_data.userid,
                    owner, USERIDSTR(drakvuf), ownerid,
                    (inetaf.addressfamily == AF_INET) ? "TCPv4" : "TCPv6",
@@ -749,6 +759,7 @@ done:
 static event_response_t tcpe_win10_x64_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 {
     socketmon* s = (socketmon*)info->trap->data;
+    timeval t;
 
     int64_t ownerid;
     addr_t p1 = 0;
@@ -831,11 +842,12 @@ static event_response_t tcpe_win10_x64_cb(drakvuf_t drakvuf, drakvuf_trap_info_t
     owner = drakvuf_get_process_name(drakvuf, tcpe.owner);
     ownerid = drakvuf_get_process_userid(drakvuf, tcpe.owner);
 
+    t = get_time();
     switch (s->format)
     {
         case OUTPUT_CSV:
-            printf("socketmon,%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64 ",%s,%" PRIi64 ",%s,%s,%s,%u,%s,%u\n",
-                   info->vcpu, info->regs->cr3,
+            printf("[" FORMAT_TIMEVAL "] socketmon,%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64 ",%s,%" PRIi64 ",%s,%s,%s,%u,%s,%u\n",
+                   UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3,
                    info->proc_data.name, info->proc_data.userid,
                    owner,ownerid,
                    (inetaf.addressfamily == AF_INET) ? "TCPv4" : "TCPv6",
@@ -844,8 +856,8 @@ static event_response_t tcpe_win10_x64_cb(drakvuf_t drakvuf, drakvuf_trap_info_t
             break;
         default:
         case OUTPUT_DEFAULT:
-            printf("[SOCKETMON] VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " Owner:%s %s:%" PRIi64 " %s State:%s Local:%s:%u Remote:%s:%u\n",
-                   info->vcpu, info->regs->cr3,
+            printf("[" FORMAT_TIMEVAL "][SOCKETMON] VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " Owner:%s %s:%" PRIi64 " %s State:%s Local:%s:%u Remote:%s:%u\n",
+                   UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3,
                    info->proc_data.name, USERIDSTR(drakvuf), info->proc_data.userid,
                    owner, USERIDSTR(drakvuf), ownerid,
                    (inetaf.addressfamily == AF_INET) ? "TCPv4" : "TCPv6",
@@ -867,6 +879,7 @@ static event_response_t tcpl_x86_ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* 
 {
     struct wrapper* w = (struct wrapper*)info->trap->data;
     socketmon* s = w->s;
+    timeval t;
 
     vmi_instance_t vmi = drakvuf_lock_and_get_vmi(drakvuf);
 
@@ -948,11 +961,12 @@ static event_response_t tcpl_x86_ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* 
     owner = drakvuf_get_process_name(drakvuf, tcpl.owner);
     ownerid = drakvuf_get_process_userid(drakvuf, tcpl.owner);
 
+    t = get_time();
     switch (s->format)
     {
         case OUTPUT_CSV:
-            printf("socketmon,%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64",%s,%" PRIi64 ",%s,listener,%s,%u\n",
-                   info->vcpu, info->regs->cr3,
+            printf("[" FORMAT_TIMEVAL "] socketmon,%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64",%s,%" PRIi64 ",%s,listener,%s,%u\n",
+                   UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3,
                    info->proc_data.name, info->proc_data.userid,
                    owner, ownerid,
                    (inetaf.addressfamily == AF_INET) ? "TCPv4" : "TCPv6",
@@ -960,8 +974,8 @@ static event_response_t tcpl_x86_ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* 
             break;
         default:
         case OUTPUT_DEFAULT:
-            printf("[SOCKETMON] VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " Owner:%s %s:%" PRIi64 " %s listener %s:%u\n",
-                   info->vcpu, info->regs->cr3, info->proc_data.name,
+            printf("[" FORMAT_TIMEVAL "][SOCKETMON] VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " Owner:%s %s:%" PRIi64 " %s listener %s:%u\n",
+                   UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3, info->proc_data.name,
                    USERIDSTR(drakvuf), info->proc_data.userid,
                    owner, USERIDSTR(drakvuf), ownerid,
                    (inetaf.addressfamily == AF_INET) ? "TCPv4" : "TCPv6",
@@ -982,6 +996,7 @@ static event_response_t tcpl_x64_ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* 
 {
     struct wrapper* w = (struct wrapper*)info->trap->data;
     socketmon* s = w->s;
+    timeval t;
 
     int64_t ownerid = 0;
     addr_t p1 = 0;
@@ -1054,11 +1069,12 @@ static event_response_t tcpl_x64_ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* 
     owner = drakvuf_get_process_name(drakvuf, tcpl.owner);
     ownerid = drakvuf_get_process_userid(drakvuf, tcpl.owner);
 
+    t = get_time();
     switch (s->format)
     {
         case OUTPUT_CSV:
-            printf("socketmon,%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64 ",%s,%" PRIi64 ",%s,listener,%s,%u\n",
-                   info->vcpu, info->regs->cr3,
+            printf("[" FORMAT_TIMEVAL "] socketmon,%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64 ",%s,%" PRIi64 ",%s,listener,%s,%u\n",
+                   UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3,
                    info->proc_data.name, info->proc_data.userid,
                    owner, ownerid,
                    (inetaf.addressfamily == AF_INET) ? "TCPv4" : "TCPv6",
@@ -1066,8 +1082,8 @@ static event_response_t tcpl_x64_ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* 
             break;
         default:
         case OUTPUT_DEFAULT:
-            printf("[SOCKETMON] VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " Owner:%s %s:%" PRIi64 " %s listener %s:%u\n",
-                   info->vcpu, info->regs->cr3, info->proc_data.name,
+            printf("[" FORMAT_TIMEVAL "][SOCKETMON] VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " Owner:%s %s:%" PRIi64 " %s listener %s:%u\n",
+                   UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3, info->proc_data.name,
                    USERIDSTR(drakvuf), info->proc_data.userid,
                    owner, USERIDSTR(drakvuf), ownerid,
                    (inetaf.addressfamily == AF_INET) ? "TCPv4" : "TCPv6",
@@ -1088,6 +1104,7 @@ static event_response_t tcpl_win10_x64_ret_cb(drakvuf_t drakvuf, drakvuf_trap_in
 {
     struct wrapper* w = (struct wrapper*)info->trap->data;
     socketmon* s = w->s;
+    timeval t;
 
     int64_t ownerid = 0;
     addr_t p1 = 0;
@@ -1160,11 +1177,12 @@ static event_response_t tcpl_win10_x64_ret_cb(drakvuf_t drakvuf, drakvuf_trap_in
     owner = drakvuf_get_process_name(drakvuf, tcpl.owner);
     ownerid = drakvuf_get_process_userid(drakvuf, tcpl.owner);
 
+    t = get_time();
     switch (s->format)
     {
         case OUTPUT_CSV:
-            printf("socketmon,%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64 ",%s,%" PRIi64 ",%s,listener,%s,%u\n",
-                   info->vcpu, info->regs->cr3,
+            printf("[" FORMAT_TIMEVAL "] socketmon,%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64 ",%s,%" PRIi64 ",%s,listener,%s,%u\n",
+                   UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3,
                    info->proc_data.name, info->proc_data.userid,
                    owner, ownerid,
                    (inetaf.addressfamily == AF_INET) ? "TCPv4" : "TCPv6",
@@ -1172,8 +1190,8 @@ static event_response_t tcpl_win10_x64_ret_cb(drakvuf_t drakvuf, drakvuf_trap_in
             break;
         default:
         case OUTPUT_DEFAULT:
-            printf("[SOCKETMON] VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " Owner:%s %s:%" PRIi64 " %s listener %s:%u\n",
-                   info->vcpu, info->regs->cr3, info->proc_data.name,
+            printf("[" FORMAT_TIMEVAL "][SOCKETMON] VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " Owner:%s %s:%" PRIi64 " %s listener %s:%u\n",
+                   UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3, info->proc_data.name,
                    USERIDSTR(drakvuf), info->proc_data.userid,
                    owner, USERIDSTR(drakvuf), ownerid,
                    (inetaf.addressfamily == AF_INET) ? "TCPv4" : "TCPv6",

--- a/src/plugins/socketmon/socketmon.cpp
+++ b/src/plugins/socketmon/socketmon.cpp
@@ -259,7 +259,7 @@ static event_response_t udpa_x86_ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* 
     switch (s->format)
     {
         case OUTPUT_CSV:
-            printf("[" FORMAT_TIMEVAL "] socketmon,%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64",%s,%" PRIi64 ",%s,%s,%u\n",
+            printf("socketmon," FORMAT_TIMEVAL ",%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64",%s,%" PRIi64 ",%s,%s,%u\n",
                    UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3,
                    info->proc_data.name, info->proc_data.userid,
                    owner, ownerid,
@@ -268,7 +268,7 @@ static event_response_t udpa_x86_ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* 
             break;
         default:
         case OUTPUT_DEFAULT:
-            printf("[" FORMAT_TIMEVAL "][SOCKETMON] VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " Owner:%s %s:%" PRIi64 " %s %s:%u\n",
+            printf("[SOCKETMON] TIME:" FORMAT_TIMEVAL " VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " Owner:%s %s:%" PRIi64 " %s %s:%u\n",
                    UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3, info->proc_data.name,
                    USERIDSTR(drakvuf), info->proc_data.userid,
                    owner, USERIDSTR(drakvuf), ownerid,
@@ -366,7 +366,7 @@ static event_response_t udpa_x64_ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* 
     switch (s->format)
     {
         case OUTPUT_CSV:
-            printf("[" FORMAT_TIMEVAL "] socketmon,%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64",%s,%" PRIi64",%s,%s,%u\n",
+            printf("socketmon," FORMAT_TIMEVAL ",%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64",%s,%" PRIi64",%s,%s,%u\n",
                    UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3,
                    info->proc_data.name, info->proc_data.userid,
                    owner, ownerid,
@@ -375,7 +375,7 @@ static event_response_t udpa_x64_ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* 
             break;
         default:
         case OUTPUT_DEFAULT:
-            printf("[" FORMAT_TIMEVAL "][SOCKETMON] VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " Owner:%s %s:%" PRIi64 " %s %s:%u\n",
+            printf("[SOCKETMON] TIME:" FORMAT_TIMEVAL " VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " Owner:%s %s:%" PRIi64 " %s %s:%u\n",
                    UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3, info->proc_data.name,
                    USERIDSTR(drakvuf), info->proc_data.userid,
                    owner, USERIDSTR(drakvuf), ownerid,
@@ -474,7 +474,7 @@ static event_response_t udpa_win10_x64_ret_cb(drakvuf_t drakvuf, drakvuf_trap_in
     switch (s->format)
     {
         case OUTPUT_CSV:
-            printf("[" FORMAT_TIMEVAL "] socketmon,%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64",%s,%" PRIi64",%s,%s,%u\n",
+            printf("socketmon," FORMAT_TIMEVAL ",%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64",%s,%" PRIi64",%s,%s,%u\n",
                    UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3,
                    info->proc_data.name, info->proc_data.userid,
                    owner, ownerid,
@@ -483,7 +483,7 @@ static event_response_t udpa_win10_x64_ret_cb(drakvuf_t drakvuf, drakvuf_trap_in
             break;
         default:
         case OUTPUT_DEFAULT:
-            printf("[" FORMAT_TIMEVAL "][SOCKETMON] VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " Owner:%s %s:%" PRIi64 " %s %s:%u\n",
+            printf("[SOCKETMON] TIME:" FORMAT_TIMEVAL " VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " Owner:%s %s:%" PRIi64 " %s %s:%u\n",
                    UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3, info->proc_data.name,
                    USERIDSTR(drakvuf), info->proc_data.userid,
                    owner, USERIDSTR(drakvuf), ownerid,
@@ -609,7 +609,7 @@ static event_response_t tcpe_x86_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info
     switch (s->format)
     {
         case OUTPUT_CSV:
-            printf("[" FORMAT_TIMEVAL "] socketmon,%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64 ",%s,%" PRIi64 ",%s,%s,%s,%u,%s,%u\n",
+            printf("socketmon," FORMAT_TIMEVAL ",%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64 ",%s,%" PRIi64 ",%s,%s,%s,%u,%s,%u\n",
                    UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3,
                    info->proc_data.name, info->proc_data.userid,
                    owner,ownerid,
@@ -619,7 +619,7 @@ static event_response_t tcpe_x86_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info
             break;
         default:
         case OUTPUT_DEFAULT:
-            printf("[" FORMAT_TIMEVAL "][SOCKETMON] VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " Owner:%s %s:%" PRIi64 " %s State:%s Local:%s:%u Remote:%s:%u\n",
+            printf("[SOCKETMON] TIME:" FORMAT_TIMEVAL " VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " Owner:%s %s:%" PRIi64 " %s State:%s Local:%s:%u Remote:%s:%u\n",
                    UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3,
                    info->proc_data.name, USERIDSTR(drakvuf), info->proc_data.userid,
                    owner, USERIDSTR(drakvuf), ownerid,
@@ -727,7 +727,7 @@ static event_response_t tcpe_x64_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info
     switch (s->format)
     {
         case OUTPUT_CSV:
-            printf("[" FORMAT_TIMEVAL "] socketmon,%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64 ",%s,%" PRIi64 ",%s,%s,%s,%u,%s,%u\n",
+            printf("socketmon," FORMAT_TIMEVAL ",%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64 ",%s,%" PRIi64 ",%s,%s,%s,%u,%s,%u\n",
                    UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3,
                    info->proc_data.name, info->proc_data.userid,
                    owner,ownerid,
@@ -737,7 +737,7 @@ static event_response_t tcpe_x64_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info
             break;
         default:
         case OUTPUT_DEFAULT:
-            printf("[" FORMAT_TIMEVAL "][SOCKETMON] VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " Owner:%s %s:%" PRIi64 " %s State:%s Local:%s:%u Remote:%s:%u\n",
+            printf("[SOCKETMON] TIMNE:" FORMAT_TIMEVAL " VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " Owner:%s %s:%" PRIi64 " %s State:%s Local:%s:%u Remote:%s:%u\n",
                    UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3,
                    info->proc_data.name, USERIDSTR(drakvuf), info->proc_data.userid,
                    owner, USERIDSTR(drakvuf), ownerid,
@@ -846,7 +846,7 @@ static event_response_t tcpe_win10_x64_cb(drakvuf_t drakvuf, drakvuf_trap_info_t
     switch (s->format)
     {
         case OUTPUT_CSV:
-            printf("[" FORMAT_TIMEVAL "] socketmon,%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64 ",%s,%" PRIi64 ",%s,%s,%s,%u,%s,%u\n",
+            printf("socketmon," FORMAT_TIMEVAL ",%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64 ",%s,%" PRIi64 ",%s,%s,%s,%u,%s,%u\n",
                    UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3,
                    info->proc_data.name, info->proc_data.userid,
                    owner,ownerid,
@@ -856,7 +856,7 @@ static event_response_t tcpe_win10_x64_cb(drakvuf_t drakvuf, drakvuf_trap_info_t
             break;
         default:
         case OUTPUT_DEFAULT:
-            printf("[" FORMAT_TIMEVAL "][SOCKETMON] VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " Owner:%s %s:%" PRIi64 " %s State:%s Local:%s:%u Remote:%s:%u\n",
+            printf("[SOCKETMON] TIME:" FORMAT_TIMEVAL " VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " Owner:%s %s:%" PRIi64 " %s State:%s Local:%s:%u Remote:%s:%u\n",
                    UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3,
                    info->proc_data.name, USERIDSTR(drakvuf), info->proc_data.userid,
                    owner, USERIDSTR(drakvuf), ownerid,
@@ -965,7 +965,7 @@ static event_response_t tcpl_x86_ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* 
     switch (s->format)
     {
         case OUTPUT_CSV:
-            printf("[" FORMAT_TIMEVAL "] socketmon,%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64",%s,%" PRIi64 ",%s,listener,%s,%u\n",
+            printf("socketmon," FORMAT_TIMEVAL ",%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64",%s,%" PRIi64 ",%s,listener,%s,%u\n",
                    UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3,
                    info->proc_data.name, info->proc_data.userid,
                    owner, ownerid,
@@ -974,7 +974,7 @@ static event_response_t tcpl_x86_ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* 
             break;
         default:
         case OUTPUT_DEFAULT:
-            printf("[" FORMAT_TIMEVAL "][SOCKETMON] VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " Owner:%s %s:%" PRIi64 " %s listener %s:%u\n",
+            printf("[SOCKETMON] TIME:" FORMAT_TIMEVAL " VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " Owner:%s %s:%" PRIi64 " %s listener %s:%u\n",
                    UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3, info->proc_data.name,
                    USERIDSTR(drakvuf), info->proc_data.userid,
                    owner, USERIDSTR(drakvuf), ownerid,
@@ -1073,7 +1073,7 @@ static event_response_t tcpl_x64_ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* 
     switch (s->format)
     {
         case OUTPUT_CSV:
-            printf("[" FORMAT_TIMEVAL "] socketmon,%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64 ",%s,%" PRIi64 ",%s,listener,%s,%u\n",
+            printf("socketmon," FORMAT_TIMEVAL ",%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64 ",%s,%" PRIi64 ",%s,listener,%s,%u\n",
                    UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3,
                    info->proc_data.name, info->proc_data.userid,
                    owner, ownerid,
@@ -1082,7 +1082,7 @@ static event_response_t tcpl_x64_ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* 
             break;
         default:
         case OUTPUT_DEFAULT:
-            printf("[" FORMAT_TIMEVAL "][SOCKETMON] VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " Owner:%s %s:%" PRIi64 " %s listener %s:%u\n",
+            printf("[SOCKETMON] TIME:" FORMAT_TIMEVAL " VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " Owner:%s %s:%" PRIi64 " %s listener %s:%u\n",
                    UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3, info->proc_data.name,
                    USERIDSTR(drakvuf), info->proc_data.userid,
                    owner, USERIDSTR(drakvuf), ownerid,
@@ -1181,7 +1181,7 @@ static event_response_t tcpl_win10_x64_ret_cb(drakvuf_t drakvuf, drakvuf_trap_in
     switch (s->format)
     {
         case OUTPUT_CSV:
-            printf("[" FORMAT_TIMEVAL "] socketmon,%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64 ",%s,%" PRIi64 ",%s,listener,%s,%u\n",
+            printf("socketmon," FORMAT_TIMEVAL ",%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64 ",%s,%" PRIi64 ",%s,listener,%s,%u\n",
                    UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3,
                    info->proc_data.name, info->proc_data.userid,
                    owner, ownerid,
@@ -1190,7 +1190,7 @@ static event_response_t tcpl_win10_x64_ret_cb(drakvuf_t drakvuf, drakvuf_trap_in
             break;
         default:
         case OUTPUT_DEFAULT:
-            printf("[" FORMAT_TIMEVAL "][SOCKETMON] VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " Owner:%s %s:%" PRIi64 " %s listener %s:%u\n",
+            printf("[SOCKETMON] TIME:" FORMAT_TIMEVAL " VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " Owner:%s %s:%" PRIi64 " %s listener %s:%u\n",
                    UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3, info->proc_data.name,
                    USERIDSTR(drakvuf), info->proc_data.userid,
                    owner, USERIDSTR(drakvuf), ownerid,

--- a/src/plugins/ssdtmon/ssdtmon.cpp
+++ b/src/plugins/ssdtmon/ssdtmon.cpp
@@ -126,19 +126,20 @@ event_response_t write_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 {
 
     ssdtmon* s = (ssdtmon*)info->trap->data;
+    timeval t = get_time();
 
     if ( info->trap_pa > s->kiservicetable - 8 && info->trap_pa <= s->kiservicetable + s->ulongs * s->kiservicelimit + s->ulongs - 1 )
     {
         switch (s->format)
         {
             case OUTPUT_CSV:
-                printf("ssdtmon,%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64 ", %" PRIi64 "\n",
-                       info->vcpu, info->regs->cr3, info->proc_data.name, info->proc_data.userid, (info->trap_pa - s->kiservicetable)/s->ulongs);
+                printf("[" FORMAT_TIMEVAL "] ssdtmon,%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64 ", %" PRIi64 "\n",
+                       UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3, info->proc_data.name, info->proc_data.userid, (info->trap_pa - s->kiservicetable)/s->ulongs);
                 break;
             default:
             case OUTPUT_DEFAULT:
-                printf("[SSDTMON] VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64" Table index:%" PRIi64 "\n",
-                       info->vcpu, info->regs->cr3, info->proc_data.name,
+                printf("[" FORMAT_TIMEVAL "][SSDTMON] VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64" Table index:%" PRIi64 "\n",
+                       UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3, info->proc_data.name,
                        USERIDSTR(drakvuf), info->proc_data.userid, (info->trap_pa - s->kiservicetable)/s->ulongs);
                 break;
         };

--- a/src/plugins/ssdtmon/ssdtmon.cpp
+++ b/src/plugins/ssdtmon/ssdtmon.cpp
@@ -133,12 +133,12 @@ event_response_t write_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
         switch (s->format)
         {
             case OUTPUT_CSV:
-                printf("[" FORMAT_TIMEVAL "] ssdtmon,%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64 ", %" PRIi64 "\n",
+                printf("ssdtmon," FORMAT_TIMEVAL ",%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64 ", %" PRIi64 "\n",
                        UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3, info->proc_data.name, info->proc_data.userid, (info->trap_pa - s->kiservicetable)/s->ulongs);
                 break;
             default:
             case OUTPUT_DEFAULT:
-                printf("[" FORMAT_TIMEVAL "][SSDTMON] VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64" Table index:%" PRIi64 "\n",
+                printf("[SSDTMON] TIME:" FORMAT_TIMEVAL " VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64" Table index:%" PRIi64 "\n",
                        UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3, info->proc_data.name,
                        USERIDSTR(drakvuf), info->proc_data.userid, (info->trap_pa - s->kiservicetable)/s->ulongs);
                 break;

--- a/src/plugins/syscalls/syscalls.cpp
+++ b/src/plugins/syscalls/syscalls.cpp
@@ -118,12 +118,12 @@ static event_response_t linux_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
     switch (s->format)
     {
         case OUTPUT_CSV:
-            printf("[" FORMAT_TIMEVAL "] syscall,%" PRIu32" 0x%" PRIx64 ",\"%s\",%" PRIi64 ",%s,%s\n",
+            printf("syscall," FORMAT_TIMEVAL ",%" PRIu32" 0x%" PRIx64 ",\"%s\",%" PRIi64 ",%s,%s\n",
                    UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3, info->proc_data.name, info->proc_data.userid, info->trap->breakpoint.module, info->trap->name);
             break;
         default:
         case OUTPUT_DEFAULT:
-            printf("[" FORMAT_TIMEVAL "][SYSCALL] vCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64" %s!%s\n",
+            printf("[SYSCALL] TIME:" FORMAT_TIMEVAL " VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64" %s!%s\n",
                    UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3, info->proc_data.name,
                    USERIDSTR(drakvuf), info->proc_data.userid,
                    info->trap->breakpoint.module, info->trap->name);
@@ -221,7 +221,7 @@ static event_response_t win_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
     switch (s->format)
     {
         case OUTPUT_CSV:
-            printf("[" FORMAT_TIMEVAL "] syscall,%" PRIu32" 0x%" PRIx64 ",\"%s\",%" PRIi64 ",%s,%s",
+            printf("syscall," FORMAT_TIMEVAL ",%" PRIu32" 0x%" PRIx64 ",\"%s\",%" PRIi64 ",%s,%s",
                    UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3, info->proc_data.name, info->proc_data.userid, info->trap->breakpoint.module, info->trap->name);
 
             if ( nargs )
@@ -277,7 +277,7 @@ static event_response_t win_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
             break;
         default:
         case OUTPUT_DEFAULT:
-            printf("[" FORMAT_TIMEVAL "][SYSCALL] vCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64" %s!%s",
+            printf("[SYSCALL] TIME:" FORMAT_TIMEVAL " VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64" %s!%s",
                    UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3, info->proc_data.name,
                    USERIDSTR(drakvuf), info->proc_data.userid,
                    info->trap->breakpoint.module, info->trap->name);

--- a/src/plugins/syscalls/syscalls.cpp
+++ b/src/plugins/syscalls/syscalls.cpp
@@ -113,17 +113,18 @@ static event_response_t linux_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 {
 
     syscalls* s = (syscalls*)info->trap->data;
+    timeval t = get_time();
 
     switch (s->format)
     {
         case OUTPUT_CSV:
-            printf("syscall,%" PRIu32" 0x%" PRIx64 ",\"%s\",%" PRIi64 ",%s,%s\n",
-                   info->vcpu, info->regs->cr3, info->proc_data.name, info->proc_data.userid, info->trap->breakpoint.module, info->trap->name);
+            printf("[" FORMAT_TIMEVAL "] syscall,%" PRIu32" 0x%" PRIx64 ",\"%s\",%" PRIi64 ",%s,%s\n",
+                   UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3, info->proc_data.name, info->proc_data.userid, info->trap->breakpoint.module, info->trap->name);
             break;
         default:
         case OUTPUT_DEFAULT:
-            printf("[SYSCALL] vCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64" %s!%s\n",
-                   info->vcpu, info->regs->cr3, info->proc_data.name,
+            printf("[" FORMAT_TIMEVAL "][SYSCALL] vCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64" %s!%s\n",
+                   UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3, info->proc_data.name,
                    USERIDSTR(drakvuf), info->proc_data.userid,
                    info->trap->breakpoint.module, info->trap->name);
             break;
@@ -177,6 +178,8 @@ static event_response_t win_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
     ctx.translate_mechanism = VMI_TM_PROCESS_DTB;
     ctx.dtb = info->regs->cr3;
 
+    timeval t;
+
     if ( nargs )
     {
         // get arguments only if we know how many to get
@@ -214,11 +217,12 @@ static event_response_t win_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
         }
     }
 
+    t = get_time();
     switch (s->format)
     {
         case OUTPUT_CSV:
-            printf("syscall,%" PRIu32" 0x%" PRIx64 ",\"%s\",%" PRIi64 ",%s,%s",
-                   info->vcpu, info->regs->cr3, info->proc_data.name, info->proc_data.userid, info->trap->breakpoint.module, info->trap->name);
+            printf("[" FORMAT_TIMEVAL "] syscall,%" PRIu32" 0x%" PRIx64 ",\"%s\",%" PRIi64 ",%s,%s",
+                   UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3, info->proc_data.name, info->proc_data.userid, info->trap->breakpoint.module, info->trap->name);
 
             if ( nargs )
             {
@@ -273,8 +277,8 @@ static event_response_t win_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
             break;
         default:
         case OUTPUT_DEFAULT:
-            printf("[SYSCALL] vCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64" %s!%s",
-                   info->vcpu, info->regs->cr3, info->proc_data.name,
+            printf("[" FORMAT_TIMEVAL "][SYSCALL] vCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64" %s!%s",
+                   UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3, info->proc_data.name,
                    USERIDSTR(drakvuf), info->proc_data.userid,
                    info->trap->breakpoint.module, info->trap->name);
 


### PR DESCRIPTION
Adds timestamps to logging statements so me can relate DRAKVUF-generated events with external ones (e.g., output from other tools).