### PR TITLE
Add Travis CI addon for SonarQube

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -175,3 +175,50 @@ matrix:
         - cd src/xen_helper && scan-build --status-bugs --use-cc=clang-5.0 make && cd ../..
         - cd src/libinjector && scan-build --status-bugs --use-cc=clang-5.0 make && cd ../..
         - cd src/dirwatch && scan-build --status-bugs --use-cc=clang-5.0 make && cd ../..
+
+#
+# SonarCloud
+#
+    - env:
+        - TEST="SonarCloud"
+      addons:
+        apt:
+            sources:
+                - ubuntu-toolchain-r-test
+                - llvm-toolchain-trusty-5.0
+            packages:
+                - bison
+                - flex
+                - check
+                - libjson-c-dev
+                - autoconf-archive
+                - libyajl2
+                - uuid-dev
+                - libpixman-1-dev
+                - libaio-dev
+                - clang-5.0
+        sonarcloud:
+            organization: "drakvuf"
+            token:
+                secure: "$SONAR_TOKEN"
+      before_install:
+        - dpkg -x test-packages/xentools_4.7-drakvuf1-1_amd64.deb .
+        - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/usr/local/lib
+        - export C_INCLUDE_PATH=$PWD/usr/local/include
+        - export PKG_CONFIG_PATH="$PWD/usr/local/lib/pkgconfig/"
+        - export LDFLAGS="-L$PWD/usr/local/lib"
+        - export CFLAGS="-I$PWD/usr/local/include"
+        - export PATH=$PATH:/usr/local/clang-5.0.0/bin
+        - git submodule update --init libvmi
+        - cd libvmi
+        - ./autogen.sh
+        - ./configure --disable-kvm --disable-examples --without-xenstore --prefix=$PWD/../usr/local
+        - make
+        - make install
+        - cd ..
+      install:
+        - ./autogen.sh
+      script:
+        - ./configure --enable-debug
+        - build-wrapper-linux-x86-64 --out-dir bw-output make -j2
+        - sonar-scanner

--- a/.travis.yml
+++ b/.travis.yml
@@ -219,6 +219,7 @@ matrix:
       install:
         - ./autogen.sh
       script:
+        - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then exit 0; fi'
         - ./configure --enable-debug
         - build-wrapper-linux-x86-64 --out-dir bw-output make -j2
         - sonar-scanner

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
     global:
         # The next declaration is the encrypted COVERITY_SCAN_TOKEN, created
         #   via the "travis encrypt" command using the project repo's public key
-        - secure: "ZkXc5huudqMN0PXeloNfnuwaq4PQ6BDmU1Ov/ONDOtnwxkm4hxHrbbPwZ9O7/DprAor9p7X7jhx6sf3fsMB+ib0ARffQPB0JQNPPEWjbgUhTLL//y0W64efuwSrRLfaHXbcm6OJT1pjeyXWOKOMPrM7GBOnnRRscpDNtjqriPAs="
+        - secure: "$COVERITY_SCAN_TOKEN"
 
 matrix:
     include:
@@ -108,12 +108,12 @@ matrix:
                 - libaio-dev
         coverity_scan:
             project:
-                name: "tklengyel/drakvuf"
+                name: "$COVERITY_PROJECT_NAME"
                 description: "Build submitted via Travis CI"
-            notification_email: tamas@tklengyel.com
+            notification_email: $COVERITY_NOTIFICATION_EMAIL
             build_command_prepend: "./autogen.sh; ./configure --enable-debug; make clean"
             build_command:   "make"
-            branch_pattern: master
+            branch_pattern: $COVERITY_BRANCH_PATTERN
       before_install:
         - dpkg -x test-packages/xentools_4.7-drakvuf1-1_amd64.deb .
         - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/usr/local/lib

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,7 @@
+sonar.projectKey=drakvuf
+sonar.projectName=Drakvuf
+sonar.projectVersion=0.5
+
+sonar.sources=src
+
+sonar.cfamily.build-wrapper-output=bw-output


### PR DESCRIPTION
One should define SONAR_TOKEN variable in Travis CI project's settings.

-----
@tklengyel this patch defines new test in `.travis.yml` which requires a project named *drakvuf* on [SonarCloud](https://sonarcloud.io). You could see my [example](https://sonarcloud.io/project/issues?id=skvl-drakvuf&resolved=false&severities=BLOCKER&types=CODE_SMELL) project.