### PR TITLE
Replace hardcoded Coverity token with Travis CI variable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
     global:
         # The next declaration is the encrypted COVERITY_SCAN_TOKEN, created
         #   via the "travis encrypt" command using the project repo's public key
-        - secure: "ZkXc5huudqMN0PXeloNfnuwaq4PQ6BDmU1Ov/ONDOtnwxkm4hxHrbbPwZ9O7/DprAor9p7X7jhx6sf3fsMB+ib0ARffQPB0JQNPPEWjbgUhTLL//y0W64efuwSrRLfaHXbcm6OJT1pjeyXWOKOMPrM7GBOnnRRscpDNtjqriPAs="
+        - secure: "$COVERITY_SCAN_TOKEN"
 
 matrix:
     include:
@@ -108,12 +108,12 @@ matrix:
                 - libaio-dev
         coverity_scan:
             project:
-                name: "tklengyel/drakvuf"
+                name: "$COVERITY_PROJECT_NAME"
                 description: "Build submitted via Travis CI"
-            notification_email: tamas@tklengyel.com
+            notification_email: $COVERITY_NOTIFICATION_EMAIL
             build_command_prepend: "./autogen.sh; ./configure --enable-debug; make clean"
             build_command:   "make"
-            branch_pattern: master
+            branch_pattern: $COVERITY_BRANCH_PATTERN
       before_install:
         - dpkg -x test-packages/xentools_4.7-drakvuf1-1_amd64.deb .
         - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/usr/local/lib


### PR DESCRIPTION
This allows all users to enable checking of their branches before
creating Pull Requests.

To enable Coverity Scan one should create COVERITY_SCAN_TOKEN
and other variables in Travis CI project's settings.

-----
@tklengyel I have changed `.travis.yml` so it could not pass Coverity test. You should define all variables in your Travis CI project's settings.