### PR TITLE
FILEDELETE: save metadata for partially read files

### DIFF
--- a/src/plugins/filedelete/private.h
+++ b/src/plugins/filedelete/private.h
@@ -219,6 +219,7 @@ struct IO_STATUS_BLOCK_64
 
 constexpr static uint32_t STATUS_SUCCESS = 0;
 constexpr static uint32_t STATUS_PENDING = 0x103;
+constexpr static uint32_t STATUS_END_OF_FILE = 0xC0000011;
 
 struct _LARGE_INTEGER
 {


### PR DESCRIPTION
Sometimes `NtReadFile` returns `STATUS_INVALID_DEVICE_REQUEST` for some reason. In that case the `.mm` file is only saved without `.metadata`.

Also I have found that I've forgotten (or somehow removed) to check for `STATUS_END_OF_FILE`.