### PR TITLE
API for additional FD-based event sources

### DIFF
--- a/src/libdrakvuf/drakvuf.c
+++ b/src/libdrakvuf/drakvuf.c
@@ -602,7 +602,7 @@ int drakvuf_event_fd_remove(drakvuf_t drakvuf, int fd)
     return 0;
 }
 
-int drakvuf_event_fd_add(drakvuf_t drakvuf, int fd, void (*event_cb) (int fd, void* data), void* data)
+int drakvuf_event_fd_add(drakvuf_t drakvuf, int fd, event_cb_t event_cb, void* data)
 {
     PRINT_DEBUG("drakvuf_event_fd_add fd=%d\n", fd);
 

--- a/src/libdrakvuf/libdrakvuf.h
+++ b/src/libdrakvuf/libdrakvuf.h
@@ -406,23 +406,11 @@ char* drakvuf_get_filename_from_handle( drakvuf_t drakvuf,
 
 int drakvuf_event_fd_add(drakvuf_t drakvuf,
                          int fd,
-                         void (*plugin_cb) (int fd, void* data),
-                         void* data,
-                         int flags);
+                         void (*event_cb) (int fd, void* data),
+                         void* data);
 
 int drakvuf_event_fd_remove(drakvuf_t drakvuf,
                             int fd);
-
-/*---------------------------------------------------------
- * Event FD flags
- */
-
-typedef enum
-{
-    __INVALID_EVENT_FD,
-    EVENT_FD_PLUGIN,
-    EVENT_FD_VMI
-} event_fd_t;
 
 /*---------------------------------------------------------
  * Output helpers

--- a/src/libdrakvuf/libdrakvuf.h
+++ b/src/libdrakvuf/libdrakvuf.h
@@ -404,6 +404,26 @@ char* drakvuf_get_filename_from_handle( drakvuf_t drakvuf,
                                         drakvuf_trap_info_t* info,
                                         addr_t handle );
 
+int drakvuf_event_fd_add(drakvuf_t drakvuf,
+                         int fd,
+                         void (*plugin_cb) (int fd, void* data),
+                         void* data,
+                         int flags);
+
+int drakvuf_event_fd_remove(drakvuf_t drakvuf,
+                            int fd);
+
+/*---------------------------------------------------------
+ * Event FD flags
+ */
+
+typedef enum
+{
+    __INVALID_EVENT_FD,
+    EVENT_FD_PLUGIN,
+    EVENT_FD_VMI
+} event_fd_t;
+
 /*---------------------------------------------------------
  * Output helpers
  */

--- a/src/libdrakvuf/libdrakvuf.h
+++ b/src/libdrakvuf/libdrakvuf.h
@@ -286,6 +286,8 @@ typedef enum object_manager_object
 
 typedef void (*drakvuf_trap_free_t)(drakvuf_trap_t* trap);
 
+typedef void (*event_cb_t) (int fd, void* data);
+
 bool drakvuf_init (drakvuf_t* drakvuf,
                    const char* domain,
                    const char* rekall_profile,
@@ -406,7 +408,7 @@ char* drakvuf_get_filename_from_handle( drakvuf_t drakvuf,
 
 int drakvuf_event_fd_add(drakvuf_t drakvuf,
                          int fd,
-                         void (*event_cb) (int fd, void* data),
+                         event_cb_t event_cb,
                          void* data);
 
 int drakvuf_event_fd_remove(drakvuf_t drakvuf,

--- a/src/libdrakvuf/private.h
+++ b/src/libdrakvuf/private.h
@@ -142,7 +142,7 @@ extern bool verbose;
 struct fd_info
 {
     int fd;
-    void (*event_cb) (int fd, void* data);
+    event_cb_t event_cb;
     void* data;
 };
 typedef struct fd_info* fd_info_t;

--- a/src/libdrakvuf/private.h
+++ b/src/libdrakvuf/private.h
@@ -142,8 +142,7 @@ extern bool verbose;
 struct fd_info
 {
     int fd;
-    int flags;
-    void (*plugin_cb) (int fd, void* data);
+    void (*event_cb) (int fd, void* data);
     void* data;
 };
 typedef struct fd_info* fd_info_t;

--- a/src/libdrakvuf/private.h
+++ b/src/libdrakvuf/private.h
@@ -120,6 +120,9 @@
 #include "os.h"
 #include "../xen_helper/xen_helper.h"
 
+#include <sys/poll.h>
+
+
 #ifdef DRAKVUF_DEBUG
 
 extern bool verbose;
@@ -135,6 +138,16 @@ extern bool verbose;
 #endif
 
 #define UNUSED(x) (void)(x)
+
+struct fd_info
+{
+    int fd;
+    int flags;
+    void (*plugin_cb) (int fd, void* data);
+    void* data;
+};
+typedef struct fd_info* fd_info_t;
+
 
 struct drakvuf
 {
@@ -197,6 +210,11 @@ struct drakvuf
     // val: struct memaccess
 
     GSList* cr0, *cr3, *cr4, *debug, *cpuid;
+
+    GSList* event_fd_info;     // the list of registered event FDs
+    struct pollfd* event_fds;  // auto-generated pollfd for poll()
+    int event_fd_cnt;          // auto-generated for poll()
+    fd_info_t fd_info_lookup;  // auto-generated for fast drakvuf_loop lookups
 };
 
 struct breakpoint

--- a/src/libdrakvuf/vmi.h
+++ b/src/libdrakvuf/vmi.h
@@ -125,6 +125,7 @@ void close_vmi(drakvuf_t drakvuf);
 event_response_t trap_guard(vmi_instance_t vmi, vmi_event_t* event);
 event_response_t vmi_reset_trap(vmi_instance_t vmi, vmi_event_t* event);
 event_response_t vmi_save_and_reset_trap(vmi_instance_t vmi, vmi_event_t* event);
+void drakvuf_vmi_event_callback (int fd, void* data);
 
 bool inject_trap(drakvuf_t drakvuf,
                  drakvuf_trap_t* trap,

--- a/src/xen_helper/xen_helper.c
+++ b/src/xen_helper/xen_helper.c
@@ -102,10 +102,12 @@
  *                                                                         *
  ***************************************************************************/
 
+#define XC_WANT_COMPAT_EVTCHN_API 1
 #define XC_WANT_COMPAT_MAP_FOREIGN_API 1
 
 #include <stdlib.h>
 #include <xenctrl.h>
+#include <xenctrl_compat.h>
 #include <libxl_utils.h>
 #include <glib.h>
 #include <sys/mman.h>
@@ -143,6 +145,14 @@ bool xen_init_interface(xen_interface_t** xen)
         goto err;
     }
 
+    (*xen)->evtchn = xc_evtchn_open(NULL, 0);
+    if (!(*xen)->evtchn)
+    {
+        printf("xc_evtchn_open() could not build event channel!\n");
+        goto err;
+    }
+    (*xen)->evtchn_fd = xc_evtchn_fd((*xen)->evtchn);
+
     return 1;
 
 err:
@@ -162,6 +172,8 @@ void xen_free_interface(xen_interface_t* xen)
         //if (xen->xsh) xs_close(xen->xsh);
         if (xen->xc)
             xc_interface_close(xen->xc);
+        if (xen->evtchn)
+            xc_evtchn_close(xen->evtchn);
         free(xen);
     }
 }

--- a/src/xen_helper/xen_helper.c
+++ b/src/xen_helper/xen_helper.c
@@ -107,7 +107,6 @@
 
 #include <stdlib.h>
 #include <xenctrl.h>
-#include <xenctrl_compat.h>
 #include <libxl_utils.h>
 #include <glib.h>
 #include <sys/mman.h>

--- a/src/xen_helper/xen_helper.h
+++ b/src/xen_helper/xen_helper.h
@@ -105,10 +105,11 @@
 #ifndef XEN_HELPER_H
 #define XEN_HELPER_H
 
+#include <xenctrl.h>
+
 #define LIBXL_API_VERSION 0x040500
 
 #include <libxl_utils.h>
-#include <xenctrl.h>
 
 typedef struct xen_interface
 {
@@ -116,6 +117,8 @@ typedef struct xen_interface
     xc_interface* xc;
     libxl_ctx* xl_ctx;
     xentoollog_logger* xl_logger;
+    void* evtchn;                  // the Xen event channel
+    int evtchn_fd;                 // its FD
 } xen_interface_t;
 
 /* FUNCTIONS */

--- a/src/xen_helper/xen_helper.h
+++ b/src/xen_helper/xen_helper.h
@@ -105,7 +105,6 @@
 #ifndef XEN_HELPER_H
 #define XEN_HELPER_H
 
-
 #define LIBXL_API_VERSION 0x040500
 
 #include <libxl_utils.h>

--- a/src/xen_helper/xen_helper.h
+++ b/src/xen_helper/xen_helper.h
@@ -105,11 +105,11 @@
 #ifndef XEN_HELPER_H
 #define XEN_HELPER_H
 
-#include <xenctrl.h>
 
 #define LIBXL_API_VERSION 0x040500
 
 #include <libxl_utils.h>
+#include <xenctrl.h>
 
 typedef struct xen_interface
 {


### PR DESCRIPTION
WIP for plugin-defined event sources:

DRAKVUF plugins allow users to build upon the core DRAKVUF framework.  Recently, I was experimenting with a use case that, in addition to consuming normal guest events, needed to also receive messages from an external event source via a ZMQ socket.  This could be used to programmatically send a DRAKVUF plugin a message to change its behavior at runtime and could allow DRAKVUF to be more easily integrated into larger security systems.  This work in progress solution might be useful to others and I wanted offer it for upstream consideration.  

This WIP allows plugins to register their own external file-descriptor-based event sources into DRAKVUF's event loop.  A plugin registers one or more file descriptors (FDs) with DRAKVUF and DRAKVUF monitors these FDs along with a guest VM's events.  When a plugin FD is raised, DRAKVUF informs the plugin via a callback passed during registration.  While the demo included in this WIP uses ZMQ, I believe it is generic enough to support other socket-based event sources.

Summary of changes:
1. Two plugin-facing DRAKVUF functions are added. Plugins use them to register and unregister FDs to DRAKVUF's event loop.
```
int drakvuf_event_fd_add(drakvuf_t drakvuf, 
                         int fd, 
                         void (*plugin_cb) (int fd, void *data), 
                         void *data, 
                         int flags)
```
```
int drakvuf_event_fd_remove(drakvuf_t drakvuf, 
                            int fd)
```
2. drakvuf_loop is modified to account for these additional FDs during polling.

drakvuf_event_fd_* functions operate on a linked list of fd_info structs stored in the main drakvuf struct.  Each object contains the fd itself, the plugin callback to be called if the fd is raised, a void* generic data pointer to pass this callback for context, and flags which (initally) are used to tell the difference between a normal VMI event (EVENT_FD_VMI) and a plugin-provided FD (EVENT_FD_PLUGIN).  Each time a new FD is added, the set of fd_info objects is used to re-generate the pollfd struct passed into poll (drakvuf->event_fds) and an array that is used in vmi_loop to quickly look up the fd_info (drakvuf->event_fds).

WIP Demo:  
In ./tools is a simple companion demo that shows how the syscall plugin might be modified to trace syscalls and monitor a ZMQ socket for external commands at the same time.

To try out the demo, overwrite the existing syscalls plugin with the demo code:
cp ./tools/event_fd_syscalls.cpp ./src/plugins/syscalls/syscalls.cpp
cp ./tools/event_fd_syscalls.h ./src/plugins/syscalls/syscalls.h

To compile, ensure ZMQ dev libraries are present in dom0, make clean, and append -lzmq to the line starting with "LIBS =" inside ./src/plugins/Makefile before recompiling.

In the syscall plugin's constructor, new code is added that creates and primes the syscall plugin's ZMQ socket (/tmp/testsocket).  This demo uses the dealer and router pattern http://zeromq.org/tutorials:dealer-and-router.

Also in syscall.cpp, two new functions, syscall_zmq_cb and zmq_dsend, are used to pass the plugin messages and for the plugin to send replies, respectively.  syscall_zmq_cb is the callback function the syscall plugin registers to drakvuf_event_fd_add.  Two other functions, syscalls::process_zmq and syscalls::process_message, actually process the message in the plugin's class namespace.  In this demo the plugin simply tests the message for a string and passes a string in reply.

Also included is a companion python script (event_fd_syscall_client.py) that connects to the syscall plugin's ZMQ socket and passes it test messages.  After starting DRAKVUF with the demo syscall plugin, wait a moment for it to initialize, then start event_fd_syscall_client.py.  The script must be run as root (alternatively, change the permissions on /tmp/testsocket). The following output should be observed:

ZMQ PYTHON CLIENT:
sudo ./event_fd_syscall_client.py
sending "b'dealer_hello'"
replied "b'router_hello'"
sending "b'dealer_hello'"
replied "b'router_hello'"
sending "b'dealer_hello'"
replied "b'router_hello'"
exiting...

DRAKVUF SYSCALL PLUGIN:
... lots of preceeding output tracing syscalls ...
[SYSCALL] TIME:1527706359.648966 VCPU:0 CR3:0x3a61d000,"salt-minion" UID:0 linux!sys_getuid
[SYSCALL] TIME:1527706359.649050 VCPU:0 CR3:0x3a61d000,"salt-minion" UID:0 linux!sys_kill
[SYSCALL] TIME:1527706359.649207 VCPU:0 CR3:0x3a61d000,"salt-minion" UID:0 linux!sys_select
process_message got message from testdealer: "dealer_hello", sending back "router_hello"
process_message got message from testdealer: "dealer_hello", sending back "router_hello"
process_message got message from testdealer: "dealer_hello", sending back "router_hello"
[SYSCALL] TIME:1527706360.922447 VCPU:0 CR3:0x3a61d000,"salt-minion" UID:0 linux!sys_epoll_ctl
[SYSCALL] TIME:1527706360.922557 VCPU:0 CR3:0x3a61d000,"salt-minion" UID:0 linux!sys_getsockopt
[SYSCALL] TIME:1527706360.922632 VCPU:0 CR3:0x3a61d000,"salt-minion" UID:0 linux!sys_close
[SYSCALL] TIME:1527706360.922729 VCPU:0 CR3:0x3a61d000,"salt-minion" UID:0 linux!sys_clock_gettime
... lots of proceeding output tracing syscalls ...