### PR TITLE
Reverse #405, CPU overhead issue

### DIFF
--- a/src/libdrakvuf/drakvuf.c
+++ b/src/libdrakvuf/drakvuf.c
@@ -123,16 +123,6 @@ void drakvuf_close(drakvuf_t drakvuf, const bool pause)
         close_vmi(drakvuf);
     }
 
-    g_free(drakvuf->event_fds);
-    g_free(drakvuf->fd_info_lookup);
-    GSList* loop = drakvuf->event_fd_info;
-    while (loop)
-    {
-        g_free(loop->data);
-        loop = loop->next;
-    }
-    g_slist_free(drakvuf->event_fd_info);
-
     if (drakvuf->xen)
     {
 
@@ -168,10 +158,6 @@ bool drakvuf_init(drakvuf_t* drakvuf, const char* domain, const char* rekall_pro
 
     if ( !xen_init_interface(&(*drakvuf)->xen) )
         goto err;
-
-    /* register the main VMI event callback */
-    drakvuf_event_fd_add(*drakvuf, (*drakvuf)->xen->evtchn_fd, drakvuf_vmi_event_callback, drakvuf);
-    PRINT_DEBUG("drakvuf_init: adding event_fd done\n");
 
     get_dom_info((*drakvuf)->xen, domain, &(*drakvuf)->domID, &(*drakvuf)->dom_name);
     domid_t test = ~0;
@@ -542,95 +528,6 @@ unicode_string_t* drakvuf_read_unicode_va(vmi_instance_t vmi, addr_t vaddr, vmi_
     };
 
     return drakvuf_read_unicode_common(vmi, &ctx);
-}
-
-static void drakvuf_event_fd_generate(drakvuf_t drakvuf)
-{
-    /* event_fds and fd_info_lookup are both generated based off of
-       drakvuf->event_fd_info */
-    if (drakvuf->event_fds != NULL)
-    {
-        PRINT_DEBUG("freeing existing event_fds\n");
-        g_free(drakvuf->event_fds);
-    }
-    if (drakvuf->fd_info_lookup != NULL)
-    {
-        PRINT_DEBUG("freeing existing fd_info_lookup\n");
-        g_free(drakvuf->fd_info_lookup);
-    }
-
-    /* allocate and populate new pollfd array and new fd_info_lookup array */
-    drakvuf->event_fds = (struct pollfd*) g_malloc0(sizeof(struct pollfd) * \
-                         (g_slist_length(drakvuf->event_fd_info)));
-
-    drakvuf->fd_info_lookup = (fd_info_t) g_malloc0(sizeof(struct fd_info) * \
-                              (g_slist_length(drakvuf->event_fd_info)));
-
-    int i = 0;
-    GSList* loop = drakvuf->event_fd_info;
-    while (loop)
-    {
-        fd_info_t fd_info = (fd_info_t) loop->data;
-        drakvuf->event_fds[i].fd = fd_info->fd;
-        drakvuf->event_fds[i].events = POLLIN;
-        drakvuf->event_fds[i].revents = 0;
-        PRINT_DEBUG("new event_fd i=%d for fd=%d\n", i, fd_info->fd);
-
-        drakvuf->fd_info_lookup[i].fd = fd_info->fd;
-        drakvuf->fd_info_lookup[i].event_cb = fd_info->event_cb;
-        drakvuf->fd_info_lookup[i].data = fd_info->data;
-        PRINT_DEBUG("new fd_info_lookup i=%d for fd=%d\n", i, fd_info->fd);
-
-        loop = loop->next;
-        i++;
-    }
-
-    return;
-}
-
-int drakvuf_event_fd_remove(drakvuf_t drakvuf, int fd)
-{
-    PRINT_DEBUG("drakvuf_event_fd_remove fd=%d\n", fd);
-    int i = 0;
-    GSList* loop = drakvuf->event_fd_info;
-    while (loop)
-    {
-        fd_info_t fd_info = (fd_info_t) loop->data;
-        if (fd_info->fd == fd)
-        {
-            PRINT_DEBUG("found match at index=%d\n", i);
-            drakvuf->event_fd_info = g_slist_remove(drakvuf->event_fd_info, fd_info);
-            drakvuf->event_fd_cnt = g_slist_length(drakvuf->event_fd_info);
-            PRINT_DEBUG("regenerating event_fds and fd_info_lookup...\n");
-            drakvuf_event_fd_generate(drakvuf);
-            return 1;
-        }
-        loop = loop->next;
-        i++;
-    }
-    PRINT_DEBUG("drakvuf_event_fd_remove could not find fd!\n");
-    return 0;
-}
-
-int drakvuf_event_fd_add(drakvuf_t drakvuf, int fd, event_cb_t event_cb, void* data)
-{
-    PRINT_DEBUG("drakvuf_event_fd_add fd=%d\n", fd);
-
-    /* add new fd_info */
-    fd_info_t new_fd_info = (fd_info_t) g_malloc0(sizeof(struct fd_info));
-    new_fd_info->fd = fd;
-    new_fd_info->event_cb = event_cb;
-    new_fd_info->data = data;
-    /* the event_fd_info list is the authoritive data source used to
-       create the event_fds and fd_info_lookup data structures */
-    drakvuf->event_fd_info = g_slist_append(drakvuf->event_fd_info, new_fd_info);
-
-    drakvuf->event_fd_cnt = g_slist_length(drakvuf->event_fd_info);
-    PRINT_DEBUG("size of list=%d\n", drakvuf->event_fd_cnt);
-
-    PRINT_DEBUG("regenerating event_fds and fd_info_lookup...\n");
-    drakvuf_event_fd_generate(drakvuf);
-    return 1;
 }
 
 size_t drakvuf_wchar_string_length(vmi_instance_t vmi, const access_context_t* ctx)

--- a/src/libdrakvuf/libdrakvuf.h
+++ b/src/libdrakvuf/libdrakvuf.h
@@ -286,8 +286,6 @@ typedef enum object_manager_object
 
 typedef void (*drakvuf_trap_free_t)(drakvuf_trap_t* trap);
 
-typedef void (*event_cb_t) (int fd, void* data);
-
 bool drakvuf_init (drakvuf_t* drakvuf,
                    const char* domain,
                    const char* rekall_profile,
@@ -411,14 +409,6 @@ char* drakvuf_reg_keyhandle_path( drakvuf_t drakvuf,
 char* drakvuf_get_filename_from_handle( drakvuf_t drakvuf,
                                         drakvuf_trap_info_t* info,
                                         addr_t handle );
-
-int drakvuf_event_fd_add(drakvuf_t drakvuf,
-                         int fd,
-                         event_cb_t event_cb,
-                         void* data);
-
-int drakvuf_event_fd_remove(drakvuf_t drakvuf,
-                            int fd);
 
 // Reads 'length' characters from array of UTF_16 charachters into unicode_string_t object with UTF_8 encoding
 unicode_string_t* drakvuf_read_wchar_array(vmi_instance_t vmi, const access_context_t* ctx, size_t length);

--- a/src/libdrakvuf/private.h
+++ b/src/libdrakvuf/private.h
@@ -120,9 +120,6 @@
 #include "os.h"
 #include "../xen_helper/xen_helper.h"
 
-#include <sys/poll.h>
-
-
 #ifdef DRAKVUF_DEBUG
 
 extern bool verbose;
@@ -138,15 +135,6 @@ extern bool verbose;
 #endif
 
 #define UNUSED(x) (void)(x)
-
-struct fd_info
-{
-    int fd;
-    event_cb_t event_cb;
-    void* data;
-};
-typedef struct fd_info* fd_info_t;
-
 
 struct drakvuf
 {
@@ -212,11 +200,6 @@ struct drakvuf
     // val: struct memaccess
 
     GSList* cr0, *cr3, *cr4, *debug, *cpuid;
-
-    GSList* event_fd_info;     // the list of registered event FDs
-    struct pollfd* event_fds;  // auto-generated pollfd for poll()
-    int event_fd_cnt;          // auto-generated for poll()
-    fd_info_t fd_info_lookup;  // auto-generated for fast drakvuf_loop lookups
 };
 
 struct breakpoint

--- a/src/libdrakvuf/vmi.h
+++ b/src/libdrakvuf/vmi.h
@@ -125,7 +125,6 @@ void close_vmi(drakvuf_t drakvuf);
 event_response_t trap_guard(vmi_instance_t vmi, vmi_event_t* event);
 event_response_t vmi_reset_trap(vmi_instance_t vmi, vmi_event_t* event);
 event_response_t vmi_save_and_reset_trap(vmi_instance_t vmi, vmi_event_t* event);
-void drakvuf_vmi_event_callback (int fd, void* data);
 
 bool inject_trap(drakvuf_t drakvuf,
                  drakvuf_trap_t* trap,

--- a/src/xen_helper/xen_helper.c
+++ b/src/xen_helper/xen_helper.c
@@ -102,7 +102,6 @@
  *                                                                         *
  ***************************************************************************/
 
-#define XC_WANT_COMPAT_EVTCHN_API 1
 #define XC_WANT_COMPAT_MAP_FOREIGN_API 1
 
 #include <stdlib.h>
@@ -144,14 +143,6 @@ bool xen_init_interface(xen_interface_t** xen)
         goto err;
     }
 
-    (*xen)->evtchn = xc_evtchn_open(NULL, 0);
-    if (!(*xen)->evtchn)
-    {
-        printf("xc_evtchn_open() could not build event channel!\n");
-        goto err;
-    }
-    (*xen)->evtchn_fd = xc_evtchn_fd((*xen)->evtchn);
-
     return 1;
 
 err:
@@ -171,8 +162,6 @@ void xen_free_interface(xen_interface_t* xen)
         //if (xen->xsh) xs_close(xen->xsh);
         if (xen->xc)
             xc_interface_close(xen->xc);
-        if (xen->evtchn)
-            xc_evtchn_close(xen->evtchn);
         free(xen);
     }
 }

--- a/src/xen_helper/xen_helper.h
+++ b/src/xen_helper/xen_helper.h
@@ -116,8 +116,6 @@ typedef struct xen_interface
     xc_interface* xc;
     libxl_ctx* xl_ctx;
     xentoollog_logger* xl_logger;
-    void* evtchn;                  // the Xen event channel
-    int evtchn_fd;                 // its FD
 } xen_interface_t;
 
 /* FUNCTIONS */


### PR DESCRIPTION
PR #405 introduced severe CPU overhead due to the changes of how polling for events is performed. Reverting it for now until the reason for the overhead is better understood.

/cc @mbushou  