### PR TITLE
(re-)Add Rekall submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,7 @@
 	path = drakvuf-doppelganging
 	url = https://github.com/tklengyel/drakvuf-doppelganging.git
 	ignore = dirty
+[submodule "rekall"]
+	path = rekall
+	url = https://github.com/google/rekall
+	ignore = dirty


### PR DESCRIPTION
Installing rekall from pip3 has issues running due to dependency errors. Install rekall manually instead from the git repository.