### PR TITLE
Added KeyValue output format

### DIFF
--- a/src/libdrakvuf/libdrakvuf.h
+++ b/src/libdrakvuf/libdrakvuf.h
@@ -416,6 +416,7 @@ typedef enum
 {
     OUTPUT_DEFAULT,
     OUTPUT_CSV,
+    OUTPUT_KV,
     __OUTPUT_MAX
 } output_format_t;
 

--- a/src/libinjector/injector.c
+++ b/src/libinjector/injector.c
@@ -1029,12 +1029,17 @@ static void print_injection_info(output_format_t format, vmi_pid_t pid, uint64_t
                    UNPACK_TIMEVAL(t), pid, dtb, file, injected_pid, injected_tid);
             break;
 
+        case OUTPUT_KV:
+            printf("inject Time=" FORMAT_TIMEVAL ",PID=%u,DTB=0x%lx,ProcessName=\"%s\",InjectedPid=%u,InjectedTid=%u\n",
+                   UNPACK_TIMEVAL(t), pid, dtb, file, injected_pid, injected_tid);
+            break;
+
         default:
         case OUTPUT_DEFAULT:
             printf("[INJECT] TIME:" FORMAT_TIMEVAL " PID:%u DTB:0x%lx FILE:\"%s\" INJECTED_PID:%u INJECTED_TID:%u\n",
                    UNPACK_TIMEVAL(t), pid, dtb, file, injected_pid, injected_tid);
             break;
-    };
+    }
 }
 
 int injector_start_app(drakvuf_t drakvuf, vmi_pid_t pid, uint32_t tid, const char* file, injection_method_t method, output_format_t format)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -225,6 +225,8 @@ int main(int argc, char** argv)
             case 'o':
                 if (!strncmp(optarg,"csv",3))
                     output = OUTPUT_CSV;
+                if (!strncmp(optarg,"kv",2))
+                    output = OUTPUT_KV;
                 break;
             case 'x':
                 disable_plugin(optarg, plugin_list);

--- a/src/plugins/cpuidmon/cpuidmon.cpp
+++ b/src/plugins/cpuidmon/cpuidmon.cpp
@@ -132,6 +132,16 @@ event_response_t cpuid_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
             printf("cpuidmon," FORMAT_TIMEVAL ",%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64 "\n",
                    UNPACK_TIMEVAL(info->timestamp), info->vcpu, info->regs->cr3, info->proc_data.name, info->proc_data.userid);
             break;
+
+        case OUTPUT_KV:
+            printf("cpuidmon Time=" FORMAT_TIMEVAL ",PID=%d,PPID=%d,ProcessName=\"%s\","
+                   "Leaf=0x%" PRIx32 ",Subleaf=0x%" PRIx32","
+                   "RAX=0x%" PRIx64 ",RBX=0x%" PRIx64 ",RCX=0x%" PRIx64 ",RDX=0x%" PRIx64 "\n",
+                   UNPACK_TIMEVAL(info->timestamp), info->proc_data.pid, info->proc_data.ppid, info->proc_data.name,
+                   info->cpuid->leaf, info->cpuid->subleaf,
+                   info->regs->rax, info->regs->rbx, info->regs->rcx, info->regs->rdx);
+            break;
+
         default:
         case OUTPUT_DEFAULT:
             printf("[CPUIDMON] TIME:" FORMAT_TIMEVAL " VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64". "

--- a/src/plugins/debugmon/debugmon.cpp
+++ b/src/plugins/debugmon/debugmon.cpp
@@ -150,6 +150,14 @@ event_response_t debug_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
                    UNPACK_TIMEVAL(info->timestamp), info->vcpu, info->regs->cr3, info->proc_data.name, info->proc_data.userid,
                    info->regs->rip, info->debug->type, debug_type[info->debug->type]);
             break;
+
+        case OUTPUT_KV:
+            printf("debugmon Time=" FORMAT_TIMEVAL ",PID=%d,PPID=%d,ProcessName=\"%s\","
+                   "RIP=0x%" PRIx64",DebugType=%" PRIi32 ",DebugTypeStr=\"%s\"\n",
+                   UNPACK_TIMEVAL(info->timestamp), info->proc_data.pid, info->proc_data.ppid, info->proc_data.name,
+                   info->regs->rip, info->debug->type, debug_type[info->debug->type]);
+            break;
+
         default:
         case OUTPUT_DEFAULT:
             printf("[DEBUGMON] TIME:" FORMAT_TIMEVAL " VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64". "

--- a/src/plugins/exmon/exmon.cpp
+++ b/src/plugins/exmon/exmon.cpp
@@ -232,6 +232,10 @@ static event_response_t cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
                 str_format=CSV_FORMAT32;
                 user_format=CSV_FORMAT_USER;
                 break;
+            case OUTPUT_KV:
+                str_format=KV_FORMAT32;
+                user_format=KV_FORMAT_USER;
+                break;
             default:
             case OUTPUT_DEFAULT:
                 str_format=DEFAULT_FORMAT32;
@@ -278,6 +282,10 @@ static event_response_t cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
             case OUTPUT_CSV:
                 str_format=CSV_FORMAT64;
                 user_format=CSV_FORMAT_USER;
+                break;
+            case OUTPUT_KV:
+                str_format=KV_FORMAT64;
+                user_format=KV_FORMAT_USER;
                 break;
             default:
             case OUTPUT_DEFAULT:

--- a/src/plugins/exmon/private.h
+++ b/src/plugins/exmon/private.h
@@ -107,13 +107,18 @@
 
 #include "plugins/plugins.h"
 
+#define KV_FORMAT32 "exmon Time=" FORMAT_TIMEVAL ",RSP=%x,ExceptionRecord=0x%x,ExceptionCode=0x%x,FirstChance=%d,EIP=%x,EAX=%x,EBX=%x,ECX=%x,EDX=%x,EDI=%x,ESI=%x,EBP=%x,ESP=%x"
+#define KV_FORMAT64 "exmon Time=" FORMAT_TIMEVAL ",ExceptionRecord=0x%x,ExceptionCode=0x%x,FirstChance=%d,RIP=%x,RAX=%x,RBX=%x,RCX=%x,RDX=%x,RSP=%x,RBP=%x,RSI=%x,RDI=%x,R8=%x,R9=%x,R10=%x,R11=%x"
+
 #define CSV_FORMAT32 "exmon," FORMAT_TIMEVAL ",%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x"
 #define CSV_FORMAT64 "exmon," FORMAT_TIMEVAL ",%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x"
 
 #define DEFAULT_FORMAT32 "[EXMON] TIME:" FORMAT_TIMEVAL " RSP: %x EXCEPTION_RECORD: %x EXCEPTION_CODE: %x FIRST_CHANCE: %x EIP: %x EAX: %x EBX: %x ECX: %x EDX: %x EDI: %x ESI: %x EBP: %x ESP: %x"
-#define DEFAULT_FORMAT64 "[EXMON] TIME:" FORMAT_TIMEVAL " EXCEPTION_RECORD: %x EXCEPTION_CODE: %x FIRST_CHANCE: %x RIP: %x RAX: %x RBX: %x RCX: %x RDX: %x RSP: %x RBP: %x RSI: %x RDI: %x R8: %x R9: %x R10: %x R11:%x"
+#define DEFAULT_FORMAT64 "[EXMON] TIME:" FORMAT_TIMEVAL " EXCEPTION_RECORD: %x EXCEPTION_CODE: %x FIRST_CHANCE: %x RIP: %x RAX: %x RBX: %x RCX: %x RDX: %x RSP: %x RBP: %x RSI: %x RDI: %x R8: %x R9: %x R10: %x R11: %x"
 
 #define CSV_FORMAT_USER ",%d,%d,%s\n"
+
+#define KV_FORMAT_USER ",PID=%d,PPID=%d,Name=\"%s\"\n"
 
 #define DEFAULT_FORMAT_USER " PID: %d PPID: %d NAME: %s\n"
 

--- a/src/plugins/filedelete/filedelete.cpp
+++ b/src/plugins/filedelete/filedelete.cpp
@@ -340,7 +340,7 @@ static void grab_file_by_handle(filedelete* f, drakvuf_t drakvuf,
                                 drakvuf_trap_info_t* info, addr_t handle)
 {
     uint8_t type = 0;
-    addr_t process=drakvuf_get_current_process(drakvuf, info->vcpu);
+    addr_t process = drakvuf_get_current_process(drakvuf, info->vcpu);
 
     // TODO: verify that the dtb in the _EPROCESS is the same as the cr3?
 
@@ -376,6 +376,11 @@ static void grab_file_by_handle(filedelete* f, drakvuf_t drakvuf,
             case OUTPUT_CSV:
                 printf("filedelete," FORMAT_TIMEVAL ",%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64 ",\"%s\"\n",
                        UNPACK_TIMEVAL(info->timestamp), info->vcpu, info->regs->cr3, info->proc_data.name, info->proc_data.userid, filename_us->contents);
+                break;
+            case OUTPUT_KV:
+                printf("filedelete Time=" FORMAT_TIMEVAL ",PID=%d,PPID=%d,ProcessName=\"%s\",Method=%s,FileName=\"%s\"\n",
+                       UNPACK_TIMEVAL(info->timestamp), info->proc_data.pid, info->proc_data.ppid, info->proc_data.name,
+                       info->trap->name, filename_us->contents);
                 break;
             default:
             case OUTPUT_DEFAULT:

--- a/src/plugins/filetracer/filetracer.cpp
+++ b/src/plugins/filetracer/filetracer.cpp
@@ -242,6 +242,12 @@ static event_response_t objattr_read(drakvuf_t drakvuf, drakvuf_trap_info_t* inf
                    UNPACK_TIMEVAL(info->timestamp), info->vcpu, info->regs->cr3, info->proc_data.name, info->proc_data.userid, syscall_name, file_root, file_sep, file_name);
             break;
 
+        case OUTPUT_KV:
+            printf("filetracer Time=" FORMAT_TIMEVAL ",PID=%d,PPID=%d,ProcessName=\"%s\",Method=%s,File=\"%s%s%s\"\n",
+                   UNPACK_TIMEVAL(info->timestamp), info->proc_data.pid, info->proc_data.ppid, info->proc_data.name,
+                   syscall_name, file_root, file_sep, file_name);
+            break;
+
         default:
         case OUTPUT_DEFAULT:
             printf("[FILETRACER] TIME:" FORMAT_TIMEVAL " VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " %s,%s%s%s\n",
@@ -332,6 +338,13 @@ static void print_rename_file_info(vmi_instance_t vmi, drakvuf_t drakvuf, drakvu
             printf("filetracer," FORMAT_TIMEVAL ",%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64",%s,%s,%s,%s\n",
                    UNPACK_TIMEVAL(info->timestamp), info->vcpu, info->regs->cr3, info->proc_data.name, info->proc_data.userid,
                    syscall_name, operation_name, src_file_us->contents, dst_file_p);
+            break;
+
+        case OUTPUT_KV:
+            printf("filetracer Time=" FORMAT_TIMEVAL ",PID=%d,PPID=%d,ProcessName=\"%s\",Method=%s,Operation=%s,FileSrc=\"%s\",FileDst=\"%s\"\n",
+                   UNPACK_TIMEVAL(info->timestamp), info->proc_data.pid, info->proc_data.ppid, info->proc_data.name,
+                   syscall_name, operation_name,
+                   src_file_us->contents, dst_file_p);
             break;
 
         default:

--- a/src/plugins/objmon/objmon.cpp
+++ b/src/plugins/objmon/objmon.cpp
@@ -173,12 +173,17 @@ static event_response_t cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
     switch (o->format)
     {
         case OUTPUT_CSV:
-        {
             printf("objmon," FORMAT_TIMEVAL ",%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64 ",%c%c%c%c",
                    UNPACK_TIMEVAL(info->timestamp), info->vcpu, info->regs->cr3, info->proc_data.name, info->proc_data.userid,
                    ckey._key[0], ckey._key[1], ckey._key[2], ckey._key[3]);
             break;
-        }
+
+        case OUTPUT_KV:
+            printf("objmon Time=" FORMAT_TIMEVAL ",PID=%d,PPID=%d,ProcessName=\"%s\",Key=\"%c%c%c%c\"",
+                   UNPACK_TIMEVAL(info->timestamp), info->proc_data.pid, info->proc_data.ppid, info->proc_data.name,
+                   ckey._key[0], ckey._key[1], ckey._key[2], ckey._key[3]);
+            break;
+
         default:
         case OUTPUT_DEFAULT:
             printf("[OBJMON] TIME:" FORMAT_TIMEVAL " VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64" '%c%c%c%c'",
@@ -186,7 +191,7 @@ static event_response_t cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
                    USERIDSTR(drakvuf), info->proc_data.userid,
                    ckey._key[0], ckey._key[1], ckey._key[2], ckey._key[3]);
             break;
-    };
+    }
 
     printf("\n");
 

--- a/src/plugins/poolmon/poolmon.cpp
+++ b/src/plugins/poolmon/poolmon.cpp
@@ -144,6 +144,7 @@ static event_response_t cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
     reg_t pool_type, size;
     char tag[5] = { [0 ... 4] = '\0' };
     struct pooltag* s = NULL;
+    const char* pool_type_str;
 
     access_context_t ctx;
     ctx.translate_mechanism = VMI_TM_PROCESS_DTB;
@@ -172,27 +173,37 @@ static event_response_t cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 
     s = (struct pooltag*)g_tree_lookup(p->pooltag_tree, tag);
 
+    pool_type_str = pool_type<MaxPoolType ? pool_types[pool_type] : "unknown_pool_type";
+
     switch (p->format)
     {
         case OUTPUT_CSV:
-        {
             printf("poolmon," FORMAT_TIMEVAL ",%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64 ",%s,%s,%" PRIu64 "",
                    UNPACK_TIMEVAL(info->timestamp), info->vcpu, info->regs->cr3, info->proc_data.name, info->proc_data.userid, tag,
-                   pool_type<MaxPoolType ? pool_types[pool_type] : "unknown_pool_type", size);
+                   pool_type_str, size);
             if (s)
                 printf(",%s,%s", s->source, s->description);
             break;
-        }
+
+        case OUTPUT_KV:
+            printf("poolmon Time=" FORMAT_TIMEVAL ",PID=%d,PPID=%d,ProcessName=\"%s\","
+                   "Tag=%s,Type=%s,Size=%" PRIu64,
+                   UNPACK_TIMEVAL(info->timestamp), info->proc_data.pid, info->proc_data.ppid, info->proc_data.name,
+                   tag, pool_type_str, size);
+            if (s)
+                printf(",Source=%s,Description=%s", s->source, s->description);
+            break;
+
         default:
         case OUTPUT_DEFAULT:
             printf("[POOLMON] TIME:" FORMAT_TIMEVAL " VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " %s (type: %s, size: %" PRIu64 ")",
                    UNPACK_TIMEVAL(info->timestamp), info->vcpu, info->regs->cr3, info->proc_data.name,
                    USERIDSTR(drakvuf), info->proc_data.userid, tag,
-                   pool_type<MaxPoolType ? pool_types[pool_type] : "unknown_pool_type", size);
+                   pool_type_str, size);
             if (s)
                 printf(": %s,%s", s->source, s->description);
             break;
-    };
+    }
 
     printf("\n");
 

--- a/src/plugins/procmon/procmon.cpp
+++ b/src/plugins/procmon/procmon.cpp
@@ -155,6 +155,13 @@ static void print_process_creation_result(
                    info->proc_data.userid, info->trap->name, status, new_pid, cmdline, imagepath);
             break;
 
+        case OUTPUT_KV:
+            printf("procmon Time=" FORMAT_TIMEVAL ",PID=%d,PPID=%d,ProcessName=\"%s\","
+                   "Method=%s,Status=0x%" PRIx64 ",NewPid=%d,CommandLine=\"%s\",ImagePathName=\"%s\"\n",
+                   UNPACK_TIMEVAL(info->timestamp), info->proc_data.pid, info->proc_data.ppid, info->proc_data.name,
+                   info->trap->name, status, new_pid, cmdline, imagepath);
+            break;
+
         default:
         case OUTPUT_DEFAULT:
             printf("[PROCMON] TIME:" FORMAT_TIMEVAL " VCPU:%" PRIu32 " CR3:0x%" PRIx64 ", EPROCESS:0x%" PRIx64
@@ -363,6 +370,13 @@ static event_response_t terminate_process_hook(
             printf("procmon," FORMAT_TIMEVAL ",%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64 ",%s,%d,0x%" PRIx64 "\n",
                    UNPACK_TIMEVAL(info->timestamp), info->vcpu, info->regs->cr3, info->proc_data.name,
                    info->proc_data.userid, info->trap->name, exit_pid, exit_status);
+            break;
+
+        case OUTPUT_KV:
+            printf("procmon Time=" FORMAT_TIMEVAL ",PID=%d,PPID=%d,ProcessName=\"%s\","
+                   "Method=%s,ExitPid=%d,ExitStatus=0x%" PRIx64 "\n",
+                   UNPACK_TIMEVAL(info->timestamp), info->proc_data.pid, info->proc_data.ppid, info->proc_data.name,
+                   info->trap->name, exit_pid, exit_status);
             break;
 
         default:

--- a/src/plugins/regmon/regmon.cpp
+++ b/src/plugins/regmon/regmon.cpp
@@ -138,6 +138,15 @@ static event_response_t log_reg_hook( drakvuf_t drakvuf, drakvuf_trap_info_t* in
                     printf("\n");
                     break;
 
+                case OUTPUT_KV:
+                    printf("regmon Time=" FORMAT_TIMEVAL ",PID=%d,PPID=%d,ProcessName=\"%s\",Method=%s,Key=\"%s\"",
+                           UNPACK_TIMEVAL(info->timestamp), info->proc_data.pid, info->proc_data.ppid, info->proc_data.name,
+                           info->trap->name, key_path);
+                    if (with_value_name)
+                        printf(",ValueName=\"%s\"", value_name);
+                    printf("\n");
+                    break;
+
                 default:
                 case OUTPUT_DEFAULT:
                     printf("[REGMON] TIME:" FORMAT_TIMEVAL " VCPU:%" PRIu32 " CR3:0x%" PRIx64 ", EPROCESS:0x%" PRIx64 ", PID:%d, PPID:%d, \"%s\" %s:%" PRIi64 " %s:%s",
@@ -216,6 +225,12 @@ static event_response_t log_reg_objattr_hook(drakvuf_t drakvuf, drakvuf_trap_inf
             case OUTPUT_CSV:
                 printf("regmon," FORMAT_TIMEVAL ",%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64",%s,%s%s%s\n",
                        UNPACK_TIMEVAL(info->timestamp), info->vcpu, info->regs->cr3, info->proc_data.name, info->proc_data.userid, syscall_name, key_root, key_sep, key_name );
+                break;
+
+            case OUTPUT_KV:
+                printf("regmon Time=" FORMAT_TIMEVAL ",PID=%d,PPID=%d,ProcessName=\"%s\",Method=%s,Key=\"%s%s%s\"\n",
+                       UNPACK_TIMEVAL(info->timestamp), info->proc_data.pid, info->proc_data.ppid, info->proc_data.name,
+                       info->trap->name, key_root, key_sep, key_name );
                 break;
 
             default:

--- a/src/plugins/socketmon/socketmon.cpp
+++ b/src/plugins/socketmon/socketmon.cpp
@@ -257,16 +257,26 @@ static event_response_t udpa_x86_ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* 
     switch (s->format)
     {
         case OUTPUT_CSV:
-            printf("socketmon," FORMAT_TIMEVAL ",%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64",%s,%" PRIi64 ",%s,%s,%u\n",
+            printf("socketmon," FORMAT_TIMEVAL ",%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64",%s,%" PRIi64 ",%s,%s,%" PRIu16 "\n",
                    UNPACK_TIMEVAL(info->timestamp), info->vcpu, info->regs->cr3,
                    info->proc_data.name, info->proc_data.userid,
                    owner, ownerid,
                    (inetaf.addressfamily == AF_INET) ? "UDPv4" : "UDPv6",
                    lip, udpa.port);
             break;
+
+        case OUTPUT_KV:
+            printf("socketmon Time=" FORMAT_TIMEVAL ",PID=%d,PPID=%d,ProcessName=\"%s\",UserId=%" PRIi64",Owner=%s,OwnerId=%" PRIi64 ",Protocol=%s,LocalIp=%s,LocalPort=%" PRIu16 "\n",
+                   UNPACK_TIMEVAL(info->timestamp), info->proc_data.pid, info->proc_data.ppid,
+                   info->proc_data.name, info->proc_data.userid,
+                   owner, ownerid,
+                   (inetaf.addressfamily == AF_INET) ? "UDPv4" : "UDPv6",
+                   lip, udpa.port);
+            break;
+
         default:
         case OUTPUT_DEFAULT:
-            printf("[SOCKETMON] TIME:" FORMAT_TIMEVAL " VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " Owner:%s %s:%" PRIi64 " %s %s:%u\n",
+            printf("[SOCKETMON] TIME:" FORMAT_TIMEVAL " VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " Owner:%s %s:%" PRIi64 " %s %s:%" PRIu16 "\n",
                    UNPACK_TIMEVAL(info->timestamp), info->vcpu, info->regs->cr3, info->proc_data.name,
                    USERIDSTR(drakvuf), info->proc_data.userid,
                    owner, USERIDSTR(drakvuf), ownerid,
@@ -362,16 +372,26 @@ static event_response_t udpa_x64_ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* 
     switch (s->format)
     {
         case OUTPUT_CSV:
-            printf("socketmon," FORMAT_TIMEVAL ",%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64",%s,%" PRIi64",%s,%s,%u\n",
+            printf("socketmon," FORMAT_TIMEVAL ",%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64",%s,%" PRIi64",%s,%s,%" PRIu16 "\n",
                    UNPACK_TIMEVAL(info->timestamp), info->vcpu, info->regs->cr3,
                    info->proc_data.name, info->proc_data.userid,
                    owner, ownerid,
                    (inetaf.addressfamily == AF_INET) ? "UDPv4" : "UDPv6",
                    lip, udpa.port);
             break;
+
+        case OUTPUT_KV:
+            printf("socketmon Time=" FORMAT_TIMEVAL ",PID=%d,PPID=%d,ProcessName=\"%s\",UserId=%" PRIi64",Owner=%s,OwnerId=%" PRIi64",Protocol=%s,LocalIp=%s,LocalPort=%" PRIu16 "\n",
+                   UNPACK_TIMEVAL(info->timestamp), info->proc_data.pid, info->proc_data.ppid,
+                   info->proc_data.name, info->proc_data.userid,
+                   owner, ownerid,
+                   (inetaf.addressfamily == AF_INET) ? "UDPv4" : "UDPv6",
+                   lip, udpa.port);
+            break;
+
         default:
         case OUTPUT_DEFAULT:
-            printf("[SOCKETMON] TIME:" FORMAT_TIMEVAL " VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " Owner:%s %s:%" PRIi64 " %s %s:%u\n",
+            printf("[SOCKETMON] TIME:" FORMAT_TIMEVAL " VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " Owner:%s %s:%" PRIi64 " %s %s:%" PRIu16 "\n",
                    UNPACK_TIMEVAL(info->timestamp), info->vcpu, info->regs->cr3, info->proc_data.name,
                    USERIDSTR(drakvuf), info->proc_data.userid,
                    owner, USERIDSTR(drakvuf), ownerid,
@@ -468,16 +488,27 @@ static event_response_t udpa_win10_x64_ret_cb(drakvuf_t drakvuf, drakvuf_trap_in
     switch (s->format)
     {
         case OUTPUT_CSV:
-            printf("socketmon," FORMAT_TIMEVAL ",%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64",%s,%" PRIi64",%s,%s,%u\n",
+            printf("socketmon," FORMAT_TIMEVAL ",%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64",%s,%" PRIi64",%s,%s,%" PRIu16 "\n",
                    UNPACK_TIMEVAL(info->timestamp), info->vcpu, info->regs->cr3,
                    info->proc_data.name, info->proc_data.userid,
                    owner, ownerid,
                    (inetaf.addressfamily == AF_INET) ? "UDPv4" : "UDPv6",
                    lip, udpa.port);
             break;
+
+        case OUTPUT_KV:
+            printf("socketmon Time=" FORMAT_TIMEVAL ",PID=%d,PPID=%d,ProcessName=\"%s\",UserId=%" PRIi64",Owner=%s,"
+                   "OwnerId=%" PRIi64",Protocol=%s,LocalIp=%s,LocalPort=%" PRIu16 "\n",
+                   UNPACK_TIMEVAL(info->timestamp), info->proc_data.pid, info->proc_data.ppid,
+                   info->proc_data.name, info->proc_data.userid,
+                   owner, ownerid,
+                   (inetaf.addressfamily == AF_INET) ? "UDPv4" : "UDPv6",
+                   lip, udpa.port);
+            break;
+
         default:
         case OUTPUT_DEFAULT:
-            printf("[SOCKETMON] TIME:" FORMAT_TIMEVAL " VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " Owner:%s %s:%" PRIi64 " %s %s:%u\n",
+            printf("[SOCKETMON] TIME:" FORMAT_TIMEVAL " VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " Owner:%s %s:%" PRIi64 " %s %s:%" PRIu16 "\n",
                    UNPACK_TIMEVAL(info->timestamp), info->vcpu, info->regs->cr3, info->proc_data.name,
                    USERIDSTR(drakvuf), info->proc_data.userid,
                    owner, USERIDSTR(drakvuf), ownerid,
@@ -601,7 +632,7 @@ static event_response_t tcpe_x86_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info
     switch (s->format)
     {
         case OUTPUT_CSV:
-            printf("socketmon," FORMAT_TIMEVAL ",%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64 ",%s,%" PRIi64 ",%s,%s,%s,%u,%s,%u\n",
+            printf("socketmon," FORMAT_TIMEVAL ",%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64 ",%s,%" PRIi64 ",%s,%s,%s,%" PRIu16 ",%s,%" PRIu16 "\n",
                    UNPACK_TIMEVAL(info->timestamp), info->vcpu, info->regs->cr3,
                    info->proc_data.name, info->proc_data.userid,
                    owner,ownerid,
@@ -609,9 +640,21 @@ static event_response_t tcpe_x86_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info
                    tcp_state_str[tcpe.state],
                    lip, tcpe.localport, rip, tcpe.remoteport);
             break;
+
+        case OUTPUT_KV:
+            printf("socketmon Time=" FORMAT_TIMEVAL ",PID=%d,PPID=%d,ProcessName=\"%s\",UserId=%" PRIi64 ",Owner=%s,OwnerId=%" PRIi64 ",Protocol=%s,TcpState=%s,"
+                   "LocalIp=%s,LocalPort=%" PRIu16 ",RemoteIp=%s,RemotePort=%" PRIu16 "\n",
+                   UNPACK_TIMEVAL(info->timestamp), info->proc_data.pid, info->proc_data.ppid,
+                   info->proc_data.name, info->proc_data.userid,
+                   owner,ownerid,
+                   (inetaf.addressfamily == AF_INET) ? "TCPv4" : "TCPv6",
+                   tcp_state_str[tcpe.state],
+                   lip, tcpe.localport, rip, tcpe.remoteport);
+            break;
+
         default:
         case OUTPUT_DEFAULT:
-            printf("[SOCKETMON] TIME:" FORMAT_TIMEVAL " VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " Owner:%s %s:%" PRIi64 " %s State:%s Local:%s:%u Remote:%s:%u\n",
+            printf("[SOCKETMON] TIME:" FORMAT_TIMEVAL " VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " Owner:%s %s:%" PRIi64 " %s State:%s Local:%s:%" PRIu16 " Remote:%s:%" PRIu16 "\n",
                    UNPACK_TIMEVAL(info->timestamp), info->vcpu, info->regs->cr3,
                    info->proc_data.name, USERIDSTR(drakvuf), info->proc_data.userid,
                    owner, USERIDSTR(drakvuf), ownerid,
@@ -717,7 +760,7 @@ static event_response_t tcpe_x64_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info
     switch (s->format)
     {
         case OUTPUT_CSV:
-            printf("socketmon," FORMAT_TIMEVAL ",%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64 ",%s,%" PRIi64 ",%s,%s,%s,%u,%s,%u\n",
+            printf("socketmon," FORMAT_TIMEVAL ",%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64 ",%s,%" PRIi64 ",%s,%s,%s,%" PRIu16 ",%s,%" PRIu16 "\n",
                    UNPACK_TIMEVAL(info->timestamp), info->vcpu, info->regs->cr3,
                    info->proc_data.name, info->proc_data.userid,
                    owner,ownerid,
@@ -725,9 +768,21 @@ static event_response_t tcpe_x64_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info
                    tcp_state_str[tcpe.state],
                    lip, tcpe.localport, rip, tcpe.remoteport);
             break;
+
+        case OUTPUT_KV:
+            printf("socketmon Time=" FORMAT_TIMEVAL ",PID=%d,PPID=%d,ProcessName=\"%s\",UserId=%" PRIi64 ",Owner=%s,OwnerId=%" PRIi64 ",Protocol=%s,TcpState=%s,"
+                   "LocalIp=%s,LocalPort=%" PRIu16 ",RemoteIp=%s,RemotePort=%" PRIu16 "\n",
+                   UNPACK_TIMEVAL(info->timestamp), info->proc_data.pid, info->proc_data.ppid,
+                   info->proc_data.name, info->proc_data.userid,
+                   owner,ownerid,
+                   (inetaf.addressfamily == AF_INET) ? "TCPv4" : "TCPv6",
+                   tcp_state_str[tcpe.state],
+                   lip, tcpe.localport, rip, tcpe.remoteport);
+            break;
+
         default:
         case OUTPUT_DEFAULT:
-            printf("[SOCKETMON] TIME:" FORMAT_TIMEVAL " VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " Owner:%s %s:%" PRIi64 " %s State:%s Local:%s:%u Remote:%s:%u\n",
+            printf("[SOCKETMON] TIME:" FORMAT_TIMEVAL " VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " Owner:%s %s:%" PRIi64 " %s State:%s Local:%s:%" PRIu16 " Remote:%s:%" PRIu16 "\n",
                    UNPACK_TIMEVAL(info->timestamp), info->vcpu, info->regs->cr3,
                    info->proc_data.name, USERIDSTR(drakvuf), info->proc_data.userid,
                    owner, USERIDSTR(drakvuf), ownerid,
@@ -834,7 +889,7 @@ static event_response_t tcpe_win10_x64_cb(drakvuf_t drakvuf, drakvuf_trap_info_t
     switch (s->format)
     {
         case OUTPUT_CSV:
-            printf("socketmon," FORMAT_TIMEVAL ",%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64 ",%s,%" PRIi64 ",%s,%s,%s,%u,%s,%u\n",
+            printf("socketmon," FORMAT_TIMEVAL ",%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64 ",%s,%" PRIi64 ",%s,%s,%s,%" PRIu16 ",%s,%" PRIu16 "\n",
                    UNPACK_TIMEVAL(info->timestamp), info->vcpu, info->regs->cr3,
                    info->proc_data.name, info->proc_data.userid,
                    owner,ownerid,
@@ -842,9 +897,21 @@ static event_response_t tcpe_win10_x64_cb(drakvuf_t drakvuf, drakvuf_trap_info_t
                    tcp_state_str[tcpe.state],
                    lip, tcpe.localport, rip, tcpe.remoteport);
             break;
+
+        case OUTPUT_KV:
+            printf("socketmon Time=" FORMAT_TIMEVAL ",PID=%d,PPID=%d,ProcessName=\"%s\",UserId=%" PRIi64 ",Owner=%s,OwnerId=%" PRIi64 ",Protocol=%s,TcpState=%s,"
+                   "LocalIp=%s,LocalPort=%" PRIu16 ",RemoteIp=%s,RemotePort=%" PRIu16 "\n",
+                   UNPACK_TIMEVAL(info->timestamp), info->proc_data.pid, info->proc_data.ppid,
+                   info->proc_data.name, info->proc_data.userid,
+                   owner,ownerid,
+                   (inetaf.addressfamily == AF_INET) ? "TCPv4" : "TCPv6",
+                   tcp_state_str[tcpe.state],
+                   lip, tcpe.localport, rip, tcpe.remoteport);
+            break;
+
         default:
         case OUTPUT_DEFAULT:
-            printf("[SOCKETMON] TIME:" FORMAT_TIMEVAL " VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " Owner:%s %s:%" PRIi64 " %s State:%s Local:%s:%u Remote:%s:%u\n",
+            printf("[SOCKETMON] TIME:" FORMAT_TIMEVAL " VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " Owner:%s %s:%" PRIi64 " %s State:%s Local:%s:%" PRIu16 " Remote:%s:%" PRIu16 "\n",
                    UNPACK_TIMEVAL(info->timestamp), info->vcpu, info->regs->cr3,
                    info->proc_data.name, USERIDSTR(drakvuf), info->proc_data.userid,
                    owner, USERIDSTR(drakvuf), ownerid,
@@ -951,16 +1018,26 @@ static event_response_t tcpl_x86_ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* 
     switch (s->format)
     {
         case OUTPUT_CSV:
-            printf("socketmon," FORMAT_TIMEVAL ",%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64",%s,%" PRIi64 ",%s,listener,%s,%u\n",
+            printf("socketmon," FORMAT_TIMEVAL ",%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64",%s,%" PRIi64 ",%s,listener,%s,%" PRIu16 "\n",
                    UNPACK_TIMEVAL(info->timestamp), info->vcpu, info->regs->cr3,
                    info->proc_data.name, info->proc_data.userid,
                    owner, ownerid,
                    (inetaf.addressfamily == AF_INET) ? "TCPv4" : "TCPv6",
                    lip, tcpl.port);
             break;
+
+        case OUTPUT_KV:
+            printf("socketmon Time=" FORMAT_TIMEVAL ",PID=%d,PPID=%d,ProcessName=\"%s\",UserId=%" PRIi64 ",Owner=%s,OwnerId=%" PRIi64 ",Protocol=%s,listener,LocalIp=%s,LocalPort=%" PRIu16 "\n",
+                   UNPACK_TIMEVAL(info->timestamp), info->proc_data.pid, info->proc_data.ppid,
+                   info->proc_data.name, info->proc_data.userid,
+                   owner, ownerid,
+                   (inetaf.addressfamily == AF_INET) ? "TCPv4" : "TCPv6",
+                   lip, tcpl.port);
+            break;
+
         default:
         case OUTPUT_DEFAULT:
-            printf("[SOCKETMON] TIME:" FORMAT_TIMEVAL " VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " Owner:%s %s:%" PRIi64 " %s listener %s:%u\n",
+            printf("[SOCKETMON] TIME:" FORMAT_TIMEVAL " VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " Owner:%s %s:%" PRIi64 " %s listener %s:%" PRIu16 "\n",
                    UNPACK_TIMEVAL(info->timestamp), info->vcpu, info->regs->cr3, info->proc_data.name,
                    USERIDSTR(drakvuf), info->proc_data.userid,
                    owner, USERIDSTR(drakvuf), ownerid,
@@ -1057,16 +1134,26 @@ static event_response_t tcpl_x64_ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* 
     switch (s->format)
     {
         case OUTPUT_CSV:
-            printf("socketmon," FORMAT_TIMEVAL ",%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64 ",%s,%" PRIi64 ",%s,listener,%s,%u\n",
+            printf("socketmon," FORMAT_TIMEVAL ",%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64 ",%s,%" PRIi64 ",%s,listener,%s,%" PRIu16 "\n",
                    UNPACK_TIMEVAL(info->timestamp), info->vcpu, info->regs->cr3,
                    info->proc_data.name, info->proc_data.userid,
                    owner, ownerid,
                    (inetaf.addressfamily == AF_INET) ? "TCPv4" : "TCPv6",
                    lip, tcpl.port);
             break;
+
+        case OUTPUT_KV:
+            printf("socketmon Time=" FORMAT_TIMEVAL ",PID=%d,PPID=%d,ProcessName=\"%s\",UserId=%" PRIi64 ",Owner=%s,OwnerId=%" PRIi64 ",Protocol=%s,listener,LocalIp=%s,LocalPort=%" PRIu16 "\n",
+                   UNPACK_TIMEVAL(info->timestamp), info->proc_data.pid, info->proc_data.ppid,
+                   info->proc_data.name, info->proc_data.userid,
+                   owner, ownerid,
+                   (inetaf.addressfamily == AF_INET) ? "TCPv4" : "TCPv6",
+                   lip, tcpl.port);
+            break;
+
         default:
         case OUTPUT_DEFAULT:
-            printf("[SOCKETMON] TIME:" FORMAT_TIMEVAL " VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " Owner:%s %s:%" PRIi64 " %s listener %s:%u\n",
+            printf("[SOCKETMON] TIME:" FORMAT_TIMEVAL " VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " Owner:%s %s:%" PRIi64 " %s listener %s:%" PRIu16 "\n",
                    UNPACK_TIMEVAL(info->timestamp), info->vcpu, info->regs->cr3, info->proc_data.name,
                    USERIDSTR(drakvuf), info->proc_data.userid,
                    owner, USERIDSTR(drakvuf), ownerid,
@@ -1163,16 +1250,26 @@ static event_response_t tcpl_win10_x64_ret_cb(drakvuf_t drakvuf, drakvuf_trap_in
     switch (s->format)
     {
         case OUTPUT_CSV:
-            printf("socketmon," FORMAT_TIMEVAL ",%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64 ",%s,%" PRIi64 ",%s,listener,%s,%u\n",
+            printf("socketmon," FORMAT_TIMEVAL ",%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64 ",%s,%" PRIi64 ",%s,listener,%s,%" PRIu16 "\n",
                    UNPACK_TIMEVAL(info->timestamp), info->vcpu, info->regs->cr3,
                    info->proc_data.name, info->proc_data.userid,
                    owner, ownerid,
                    (inetaf.addressfamily == AF_INET) ? "TCPv4" : "TCPv6",
                    lip, tcpl.port);
             break;
+
+        case OUTPUT_KV:
+            printf("socketmon Time=" FORMAT_TIMEVAL ",PID=%d,PPID=%d,ProcessName=\"%s\",UserId=%" PRIi64 ",Owner=%s,OwnerId=%" PRIi64 ",Protocol=%s,listener,LocalIp=%s,LocalPort=%" PRIu16 "\n",
+                   UNPACK_TIMEVAL(info->timestamp), info->proc_data.pid, info->proc_data.ppid,
+                   info->proc_data.name, info->proc_data.userid,
+                   owner, ownerid,
+                   (inetaf.addressfamily == AF_INET) ? "TCPv4" : "TCPv6",
+                   lip, tcpl.port);
+            break;
+
         default:
         case OUTPUT_DEFAULT:
-            printf("[SOCKETMON] TIME:" FORMAT_TIMEVAL " VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " Owner:%s %s:%" PRIi64 " %s listener %s:%u\n",
+            printf("[SOCKETMON] TIME:" FORMAT_TIMEVAL " VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64 " Owner:%s %s:%" PRIi64 " %s listener %s:%" PRIu16 "\n",
                    UNPACK_TIMEVAL(info->timestamp), info->vcpu, info->regs->cr3, info->proc_data.name,
                    USERIDSTR(drakvuf), info->proc_data.userid,
                    owner, USERIDSTR(drakvuf), ownerid,

--- a/src/plugins/ssdtmon/ssdtmon.cpp
+++ b/src/plugins/ssdtmon/ssdtmon.cpp
@@ -129,19 +129,26 @@ event_response_t write_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 
     if ( info->trap_pa > s->kiservicetable - 8 && info->trap_pa <= s->kiservicetable + s->ulongs * s->kiservicelimit + s->ulongs - 1 )
     {
+        int64_t table_index = (info->trap_pa - s->kiservicetable) / s->ulongs;
         switch (s->format)
         {
             case OUTPUT_CSV:
                 printf("ssdtmon," FORMAT_TIMEVAL ",%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64 ", %" PRIi64 "\n",
-                       UNPACK_TIMEVAL(info->timestamp), info->vcpu, info->regs->cr3, info->proc_data.name, info->proc_data.userid, (info->trap_pa - s->kiservicetable)/s->ulongs);
+                       UNPACK_TIMEVAL(info->timestamp), info->vcpu, info->regs->cr3, info->proc_data.name, info->proc_data.userid, table_index);
                 break;
+
+            case OUTPUT_KV:
+                printf("ssdtmon Time=" FORMAT_TIMEVAL ",PID=%d,PPID=%d,ProcessName=\"%s\",TableIndex=%" PRIi64 "\n",
+                       UNPACK_TIMEVAL(info->timestamp), info->proc_data.pid, info->proc_data.ppid, info->proc_data.name, table_index);
+                break;
+
             default:
             case OUTPUT_DEFAULT:
                 printf("[SSDTMON] TIME:" FORMAT_TIMEVAL " VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64" Table index:%" PRIi64 "\n",
                        UNPACK_TIMEVAL(info->timestamp), info->vcpu, info->regs->cr3, info->proc_data.name,
-                       USERIDSTR(drakvuf), info->proc_data.userid, (info->trap_pa - s->kiservicetable)/s->ulongs);
+                       USERIDSTR(drakvuf), info->proc_data.userid, table_index);
                 break;
-        };
+        }
     }
     return 0;
 }


### PR DESCRIPTION
Existing output formats does not automatic parser friendly.
Default format is multi-line. The CSV format is inconvenient for writing parsing rules.