### PR TITLE
* Inject program via creation of suspended process and resuming it

### DIFF
--- a/src/drakvuf.cpp
+++ b/src/drakvuf.cpp
@@ -268,17 +268,11 @@ void drakvuf_c::resume()
     drakvuf_resume(drakvuf);
 }
 
-int drakvuf_c::inject_cmd(vmi_pid_t injection_pid, uint32_t injection_tid, const char* inject_cmd, const char* cwd, injection_method_t method, output_format_t format, const char* binary_path, const char* target_process, bool wait_for_process)
+int drakvuf_c::inject_cmd(vmi_pid_t injection_pid, uint32_t injection_tid, const char* inject_cmd, const char* cwd, injection_method_t method, output_format_t format, const char* binary_path, const char* target_process)
 {
-    int rc = 0;
-    injector = injector_start_app(drakvuf, injection_pid, injection_tid, inject_cmd, cwd, method, format, binary_path, target_process, wait_for_process, &rc);
+    int rc = injector_start_app(drakvuf, injection_pid, injection_tid, inject_cmd, cwd, method, format, binary_path, target_process);
 
     if (!rc)
         fprintf(stderr, "Process startup failed\n");
     return rc;
-}
-
-void drakvuf_c::inject_cmd_cleanup(void)
-{
-    injector_cleanup(injector);
 }

--- a/src/drakvuf.h
+++ b/src/drakvuf.h
@@ -139,9 +139,7 @@ private:
     bool leave_paused;
     drakvuf_t drakvuf { nullptr };
     drakvuf_plugins* plugins;
-    injector_t injector;
     GThread* timeout_thread { nullptr };
-    GThread* timeout_thread2 { nullptr };
     os_t os;
 
 public:
@@ -174,9 +172,7 @@ public:
                    injection_method_t method,
                    output_format_t format,
                    const char* binary_path,
-                   const char* target_process,
-                   bool wait_for_process);
-    void inject_cmd_cleanup();
+                   const char* target_process);
     int start_plugins(const bool* plugin_list,
                       const char* dump_folder,
                       bool dump_modified_files,

--- a/src/injector.c
+++ b/src/injector.c
@@ -241,8 +241,7 @@ int main(int argc, char** argv)
 
     printf("Injector starting %s through PID %u TID: %u\n", inject_file, injection_pid, injection_thread);
 
-    int injection_result = 0;
-    injector_t injector = injector_start_app(drakvuf, injection_pid, injection_thread, inject_file, inject_cwd, injection_method, OUTPUT_DEFAULT, binary_path, target_process, 1, &injection_result);
+    int injection_result = injector_start_app(drakvuf, injection_pid, injection_thread, inject_file, inject_cwd, injection_method, OUTPUT_DEFAULT, binary_path, target_process);
 
     if (injection_result)
         printf("Process startup success\n");
@@ -251,8 +250,6 @@ int main(int argc, char** argv)
         printf("Process startup failed\n");
         rc = 1;
     }
-
-    injector_cleanup(injector);
 
     drakvuf_resume(drakvuf);
 

--- a/src/libinjector/Makefile.am
+++ b/src/libinjector/Makefile.am
@@ -103,7 +103,7 @@
 #*************************************************************************#
 
 h_sources = libinjector.h private.h
-c_sources = injector.c
+c_sources = injector.c injector_stack.c
 
 AM_CFLAGS = -I$(top_srcdir) -I$(top_srcdir)/src -I$(srcdir)
 AM_CFLAGS += $(CFLAGS)

--- a/src/libinjector/injector_stack.c
+++ b/src/libinjector/injector_stack.c
@@ -1,0 +1,404 @@
+/*********************IMPORTANT DRAKVUF LICENSE TERMS**********************
+*                                                                         *
+* DRAKVUF (C) 2014-2017 Tamas K Lengyel.                                  *
+* Tamas K Lengyel is hereinafter referred to as the author.               *
+* This program is free software; you may redistribute and/or modify it    *
+* under the terms of the GNU General Public License as published by the   *
+* Free Software Foundation; Version 2 ("GPL"), BUT ONLY WITH ALL OF THE   *
+* CLARIFICATIONS AND EXCEPTIONS DESCRIBED HEREIN.  This guarantees your   *
+* right to use, modify, and redistribute this software under certain      *
+* conditions.  If you wish to embed DRAKVUF technology into proprietary   *
+* software, alternative licenses can be aquired from the author.          *
+*                                                                         *
+* Note that the GPL places important restrictions on "derivative works",  *
+* yet it does not provide a detailed definition of that term.  To avoid   *
+* misunderstandings, we interpret that term as broadly as copyright law   *
+* allows.  For example, we consider an application to constitute a        *
+* derivative work for the purpose of this license if it does any of the   *
+* following with any software or content covered by this license          *
+* ("Covered Software"):                                                   *
+*                                                                         *
+* o Integrates source code from Covered Software.                         *
+*                                                                         *
+* o Reads or includes copyrighted data files.                             *
+*                                                                         *
+* o Is designed specifically to execute Covered Software and parse the    *
+* results (as opposed to typical shell or execution-menu apps, which will *
+* execute anything you tell them to).                                     *
+*                                                                         *
+* o Includes Covered Software in a proprietary executable installer.  The *
+* installers produced by InstallShield are an example of this.  Including *
+* DRAKVUF with other software in compressed or archival form does not     *
+* trigger this provision, provided appropriate open source decompression  *
+* or de-archiving software is widely available for no charge.  For the    *
+* purposes of this license, an installer is considered to include Covered *
+* Software even if it actually retrieves a copy of Covered Software from  *
+* another source during runtime (such as by downloading it from the       *
+* Internet).                                                              *
+*                                                                         *
+* o Links (statically or dynamically) to a library which does any of the  *
+* above.                                                                  *
+*                                                                         *
+* o Executes a helper program, module, or script to do any of the above.  *
+*                                                                         *
+* This list is not exclusive, but is meant to clarify our interpretation  *
+* of derived works with some common examples.  Other people may interpret *
+* the plain GPL differently, so we consider this a special exception to   *
+* the GPL that we apply to Covered Software.  Works which meet any of     *
+* these conditions must conform to all of the terms of this license,      *
+* particularly including the GPL Section 3 requirements of providing      *
+* source code and allowing free redistribution of the work as a whole.    *
+*                                                                         *
+* Any redistribution of Covered Software, including any derived works,    *
+* must obey and carry forward all of the terms of this license, including *
+* obeying all GPL rules and restrictions.  For example, source code of    *
+* the whole work must be provided and free redistribution must be         *
+* allowed.  All GPL references to "this License", are to be treated as    *
+* including the terms and conditions of this license text as well.        *
+*                                                                         *
+* Because this license imposes special exceptions to the GPL, Covered     *
+* Work may not be combined (even as part of a larger work) with plain GPL *
+* software.  The terms, conditions, and exceptions of this license must   *
+* be included as well.  This license is incompatible with some other open *
+* source licenses as well.  In some cases we can relicense portions of    *
+* DRAKVUF or grant special permissions to use it in other open source     *
+* software.  Please contact tamas.k.lengyel@gmail.com with any such       *
+* requests.  Similarly, we don't incorporate incompatible open source     *
+* software into Covered Software without special permission from the      *
+* copyright holders.                                                      *
+*                                                                         *
+* If you have any questions about the licensing restrictions on using     *
+* DRAKVUF in other works, are happy to help.  As mentioned above,         *
+* alternative license can be requested from the author to integrate       *
+* DRAKVUF into proprietary applications and appliances.  Please email     *
+* tamas.k.lengyel@gmail.com for further information.                      *
+*                                                                         *
+* If you have received a written license agreement or contract for        *
+* Covered Software stating terms other than these, you may choose to use  *
+* and redistribute Covered Software under those terms instead of these.   *
+*                                                                         *
+* Source is provided to this software because we believe users have a     *
+* right to know exactly what a program is going to do before they run it. *
+* This also allows you to audit the software for security holes.          *
+*                                                                         *
+* Source code also allows you to port DRAKVUF to new platforms, fix bugs, *
+* and add new features.  You are highly encouraged to submit your changes *
+* on https://github.com/tklengyel/drakvuf, or by other methods.           *
+* By sending these changes, it is understood (unless you specify          *
+* otherwise) that you are offering unlimited, non-exclusive right to      *
+* reuse, modify, and relicense the code.  DRAKVUF will always be          *
+* available Open Source, but this is important because the inability to   *
+* relicense code has caused devastating problems for other Free Software  *
+* projects (such as KDE and NASM).                                        *
+* To specify special license conditions of your contributions, just say   *
+* so when you send them.                                                  *
+*                                                                         *
+* This program is distributed in the hope that it will be useful, but     *
+* WITHOUT ANY WARRANTY; without even the implied warranty of              *
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the DRAKVUF   *
+* license file for more details (it's in a COPYING file included with     *
+* DRAKVUF, and also available from                                        *
+* https://github.com/tklengyel/drakvuf/COPYING)                           *
+*                                                                         *
+***************************************************************************/
+
+#include <libvmi/libvmi.h>
+#include <libvmi/libvmi_extra.h>
+#include <libvmi/x86.h>
+#include <stdlib.h>
+#include <string.h>
+#include <inttypes.h>
+#include <glib.h>
+
+#include "libdrakvuf/libdrakvuf.h"
+#include <libinjector/libinjector.h>
+
+void init_argument(struct argument* arg, argument_type_t type, size_t size, void* data)
+{
+    arg->type = type;
+    arg->size = size;
+    arg->data = data;
+    arg->data_on_stack = 0;
+}
+
+void init_int_argument(struct argument* arg, uint64_t value)
+{
+    arg->type = ARGUMENT_INT;
+    arg->size = 0; // unused
+    arg->data = (void*)value;
+    arg->data_on_stack = 0;
+}
+
+void init_unicode_argument(struct argument* arg, unicode_string_t* us)
+{
+    if (us && us->length)
+        init_argument(arg, ARGUMENT_STRING, us->length, us->contents);
+    else
+        init_int_argument(arg, 0);
+}
+
+static addr_t place_string_on_stack_32(vmi_instance_t vmi, drakvuf_trap_info_t* info, addr_t addr, void const* str, size_t str_len)
+{
+    if (!str) return 0;
+
+    const uint32_t string_align = 64;
+    const size_t len = str_len + 2;// null terminated string
+
+    // the stack has to be aligned _not_ to 0x4 but to 64
+    // for special instructions operating on strings to work correctly
+    // this string has to be aligned as well!
+    addr -= len + string_align - (len % string_align);
+
+    access_context_t ctx =
+    {
+        .translate_mechanism = VMI_TM_PROCESS_DTB,
+        .dtb = info->regs->cr3,
+        .addr = addr,
+    };
+
+    if (VMI_FAILURE == vmi_write(vmi, &ctx, len, (void*) str, NULL))
+        return 0;
+
+    return addr;
+}
+
+static addr_t place_string_on_stack_64(vmi_instance_t vmi, drakvuf_trap_info_t* info, addr_t addr, void const* str, size_t str_len)
+{
+    if (!str) return addr;
+    // String length with null terminator
+    size_t len = str_len + 2;
+    addr_t orig_addr = addr;
+
+    addr -= len;
+    // Align string address on 32B boundary (for SSE2 instructions).
+    addr &= ~0x1f;
+
+    size_t buf_len = orig_addr - addr;
+    void* buf = g_malloc0(buf_len);
+    if (!buf) return 0;
+    memcpy(buf, str, str_len);
+
+    access_context_t ctx =
+    {
+        .translate_mechanism = VMI_TM_PROCESS_DTB,
+        .dtb = info->regs->cr3,
+        .addr = addr,
+    };
+
+    status_t status = vmi_write(vmi, &ctx, buf_len, buf, NULL);
+    g_free(buf);
+
+    return status == VMI_FAILURE ? 0 : addr;
+}
+
+bool setup_stack_32(vmi_instance_t vmi, drakvuf_trap_info_t* info, struct argument args[], int nb_args)
+{
+    const uint32_t stack_align = 64;
+
+    access_context_t ctx =
+    {
+        .translate_mechanism = VMI_TM_PROCESS_DTB,
+        .dtb = info->regs->cr3,
+    };
+
+    addr_t addr = info->regs->rsp;
+
+    // make room for strings and structs into guest's stack
+    for (int i = 0; i < nb_args; i++)
+    {
+        switch (args[i].type)
+        {
+            case ARGUMENT_STRING:
+            {
+                addr = place_string_on_stack_32(vmi, info, addr, args[i].data, args[i].size);
+                if ( !addr ) goto err;
+                args[i].data_on_stack = addr;
+                break;
+            }
+            case ARGUMENT_STRUCT:
+            {
+                size_t len = args[i].size;
+                addr -= len;
+                addr -= addr % stack_align;
+                args[i].data_on_stack = addr;
+
+                ctx.addr = addr;
+                if (VMI_FAILURE == vmi_write(vmi, &ctx, len, args[i].data, NULL))
+                    goto err;
+                break;
+            }
+            case ARGUMENT_INT:
+            {
+                args[i].data_on_stack = (uint64_t)args[i].data;
+                break;
+            }
+            default:
+                goto err;
+        }
+    }
+
+    // write parameters into guest's stack
+    for (int i = nb_args-1; i >= 0; i--)
+    {
+        addr -= 0x4;
+        ctx.addr = addr;
+        if (VMI_FAILURE == vmi_write_32(vmi, &ctx, (uint32_t*)&args[i].data_on_stack))
+            goto err;
+    }
+
+    // save the return address
+    addr -= 0x4;
+    ctx.addr = addr;
+    if (VMI_FAILURE == vmi_write_32(vmi, &ctx, (uint32_t*) &info->regs->rip))
+        goto err;
+
+    // grow the stack
+    info->regs->rsp = addr;
+
+    return 1;
+
+err:
+    return 0;
+}
+
+bool setup_stack_64(vmi_instance_t vmi, drakvuf_trap_info_t* info, struct argument args[], int nb_args)
+{
+    uint64_t nul64 = 0;
+
+    access_context_t ctx =
+    {
+        .translate_mechanism = VMI_TM_PROCESS_DTB,
+        .dtb = info->regs->cr3,
+    };
+
+    addr_t addr = info->regs->rsp;
+
+    if ( args )
+    {
+        // make room for strings and structs into guest's stack
+        for (int i = 0; i < nb_args; i++)
+        {
+            switch (args[i].type)
+            {
+                case ARGUMENT_STRING:
+                {
+                    addr = place_string_on_stack_64(vmi, info, addr, args[i].data, args[i].size);
+                    if ( !addr ) goto err;
+                    args[i].data_on_stack = addr;
+                    break;
+                }
+                case ARGUMENT_STRUCT:
+                {
+                    /* According to Microsoft Doc "Building C/C++ Programs":
+                     * > The alignment of the beginning of a structure or a union is the maximum
+                     * > alignment of any individual member.
+                     */
+                    size_t len = args[i].size;
+                    addr -= len;
+                    addr &= ~0xf; // Align stack
+                    args[i].data_on_stack = addr;
+
+                    ctx.addr = addr;
+                    if (VMI_FAILURE == vmi_write(vmi, &ctx, len, args[i].data, NULL))
+                        goto err;
+                    break;
+                }
+                case ARGUMENT_INT:
+                {
+                    args[i].data_on_stack = (uint64_t)args[i].data;
+                    break;
+                }
+                default:
+                    goto err;
+            }
+        }
+
+        /* According to Microsoft Doc "Building C/C++ Programs":
+         * > The stack will always be maintained 16-byte aligned, except within the prolog
+         * > (for example, after the return address is pushed), and except where indicated
+         * > in Function Types for a certain class of frame functions.
+         *
+         * So place one extra argument to achieve alignment just before CALL instruction.
+         */
+        if (nb_args % 2)
+        {
+            addr -= 0x8;
+            ctx.addr = addr;
+            if (VMI_FAILURE == vmi_write_64(vmi, &ctx, &nul64))
+                goto err;
+        }
+
+        // http://www.codemachine.com/presentations/GES2010.TRoy.Slides.pdf
+        //
+        // First 4 parameters to functions are always passed in registers
+        // P1=rcx, P2=rdx, P3=r8, P4=r9
+        // 5th parameter onwards (if any) passed via the stack
+
+        // write parameters (5th onwards) into guest's stack
+        for (int i = nb_args-1; i > 3; i--)
+        {
+            addr -= 0x8;
+            ctx.addr = addr;
+            if (VMI_FAILURE == vmi_write_64(vmi, &ctx, &(args[i].data_on_stack)) )
+                goto err;
+        }
+
+        switch (nb_args)
+        {
+            default:
+                // p4
+                info->regs->r9 = args[3].data_on_stack;
+            // fall through
+            case 3:
+                // p3
+                info->regs->r8 = args[2].data_on_stack;
+            // fall through
+            case 2:
+                // p2
+                info->regs->rdx = args[1].data_on_stack;
+            // fall through
+            case 1:
+                // p1
+                info->regs->rcx = args[0].data_on_stack;
+            // fall through
+            case 0:
+                break;
+        }
+    }
+
+    // allocate 0x20 "homing space"
+    for (int i = 0; i < 4; i++)
+    {
+        addr -= 0x8;
+        ctx.addr = addr;
+        if (VMI_FAILURE == vmi_write_64(vmi, &ctx, &nul64))
+            goto err;
+    }
+
+    // save the return address
+    addr -= 0x8;
+    ctx.addr = addr;
+    if (VMI_FAILURE == vmi_write_64(vmi, &ctx, &info->regs->rip))
+        goto err;
+
+    // grow the stack
+    info->regs->rsp = addr;
+
+    return 1;
+
+err:
+    return 0;
+}
+
+bool setup_stack(
+    drakvuf_t drakvuf,
+    drakvuf_trap_info_t* info,
+    struct argument args[],
+    int nb_args)
+{
+    bool is32bit = (drakvuf_get_page_mode(drakvuf) != VMI_PM_IA32E);
+    vmi_instance_t vmi = drakvuf_lock_and_get_vmi(drakvuf);
+    bool success = is32bit ? setup_stack_32(vmi, info, args, nb_args) : setup_stack_64(vmi, info, args, nb_args);
+    drakvuf_release_vmi(drakvuf);
+    return success;
+}

--- a/src/libinjector/libinjector.h
+++ b/src/libinjector/libinjector.h
@@ -141,6 +141,8 @@ typedef enum
     STATUS_WRITE_OK,
     STATUS_EXEC_OK,
     STATUS_BP_HIT,
+    STATUS_CREATE_OK,
+    STATUS_RESUME_OK,
     __STATUS_MAX
 } status_type_t;
 
@@ -152,20 +154,20 @@ struct argument
     void* data;
 };
 
-static inline
-void init_argument(
-    struct argument* arg,
-    argument_type_t type,
-    size_t size,
-    void* data)
-{
-    arg->type = type;
-    arg->size = size;
 
-    arg->data = data;
+void init_argument(struct argument* arg,
+                   argument_type_t type,
+                   size_t size,
+                   void* data);
 
-    arg->data_on_stack = 0;
-}
+void init_int_argument(struct argument* arg,
+                       uint64_t value);
+
+void init_unicode_argument(struct argument* arg,
+                           unicode_string_t* us);
+
+#define init_struct_argument(arg, sv) \
+    init_argument((arg), ARGUMENT_STRUCT, sizeof((sv)), (void*)&(sv))
 
 bool setup_stack_32(vmi_instance_t vmi,
                     drakvuf_trap_info_t* info,
@@ -177,19 +179,20 @@ bool setup_stack_64(vmi_instance_t vmi,
                     struct argument args[],
                     int nb_args);
 
-injector_t injector_start_app(drakvuf_t drakvuf,
-                              vmi_pid_t pid,
-                              uint32_t tid, // optional, if tid=0 the first thread that gets scheduled is used
-                              const char* app,
-                              const char* cwd,
-                              injection_method_t method,
-                              output_format_t format,
-                              const char* binary_path,     // if -m = doppelganging
-                              const char* target_process,  // if -m = doppelganging
-                              bool wait_for_process,
-                              int* ret);
+bool setup_stack(drakvuf_t drakvuf,
+                 drakvuf_trap_info_t* info,
+                 struct argument args[],
+                 int nb_args);
 
-void injector_cleanup(injector_t injector);
+int injector_start_app(drakvuf_t drakvuf,
+                       vmi_pid_t pid,
+                       uint32_t tid, // optional, if tid=0 the first thread that gets scheduled is used
+                       const char* app,
+                       const char* cwd,
+                       injection_method_t method,
+                       output_format_t format,
+                       const char* binary_path,     // if -m = doppelganging
+                       const char* target_process); // if -m = doppelganging
 
 #pragma GCC visibility pop
 

--- a/src/libinjector/private.h
+++ b/src/libinjector/private.h
@@ -119,6 +119,8 @@ extern bool verbose;
     do {} while(0)
 #endif
 
+#define ARRAY_SIZE(arr) sizeof((arr)) / sizeof((arr)[0])
+
 enum offset
 {
     KTHREAD_TRAPFRAME,
@@ -132,8 +134,5 @@ static const char* offset_names[OFFSET_MAX][2] =
     [KTHREAD_TRAPFRAME] = {"_KTHREAD", "TrapFrame" },
     [KTRAP_FRAME_RIP] = {"_KTRAP_FRAME", "Rip" },
 };
-
-event_response_t injector_int3_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
-event_response_t cr3_callback(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -136,7 +136,6 @@ int main(int argc, char** argv)
     char* domain = nullptr;
     char* rekall_profile = nullptr;
     char* dump_folder = nullptr;
-    bool wait_for_process = false;
     char* tcpip = nullptr;
     char* binary_path = nullptr;
     char* target_process = nullptr;
@@ -174,7 +173,6 @@ int main(int argc, char** argv)
                 "\t -e <inject_file>          The executable to start with injection\n"
                 "\t -c <current_working_dir>  The current working directory for injected executable\n"
                 "\t -m <inject_method>        The injection method: createproc, shellexec, shellcode, doppelganging\n"
-                "\t -w                        Wait with plugin start until injected process name is detected\n"
                 "\t -t <timeout>              Timeout (in seconds)\n"
                 "\t -o <format>               Output format (default or csv)\n"
                 "\t -x <plugin>               Don't activate the specified plugin\n"
@@ -207,7 +205,7 @@ int main(int argc, char** argv)
         return rc;
     }
 
-    while ((c = getopt (argc, argv, "r:d:i:I:e:m:t:D:o:vx:spwT:S:Mc:nb")) != -1)
+    while ((c = getopt (argc, argv, "r:d:i:I:e:m:t:D:o:vx:spT:S:Mc:nb")) != -1)
         switch (c)
         {
             case 'r':
@@ -273,9 +271,6 @@ int main(int argc, char** argv)
                 break;
             case 'p':
                 leave_paused = true;
-                break;
-            case 'w':
-                wait_for_process = true;
                 break;
             case 'T':
                 tcpip = optarg;
@@ -346,7 +341,7 @@ int main(int argc, char** argv)
     if ( injection_pid > 0 && inject_file )
     {
         PRINT_DEBUG("Starting injection with PID %i(%i) for %s\n", injection_pid, injection_thread, inject_file);
-        int ret = drakvuf->inject_cmd(injection_pid, injection_thread, inject_file, inject_cwd, injection_method, output, binary_path, target_process, wait_for_process);
+        int ret = drakvuf->inject_cmd(injection_pid, injection_thread, inject_file, inject_cwd, injection_method, output, binary_path, target_process);
         if (!ret)
             goto exit;
     }
@@ -355,11 +350,6 @@ int main(int argc, char** argv)
 
     if ( drakvuf->start_plugins(plugin_list, dump_folder, dump_modified_files, filedelete_use_injector, cpuid_stealth, tcpip, syscalls_filter_file, abort_on_bsod) < 0 )
         goto exit;
-
-    if ( injection_pid > 0 && inject_file )
-    {
-        drakvuf->inject_cmd_cleanup();
-    }
 
     PRINT_DEBUG("Beginning DRAKVUF loop\n");
 


### PR DESCRIPTION
* Move setup_stack functionality into separate file
* Add support for injection via ShellExecute on x86 arch
* Remove -w command line argument (always wait for first execution of injected process before initializing plugins)
* Remove unused structure definitions and unused structure fields from
injector code.

This PR implements injection algorithm from #474:
1. Call CreateProcess with CREATE_SUSPENDED flag; 
2. Store PID of created suspended process;
3. Install cr3_callback for waiting of first occurence of PID;
4. Call ResumeThread to wake up process;
5. Freeze VM on first occurence of PID;
6. Initialize plugins;
7. Do looping.