### PR TITLE
filedelete: fix bogus alignment check on _SUBSECTION's _MMPTEs

### DIFF
--- a/src/plugins/filedelete/filedelete.cpp
+++ b/src/plugins/filedelete/filedelete.cpp
@@ -261,9 +261,6 @@ static void extract_ca_file(filedelete* f,
         if ( VMI_FAILURE == vmi_read_addr(vmi, ctx, &base) )
             break;
 
-        if ( !(base & VMI_BIT_MASK(0,11)) )
-            break;
-
         ctx->addr = subsection + f->offsets[SUBSECTION_PTESINSUBSECTION];
         if ( VMI_FAILURE == vmi_read_32(vmi, ctx, &ptes) )
             break;


### PR DESCRIPTION
The array is heap allocated and not guaranteed to be page aligned.

This addresses Issue #467.