### PR TITLE
Added SMC traps for ARM64 platforms

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -114,6 +114,23 @@ AC_PROG_CXX(clang++)
 AX_REQUIRE_DEFINED([AX_CXX_COMPILE_STDCXX_11])
 AX_CXX_COMPILE_STDCXX_11
 
+AC_MSG_CHECKING([for supported architecture])
+case "$host_cpu" in
+i[[3456]]86|pentium)
+    arch=i386
+    AC_DEFINE([I386], 1, [Define for the i386 architecture.])
+    ;;
+x86?64*)
+    arch=x86_64
+    AC_DEFINE([X86_64], 1, [Define for the AMD x86-64 architecture.])
+    ;;
+aarch64*)
+    arch=arm64
+    AC_DEFINE([ARM64], 1, [Define for the ARM64 architecture.])
+    ;;
+esac
+AC_MSG_RESULT($arch)
+
 ######################################################
 
 AC_ARG_ENABLE([plugin_syscalls],

--- a/src/libdrakvuf/drakvuf.c
+++ b/src/libdrakvuf/drakvuf.c
@@ -219,7 +219,7 @@ void drakvuf_interrupt(drakvuf_t drakvuf, int sig)
     drakvuf->interrupted = sig;
 }
 
-bool inject_trap_breakpoint(drakvuf_t drakvuf, drakvuf_trap_t* trap)
+bool inject_trap_sw(drakvuf_t drakvuf, drakvuf_trap_t* trap)
 {
 
     if (trap->breakpoint.lookup_type == LOOKUP_NONE)
@@ -365,7 +365,7 @@ bool drakvuf_add_trap(drakvuf_t drakvuf, drakvuf_trap_t* trap)
     switch (trap->type)
     {
         case BREAKPOINT:
-            ret = inject_trap_breakpoint(drakvuf, trap);
+            ret = inject_trap_sw(drakvuf, trap);
             break;
         case MEMACCESS:
             ret = inject_trap_mem(drakvuf, trap, 0);

--- a/src/libdrakvuf/drakvuf.c
+++ b/src/libdrakvuf/drakvuf.c
@@ -379,6 +379,9 @@ bool drakvuf_add_trap(drakvuf_t drakvuf, drakvuf_trap_t* trap)
         case CPUID:
             ret = inject_trap_cpuid(drakvuf, trap);
             break;
+        case PRIVCALL:
+            ret = inject_trap_sw(drakvuf, trap);
+            break;
         default:
             ret = 0;
             break;

--- a/src/libdrakvuf/libdrakvuf.h
+++ b/src/libdrakvuf/libdrakvuf.h
@@ -179,7 +179,8 @@ typedef enum trap_type
     MEMACCESS,
     REGISTER,
     DEBUG,
-    CPUID
+    CPUID,
+    PRIVCALL
 } trap_type_t;
 
 typedef enum memaccess_type
@@ -210,6 +211,7 @@ typedef struct drakvuf_trap_info
     proc_data_t proc_data ; /* Current executing process data */
     addr_t trap_pa;
     x86_registers_t* regs;
+    arm_registers_t* arm_regs;
     drakvuf_trap_t* trap;
     union
     {

--- a/src/libdrakvuf/vmi.c
+++ b/src/libdrakvuf/vmi.c
@@ -124,7 +124,7 @@
 #include "vmi.h"
 #include "rekall-profile.h"
 
-static uint8_t bp = TRAP;
+static uint8_t sw_trap = SW_TRAP;
 
 /*
  * This function gets called from the singlestep event
@@ -263,7 +263,7 @@ event_response_t post_mem_cb(vmi_instance_t vmi, vmi_event_t* event)
                 return 0;
             }
 
-            if ( test == bp )
+            if ( test == sw_trap )
             {
                 PRINT_DEBUG("Double-trap at 0x%lx\n", *pa);
                 s->breakpoint.doubletrap = 1;
@@ -273,7 +273,7 @@ event_response_t post_mem_cb(vmi_instance_t vmi, vmi_event_t* event)
                 s->breakpoint.doubletrap = 0;
                 if ( VMI_FAILURE == vmi_write_8_pa(drakvuf->vmi,
                                                    (pass->remapped_gfn->r << 12) + (*pa & VMI_BIT_MASK(0,11)),
-                                                   &bp) )
+                                                   &sw_trap) )
                 {
                     fprintf(stderr, "Critical error in re-copying remapped gfn\n");
                     drakvuf->interrupted = -1;
@@ -495,7 +495,7 @@ event_response_t int3_cb(vmi_instance_t vmi, vmi_event_t* event)
             return 0;
         }
 
-        if (test == bp)
+        if (test == sw_trap)
         {
             // There is a breakpoint instruction in memory here
             // so we need to reinject this to the guest.
@@ -1095,7 +1095,7 @@ bool inject_trap_pa(drakvuf_t drakvuf,
         goto err_exit;
     }
 
-    if (test == bp)
+    if (test == sw_trap)
     {
         PRINT_DEBUG("Double-trap location @ 0x%lx !\n", container->breakpoint.pa);
         container->breakpoint.doubletrap = 1;
@@ -1104,7 +1104,7 @@ bool inject_trap_pa(drakvuf_t drakvuf,
     {
         container->breakpoint.doubletrap = 0;
 
-        if (VMI_FAILURE == vmi_write_8_pa(vmi, rpa, &bp))
+        if (VMI_FAILURE == vmi_write_8_pa(vmi, rpa, &sw_trap))
         {
             PRINT_DEBUG("FAILED TO INJECT TRAP @ 0x%lx !\n", container->breakpoint.pa);
             goto err_exit;

--- a/src/libdrakvuf/vmi.h
+++ b/src/libdrakvuf/vmi.h
@@ -109,7 +109,11 @@
 #define BIT64 1
 #define PM2BIT(pm) ((pm == VMI_PM_IA32E) ? BIT64 : BIT32)
 
-#define SW_TRAP 0xCC
+#if defined(I386) || defined(X86_64)
+#define SW_TRAP 0xCC //INT3
+#elif defined(ARM64)
+#define SW_TRAP 0xD4000003 //SMC64
+#endif
 
 #include <glib.h>
 #include <stdbool.h>

--- a/src/libdrakvuf/vmi.h
+++ b/src/libdrakvuf/vmi.h
@@ -109,7 +109,7 @@
 #define BIT64 1
 #define PM2BIT(pm) ((pm == VMI_PM_IA32E) ? BIT64 : BIT32)
 
-#define TRAP 0xCC
+#define SW_TRAP 0xCC
 
 #include <glib.h>
 #include <stdbool.h>

--- a/src/plugins/syscalls/syscalls.cpp
+++ b/src/plugins/syscalls/syscalls.cpp
@@ -128,10 +128,18 @@ static event_response_t linux_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
             break;
         default:
         case OUTPUT_DEFAULT:
+#if defined (I386) || defined (X86_64)
             printf("[SYSCALL] TIME:" FORMAT_TIMEVAL " VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64" %s!%s\n",
                    UNPACK_TIMEVAL(t), info->vcpu, info->regs->cr3, info->proc_data.name,
                    USERIDSTR(drakvuf), info->proc_data.userid,
                    info->trap->breakpoint.module, info->trap->name);
+#elif defined (ARM64)
+            printf("[SYSCALL] vCPU:%" PRIu32 " PC:%" PRIx64 " CPSR:%" PRIx32 " TTBR0:0x%" PRIx64 " TTBR1:0x%" PRIx64 ", %s: %s!%s\n",
+                   info->vcpu, info->arm_regs->pc, info->arm_regs->cpsr,
+                   info->arm_regs->ttbr0, info->arm_regs->ttbr1,
+                   USERIDSTR(drakvuf),
+                   info->trap->breakpoint.module, info->trap->name);
+#endif
             break;
     }
 
@@ -381,6 +389,12 @@ static GSList* create_trap_config(drakvuf_t drakvuf, syscalls* s, symbols_t* sym
 
     GSList* ret = NULL;
     unsigned long i,j;
+    trap_type_t traptype;
+#if defined (I386) || defined(X86_64)
+    traptype = BREAKPOINT;
+#elif defined (ARM64)
+    traptype = PRIVCALL;
+#endif
 
     PRINT_DEBUG("Received %lu symbols\n", symbols->count);
 
@@ -424,7 +438,7 @@ static GSList* create_trap_config(drakvuf_t drakvuf, syscalls* s, symbols_t* sym
             trap->breakpoint.addr = ntoskrnl + symbol->rva;
             trap->breakpoint.module = "ntoskrnl.exe";
             trap->name = g_strdup(symbol->name);
-            trap->type = BREAKPOINT;
+            trap->type = traptype;
             trap->cb = win_cb;
             trap->data = wrapper;
 
@@ -467,6 +481,9 @@ static GSList* create_trap_config(drakvuf_t drakvuf, syscalls* s, symbols_t* sym
             if (!strcmp(symbol->name, "sys_table"))
                 continue;
 
+            if (!strcmp(symbol->name, "sys_reg_genericv8_init"))
+                continue;
+
             PRINT_DEBUG("[SYSCALLS] Adding trap to %s at 0x%lx (kaslr 0x%lx)\n", symbol->name, symbol->rva + kaslr, kaslr);
 
             drakvuf_trap_t* trap = (drakvuf_trap_t*)g_malloc0(sizeof(drakvuf_trap_t));
@@ -476,7 +493,7 @@ static GSList* create_trap_config(drakvuf_t drakvuf, syscalls* s, symbols_t* sym
             trap->breakpoint.addr = symbol->rva + kaslr;
             trap->breakpoint.module = "linux";
             trap->name = g_strdup(symbol->name);
-            trap->type = BREAKPOINT;
+            trap->type = traptype;
             trap->cb = linux_cb;
             trap->data = s;
 


### PR DESCRIPTION
Renamed TRAP to SW_TRAP:
This patch introduces sw_trap as a name for both software traps: INT3 and SMC.
This patch prepares drakvuf for the ARM support added by the following commits.

Added SMC traps for ARM64 platforms:
This patch adds an preprocessor to differentiate x86 and ARM64.
This patch further adds the function smc_cb which is similar to the int3_cb.
smc_cb also helps us to emulate single-stepping:

As Xen does not support single-stepping on ARM, yet, we emulate the
single-stepping behavior by using two logically adjacent SMC instructions
placed in two different views; the first SMC instruction is placed instead
of the original instruction in the execute-view. The second SMC instruction
follows the original instruction in the step-view. By switching to the
step-view right after the first SMC invocation, the system will trap
immediately after executing the original instruction. In this way, this allows
the monitor to switch back to the exec-view and continue execution.

Because this patch uses inject_trap_breakpoint in the code path,
we renamed the function to inject_trap_sw.

This patch need the libvmi commit: 69b3198 to build.

Adds ARM64 support for the syscall plugin:
We make the trap type architecture dependent.
The function sys_reg_genericv8_init is ignored as it is no syscall.