### PR TITLE
Remove drakvuf_get_current_process() call from plugins

### DIFF
--- a/src/plugins/filedelete/filedelete.cpp
+++ b/src/plugins/filedelete/filedelete.cpp
@@ -207,14 +207,12 @@ static std::string get_file_name(filedelete* f, drakvuf_t drakvuf, vmi_instance_
                                  addr_t handle,
                                  addr_t* out_file, addr_t* out_filetype)
 {
-    addr_t process = drakvuf_get_current_process(drakvuf, info->vcpu);
-
     // TODO: verify that the dtb in the _EPROCESS is the same as the cr3?
 
-    if (!process)
+    if (!info->proc_data.base_addr)
         return {};
 
-    addr_t obj = drakvuf_get_obj_by_handle(drakvuf, process, handle);
+    addr_t obj = drakvuf_get_obj_by_handle(drakvuf, info->proc_data.base_addr, handle);
 
     if (!obj)
         return {};
@@ -789,7 +787,7 @@ static event_response_t start_readfile(drakvuf_t drakvuf, drakvuf_trap_info_t* i
     injector->target_cr3 = info->regs->cr3;
     injector->curr_sequence_number = -1;
 
-    injector->eprocess_base = drakvuf_get_current_process(drakvuf, info->vcpu);
+    injector->eprocess_base = info->proc_data.base_addr;
     if ( 0 == injector->eprocess_base )
     {
         PRINT_DEBUG("[FILEDELETE2] Failed to get process base on vCPU 0x%d\n",

--- a/src/plugins/procmon/procmon.cpp
+++ b/src/plugins/procmon/procmon.cpp
@@ -201,10 +201,9 @@ static void print_process_creation_result(
 
 static vmi_pid_t get_pid_from_handle(procmon* f, drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t handle)
 {
-    addr_t process = drakvuf_get_current_process(drakvuf, info->vcpu);
-    if (!process) return 0;
+    if (!info->proc_data.base_addr ) return 0;
 
-    addr_t obj = drakvuf_get_obj_by_handle(drakvuf, process, handle);
+    addr_t obj = drakvuf_get_obj_by_handle(drakvuf, info->proc_data.base_addr, handle);
     if (!obj) return 0;
 
     addr_t eprocess_base = obj + f->object_header_body;

--- a/src/plugins/socketmon/socketmon.cpp
+++ b/src/plugins/socketmon/socketmon.cpp
@@ -1579,15 +1579,14 @@ static int set_trap_universal(socketmon_trapinfo& ti, socketmon* f, drakvuf_t dr
     auto response = 0;
     addr_t exec_func = 0;
 
-    auto eprocess_base = drakvuf_get_current_process(drakvuf, info->vcpu);
-    if ( 0 == eprocess_base )
+    if ( 0 == info->proc_data.base_addr )
     {
         PRINT_DEBUG("[SOCKETMON] Failed to get process base on vCPU 0x%d\n",
                     info->vcpu);
         goto err;
     }
 
-    exec_func = drakvuf_exportsym_to_va(drakvuf, eprocess_base, ti.lib, ti.fun);
+    exec_func = drakvuf_exportsym_to_va(drakvuf, info->proc_data.base_addr, ti.lib, ti.fun);
     if (!exec_func)
     {
         PRINT_DEBUG("[SOCKETMON] Failed to get address of %s!%s\n", ti.lib, ti.fun);


### PR DESCRIPTION
The EPROCESS address from the process that triggered the trap can be obtained just using the `proc_data` info instead of calling (again) the `drakvuf_get_current_process()` function from inside the plugin.