### PR TITLE
Define each identifier in a dedicated statement

### DIFF
--- a/src/dirwatch/dirwatch.c
+++ b/src/dirwatch/dirwatch.c
@@ -293,7 +293,8 @@ void run_drakvuf(gpointer data, gpointer user_data)
     struct start_drakvuf* start = data;
     char* command;
     gint rc;
-    GThread* timer, *tcpd;
+    GThread* timer;
+    GThread* tcpd;
 
 restart:
     command = NULL;
@@ -363,7 +364,9 @@ int main(int argc, char** argv)
 {
     DIR* dir;
     struct dirent* ent;
-    unsigned int i, processed = 0, total_processed = 0;
+    unsigned int i;
+    unsigned int processed = 0;
+    unsigned int total_processed = 0;
     int ret = 0;
     struct sigaction act;
     shutting_down = 0;

--- a/src/dirwatch/distributor.c
+++ b/src/dirwatch/distributor.c
@@ -127,9 +127,13 @@ static const char* queue_folder;
 
 int main(int argc, char** argv)
 {
-    DIR* indir, *qdir;
-    struct dirent* inent, *qdent;
-    uint64_t processed = 0, total_processed = 0, jobs = 0;
+    DIR* indir;
+    DIR* qdir;
+    struct dirent* inent;
+    struct dirent* qdent;
+    uint64_t processed = 0;
+    uint64_t total_processed = 0;
+    uint64_t jobs = 0;
     int ret = 0;
     uint64_t limit = 0;
 
@@ -181,7 +185,8 @@ int main(int argc, char** argv)
                             continue;
 
                         gchar** qinfo = g_strsplit(qdent->d_name, "_", 2);
-                        int qsize = atoi(qinfo[1]), count = -1;
+                        int qsize = atoi(qinfo[1]);
+                        int count = -1;
                         DIR* q;
                         struct dirent* qent;
 

--- a/src/drakvuf.cpp
+++ b/src/drakvuf.cpp
@@ -155,7 +155,8 @@ int drakvuf_c::start_plugins(const bool* plugin_list,
                              const char* syscalls_filter_file, // PLUGIN_SYSCALLS
                              bool abort_on_bsod )              // PLUGIN_BSODMON
 {
-    int i, rc;
+    int i;
+    int rc;
 
     for (i=0; i<__DRAKVUF_PLUGIN_LIST_MAX; i++)
     {

--- a/src/libdrakvuf/drakvuf.c
+++ b/src/libdrakvuf/drakvuf.c
@@ -301,7 +301,8 @@ bool inject_trap_breakpoint(drakvuf_t drakvuf, drakvuf_trap_t* trap)
 
         if (trap->breakpoint.addr_type == ADDR_VA)
         {
-            addr_t dtb, trap_pa;
+            addr_t dtb;
+            addr_t trap_pa;
             if ( VMI_FAILURE == vmi_pid_to_dtb(drakvuf->vmi, trap->breakpoint.pid, &dtb) )
             {
                 PRINT_DEBUG("No DTB found for pid %i\n", trap->breakpoint.pid);

--- a/src/libdrakvuf/rekall-profile.c
+++ b/src/libdrakvuf/rekall-profile.c
@@ -384,7 +384,7 @@ int drakvuf_get_os_build_date(drakvuf_t drakvuf)
         goto err_exit;
     }
 
-    json_object* metadata = NULL; 
+    json_object* metadata = NULL;
     json_object* timestamp = NULL;
     if (!json_object_object_get_ex(drakvuf->rekall_profile_json, "$METADATA", &metadata))
     {

--- a/src/libdrakvuf/rekall-profile.c
+++ b/src/libdrakvuf/rekall-profile.c
@@ -137,7 +137,8 @@ static bool rekall_lookup_in_json(
 
     if (!subsymbol && !size)
     {
-        json_object* constants = NULL, *jsymbol = NULL;
+        json_object* constants = NULL;
+        json_object* jsymbol = NULL;
         if (!json_object_object_get_ex(rekall_profile_json, "$CONSTANTS", &constants))
         {
             PRINT_DEBUG("Rekall profile: no $CONSTANTS section found\n");
@@ -156,7 +157,11 @@ static bool rekall_lookup_in_json(
     }
     else
     {
-        json_object* structs = NULL, *jstruct = NULL, *jstruct2 = NULL, *jmember = NULL, *jvalue = NULL;
+        json_object* structs = NULL;
+        json_object* jstruct = NULL;
+        json_object* jstruct2 = NULL;
+        json_object* jmember = NULL;
+        json_object* jvalue = NULL;
         if (!json_object_object_get_ex(rekall_profile_json, "$STRUCTS", &structs))
         {
             PRINT_DEBUG("Rekall profile: no $STRUCTS section found\n");
@@ -336,7 +341,8 @@ os_t rekall_get_os_type(json_object* rekall_profile_json)
         goto err_exit;
     }
 
-    json_object* metadata = NULL, *profileclass = NULL;
+    json_object* metadata = NULL;
+    json_object* profileclass = NULL;
     if (!json_object_object_get_ex(rekall_profile_json, "$METADATA", &metadata))
     {
         PRINT_DEBUG("Rekall profile: no $METADATA section found\n");
@@ -366,7 +372,9 @@ err_exit:
 int drakvuf_get_os_build_date(drakvuf_t drakvuf)
 {
     int ret = 0;
-    int year = 0, month = 0, day = 0;
+    int year = 0;
+    int month = 0;
+    int day = 0;
     char junk[15] = {'\0'};
     char build_date[10] = {'\0'};
 
@@ -376,7 +384,8 @@ int drakvuf_get_os_build_date(drakvuf_t drakvuf)
         goto err_exit;
     }
 
-    json_object* metadata = NULL, *timestamp = NULL;
+    json_object* metadata = NULL; 
+    json_object* timestamp = NULL;
     if (!json_object_object_get_ex(drakvuf->rekall_profile_json, "$METADATA", &metadata))
     {
         PRINT_DEBUG("Rekall profile: no $METADATA section found\n");
@@ -409,7 +418,8 @@ bool rekall_get_function_rva(json_object* rekall_profile_json, const char* funct
         goto err_exit;
     }
 
-    json_object* functions = NULL, *jsymbol = NULL;
+    json_object* functions = NULL;
+    json_object* jsymbol = NULL;
     if (!json_object_object_get_ex(rekall_profile_json, "$FUNCTIONS", &functions))
     {
         PRINT_DEBUG("Rekall profile: no $FUNCTIONS section found\n");
@@ -442,7 +452,8 @@ bool drakvuf_get_constant_rva(drakvuf_t drakvuf, const char* constant, addr_t* r
         goto err_exit;
     }
 
-    json_object* constants = NULL, *jsymbol = NULL;
+    json_object* constants = NULL;
+    json_object* jsymbol = NULL;
     if (!json_object_object_get_ex(drakvuf->rekall_profile_json, "$CONSTANTS", &constants))
     {
         PRINT_DEBUG("Rekall profile: no $CONSTANTS section found\n");

--- a/src/libdrakvuf/vmi.c
+++ b/src/libdrakvuf/vmi.c
@@ -1154,7 +1154,8 @@ bool inject_trap(drakvuf_t drakvuf,
 {
 
     vmi_instance_t vmi = drakvuf->vmi;
-    addr_t dtb, pa = 0;
+    addr_t dtb;
+    addr_t pa = 0;
     status_t status;
 
     if ( VMI_FAILURE == vmi_pid_to_dtb(vmi, pid, &dtb) )

--- a/src/libdrakvuf/win-exports.c
+++ b/src/libdrakvuf/win-exports.c
@@ -268,7 +268,10 @@ addr_t ksym2va(drakvuf_t drakvuf, vmi_pid_t pid, const char* proc_name, const ch
 
 addr_t eprocess_sym2va (drakvuf_t drakvuf, addr_t eprocess_base, const char* mod_name, const char* symbol)
 {
-    addr_t peb, ldr, inloadorder, ret = 0;
+    addr_t peb;
+    addr_t ldr;
+    addr_t inloadorder;
+    addr_t ret = 0;
     access_context_t ctx =
     {
         .translate_mechanism = VMI_TM_PROCESS_DTB,

--- a/src/libdrakvuf/win-handles.c
+++ b/src/libdrakvuf/win-handles.c
@@ -121,7 +121,9 @@
 static addr_t drakvuf_get_obj_by_handle_impl(drakvuf_t drakvuf, addr_t process, uint64_t handle)
 {
     vmi_instance_t vmi = drakvuf->vmi;
-    addr_t handletable = 0, tablecode = 0, obj = 0;
+    addr_t handletable = 0;
+    addr_t tablecode = 0;
+    addr_t obj = 0;
 
     if ( VMI_FAILURE == vmi_read_addr_va(vmi, process + drakvuf->offsets[EPROCESS_OBJECTTABLE], 0, &handletable) )
         return 0;
@@ -143,7 +145,8 @@ static addr_t drakvuf_get_obj_by_handle_impl(drakvuf_t drakvuf, addr_t process, 
             addr_t table = 0;
             size_t psize = drakvuf->address_width;
             uint32_t low_count = VMI_PS_4KB / drakvuf->sizes[HANDLE_TABLE_ENTRY];
-            uint32_t j, i = handle % (low_count * HANDLE_MULTIPLIER);
+            uint32_t j;
+            uint32_t i = handle % (low_count * HANDLE_MULTIPLIER);
 
             handle -= i;
             j = handle / ((low_count * HANDLE_MULTIPLIER) / psize);
@@ -156,11 +159,14 @@ static addr_t drakvuf_get_obj_by_handle_impl(drakvuf_t drakvuf, addr_t process, 
         }
         case 2:
         {
-            addr_t table = 0, table2 = 0;
+            addr_t table = 0;
+            addr_t table2 = 0;
             size_t psize = drakvuf->address_width;
             uint32_t low_count = VMI_PS_4KB / drakvuf->sizes[HANDLE_TABLE_ENTRY];
             uint32_t mid_count = VMI_PS_4KB / psize;
-            uint32_t k, j, i = handle % (low_count * HANDLE_MULTIPLIER);
+            uint32_t k; 
+            uint32_t j;
+            uint32_t i = handle % (low_count * HANDLE_MULTIPLIER);
 
             handle -= i;
             j = handle / (low_count * HANDLE_MULTIPLIER / psize);

--- a/src/libdrakvuf/win-handles.c
+++ b/src/libdrakvuf/win-handles.c
@@ -164,7 +164,7 @@ static addr_t drakvuf_get_obj_by_handle_impl(drakvuf_t drakvuf, addr_t process, 
             size_t psize = drakvuf->address_width;
             uint32_t low_count = VMI_PS_4KB / drakvuf->sizes[HANDLE_TABLE_ENTRY];
             uint32_t mid_count = VMI_PS_4KB / psize;
-            uint
+            uint32_t k;
             uint32_t j;
             uint32_t i = handle % (low_count * HANDLE_MULTIPLIER);
 

--- a/src/libdrakvuf/win-handles.c
+++ b/src/libdrakvuf/win-handles.c
@@ -164,7 +164,7 @@ static addr_t drakvuf_get_obj_by_handle_impl(drakvuf_t drakvuf, addr_t process, 
             size_t psize = drakvuf->address_width;
             uint32_t low_count = VMI_PS_4KB / drakvuf->sizes[HANDLE_TABLE_ENTRY];
             uint32_t mid_count = VMI_PS_4KB / psize;
-            uint32_t k; 
+            uint
             uint32_t j;
             uint32_t i = handle % (low_count * HANDLE_MULTIPLIER);
 

--- a/src/libdrakvuf/win-processes.c
+++ b/src/libdrakvuf/win-processes.c
@@ -150,7 +150,8 @@ addr_t win_get_current_thread(drakvuf_t drakvuf, uint64_t vcpu_id)
 
 addr_t win_get_current_process(drakvuf_t drakvuf, uint64_t vcpu_id)
 {
-    addr_t thread, process;
+    addr_t thread;
+    addr_t process;
 
     thread=win_get_current_thread(drakvuf,vcpu_id);
 
@@ -287,7 +288,8 @@ char* win_get_current_process_name(drakvuf_t drakvuf, uint64_t vcpu_id, bool ful
 int64_t win_get_process_userid(drakvuf_t drakvuf, addr_t eprocess_base)
 {
 
-    addr_t peb, userid;
+    addr_t peb;
+    addr_t userid;
     vmi_instance_t vmi = drakvuf->vmi;
     access_context_t ctx = {.translate_mechanism = VMI_TM_PROCESS_DTB};
 
@@ -424,7 +426,9 @@ bool win_is_eprocess( drakvuf_t drakvuf, addr_t dtb, addr_t eprocess_addr )
 bool win_get_module_list(drakvuf_t drakvuf, addr_t eprocess_base, addr_t* module_list)
 {
     vmi_instance_t vmi = drakvuf->vmi;
-    addr_t peb=0, ldr=0, modlist=0;
+    addr_t peb=0;
+    addr_t ldr=0;
+    addr_t modlist=0;
 
     access_context_t ctx = {.translate_mechanism = VMI_TM_PROCESS_DTB};
 
@@ -458,7 +462,8 @@ bool win_get_module_list_wow( drakvuf_t drakvuf, access_context_t* ctx, addr_t w
     if ( wow_peb )
     {
         vmi_instance_t vmi = drakvuf->vmi;
-        addr_t ldr=0, modlist=0;
+        addr_t ldr=0;
+        addr_t modlist=0;
 
         ctx->addr = wow_peb + drakvuf->wow_offsets[WOW_PEB_LDR];
 

--- a/src/libdrakvuf/win.c
+++ b/src/libdrakvuf/win.c
@@ -351,7 +351,8 @@ module_info_t* win_get_module_info_ctx_wow( drakvuf_t drakvuf, addr_t module_lis
 
 static bool find_kernbase(drakvuf_t drakvuf)
 {
-    addr_t sysproc_rva, sysproc;
+    addr_t sysproc_rva;
+    addr_t sysproc;
     if ( VMI_FAILURE == vmi_translate_ksym2v(drakvuf->vmi, "PsInitialSystemProcess", &sysproc) )
     {
         printf("LibVMI failed to get us the VA of PsInitialSystemProcess!\n");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -131,7 +131,9 @@ static inline void disable_plugin(char* optarg, bool* plugin_list)
 
 int main(int argc, char** argv)
 {
-    int c, rc = 1, timeout = 0;
+    int c;
+    int rc = 1;
+    int timeout = 0;
     char const* inject_file = nullptr;
     char const* inject_cwd = nullptr;
     injection_method_t injection_method = INJECT_METHOD_CREATEPROC;

--- a/src/plugins/exmon/exmon.cpp
+++ b/src/plugins/exmon/exmon.cpp
@@ -212,7 +212,9 @@ static event_response_t cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 
     if (e->pm != VMI_PM_IA32E)
     {
-        reg_t exception_record, ptrap_frame, exception_code;
+        reg_t exception_record;
+        reg_t ptrap_frame;
+        reg_t exception_code;
         uint8_t previous_mode;
 
         ctx.addr = info->regs->rsp+4;

--- a/src/plugins/filedelete/filedelete.cpp
+++ b/src/plugins/filedelete/filedelete.cpp
@@ -417,7 +417,9 @@ static void extract_ca_file(filedelete* f,
                             uint64_t fo_flags)
 {
     addr_t subsection = control_area + f->control_area_size;
-    addr_t segment = 0, test = 0, test2 = 0;
+    addr_t segment = 0;
+    addr_t test = 0;
+    addr_t test2 = 0;
     size_t filesize = 0;
 
     /* Check whether subsection points back to the control area */
@@ -458,7 +460,8 @@ static void extract_ca_file(filedelete* f,
         if ( VMI_FAILURE == vmi_read_addr(vmi, ctx, &test) || test != control_area )
             break;
 
-        addr_t base = 0, start = 0;
+        addr_t base = 0;
+        addr_t start = 0;
         uint32_t ptes = 0;
 
         ctx->addr = subsection + f->offsets[SUBSECTION_SUBSECTIONBASE];
@@ -525,7 +528,9 @@ static void extract_file(filedelete* f,
                          uint64_t fo_flags)
 {
     addr_t sop = 0;
-    addr_t datasection = 0, sharedcachemap = 0, imagesection = 0;
+    addr_t datasection = 0;
+    addr_t sharedcachemap = 0;
+    addr_t imagesection = 0;
 
     ctx->addr = file_pa + f->offsets[FILE_OBJECT_SECTIONOBJECTPOINTER];
     if ( VMI_FAILURE == vmi_read_addr(vmi, ctx, &sop) )

--- a/src/plugins/filedelete/filedelete.h
+++ b/src/plugins/filedelete/filedelete.h
@@ -132,7 +132,8 @@ public:
         }
     };
     size_t* offsets;
-    size_t control_area_size, mmpte_size;
+    size_t control_area_size;
+    size_t mmpte_size;
 
     const char* dump_folder;
     page_mode_t pm;

--- a/src/plugins/poolmon/poolmon.cpp
+++ b/src/plugins/poolmon/poolmon.cpp
@@ -141,7 +141,8 @@ static event_response_t cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 {
     poolmon* p = (poolmon*)info->trap->data;
     page_mode_t pm = drakvuf_get_page_mode(drakvuf);
-    reg_t pool_type, size;
+    reg_t pool_type;
+    reg_t size;
     char tag[5] = { [0 ... 4] = '\0' };
     struct pooltag* s = NULL;
     const char* pool_type_str;

--- a/src/plugins/socketmon/socketmon.cpp
+++ b/src/plugins/socketmon/socketmon.cpp
@@ -213,7 +213,8 @@ static event_response_t udpa_x86_ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* 
 
     int64_t ownerid = 0;
     addr_t p1 = 0;
-    char* lip = NULL, *owner = NULL;
+    char* lip = NULL;
+    char* owner = NULL;
     struct wrapper* w = (struct wrapper*)info->trap->data;
     socketmon* s = w->s;
 
@@ -331,7 +332,8 @@ static event_response_t udpa_x64_ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* 
 
     int64_t ownerid = 0;
     addr_t p1 = 0;
-    char* lip = NULL, *owner = NULL;
+    char* lip = NULL;
+    char* owner = NULL;
     struct wrapper* w = (struct wrapper*)info->trap->data;
     socketmon* s = w->s;
 
@@ -450,7 +452,8 @@ static event_response_t udpa_win10_x64_ret_cb(drakvuf_t drakvuf, drakvuf_trap_in
 
     int64_t ownerid = 0;
     addr_t p1 = 0;
-    char* lip = NULL, *owner = NULL;
+    char* lip = NULL;
+    char* owner = NULL;
     struct wrapper* w = (struct wrapper*)info->trap->data;
     socketmon* s = w->s;
     gchar* escaped_pname = NULL;
@@ -568,7 +571,9 @@ static event_response_t tcpe_x86_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info
 
     int64_t ownerid = -1;
     addr_t p1 = 0;
-    char* lip = NULL, *rip = NULL, *owner=NULL;
+    char* lip = NULL;
+    char* rip = NULL;
+    char* owner=NULL;
     access_context_t ctx;
     ctx.translate_mechanism = VMI_TM_PROCESS_DTB;
     ctx.dtb = info->regs->cr3;
@@ -710,7 +715,9 @@ static event_response_t tcpe_x64_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info
 
     int64_t ownerid;
     addr_t p1 = 0;
-    char* lip = NULL, *rip = NULL, *owner = NULL;
+    char* lip = NULL;
+    char* rip = NULL;
+    char* owner = NULL;
     access_context_t ctx;
     ctx.translate_mechanism = VMI_TM_PROCESS_DTB;
     ctx.dtb = info->regs->cr3;
@@ -841,7 +848,9 @@ static event_response_t tcpe_win10_x64_cb(drakvuf_t drakvuf, drakvuf_trap_info_t
 
     int64_t ownerid;
     addr_t p1 = 0;
-    char* lip = NULL, *rip = NULL, *owner = NULL;
+    char* lip = NULL;
+    char* rip = NULL;
+    char* owner = NULL;
     access_context_t ctx;
     ctx.translate_mechanism = VMI_TM_PROCESS_DTB;
     ctx.dtb = info->regs->cr3;
@@ -977,7 +986,8 @@ static event_response_t tcpl_x86_ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* 
 
     int64_t ownerid = 0;
     addr_t p1 = 0;
-    char* lip = NULL, *owner = NULL;
+    char* lip = NULL;
+    char* owner = NULL;
     access_context_t ctx;
     ctx.translate_mechanism = VMI_TM_PROCESS_DTB;
     ctx.dtb = info->regs->cr3;
@@ -1103,7 +1113,8 @@ static event_response_t tcpl_x64_ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* 
 
     int64_t ownerid = 0;
     addr_t p1 = 0;
-    char* lip = NULL, *owner = NULL;
+    char* lip = NULL;
+    char* owner = NULL;
     access_context_t ctx;
     ctx.translate_mechanism = VMI_TM_PROCESS_DTB;
     ctx.dtb = info->regs->cr3;
@@ -1222,7 +1233,8 @@ static event_response_t tcpl_win10_x64_ret_cb(drakvuf_t drakvuf, drakvuf_trap_in
 
     int64_t ownerid = 0;
     addr_t p1 = 0;
-    char* lip = NULL, *owner = NULL;
+    char* lip = NULL;
+    char* owner = NULL;
     access_context_t ctx;
     ctx.translate_mechanism = VMI_TM_PROCESS_DTB;
     ctx.dtb = info->regs->cr3;

--- a/src/plugins/ssdtmon/ssdtmon.cpp
+++ b/src/plugins/ssdtmon/ssdtmon.cpp
@@ -177,7 +177,8 @@ event_response_t write_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 
 ssdtmon::ssdtmon(drakvuf_t drakvuf, const void* config, output_format_t output)
 {
-    addr_t kiservicetable_rva = 0, kiservicelimit_rva = 0;
+    addr_t kiservicetable_rva = 0;
+    addr_t kiservicelimit_rva = 0;
     addr_t kernbase = 0;
 
     this->format = output;

--- a/src/plugins/syscalls/syscalls.cpp
+++ b/src/plugins/syscalls/syscalls.cpp
@@ -459,7 +459,8 @@ static GSList* create_trap_config(drakvuf_t drakvuf, syscalls* s, symbols_t* sym
 {
 
     GSList* ret = NULL;
-    unsigned long i,j;
+    unsigned long i;
+    unsigned long j;
 
     PRINT_DEBUG("Received %lu symbols\n", symbols->count);
 

--- a/src/xen_helper/xen_helper.c
+++ b/src/xen_helper/xen_helper.c
@@ -245,7 +245,8 @@ uint64_t xen_memshare(xen_interface_t* xen, domid_t domID, domid_t cloneID)
 #if __XEN_INTERFACE_VERSION__ < 0x00040600
     uint64_t page, max_page = xc_domain_maximum_gpfn(xen->xc, domID);
 #else
-    xen_pfn_t page, max_page;
+    xen_pfn_t page;
+    xen_pfn_t max_page;
     if (xc_domain_maximum_gpfn(xen->xc, domID, &max_page))
     {
         printf("Failed to get max gpfn from Xen!\n");
@@ -275,7 +276,8 @@ uint64_t xen_memshare(xen_interface_t* xen, domid_t domID, domid_t cloneID)
      */
     for (page = max_page; page <= max_page; page--)
     {
-        uint64_t shandle, chandle;
+        uint64_t shandle;
+        uint64_t chandle;
 
         if (xc_memshr_nominate_gfn(xen->xc, domID, page, &shandle))
             continue;

--- a/src/xen_memclone.c
+++ b/src/xen_memclone.c
@@ -140,8 +140,10 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    char* origin_name = NULL, *clone_name = NULL;
-    domid_t origin_domID = 0, clone_domID = 0;
+    char* origin_name = NULL;
+    char* clone_name = NULL;
+    domid_t origin_domID = 0;
+    domid_t clone_domID = 0;
 
     get_dom_info(xen, argv[1], &origin_domID, &origin_name);
     get_dom_info(xen, argv[2], &clone_domID, &clone_name);


### PR DESCRIPTION
Init-declarator-lists and member-declarator-lists should consist of single init-declarators and member-declarators respectively for c and c++.
