### PR TITLE
[syscall] Get the return value of a syscall

### DIFF
--- a/src/plugins/syscalls/commonscproto.h
+++ b/src/plugins/syscalls/commonscproto.h
@@ -450,7 +450,6 @@ typedef struct
     int32_t          target_pid;
     unsigned char*   args;
     unsigned int     nargs;
-    addr_t           ret_addr;
 } syscall_wrapper_t;
 
 

--- a/src/plugins/syscalls/commonscproto.h
+++ b/src/plugins/syscalls/commonscproto.h
@@ -442,9 +442,15 @@ typedef struct
 
 typedef struct
 {
-    syscalls* sc;
-    int       syscall_index;
-    uint32_t  flags;
+    syscalls*        s;
+    const syscall_t* sc;
+    int              syscall_index;
+    uint32_t         flags;
+    uint32_t         target_tid;
+    int32_t          target_pid;
+    unsigned char*   args;
+    unsigned int     nargs;
+    addr_t           ret_addr;
 } syscall_wrapper_t;
 
 


### PR DESCRIPTION
* Fix issue #442

* When entering a syscall trap, add a new one to its return address

* Create another callback for the return address

* Print args and return value at the same time in that new callback