### PR TITLE
Listen on CR3 event during injection to catch new process

### DIFF
--- a/src/drakvuf.cpp
+++ b/src/drakvuf.cpp
@@ -274,76 +274,17 @@ void drakvuf_c::resume()
     drakvuf_resume(this->drakvuf);
 }
 
-int drakvuf_c::inject_cmd(vmi_pid_t injection_pid, uint32_t injection_tid, const char* inject_cmd, const char* cwd, injection_method_t method, output_format_t format, const char* binary_path, const char* target_process)
+int drakvuf_c::inject_cmd(vmi_pid_t injection_pid, uint32_t injection_tid, const char* inject_cmd, const char* cwd, injection_method_t method, output_format_t format, const char* binary_path, const char* target_process, bool wait_for_process)
 {
-    int rc = injector_start_app(this->drakvuf, injection_pid, injection_tid, inject_cmd, cwd, method, format, binary_path, target_process);
+    int rc = 0;
+    this->injector = injector_start_app(this->drakvuf, injection_pid, injection_tid, inject_cmd, cwd, method, format, binary_path, target_process, wait_for_process, &rc);
+
     if (!rc)
         fprintf(stderr, "Process startup failed\n");
     return rc;
 }
 
-static gpointer timer2(gpointer data)
+void drakvuf_c::inject_cmd_cleanup(void)
 {
-    drakvuf_c* drakvuf = (drakvuf_c*)data;
-
-    /* Wait for the loop to start */
-    g_mutex_lock(&drakvuf->loop_signal2);
-    g_mutex_unlock(&drakvuf->loop_signal2);
-
-    while (drakvuf->process_start_timeout && !drakvuf->interrupted)
-    {
-        sleep(1);
-        --drakvuf->process_start_timeout;
-    }
-
-    if (!drakvuf->interrupted)
-    {
-        drakvuf->interrupt(-1);
-    }
-
-    g_thread_exit(NULL);
-    return NULL;
-}
-
-static event_response_t wait_for_process_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
-{
-    UNUSED(drakvuf);
-    drakvuf_c* dc = (drakvuf_c*)info->trap->data;
-
-    const char* begin_name = strrchr(info->proc_data.name, '\\');
-
-    if ( !strcmp(begin_name ? begin_name + 1 : info->proc_data.name, dc->process_start_name) )
-    {
-        dc->interrupt(-1);
-        dc->process_start_detected = 1;
-    }
-
-    return 0;
-}
-
-bool drakvuf_c::wait_for_process(const char* processname)
-{
-    drakvuf_trap_t trap =
-    {
-        .cb = wait_for_process_cb,
-        .type = REGISTER,
-        .reg = CR3,
-        .data = (void*)this
-    };
-
-    if ( !drakvuf_add_trap(this->drakvuf,&trap) )
-        return 0;
-
-    this->timeout_thread2 = g_thread_new(NULL, timer2, (void*)this);
-
-    this->process_start_name = processname;
-
-    g_mutex_unlock(&this->loop_signal2);
-    drakvuf_loop(this->drakvuf);
-
-    drakvuf_remove_trap(this->drakvuf, &trap, NULL);
-
-    g_thread_join(this->timeout_thread2);
-
-    return this->process_start_detected;
+    injector_cleanup(this->injector);
 }

--- a/src/drakvuf.h
+++ b/src/drakvuf.h
@@ -139,6 +139,7 @@ private:
     bool leave_paused;
     drakvuf_t drakvuf;
     drakvuf_plugins* plugins;
+    injector_t injector;
     GThread* timeout_thread = NULL;
     GThread* timeout_thread2 = NULL;
     os_t os;
@@ -166,7 +167,16 @@ public:
     void loop();
     void pause();
     void resume();
-    int inject_cmd(vmi_pid_t injection_pid, uint32_t injection_tid, const char* inject_cmd, const char* cwd, injection_method_t method, output_format_t format, const char* binary_path, const char* target_process);
+    int inject_cmd(vmi_pid_t injection_pid,
+                   uint32_t injection_tid,
+                   const char* inject_cmd,
+                   const char* cwd,
+                   injection_method_t method,
+                   output_format_t format,
+                   const char* binary_path,
+                   const char* target_process,
+                   bool wait_for_process);
+    void inject_cmd_cleanup();
     int start_plugins(const bool* plugin_list,
                       const char* dump_folder,
                       bool dump_modified_files,

--- a/src/injector.c
+++ b/src/injector.c
@@ -240,7 +240,9 @@ int main(int argc, char** argv)
     }
 
     printf("Injector starting %s through PID %u TID: %u\n", inject_file, injection_pid, injection_thread);
-    int injection_result = injector_start_app(drakvuf, injection_pid, injection_thread, inject_file, inject_cwd, injection_method, OUTPUT_DEFAULT, binary_path, target_process);
+
+    int injection_result = 0;
+    injector_t injector = injector_start_app(drakvuf, injection_pid, injection_thread, inject_file, inject_cwd, injection_method, OUTPUT_DEFAULT, binary_path, target_process, 1, &injection_result);
 
     if (injection_result)
         printf("Process startup success\n");
@@ -249,6 +251,10 @@ int main(int argc, char** argv)
         printf("Process startup failed\n");
         rc = 1;
     }
+
+    injector_cleanup(injector);
+
+    drakvuf_resume(drakvuf);
 
     drakvuf_close(drakvuf, 0);
 

--- a/src/libdrakvuf/libdrakvuf.h
+++ b/src/libdrakvuf/libdrakvuf.h
@@ -364,7 +364,8 @@ addr_t drakvuf_get_current_thread(drakvuf_t drakvuf,
 
 /* Caller must free the returned string */
 char* drakvuf_get_process_name(drakvuf_t drakvuf,
-                               addr_t process_base);
+                               addr_t process_base,
+                               bool fullpath);
 
 status_t drakvuf_get_process_pid( drakvuf_t drakvuf,
                                   addr_t process_base,

--- a/src/libdrakvuf/linux-processes.c
+++ b/src/libdrakvuf/linux-processes.c
@@ -162,8 +162,9 @@ addr_t linux_get_current_thread(drakvuf_t drakvuf, uint64_t vcpu_id)
     return linux_get_current_process(drakvuf, vcpu_id);
 }
 
-char* linux_get_process_name(drakvuf_t drakvuf, addr_t process_base)
+char* linux_get_process_name(drakvuf_t drakvuf, addr_t process_base, bool fullpath)
 {
+    UNUSED(fullpath);
     access_context_t ctx =
     {
         .translate_mechanism = VMI_TM_PROCESS_PID,
@@ -190,8 +191,9 @@ status_t linux_get_process_pid(drakvuf_t drakvuf, addr_t process_base, vmi_pid_t
     return vmi_read_32(drakvuf->vmi, &ctx, (uint32_t*)pid);
 }
 
-char* linux_get_current_process_name(drakvuf_t drakvuf, uint64_t vcpu_id)
+char* linux_get_current_process_name(drakvuf_t drakvuf, uint64_t vcpu_id, bool fullpath)
 {
+    UNUSED(fullpath);
     addr_t process_base = linux_get_current_process(drakvuf, vcpu_id);
     if ( !process_base )
         return NULL;
@@ -316,7 +318,7 @@ bool linux_get_current_process_data( drakvuf_t drakvuf, uint64_t vcpu_id, proc_d
     {
         if ( linux_get_process_pid( drakvuf, proc_data->base_addr, &proc_data->pid ) == VMI_SUCCESS )
         {
-            proc_data->name = linux_get_process_name( drakvuf, proc_data->base_addr );
+            proc_data->name = linux_get_process_name( drakvuf, proc_data->base_addr, 1 );
 
             if ( proc_data->name )
             {

--- a/src/libdrakvuf/linux.h
+++ b/src/libdrakvuf/linux.h
@@ -112,11 +112,11 @@ addr_t linux_get_current_thread(drakvuf_t drakvuf, uint64_t vcpu_id);
 
 addr_t linux_get_current_process(drakvuf_t drakvuf, uint64_t vcpu_id);
 
-char* linux_get_process_name(drakvuf_t drakvuf, addr_t process_base);
+char* linux_get_process_name(drakvuf_t drakvuf, addr_t process_base, bool fullpath);
 
 status_t linux_get_process_pid(drakvuf_t drakvuf, addr_t process_base, vmi_pid_t* pid);
 
-char* linux_get_current_process_name(drakvuf_t drakvuf, uint64_t vcpu_id);
+char* linux_get_current_process_name(drakvuf_t drakvuf, uint64_t vcpu_id, bool fullpath);
 
 int64_t linux_get_process_userid(drakvuf_t drakvuf, addr_t process_base);
 

--- a/src/libdrakvuf/os.c
+++ b/src/libdrakvuf/os.c
@@ -144,10 +144,10 @@ addr_t drakvuf_get_current_process(drakvuf_t drakvuf, uint64_t vcpu_id)
     return 0;
 }
 
-char* drakvuf_get_process_name(drakvuf_t drakvuf, addr_t process_base)
+char* drakvuf_get_process_name(drakvuf_t drakvuf, addr_t process_base, bool fullpath)
 {
     if ( drakvuf->osi.get_process_name )
-        return drakvuf->osi.get_process_name(drakvuf, process_base);
+        return drakvuf->osi.get_process_name(drakvuf, process_base, fullpath);
 
     return NULL;
 }
@@ -160,10 +160,10 @@ status_t drakvuf_get_process_pid(drakvuf_t drakvuf, addr_t process_base, vmi_pid
     return VMI_FAILURE;
 }
 
-char* drakvuf_get_current_process_name(drakvuf_t drakvuf, uint64_t vcpu_id)
+char* drakvuf_get_current_process_name(drakvuf_t drakvuf, uint64_t vcpu_id, bool fullpath)
 {
     if ( drakvuf->osi.get_current_process_name )
-        return drakvuf->osi.get_current_process_name(drakvuf, vcpu_id);
+        return drakvuf->osi.get_current_process_name(drakvuf, vcpu_id, fullpath);
 
     return NULL;
 }

--- a/src/libdrakvuf/os.h
+++ b/src/libdrakvuf/os.h
@@ -114,10 +114,10 @@ typedef struct os_interface
     (drakvuf_t drakvuf, uint64_t vcpu_id);
 
     char* (*get_process_name)
-    (drakvuf_t drakvuf, addr_t process_base);
+    (drakvuf_t drakvuf, addr_t process_base, bool fullpath);
 
     char* (*get_current_process_name)
-    (drakvuf_t drakvuf, uint64_t vcpu_id);
+    (drakvuf_t drakvuf, uint64_t vcpu_id, bool fullpath);
 
     int64_t (*get_process_userid)
     (drakvuf_t drakvuf, addr_t process_base);

--- a/src/libdrakvuf/private.h
+++ b/src/libdrakvuf/private.h
@@ -276,7 +276,8 @@ struct memcb_pass
 void drakvuf_force_resume (drakvuf_t drakvuf);
 
 char* drakvuf_get_current_process_name(drakvuf_t drakvuf,
-                                       uint64_t vcpu_id);
+                                       uint64_t vcpu_id,
+                                       bool fullpath);
 
 int64_t drakvuf_get_current_process_userid(drakvuf_t drakvuf,
         uint64_t vcpu_id);

--- a/src/libdrakvuf/win.h
+++ b/src/libdrakvuf/win.h
@@ -113,11 +113,11 @@ addr_t win_get_current_thread(drakvuf_t drakvuf, uint64_t vcpu_id);
 
 addr_t win_get_current_process(drakvuf_t drakvuf, uint64_t vcpu_id);
 
-char* win_get_process_name(drakvuf_t drakvuf, addr_t eprocess_base);
+char* win_get_process_name(drakvuf_t drakvuf, addr_t eprocess_base, bool fullpath);
 
 status_t win_get_process_pid(drakvuf_t drakvuf, addr_t eprocess_base, int32_t* pid);
 
-char* win_get_current_process_name(drakvuf_t drakvuf, uint64_t vcpu_id);
+char* win_get_current_process_name(drakvuf_t drakvuf, uint64_t vcpu_id, bool fullpath);
 
 int64_t win_get_process_userid(drakvuf_t drakvuf, addr_t eprocess_base);
 

--- a/src/libinjector/libinjector.h
+++ b/src/libinjector/libinjector.h
@@ -113,6 +113,8 @@ extern "C" {
 
 #include <libdrakvuf/libdrakvuf.h>
 
+typedef struct injector* injector_t;
+
 typedef enum
 {
     INJECT_METHOD_CREATEPROC,
@@ -177,15 +179,19 @@ bool setup_stack_64(vmi_instance_t vmi,
                     struct argument args[],
                     int nb_args);
 
-int injector_start_app(drakvuf_t drakvuf,
-                       vmi_pid_t pid,
-                       uint32_t tid, // optional, if tid=0 the first thread that gets scheduled is used
-                       const char* app,
-                       const char* cwd,
-                       injection_method_t method,
-                       output_format_t format,
-                       const char* binary_path,     // if -m = doppelganging
-                       const char* target_process); // if -m = doppelganging
+injector_t injector_start_app(drakvuf_t drakvuf,
+                              vmi_pid_t pid,
+                              uint32_t tid, // optional, if tid=0 the first thread that gets scheduled is used
+                              const char* app,
+                              const char* cwd,
+                              injection_method_t method,
+                              output_format_t format,
+                              const char* binary_path,     // if -m = doppelganging
+                              const char* target_process,  // if -m = doppelganging
+                              bool wait_for_process,
+                              int* ret);
+
+void injector_cleanup(injector_t injector);
 
 #pragma GCC visibility pop
 

--- a/src/plugins/socketmon/socketmon.cpp
+++ b/src/plugins/socketmon/socketmon.cpp
@@ -254,7 +254,7 @@ static event_response_t udpa_x86_ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* 
         ipv6_to_str(&lip, localip);
     }
 
-    owner = drakvuf_get_process_name(drakvuf, udpa.owner);
+    owner = drakvuf_get_process_name(drakvuf, udpa.owner, 1);
     ownerid = drakvuf_get_process_userid(drakvuf, udpa.owner);
 
     switch (s->format)
@@ -369,7 +369,7 @@ static event_response_t udpa_x64_ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* 
         ipv6_to_str(&lip, localip);
     }
 
-    owner = drakvuf_get_process_name(drakvuf, udpa.owner);
+    owner = drakvuf_get_process_name(drakvuf, udpa.owner, 1);
     ownerid = drakvuf_get_process_userid(drakvuf, udpa.owner);
 
     switch (s->format)
@@ -485,7 +485,7 @@ static event_response_t udpa_win10_x64_ret_cb(drakvuf_t drakvuf, drakvuf_trap_in
         ipv6_to_str(&lip, localip);
     }
 
-    owner = drakvuf_get_process_name(drakvuf, udpa.owner);
+    owner = drakvuf_get_process_name(drakvuf, udpa.owner, 1);
     ownerid = drakvuf_get_process_userid(drakvuf, udpa.owner);
 
     switch (s->format)
@@ -629,7 +629,7 @@ static event_response_t tcpe_x86_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info
         ipv6_to_str(&rip, remoteip);
     }
 
-    owner = drakvuf_get_process_name(drakvuf, tcpe.owner);
+    owner = drakvuf_get_process_name(drakvuf, tcpe.owner, 1);
     ownerid = drakvuf_get_process_userid(drakvuf, tcpe.owner);
 
     switch (s->format)
@@ -757,7 +757,7 @@ static event_response_t tcpe_x64_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info
         ipv6_to_str(&rip, remoteip);
     }
 
-    owner = drakvuf_get_process_name(drakvuf, tcpe.owner);
+    owner = drakvuf_get_process_name(drakvuf, tcpe.owner, 1);
     ownerid = drakvuf_get_process_userid(drakvuf, tcpe.owner);
 
     switch (s->format)
@@ -886,7 +886,7 @@ static event_response_t tcpe_win10_x64_cb(drakvuf_t drakvuf, drakvuf_trap_info_t
         ipv6_to_str(&rip, remoteip);
     }
 
-    owner = drakvuf_get_process_name(drakvuf, tcpe.owner);
+    owner = drakvuf_get_process_name(drakvuf, tcpe.owner, 1);
     ownerid = drakvuf_get_process_userid(drakvuf, tcpe.owner);
 
     switch (s->format)
@@ -1015,7 +1015,7 @@ static event_response_t tcpl_x86_ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* 
         ipv6_to_str(&lip, localip);
     }
 
-    owner = drakvuf_get_process_name(drakvuf, tcpl.owner);
+    owner = drakvuf_get_process_name(drakvuf, tcpl.owner, 1);
     ownerid = drakvuf_get_process_userid(drakvuf, tcpl.owner);
 
     switch (s->format)
@@ -1131,7 +1131,7 @@ static event_response_t tcpl_x64_ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* 
         ipv6_to_str(&lip, localip);
     }
 
-    owner = drakvuf_get_process_name(drakvuf, tcpl.owner);
+    owner = drakvuf_get_process_name(drakvuf, tcpl.owner, 1);
     ownerid = drakvuf_get_process_userid(drakvuf, tcpl.owner);
 
     switch (s->format)
@@ -1247,7 +1247,7 @@ static event_response_t tcpl_win10_x64_ret_cb(drakvuf_t drakvuf, drakvuf_trap_in
         ipv6_to_str(&lip, localip);
     }
 
-    owner = drakvuf_get_process_name(drakvuf, tcpl.owner);
+    owner = drakvuf_get_process_name(drakvuf, tcpl.owner, 1);
     ownerid = drakvuf_get_process_userid(drakvuf, tcpl.owner);
 
     switch (s->format)


### PR DESCRIPTION
PR #471 identified a race-condition in which a multi-vCPU guest can start executing the injected process before returning to the trapped userspace address. This is problematic because events of interest can be missed while the process executes as the plugins haven't yet started. In this PR we continue listening to CR3 events in injector and if the injected process is detected to be running, the loop is broken and `start_app` returns. To allow the trapped userspace stack to be fixed-up a final cleanup needs to be called.