### PR TITLE
Add option to specify C++ stdlib

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -252,6 +252,12 @@ AC_ARG_ENABLE([debug],
   [debug="no"])
 AM_CONDITIONAL([DEBUG], [test x$debug = xyes])
 
+AC_ARG_WITH([stdlib],
+  [AS_HELP_STRING([--with-stdlib=LIB], [specify the C++ standard library to use [default=system]])],
+  [], [with_stdlib=system])
+AS_IF([test "x$with_stdlib" != "xsystem"],
+  [CXXFLAGS="$CXXFLAGS -stdlib=$with_stdlib"])
+
 #####################################################
 # AUTOHARDEN START
 # We want to check for compiler flag support, but there is no way to make


### PR DESCRIPTION
On occasion compilation fails with `fatal error: 'set' file not found` or `fatal error: 'cassert' file not found`. This is due to clang++ not finding the stdc++ library, so manually specifying `--with-stdlib=libc++` works around the problem.