### PR TITLE
Filedelete: print file size and _FILE_OBJECT.Flags

### DIFF
--- a/src/plugins/filedelete/filedelete.cpp
+++ b/src/plugins/filedelete/filedelete.cpp
@@ -299,7 +299,8 @@ static void extract_ca_file(filedelete* f,
                 if ( VMI_FAILURE == vmi_read_pa(vmi, VMI_BIT_MASK(12,48) & pte, 4096, &page, NULL) )
                     continue;
 
-                if ( !fseek ( fp, fileoffset, SEEK_SET ) ) {
+                if ( !fseek ( fp, fileoffset, SEEK_SET ) )
+                {
                     if ( fwrite(page, 4096, 1, fp) )
                         filesize = fileoffset + 4096;
                 }

--- a/src/plugins/filedelete/filedelete.cpp
+++ b/src/plugins/filedelete/filedelete.cpp
@@ -135,6 +135,103 @@ const char* offset_names[__OFFSET_MAX][2] =
     [OBJECT_HEADER_BODY] = { "_OBJECT_HEADER", "Body" },
 };
 
+static std::string fo_flags_to_string(uint64_t fo_flags)
+{
+    std::string str("");
+
+    if (FO_FILE_OPEN & fo_flags)
+        str += "FO_FILE_OPEN | ";
+
+    if (FO_SYNCHRONOUS_IO & fo_flags)
+        str += "FO_SYNCHRONOUS_IO | ";
+
+    if (FO_ALERTABLE_IO & fo_flags)
+        str += "FO_ALERTABLE_IO | ";
+
+    if (FO_NO_INTERMEDIATE_BUFFERING & fo_flags)
+        str += "FO_NO_INTERMEDIATE_BUFFERING | ";
+
+    if (FO_WRITE_THROUGH & fo_flags)
+        str += "FO_WRITE_THROUGH | ";
+
+    if (FO_SEQUENTIAL_ONLY & fo_flags)
+        str += "FO_SEQUENTIAL_ONLY | ";
+
+    if (FO_CACHE_SUPPORTED & fo_flags)
+        str += "FO_CACHE_SUPPORTED | ";
+
+    if (FO_NAMED_PIPE & fo_flags)
+        str += "FO_NAMED_PIPE | ";
+
+    if (FO_STREAM_FILE & fo_flags)
+        str += "FO_STREAM_FILE | ";
+
+    if (FO_MAILSLOT & fo_flags)
+        str += "FO_MAILSLOT | ";
+
+    if (FO_GENERATE_AUDIT_ON_CLOSE & fo_flags)
+        str += "FO_GENERATE_AUDIT_ON_CLOSE | ";
+
+    if (FO_DIRECT_DEVICE_OPEN & fo_flags)
+        str += "FO_DIRECT_DEVICE_OPEN | ";
+
+    if (FO_FILE_MODIFIED & fo_flags)
+        str += "FO_FILE_MODIFIED | ";
+
+    if (FO_FILE_SIZE_CHANGED & fo_flags)
+        str += "FO_FILE_SIZE_CHANGED | ";
+
+    if (FO_CLEANUP_COMPLETE & fo_flags)
+        str += "FO_CLEANUP_COMPLETE | ";
+
+    if (FO_TEMPORARY_FILE & fo_flags)
+        str += "FO_TEMPORARY_FILE | ";
+
+    if (FO_DELETE_ON_CLOSE & fo_flags)
+        str += "FO_DELETE_ON_CLOSE | ";
+
+    if (FO_OPENED_CASE_SENSITIVE & fo_flags)
+        str += "FO_OPENED_CASE_SENSITIVE | ";
+
+    if (FO_HANDLE_CREATED & fo_flags)
+        str += "FO_HANDLE_CREATED | ";
+
+    if (FO_FILE_FAST_IO_READ & fo_flags)
+        str += "FO_FILE_FAST_IO_READ | ";
+
+    if (FO_RANDOM_ACCESS & fo_flags)
+        str += "FO_RANDOM_ACCESS | ";
+
+    if (FO_FILE_OPEN_CANCELLED & fo_flags)
+        str += "FO_FILE_OPEN_CANCELLED | ";
+
+    if (FO_VOLUME_OPEN & fo_flags)
+        str += "FO_VOLUME_OPEN | ";
+
+    if (FO_REMOTE_ORIGIN & fo_flags)
+        str += "FO_REMOTE_ORIGIN | ";
+
+    if (FO_DISALLOW_EXCLUSIVE & fo_flags)
+        str += "FO_DISALLOW_EXCLUSIVE | ";
+
+    if (FO_SKIP_SET_EVENT & fo_flags)
+        str += "FO_SKIP_SET_EVENT | ";
+
+    if (FO_SKIP_SET_FAST_IO & fo_flags)
+        str += "FO_SKIP_SET_FAST_IO | ";
+
+    if (FO_INDIRECT_WAIT_OBJECT & fo_flags)
+        str += "FO_INDIRECT_WAIT_OBJECT | ";
+
+    if (FO_SECTION_MINSTORE_TREATMENT & fo_flags)
+        str += "FO_SECTION_MINSTORE_TREATMENT | ";
+
+    if (str.size() >= 3)
+        str.resize(str.size() - 3);
+
+    return str;
+}
+
 static std::string get_file_name(filedelete* f, drakvuf_t drakvuf, vmi_instance_t vmi,
                                  drakvuf_trap_info_t* info,
                                  addr_t handle,
@@ -201,7 +298,7 @@ static void save_file_metadata(filedelete* f,
     if (bytes_read)
         fprintf(fp, "FileSize: %ld\n", bytes_read);
     if (fo_flags)
-        fprintf(fp, "_FILE_OBJECT.Flags: 0x%lx\n", fo_flags);
+        fprintf(fp, "_FILE_OBJECT.Flags: 0x%lx (%s)\n", fo_flags, fo_flags_to_string(fo_flags).c_str());
     fprintf(fp, "SequenceNumber: %d\n", sequence_number);
     fprintf(fp, "ControlArea: 0x%lx\n", control_area);
     fprintf(fp, "PID: %" PRIu64 "\n", static_cast<uint64_t>(info->proc_data.pid));
@@ -358,20 +455,20 @@ static void print_filedelete_information(filedelete* f, drakvuf_t drakvuf, drakv
     switch (f->format)
     {
         case OUTPUT_CSV:
-            printf("filedelete," FORMAT_TIMEVAL ",%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64 ",\"%s\",%" PRIu64 ",%" PRIx64 "\n",
+            printf("filedelete," FORMAT_TIMEVAL ",%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64 ",\"%s\",%" PRIu64 ",%" PRIx64 "(%s)\n",
                    UNPACK_TIMEVAL(info->timestamp), info->vcpu, info->regs->cr3, info->proc_data.name,
-                   info->proc_data.userid, filename, bytes_read, fo_flags);
+                   info->proc_data.userid, filename, bytes_read, fo_flags, fo_flags_to_string(fo_flags).c_str());
             break;
         case OUTPUT_KV:
-            printf("filedelete Time=" FORMAT_TIMEVAL ",PID=%d,PPID=%d,ProcessName=\"%s\",Method=%s,FileName=\"%s\",Size=%ld,FO_FLAGS=0x%lx\n",
+            printf("filedelete Time=" FORMAT_TIMEVAL ",PID=%d,PPID=%d,ProcessName=\"%s\",Method=%s,FileName=\"%s\",Size=%ld,FO_FLAGS=0x%lx(%s)\n",
                    UNPACK_TIMEVAL(info->timestamp), info->proc_data.pid, info->proc_data.ppid, info->proc_data.name,
-                   info->trap->name, filename, bytes_read, fo_flags);
+                   info->trap->name, filename, bytes_read, fo_flags, fo_flags_to_string(fo_flags).c_str());
             break;
         default:
         case OUTPUT_DEFAULT:
-            printf("[FILEDELETE] TIME:" FORMAT_TIMEVAL " VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64" \"%s\" SIZE:%" PRIu64 " FO_FLAGS:0x%" PRIx64 "\n",
+            printf("[FILEDELETE] TIME:" FORMAT_TIMEVAL " VCPU:%" PRIu32 " CR3:0x%" PRIx64 ",\"%s\" %s:%" PRIi64" \"%s\" SIZE:%" PRIu64 " FO_FLAGS:0x%" PRIx64 "(%s)\n",
                    UNPACK_TIMEVAL(info->timestamp), info->vcpu, info->regs->cr3, info->proc_data.name,
-                   USERIDSTR(drakvuf), info->proc_data.userid, filename, bytes_read, fo_flags);
+                   USERIDSTR(drakvuf), info->proc_data.userid, filename, bytes_read, fo_flags, fo_flags_to_string(fo_flags).c_str());
             break;
     }
 }

--- a/src/plugins/filedelete/private.h
+++ b/src/plugins/filedelete/private.h
@@ -135,6 +135,39 @@ extern const char* offset_names[__OFFSET_MAX][2];
  * # For filedelete 2
  ************************/
 
+enum file_object_flags
+{
+    FO_FILE_OPEN                    = 0x00000001,
+    FO_SYNCHRONOUS_IO               = 0x00000002,
+    FO_ALERTABLE_IO                 = 0x00000004,
+    FO_NO_INTERMEDIATE_BUFFERING    = 0x00000008,
+    FO_WRITE_THROUGH                = 0x00000010,
+    FO_SEQUENTIAL_ONLY              = 0x00000020,
+    FO_CACHE_SUPPORTED              = 0x00000040,
+    FO_NAMED_PIPE                   = 0x00000080,
+    FO_STREAM_FILE                  = 0x00000100,
+    FO_MAILSLOT                     = 0x00000200,
+    FO_GENERATE_AUDIT_ON_CLOSE      = 0x00000400,
+    FO_DIRECT_DEVICE_OPEN           = 0x00000800,
+    FO_FILE_MODIFIED                = 0x00001000,
+    FO_FILE_SIZE_CHANGED            = 0x00002000,
+    FO_CLEANUP_COMPLETE             = 0x00004000,
+    FO_TEMPORARY_FILE               = 0x00008000,
+    FO_DELETE_ON_CLOSE              = 0x00010000,
+    FO_OPENED_CASE_SENSITIVE        = 0x00020000,
+    FO_HANDLE_CREATED               = 0x00040000,
+    FO_FILE_FAST_IO_READ            = 0x00080000,
+    FO_RANDOM_ACCESS                = 0x00100000,
+    FO_FILE_OPEN_CANCELLED          = 0x00200000,
+    FO_VOLUME_OPEN                  = 0x00400000,
+    FO_REMOTE_ORIGIN                = 0x01000000,
+    FO_DISALLOW_EXCLUSIVE           = 0x02000000,
+    FO_SKIP_SET_EVENT               = 0x04000000,
+    FO_SKIP_SET_FAST_IO             = 0x08000000,
+    FO_INDIRECT_WAIT_OBJECT         = 0x10000000,
+    FO_SECTION_MINSTORE_TREATMENT   = 0x20000000,
+};
+
 struct wrapper_t
 {
     filedelete* f;

--- a/src/plugins/filedelete/private.h
+++ b/src/plugins/filedelete/private.h
@@ -141,6 +141,7 @@ struct wrapper_t
     bool is32bit;
 
     handle_t handle;
+    uint64_t fo_flags;
 
     reg_t target_cr3;
     uint32_t target_thread_id;

--- a/src/plugins/regmon/regmon.cpp
+++ b/src/plugins/regmon/regmon.cpp
@@ -364,7 +364,10 @@ static event_response_t log_reg_set_value_hook_cb( drakvuf_t drakvuf, drakvuf_tr
                         // Read current wchar string
                         multiple_strings.emplace_back(
                             drakvuf_read_wchar_string(vmi_lg.vmi, &ctx),
-                        [](unicode_string_t* p) { vmi_free_unicode_str(p); }
+                            [](unicode_string_t* p)
+                        {
+                            vmi_free_unicode_str(p);
+                        }
                         );
                         ctx.addr = data_addr + i + 2;
                     }


### PR DESCRIPTION
It looks like this (for kv output):
> filedelete Time=1544205779.986203,PID=2980,PPID=1612,ProcessName="\Device\HarddiskVolume2\Program Files (x86)\Mozilla Firefox\firefox.exe",Method=ReadFile ret,FileName="",Size=8759,FO_FLAGS=0x40042(FO_SYNCHRONOUS_IO | FO_CACHE_SUPPORTED | FO_HANDLE_CREATED)

Note new `Size` and `FO_FLAGS` fields.