### PR TITLE
Plugin Filedelete | Catch whole file contents on NtClose (Part 1)

### DIFF
--- a/src/drakvuf.cpp
+++ b/src/drakvuf.cpp
@@ -130,6 +130,7 @@ static gpointer timer(gpointer data)
 int drakvuf_c::start_plugins(const bool* plugin_list,
                              const char* dump_folder,          // PLUGIN_FILEDELETE
                              bool dump_modified_files,         // PLUGIN_FILEDELETE
+                             bool filedelete_use_injector,     // PLUGIN_FILEDELETE
                              bool cpuid_stealth,               // PLUGIN_CPUIDMON
                              const char* tcpip_profile,        // PLUGIN_SOCKETMON
                              const char* syscalls_filter_file) // PLUGIN_SYSCALLS
@@ -148,7 +149,8 @@ int drakvuf_c::start_plugins(const bool* plugin_list,
                     {
                         .rekall_profile = this->rekall_profile,
                         .dump_folder = dump_folder,
-                        .dump_modified_files = dump_modified_files
+                        .dump_modified_files = dump_modified_files,
+                        .filedelete_use_injector = filedelete_use_injector,
                     };
 
                     rc = this->plugins->start((drakvuf_plugin_t)i, &c);

--- a/src/drakvuf.h
+++ b/src/drakvuf.h
@@ -171,6 +171,7 @@ public:
     int start_plugins(const bool* plugin_list,
                       const char* dump_folder,
                       bool dump_modified_files,
+                      bool filedelete_use_injector,
                       bool cpuid_stealth,
                       const char* tcpip_profile,
                       const char* syscalls_filter_file);

--- a/src/libdrakvuf/libdrakvuf.h
+++ b/src/libdrakvuf/libdrakvuf.h
@@ -344,6 +344,10 @@ bool drakvuf_get_current_thread_id(drakvuf_t drakvuf,
                                    uint64_t vcpu_id,
                                    uint32_t* thread_id);
 
+addr_t drakvuf_exportksym_to_va(drakvuf_t drakvuf,
+                                const vmi_pid_t pid, const char* proc_name,
+                                const char* mod_name, addr_t rva);
+
 addr_t drakvuf_exportsym_to_va(drakvuf_t drakvuf, addr_t process_addr,
                                const char* module, const char* sym);
 

--- a/src/libdrakvuf/os.c
+++ b/src/libdrakvuf/os.c
@@ -266,6 +266,15 @@ bool drakvuf_get_module_base_addr(drakvuf_t drakvuf, addr_t module_list_head, co
     return 0;
 }
 
+addr_t drakvuf_exportksym_to_va(drakvuf_t drakvuf, const vmi_pid_t pid, const char* proc_name,
+                                const char* mod_name, addr_t rva)
+{
+    if ( drakvuf->osi.exportksym_to_va )
+        return drakvuf->osi.exportksym_to_va(drakvuf, pid, proc_name, mod_name, rva);
+
+    return 0;
+}
+
 addr_t drakvuf_exportsym_to_va(drakvuf_t drakvuf, addr_t process_addr,
                                const char* module, const char* sym)
 {

--- a/src/libdrakvuf/os.h
+++ b/src/libdrakvuf/os.h
@@ -155,6 +155,9 @@ typedef struct os_interface
     bool (*get_module_base_addr)
     (drakvuf_t drakvuf, addr_t module_list_head, const char* module_name, addr_t* base_addr_out);
 
+    addr_t (*exportksym_to_va)
+    (drakvuf_t drakvuf, const vmi_pid_t pid, const char* proc_name, const char* mod_name, addr_t rva);
+
     addr_t (*exportsym_to_va)
     (drakvuf_t drakvuf, addr_t process_addr, const char* module, const char* sym);
 

--- a/src/libdrakvuf/win-exports.h
+++ b/src/libdrakvuf/win-exports.h
@@ -108,6 +108,7 @@
 #include <libvmi/libvmi.h>
 
 addr_t sym2va(drakvuf_t drakvuf, vmi_pid_t pid, const char* mod_name, const char* sym);
+addr_t ksym2va(drakvuf_t drakvuf, vmi_pid_t pid, const char* proc_name, const char* mod_name, addr_t rva);
 addr_t eprocess_sym2va(drakvuf_t drakvuf, addr_t eprocess_base, const char* mod_name, const char* sym);
 const char* rva2sym(drakvuf_t drakvuf, const char* mod_name, addr_t base_vaddr, vmi_pid_t pid, addr_t rva);
 status_t va2sym(drakvuf_t drakvuf, addr_t va, vmi_pid_t pid, char** mod, char** sym);

--- a/src/libdrakvuf/win.c
+++ b/src/libdrakvuf/win.c
@@ -307,6 +307,7 @@ bool set_os_windows(drakvuf_t drakvuf)
     drakvuf->osi.get_module_list = win_get_module_list;
     drakvuf->osi.find_process = win_find_eprocess;
     drakvuf->osi.inject_traps_modules = win_inject_traps_modules;
+    drakvuf->osi.exportksym_to_va = ksym2va;
     drakvuf->osi.exportsym_to_va = eprocess_sym2va;
     drakvuf->osi.get_process_pid = win_get_process_pid;
     drakvuf->osi.get_process_ppid = win_get_process_ppid;

--- a/src/plugins/Makefile.am
+++ b/src/plugins/Makefile.am
@@ -120,6 +120,7 @@ endif
 
 if PLUGIN_FILEDELETE
 sources += filedelete/filedelete.cpp
+sources += filedelete/filedelete2.cpp
 endif
 
 if PLUGIN_OBJMON

--- a/src/plugins/filedelete/filedelete.h
+++ b/src/plugins/filedelete/filedelete.h
@@ -112,6 +112,14 @@
 #include <utility>
 #include <cstdint>
 
+// For `filedelete2`
+#include <map>
+
+// For `filedelete2`
+using handle_t = reg_t;
+using handled_t = bool;
+using file_name_t = std::string;
+
 class filedelete: public plugin
 {
 public:
@@ -139,6 +147,15 @@ public:
 
     filedelete(drakvuf_t drakvuf, const void* config, output_format_t output);
     ~filedelete();
+
+    // For `filedelete2`
+    addr_t queryobject_va;
+    addr_t readfile_va;
+    std::map<std::pair<addr_t, uint32_t>, handled_t> closing_handles;
+    std::map<vmi_pid_t, std::map<handle_t, file_name_t>> files;
+
+private:
+    void filedelete2(drakvuf_t drakvuf, const char* rekall_profile);
 };
 
 #endif

--- a/src/plugins/filedelete/filedelete2.cpp
+++ b/src/plugins/filedelete/filedelete2.cpp
@@ -1,0 +1,755 @@
+/*********************IMPORTANT DRAKVUF LICENSE TERMS***********************
+*                                                                         *
+* DRAKVUF (C) 2014-2017 Tamas K Lengyel.                                  *
+* Tamas K Lengyel is hereinafter referred to as the author.               *
+* This program is free software; you may redistribute and/or modify it    *
+* under the terms of the GNU General Public License as published by the   *
+* Free Software Foundation; Version 2 ("GPL"), BUT ONLY WITH ALL OF THE   *
+* CLARIFICATIONS AND EXCEPTIONS DESCRIBED HEREIN.  This guarantees your   *
+* right to use, modify, and redistribute this software under certain      *
+* conditions.  If you wish to embed DRAKVUF technology into proprietary   *
+* software, alternative licenses can be aquired from the author.          *
+*                                                                         *
+* Note that the GPL places important restrictions on "derivative works",  *
+* yet it does not provide a detailed definition of that term.  To avoid   *
+* misunderstandings, we interpret that term as broadly as copyright law   *
+* allows.  For example, we consider an application to constitute a        *
+* derivative work for the purpose of this license if it does any of the   *
+* following with any software or content covered by this license          *
+* ("Covered Software"):                                                   *
+*                                                                         *
+* o Integrates source code from Covered Software.                         *
+*                                                                         *
+* o Reads or includes copyrighted data files.                             *
+*                                                                         *
+* o Is designed specifically to execute Covered Software and parse the    *
+* results (as opposed to typical shell or execution-menu apps, which will *
+* execute anything you tell them to).                                     *
+*                                                                         *
+* o Includes Covered Software in a proprietary executable installer.  The *
+* installers produced by InstallShield are an example of this.  Including *
+* DRAKVUF with other software in compressed or archival form does not     *
+* trigger this provision, provided appropriate open source decompression  *
+* or de-archiving software is widely available for no charge.  For the    *
+* purposes of this license, an installer is considered to include Covered *
+* Software even if it actually retrieves a copy of Covered Software from  *
+* another source during runtime (such as by downloading it from the       *
+* Internet).                                                              *
+*                                                                         *
+* o Links (statically or dynamically) to a library which does any of the  *
+* above.                                                                  *
+*                                                                         *
+* o Executes a helper program, module, or script to do any of the above.  *
+*                                                                         *
+* This list is not exclusive, but is meant to clarify our interpretation  *
+* of derived works with some common examples.  Other people may interpret *
+* the plain GPL differently, so we consider this a special exception to   *
+* the GPL that we apply to Covered Software.  Works which meet any of     *
+* these conditions must conform to all of the terms of this license,      *
+* particularly including the GPL Section 3 requirements of providing      *
+* source code and allowing free redistribution of the work as a whole.    *
+*                                                                         *
+* Any redistribution of Covered Software, including any derived works,    *
+* must obey and carry forward all of the terms of this license, including *
+* obeying all GPL rules and restrictions.  For example, source code of    *
+* the whole work must be provided and free redistribution must be         *
+* allowed.  All GPL references to "this License", are to be treated as    *
+* including the terms and conditions of this license text as well.        *
+*                                                                         *
+* Because this license imposes special exceptions to the GPL, Covered     *
+* Work may not be combined (even as part of a larger work) with plain GPL *
+* software.  The terms, conditions, and exceptions of this license must   *
+* be included as well.  This license is incompatible with some other open *
+* source licenses as well.  In some cases we can relicense portions of    *
+* DRAKVUF or grant special permissions to use it in other open source     *
+* software.  Please contact tamas.k.lengyel@gmail.com with any such       *
+* requests.  Similarly, we don't incorporate incompatible open source     *
+* software into Covered Software without special permission from the      *
+* copyright holders.                                                      *
+*                                                                         *
+* If you have any questions about the licensing restrictions on using     *
+* DRAKVUF in other works, are happy to help.  As mentioned above,         *
+* alternative license can be requested from the author to integrate       *
+* DRAKVUF into proprietary applications and appliances.  Please email     *
+* tamas.k.lengyel@gmail.com for further information.                      *
+*                                                                         *
+* If you have received a written license agreement or contract for        *
+* Covered Software stating terms other than these, you may choose to use  *
+* and redistribute Covered Software under those terms instead of these.   *
+*                                                                         *
+* Source is provided to this software because we believe users have a     *
+* right to know exactly what a program is going to do before they run it. *
+* This also allows you to audit the software for security holes.          *
+*                                                                         *
+* Source code also allows you to port DRAKVUF to new platforms, fix bugs, *
+* and add new features.  You are highly encouraged to submit your changes *
+* on https://github.com/tklengyel/drakvuf, or by other methods.           *
+* By sending these changes, it is understood (unless you specify          *
+* otherwise) that you are offering unlimited, non-exclusive right to      *
+* reuse, modify, and relicense the code.  DRAKVUF will always be          *
+* available Open Source, but this is important because the inability to   *
+* relicense code has caused devastating problems for other Free Software  *
+* projects (such as KDE and NASM).                                        *
+* To specify special license conditions of your contributions, just say   *
+* so when you send them.                                                  *
+*                                                                         *
+* This program is distributed in the hope that it will be useful, but     *
+* WITHOUT ANY WARRANTY; without even the implied warranty of              *
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the DRAKVUF   *
+* license file for more details (it's in a COPYING file included with     *
+* DRAKVUF, and also available from                                        *
+* https://github.com/tklengyel/drakvuf/COPYING)                           *
+*                                                                         *
+***************************************************************************/
+
+#include <glib.h>
+#include <config.h>
+#include <inttypes.h>
+#include <libvmi/x86.h>
+#include <algorithm>
+#include <cassert>
+#include <set>
+
+#include "../plugins.h"
+#include "filedelete.h"
+#include "private.h"
+
+#include <libinjector/libinjector.h>
+
+struct injector
+{
+    filedelete* f;
+    bool is32bit;
+
+    handle_t handle;
+
+    reg_t target_cr3;
+    uint32_t target_thread_id;
+    addr_t eprocess_base;
+
+    x86_registers_t saved_regs;
+
+    union
+    {
+        struct
+        {
+            addr_t out;
+            size_t size;
+        } ntqueryobject_info;
+
+        struct
+        {
+            size_t bytes_read;
+            addr_t out;
+            addr_t io_status_block;
+        } ntreadfile_info;
+    };
+
+    drakvuf_trap_t* bp;
+};
+
+static const uint64_t BYTES_TO_READ = 0x4000;
+
+struct IO_STATUS_BLOCK
+{
+    uint64_t dummy;
+    uint64_t info;
+} __attribute__((packed));
+
+struct _LARGE_INTEGER
+{
+    uint64_t QuadPart;
+} __attribute__((packed));
+
+struct FILE_FS_DEVICE_INFORMATION
+{
+    uint32_t device_type;
+    uint32_t characteristics;
+} __attribute__((packed));
+
+static event_response_t readfile_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
+{
+    struct injector* injector = (struct injector*)info->trap->data;
+
+    auto response = 0;
+    uint32_t thread_id = 0;
+    std::pair<addr_t, uint32_t> thread;
+    filedelete* f = injector->f;
+
+    access_context_t ctx =
+    {
+        .translate_mechanism = VMI_TM_PROCESS_DTB,
+        .dtb = info->regs->cr3,
+    };
+
+    struct IO_STATUS_BLOCK io_status_block = { 0 };
+
+    vmi_instance_t vmi = drakvuf_lock_and_get_vmi(drakvuf);
+
+    if (info->regs->cr3 != injector->target_cr3)
+        goto done;
+
+    if ( !drakvuf_get_current_thread_id(drakvuf, info->vcpu, &thread_id) ||
+            !injector->target_thread_id || thread_id != injector->target_thread_id )
+        goto done;
+
+    if ( !info->regs->rax )
+    {
+        ctx.addr = injector->ntreadfile_info.io_status_block;
+        if ((VMI_FAILURE == vmi_read(vmi, &ctx, sizeof(struct IO_STATUS_BLOCK), &io_status_block, NULL)))
+            goto err;
+    }
+
+    if ( !info->regs->rax)
+    {
+        static uint64_t idx = 0;
+        char* file = NULL;
+
+        if (injector->ntreadfile_info.bytes_read == 0)
+            ++idx;
+
+        if ( asprintf(&file, "%s/file.%06lu.metadata", f->dump_folder, idx) < 0 )
+            goto err;
+
+        FILE* fp = fopen(file, "w");
+        if (!fp)
+        {
+            free(file);
+            goto err;
+        }
+
+        fprintf(fp, "FileName: \"%s\"\n", injector->f->files[info->proc_data.pid][injector->handle].c_str());
+        fprintf(fp, "PID: %" PRIu64 "\n", static_cast<uint64_t>(info->proc_data.pid));
+        fprintf(fp, "PPID: %" PRIu64 "\n", static_cast<uint64_t>(info->proc_data.ppid));
+        fprintf(fp, "ProcessName: \"%s\"\n", info->proc_data.name);
+
+        fclose(fp);
+        free(file);
+
+        ctx.addr = injector->ntreadfile_info.out;
+        void* buffer = g_malloc0(io_status_block.info);
+        auto status = vmi_read(vmi, &ctx, io_status_block.info, buffer, NULL);
+        if ((VMI_FAILURE == status))
+            goto err;
+
+        if ( asprintf(&file, "%s/file.%06lu", f->dump_folder, idx) < 0 )
+            goto err;
+
+        fp = fopen(file, "a");
+        if (!fp)
+        {
+            free(file);
+            goto err;
+        }
+
+        fwrite(buffer, 1, io_status_block.info, fp);
+        fclose(fp);
+        free(file);
+        g_free(buffer);
+
+        injector->ntreadfile_info.bytes_read += io_status_block.info;
+
+        if (BYTES_TO_READ == io_status_block.info)
+        {
+            // Remove stack arguments and home space from previous injection
+            info->regs->rsp = injector->saved_regs.rsp;
+
+            ctx.addr = info->regs->rsp;
+
+            if (injector->is32bit)
+            {
+                PRINT_DEBUG("[FILEDELETE2] 32bit VMs not supported yet\n");
+                goto err;
+            }
+
+            struct argument args[9] = { {0} };
+            struct _LARGE_INTEGER byte_offset = { .QuadPart = injector->ntreadfile_info.bytes_read };
+            const struct IO_STATUS_BLOCK io_status_block = { 0 };
+            const uint8_t buffer[BYTES_TO_READ] = { 0 };
+            uint64_t null64 = 0;
+
+            init_argument(0, &args[0], ARGUMENT_INT, sizeof(uint64_t), (void*)injector->handle);
+            init_argument(0, &args[1], ARGUMENT_INT, sizeof(uint64_t), (void*)null64);
+            init_argument(0, &args[2], ARGUMENT_INT, sizeof(uint64_t), (void*)null64);
+            init_argument(0, &args[3], ARGUMENT_INT, sizeof(uint64_t), (void*)null64);
+            init_argument(0, &args[4], ARGUMENT_STRUCT, sizeof(struct IO_STATUS_BLOCK), (void*)&io_status_block);
+            init_argument(0, &args[5], ARGUMENT_STRUCT, BYTES_TO_READ, (void*)buffer);
+            init_argument(0, &args[6], ARGUMENT_INT, sizeof(uint64_t), (void*)BYTES_TO_READ);
+            init_argument(0, &args[7], ARGUMENT_STRUCT, sizeof(byte_offset), (void*)&byte_offset);
+            init_argument(0, &args[8], ARGUMENT_INT, sizeof(uint64_t), (void*)null64);
+
+            if ( !setup_stack_64(vmi, info, &ctx, args, 9) )
+                goto err;
+
+            injector->ntreadfile_info.io_status_block = args[4].data_on_stack;
+            injector->ntreadfile_info.out = args[5].data_on_stack;
+
+            info->regs->rip = f->readfile_va;
+
+            response = VMI_EVENT_RESPONSE_SET_REGISTERS;
+
+            goto done;
+        }
+    }
+    else
+        PRINT_DEBUG("[FILEDELETE2] [ReadFile] Failed to read %s with status 0x%lx.\n", injector->f->files[info->proc_data.pid][injector->handle].c_str(), info->regs->rax);
+
+    thread = std::make_pair(info->regs->cr3, thread_id);
+    injector->f->closing_handles[thread] = true;
+    injector->f->files[info->proc_data.pid].erase(injector->handle);
+    if (injector->f->files[info->proc_data.pid].size() == 0)
+        injector->f->files.erase(info->proc_data.pid);
+
+    memcpy(info->regs, &injector->saved_regs, sizeof(x86_registers_t));
+    response = VMI_EVENT_RESPONSE_SET_REGISTERS;
+
+    drakvuf_remove_trap(drakvuf, injector->bp, (drakvuf_trap_free_t)free);
+
+    delete injector;
+
+    goto done;
+
+err:
+    PRINT_DEBUG("[FILEDELETE2] [ReadFile] Error. Stop processing (CR3 0x%lx, TID %d).\n",
+                info->regs->cr3, thread_id);
+
+    thread = std::make_pair(info->regs->cr3, thread_id);
+    injector->f->closing_handles[thread] = true;
+
+    memcpy(info->regs, &injector->saved_regs, sizeof(x86_registers_t));
+    response = VMI_EVENT_RESPONSE_SET_REGISTERS;
+
+    drakvuf_remove_trap(drakvuf, injector->bp, (drakvuf_trap_free_t)free);
+
+    delete injector;
+
+done:
+    drakvuf_release_vmi(drakvuf);
+
+    return response;
+}
+
+static event_response_t queryobject_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
+{
+    struct injector* injector = (struct injector*)info->trap->data;
+    filedelete* f = injector->f;
+
+    auto response = 0;
+    uint32_t thread_id = 0;
+    std::pair<addr_t, uint32_t> thread;
+
+    vmi_instance_t vmi = drakvuf_lock_and_get_vmi(drakvuf);
+
+    if (info->regs->cr3 != injector->target_cr3)
+        goto done;
+
+    if ( !drakvuf_get_current_thread_id(drakvuf, info->vcpu, &thread_id) ||
+            !injector->target_thread_id || thread_id != injector->target_thread_id )
+        goto done;
+
+    if (info->regs->rax)
+        goto handled;
+    else
+    {
+        access_context_t ctx =
+        {
+            .translate_mechanism = VMI_TM_PROCESS_DTB,
+            .dtb = info->regs->cr3,
+            .addr = injector->ntqueryobject_info.out,
+        };
+
+        struct FILE_FS_DEVICE_INFORMATION dev_info = { 0 };
+        if ((VMI_FAILURE == vmi_read(vmi, &ctx, sizeof(struct FILE_FS_DEVICE_INFORMATION), &dev_info, NULL)))
+        {
+            PRINT_DEBUG("[FILEDELETE2] [QueryObject] Failed to read FsDeviceInformation\n");
+            goto err;
+        }
+
+        if (7 != dev_info.device_type) // FILE_DEVICE_DISK
+            goto handled;
+
+        injector->ntreadfile_info.bytes_read = 0UL;
+
+        {
+            // Remove stack arguments and home space from previous injection
+            info->regs->rsp = injector->saved_regs.rsp;
+
+            ctx.addr = info->regs->rsp;
+
+            if (injector->is32bit)
+            {
+                PRINT_DEBUG("[FILEDELETE2] 32bit VMs not supported yet\n");
+                goto err;
+            }
+
+            struct argument args[9] = { {0} };
+            struct _LARGE_INTEGER byte_offset = { .QuadPart = 0 };
+            const struct IO_STATUS_BLOCK io_status_block = { 0 };
+            const uint8_t buffer[BYTES_TO_READ] = { 0 };
+            uint64_t null64 = 0;
+
+            init_argument(0, &args[0], ARGUMENT_INT, sizeof(uint64_t), (void*)injector->handle);
+            init_argument(0, &args[1], ARGUMENT_INT, sizeof(uint64_t), (void*)null64);
+            init_argument(0, &args[2], ARGUMENT_INT, sizeof(uint64_t), (void*)null64);
+            init_argument(0, &args[3], ARGUMENT_INT, sizeof(uint64_t), (void*)null64);
+            init_argument(0, &args[4], ARGUMENT_STRUCT, sizeof(struct IO_STATUS_BLOCK), (void*)&io_status_block);
+            init_argument(0, &args[5], ARGUMENT_STRUCT, BYTES_TO_READ, (void*)buffer);
+            init_argument(0, &args[6], ARGUMENT_INT, sizeof(uint64_t), (void*)BYTES_TO_READ);
+            init_argument(0, &args[7], ARGUMENT_STRUCT, sizeof(byte_offset), (void*)&byte_offset);
+            init_argument(0, &args[8], ARGUMENT_INT, sizeof(uint64_t), (void*)null64);
+
+            if ( !setup_stack_64(vmi, info, &ctx, args, 9) )
+                goto err;
+
+            injector->ntreadfile_info.io_status_block = args[4].data_on_stack;
+            injector->ntreadfile_info.out = args[5].data_on_stack;
+        }
+
+        info->regs->rip = f->readfile_va;
+
+        injector->bp->name = "ReadFile ret";
+        injector->bp->cb = readfile_cb;
+
+        response = VMI_EVENT_RESPONSE_SET_REGISTERS;
+
+        goto done;
+    }
+
+
+err:
+    PRINT_DEBUG("[FILEDELETE2] [QueryObject] Error. Stop processing (CR3 0x%lx, TID %d).\n",
+                info->regs->cr3, thread_id);
+
+handled:
+    thread = std::make_pair(info->regs->cr3, thread_id);
+    injector->f->closing_handles[thread] = true;
+
+    memcpy(info->regs, &injector->saved_regs, sizeof(x86_registers_t));
+    response = VMI_EVENT_RESPONSE_SET_REGISTERS;
+
+    drakvuf_remove_trap(drakvuf, injector->bp, (drakvuf_trap_free_t)free);
+
+    delete injector;
+
+done:
+    drakvuf_release_vmi(drakvuf);
+
+    return response;
+}
+
+/*
+ * Drakvuf must be locked/unlocked in the caller
+ */
+static event_response_t start_readfile(drakvuf_t drakvuf, drakvuf_trap_info_t* info, vmi_instance_t vmi, handle_t handle)
+{
+    auto response = 0;
+    auto restore_regs = false;
+    struct injector* injector = nullptr;
+    filedelete* f = (filedelete*)info->trap->data;
+
+    injector = new struct injector;
+    injector->f = f;
+    injector->handle = handle;
+    injector->is32bit = f->pm == VMI_PM_IA32E ? false : true;
+    injector->target_cr3 = info->regs->cr3;
+
+    injector->eprocess_base = drakvuf_get_current_process(drakvuf, info->vcpu);
+    if ( 0 == injector->eprocess_base )
+    {
+        PRINT_DEBUG("[FILEDELETE2] Failed to get process base on vCPU 0x%d\n",
+                    info->vcpu);
+        goto err;
+    }
+
+    if ( !drakvuf_get_current_thread_id(drakvuf, info->vcpu, &injector->target_thread_id) ||
+            !injector->target_thread_id )
+    {
+        PRINT_DEBUG("[FILEDELETE2] Failed to get Thread ID\n");
+        goto err;
+    }
+
+    /*
+     * Check if process/thread is being processed. If so skip it. Add it into
+     * regestry otherwise.
+     */
+    {
+        auto thread = std::make_pair(info->regs->cr3, injector->target_thread_id);
+        auto thread_it = f->closing_handles.find(thread);
+        auto map_end = f->closing_handles.end();
+        if (map_end != thread_it)
+        {
+            bool handled = thread_it->second;
+            if (handled)
+                f->closing_handles.erase(thread);
+
+            goto err;
+        }
+        else
+            f->closing_handles[thread] = false;
+    }
+
+    /*
+     * Real function body.
+     *
+     * Now we are sure this is new call to NtClose (not result of function injection) and
+     * the Handle have been modified in NtWriteFile. So we should save it on the host.
+     */
+    memcpy(&injector->saved_regs, info->regs, sizeof(x86_registers_t));
+    restore_regs = true;
+
+    {
+        access_context_t ctx =
+        {
+            .translate_mechanism = VMI_TM_PROCESS_DTB,
+            .dtb = info->regs->cr3,
+            .addr = info->regs->rsp,
+        };
+
+        if (injector->is32bit)
+        {
+            PRINT_DEBUG("[FILEDELETE2] 32bit VMs not supported yet\n");
+            goto err;
+        }
+
+        struct argument args[5] = { {0} };
+        const struct IO_STATUS_BLOCK io_status_block = { 0 };
+        struct FILE_FS_DEVICE_INFORMATION dev_info = { 0 };
+
+        init_argument(0, &args[0], ARGUMENT_INT, sizeof(uint64_t), (void*)handle);
+        init_argument(0, &args[1], ARGUMENT_STRUCT, sizeof(struct IO_STATUS_BLOCK), (void*)&io_status_block);
+        init_argument(0, &args[2], ARGUMENT_STRUCT, sizeof(struct FILE_FS_DEVICE_INFORMATION), (void*)&dev_info);
+        init_argument(0, &args[3], ARGUMENT_INT, sizeof(uint64_t), (void*)sizeof(struct FILE_FS_DEVICE_INFORMATION));
+        init_argument(0, &args[4], ARGUMENT_INT, sizeof(uint64_t), (void*)4); // FileFsDeviceInformation
+
+        if ( !setup_stack_64(vmi, info, &ctx, args, 5) )
+            goto err;
+
+        injector->ntqueryobject_info.out = args[2].data_on_stack;
+    }
+
+    injector->bp = (drakvuf_trap_t*)g_malloc0(sizeof(drakvuf_trap_t));
+    if (!injector->bp)
+        goto err;
+
+    injector->bp->type = BREAKPOINT;
+    injector->bp->name = "QueryObject ret";
+    injector->bp->cb = queryobject_cb;
+    injector->bp->data = injector;
+    injector->bp->breakpoint.lookup_type = LOOKUP_DTB;
+    injector->bp->breakpoint.dtb = info->regs->cr3;
+    injector->bp->breakpoint.addr_type = ADDR_VA;
+    injector->bp->breakpoint.addr = info->regs->rip;
+
+    if ( !drakvuf_add_trap(drakvuf, injector->bp) )
+    {
+        fprintf(stderr, "Failed to trap return location of injected function call @ 0x%lx!\n",
+                injector->bp->breakpoint.addr);
+        goto err;
+    }
+
+    info->regs->rip = f->queryobject_va;
+
+    response = VMI_EVENT_RESPONSE_SET_REGISTERS;
+
+    return response;
+
+err:
+    if (restore_regs)
+        memcpy(info->regs, &injector->saved_regs, sizeof(x86_registers_t));
+
+    if (injector)
+        delete injector;
+
+    return response;
+}
+
+/*
+ * Intercept all handles close and filter file handles.
+ *
+ * The main difficulty is that this handler intercepts not only CloseHandle()
+ * calls but returns from injected functions. To distinguish such situations
+ * we use the regestry of processes/threads being processed.
+ */
+static event_response_t closehandle_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
+{
+    auto response = 0;
+    filedelete* f = (filedelete*)info->trap->data;
+
+    vmi_instance_t vmi = drakvuf_lock_and_get_vmi(drakvuf);
+
+    access_context_t ctx;
+    reg_t handle = 0;
+
+    if (f->pm == VMI_PM_IA32E)
+    {
+        handle = info->regs->rcx;
+    }
+    else
+    {
+        ctx.translate_mechanism = VMI_TM_PROCESS_DTB;
+        ctx.dtb = info->regs->cr3;
+        ctx.addr = info->regs->rsp + sizeof(uint32_t);
+        if ( VMI_FAILURE == vmi_read_32(vmi, &ctx, (uint32_t*) &handle) )
+            goto err;
+    }
+
+    /*
+     * Check if closing handle have been changed with NtWriteFile
+     */
+    if (f->files[info->proc_data.pid][handle].empty())
+        goto err;
+
+    response = start_readfile(drakvuf, info, vmi, handle);
+
+err:
+    drakvuf_release_vmi(drakvuf);
+    return response;
+}
+
+/*
+ * NTSTATUS ZwSetInformationFile(
+ *  HANDLE                 FileHandle,
+ *  PIO_STATUS_BLOCK       IoStatusBlock,
+ *  PVOID                  FileInformation,
+ *  ULONG                  Length,
+ *  FILE_INFORMATION_CLASS FileInformationClass
+ * );
+ *
+ * When FileInformationClass is FileDispositionInformation then FileInformation points to
+ * struct _FILE_DISPOSITION_INFORMATION {
+ *  BOOLEAN DeleteFile;
+ * }
+ */
+static event_response_t setinformation_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
+{
+    event_response_t response = 0;
+    filedelete* f = (filedelete*)info->trap->data;
+    vmi_instance_t vmi = drakvuf_lock_and_get_vmi(drakvuf);
+
+    access_context_t ctx;
+    ctx.translate_mechanism = VMI_TM_PROCESS_DTB;
+    ctx.dtb = info->regs->cr3;
+
+    uint32_t fileinfoclass = 0;
+    reg_t handle = 0, fileinfo = 0;
+
+    if (f->pm == VMI_PM_IA32E)
+    {
+        handle = info->regs->rcx;
+        fileinfo = info->regs->r8;
+
+        ctx.addr = info->regs->rsp + 5 * sizeof(addr_t); // addr of fileinfoclass
+        if ( VMI_FAILURE == vmi_read_32(vmi, &ctx, &fileinfoclass) )
+            goto done;
+    }
+    else
+    {
+        ctx.addr = info->regs->rsp + sizeof(uint32_t);
+        if ( VMI_FAILURE == vmi_read_32(vmi, &ctx, (uint32_t*) &handle) )
+            goto done;
+        ctx.addr += 2 * sizeof(uint32_t);
+        if ( VMI_FAILURE == vmi_read_32(vmi, &ctx, (uint32_t*) &fileinfo) )
+            goto done;
+        ctx.addr += 2 * sizeof(uint32_t);
+        if ( VMI_FAILURE == vmi_read_32(vmi, &ctx, &fileinfoclass) )
+            goto done;
+    }
+
+    if (fileinfoclass == FILE_DISPOSITION_INFORMATION)
+    {
+        uint8_t del = 0;
+        ctx.addr = fileinfo;
+        if ( VMI_FAILURE == vmi_read_8(vmi, &ctx, &del) )
+            goto done;
+
+        if (del)
+        {
+            auto filename_us = get_file_name(f, drakvuf, vmi, info, handle, nullptr, nullptr);
+            std::string filename = "<UNKNOWN>";
+            if (filename_us)
+                filename = std::string((const char*)filename_us->contents);
+
+            f->files[info->proc_data.pid][handle] = filename;
+
+            response = start_readfile(drakvuf, info, vmi, handle);
+        }
+    }
+
+done:
+    drakvuf_release_vmi(drakvuf);
+    return response;
+}
+
+static event_response_t writefile_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
+{
+    filedelete* f = (filedelete*)info->trap->data;
+    vmi_instance_t vmi = drakvuf_lock_and_get_vmi(drakvuf);
+
+    unicode_string_t* filename_us = nullptr;
+    std::string filename = "<UNKNOWN>";
+    handle_t handle = 0;
+    access_context_t ctx;
+
+    if (f->pm == VMI_PM_IA32E)
+    {
+        handle = info->regs->rcx;
+    }
+    else
+    {
+        ctx.translate_mechanism = VMI_TM_PROCESS_DTB;
+        ctx.dtb = info->regs->cr3;
+        ctx.addr = info->regs->rsp + sizeof(uint32_t);
+        if ( VMI_FAILURE == vmi_read_32(vmi, &ctx, (uint32_t*) &handle) )
+            goto done;
+    }
+
+    filename_us = get_file_name(f, drakvuf, vmi, info, handle, nullptr, nullptr);
+    if (filename_us)
+        filename = std::string((const char*)filename_us->contents);
+
+    f->files[info->proc_data.pid][handle] = filename;
+
+done:
+    drakvuf_release_vmi(drakvuf);
+    return 0;
+}
+
+void filedelete::filedelete2(drakvuf_t drakvuf, const char* rekall_profile)
+{
+    const char* lib = "ntoskrnl.exe";
+    const char* queryobject_name = "ZwQueryVolumeInformationFile";
+    addr_t rva = 0;
+
+    if ( !drakvuf_get_function_rva( rekall_profile, queryobject_name, &rva) )
+    {
+        PRINT_DEBUG("[FILEDELETE2] [Init] Failed to get RVA of %s\n", queryobject_name);
+        throw -1;
+    }
+
+    queryobject_va = drakvuf_exportksym_to_va(drakvuf, 4, nullptr, lib, rva);
+    if (!queryobject_va)
+    {
+        PRINT_DEBUG("[FILEDELETE2] [Init] Failed to get VA of %s\n", queryobject_name);
+        throw -1;
+    }
+
+    const char* readfile_name = "ZwReadFile";
+
+    if ( !drakvuf_get_function_rva( rekall_profile, readfile_name, &rva) )
+    {
+        PRINT_DEBUG("[FILEDELETE2] [Init] Failed to get RVA of %s\n", readfile_name);
+        throw -1;
+    }
+
+    readfile_va = drakvuf_exportksym_to_va(drakvuf, 4, nullptr, lib, rva);
+    if (!readfile_va)
+    {
+        PRINT_DEBUG("[FILEDELETE2] [Init] Failed to get VA of %s\n", readfile_name);
+        throw -1;
+    }
+
+    assert(sizeof(traps)/sizeof(traps[0]) > 3);
+    register_trap(drakvuf, rekall_profile, "NtSetInformationFile", &traps[0], setinformation_cb);
+    register_trap(drakvuf, rekall_profile, "NtWriteFile", &traps[1], writefile_cb);
+    register_trap(drakvuf, rekall_profile, "NtClose", &traps[2], closehandle_cb);
+}

--- a/src/plugins/filedelete/private.h
+++ b/src/plugins/filedelete/private.h
@@ -102,236 +102,41 @@
  *                                                                         *
  ***************************************************************************/
 
-#include <config.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <inttypes.h>
-#include <stdbool.h>
-#include <string.h>
-#include <unistd.h>
-#include <glib.h>
+#ifndef FILEDELETE_PRIVATE_H
+#define FILEDELETE_PRIVATE_H
 
-#include "drakvuf.h"
+#define FILE_DISPOSITION_INFORMATION 13
 
-static drakvuf_c* drakvuf;
-
-void close_handler(int signal)
+enum offset
 {
-    drakvuf->interrupt(signal);
-}
+    FILE_OBJECT_TYPE,
+    FILE_OBJECT_FILENAME,
+    FILE_OBJECT_SECTIONOBJECTPOINTER,
+    SECTIONOBJECTPOINTER_DATASECTIONOBJECT,
+    SECTIONOBJECTPOINTER_SHAREDCACHEMAP,
+    SECTIONOBJECTPOINTER_IMAGESECTIONOBJECT,
+    CONTROL_AREA_SEGMENT,
+    SEGMENT_CONTROLAREA,
+    SEGMENT_SIZEOFSEGMENT,
+    SEGMENT_TOTALNUMBEROFPTES,
+    SUBSECTION_NEXTSUBSECTION,
+    SUBSECTION_SUBSECTIONBASE,
+    SUBSECTION_PTESINSUBSECTION,
+    SUBSECTION_CONTROLAREA,
+    SUBSECTION_STARTINGSECTOR,
+    OBJECT_HEADER_BODY,
+    __OFFSET_MAX
+};
 
-static inline void disable_plugin(char* optarg, bool* plugin_list)
-{
-    int i;
-    for (i=0; i<__DRAKVUF_PLUGIN_LIST_MAX; i++)
-        if (!strcmp(optarg, drakvuf_plugin_names[i]))
-            plugin_list[i] = 0;
-}
+extern const char* offset_names[__OFFSET_MAX][2];
 
-int main(int argc, char** argv)
-{
-    int c, rc = 1, timeout = 0;
-    char const* inject_file = NULL;
-    char const* inject_cwd = NULL;
-    injection_method_t injection_method = INJECT_METHOD_CREATEPROC;
-    char* domain = NULL;
-    char* rekall_profile = NULL;
-    char* dump_folder = NULL;
-    char* start_process_name = NULL;
-    char* tcpip = NULL;
-    vmi_pid_t injection_pid = -1;
-    uint32_t injection_thread = 0;
-    struct sigaction act;
-    output_format_t output = OUTPUT_DEFAULT;
-    bool plugin_list[] = {[0 ... __DRAKVUF_PLUGIN_LIST_MAX-1] = 1};
-    bool verbose = 0;
-    bool cpuid_stealth = 0;
-    bool leave_paused = 0;
-    char const* syscalls_filter_file = NULL;
-    bool dump_modified_files = false;
-    bool filedelete_use_injector = false;
+void register_trap( drakvuf_t drakvuf, const char* rekall_profile, const char* syscall_name,
+                    drakvuf_trap_t* trap,
+                    event_response_t(*hook_cb)( drakvuf_t drakvuf, drakvuf_trap_info_t* info ) );
 
-    fprintf(stderr, "%s v%s\n", PACKAGE_NAME, PACKAGE_VERSION);
+unicode_string_t* get_file_name(filedelete* f, drakvuf_t drakvuf,
+                                vmi_instance_t vmi,
+                                drakvuf_trap_info_t* info, addr_t handle,
+                                addr_t* out_file, addr_t* out_filetype);
 
-    if ( __DRAKVUF_PLUGIN_LIST_MAX == 0 )
-    {
-        fprintf(stderr, "No plugins have been enabled, nothing to do!\n");
-        return rc;
-    }
-
-    if (argc < 4)
-    {
-        fprintf(stderr, "Required input:\n"
-                "\t -r <rekall profile>       The Rekall profile of the OS kernel\n"
-                "\t -d <domain ID or name>    The domain's ID or name\n"
-                "Optional inputs:\n"
-                "\t -i <injection pid>        The PID of the process to hijack for injection\n"
-                "\t -I <injection thread>     The ThreadID in the process to hijack for injection (requires -i)\n"
-                "\t -e <inject_file>          The executable to start with injection\n"
-                "\t -c <current_working_dir>  The current working directory for injected executable\n"
-                "\t -m <inject_method>        The injection method (default or shellexec for Windows amd64 only)\n"
-                "\t -t <timeout>              Timeout (in seconds)\n"
-                "\t -o <format>               Output format (default or csv)\n"
-                "\t -x <plugin>               Don't activate the specified plugin\n"
-                "\t -p                        Leave domain paused after DRAKVUF exits\n"
-                "\t -w <process name>         Wait with plugin start until process name is detected\n"
-#ifdef ENABLE_PLUGIN_FILEDELETE
-                "\t -D <file dump folder>     Folder where extracted files should be stored at\n"
-                "\t -M                        Dump new or modified files also (requires -D)\n"
-                "\t -n                        Use extraction method based on function injection (requires -D)\n"
-#endif
-#ifdef ENABLE_PLUGIN_SOCKETMON
-                "\t -T <rekall profile>       The Rekall profile for tcpip.sys\n"
-#endif
-#ifdef ENABLE_PLUGIN_CPUIDMON
-                "\t -s                        Hide Hypervisor bits and signature in CPUID\n"
-#endif
-#ifdef DRAKVUF_DEBUG
-                "\t -v                        Turn on verbose (debug) output\n"
-#endif
-#ifdef ENABLE_PLUGIN_SYSCALLS
-                "\t -S <syscalls filter>      File with list of syscalls for trap in syscalls plugin (trap all if parameter is absent)\n"
-#endif
-               );
-        return rc;
-    }
-
-    while ((c = getopt (argc, argv, "r:d:i:I:e:m:t:D:o:vx:spw:T:S:Mc:n")) != -1)
-        switch (c)
-        {
-            case 'r':
-                rekall_profile = optarg;
-                break;
-            case 'd':
-                domain = optarg;
-                break;
-            case 'i':
-                injection_pid = atoi(optarg);
-                break;
-            case 'I':
-                injection_thread = atoi(optarg);
-                break;
-            case 'e':
-                inject_file = optarg;
-                break;
-            case 'c':
-                inject_cwd = optarg;
-                break;
-            case 'm':
-                if (!strncmp(optarg,"shellexec",9))
-                    injection_method = INJECT_METHOD_SHELLEXEC;
-                if (!strncmp(optarg,"createproc",10))
-                    injection_method = INJECT_METHOD_CREATEPROC;
-                break;
-            case 't':
-                timeout = atoi(optarg);
-                break;
-            case 'D':
-                dump_folder = optarg;
-                break;
-            case 'o':
-                if (!strncmp(optarg,"csv",3))
-                    output = OUTPUT_CSV;
-                if (!strncmp(optarg,"kv",2))
-                    output = OUTPUT_KV;
-                break;
-            case 'x':
-                disable_plugin(optarg, plugin_list);
-                break;
-            case 's':
-                cpuid_stealth = 1;
-                break;
-            case 'p':
-                leave_paused = 1;
-                break;
-            case 'w':
-                start_process_name = optarg;
-                break;
-            case 'T':
-                tcpip = optarg;
-                break;
-#ifdef DRAKVUF_DEBUG
-            case 'v':
-                verbose = 1;
-                break;
-#endif
-            case 'S':
-                syscalls_filter_file = optarg;
-                break;
-            case 'M':
-                dump_modified_files = true;
-                break;
-            case 'n':
-                filedelete_use_injector = true;
-                break;
-            default:
-                fprintf(stderr, "Unrecognized option: %c\n", c);
-                return rc;
-        }
-
-    if (!domain)
-    {
-        fprintf(stderr, "No domain name specified (-d)!\n");
-        return rc;
-    }
-
-    if (!rekall_profile)
-    {
-        fprintf(stderr, "No Rekall profile specified (-r)!\n");
-        return rc;
-    }
-
-    PRINT_DEBUG("Starting DRAKVUF initialization\n");
-
-    try
-    {
-        drakvuf = new drakvuf_c(domain, rekall_profile, output, timeout, verbose, leave_paused);
-    }
-    catch (int e)
-    {
-        fprintf(stderr, "Failed to initialize DRAKVUF\n");
-        return rc;
-    }
-
-    PRINT_DEBUG("DRAKVUF initializated\n");
-
-    /* for a clean exit */
-    act.sa_handler = close_handler;
-    act.sa_flags = 0;
-    sigemptyset(&act.sa_mask);
-    sigaction(SIGHUP, &act, NULL);
-    sigaction(SIGTERM, &act, NULL);
-    sigaction(SIGINT, &act, NULL);
-    sigaction(SIGALRM, &act, NULL);
-
-    if ( injection_pid > 0 && inject_file )
-    {
-        PRINT_DEBUG("Starting injection with PID %i(%i) for %s\n", injection_pid, injection_thread, inject_file);
-        int ret = drakvuf->inject_cmd(injection_pid, injection_thread, inject_file, inject_cwd, injection_method, output);
-        if (!ret)
-            goto exit;
-    }
-
-    if ( start_process_name )
-    {
-        if ( !drakvuf->wait_for_process(start_process_name) )
-            goto exit;
-    }
-
-    PRINT_DEBUG("Starting plugins\n");
-
-    if ( drakvuf->start_plugins(plugin_list, dump_folder, dump_modified_files, filedelete_use_injector, cpuid_stealth, tcpip, syscalls_filter_file) < 0 )
-        goto exit;
-
-    PRINT_DEBUG("Beginning DRAKVUF loop\n");
-
-    /* Start the event listener */
-    drakvuf->loop();
-    rc = 0;
-
-    PRINT_DEBUG("Finished DRAKVUF loop\n");
-
-exit:
-    delete drakvuf;
-    return rc;
-}
+#endif // FILEDELETE_PRIVATE_H

--- a/src/plugins/plugins.h
+++ b/src/plugins/plugins.h
@@ -119,6 +119,7 @@ struct filedelete_config
     const char* rekall_profile;
     const char* dump_folder;
     bool dump_modified_files;
+    bool filedelete_use_injector;
 };
 struct socketmon_config
 {


### PR DESCRIPTION
Hello.

This a work in progress to make filedelete plugin capable to catch the whole file contents of modified or deleted files.

Current status:
- Content fetching is based on function injection on NtClose.
- File modification catching is based on trapping NtWriteFile (ZwCreateSection in future).
- [x] Only modified files are catched (deleted files will be catched in future).
- [x] Only first 16KB of file is catched (full contents catch in future).
- [x] All traps in Ring3 (Ring0 in future).
- [x] Merge into original *plugin/filedelete*.

Known issues:
~~Sometimes files not catched.~~
    Advanced research needed for `STATUS_PENDING` and `STATUS_INVALID_DEVICE_REQUEST`
~~Adwanced applications use NtCreateSection/NtMapViewOfSection for writing into files.~~
    Advanced research needed to handle `STATUS_PENDING`. Seems like file handle could be closed after section handle obtaining.