### PR TITLE
dkommon: Monitor writes to zero page

### DIFF
--- a/src/plugins/dkommon/dkommon.h
+++ b/src/plugins/dkommon/dkommon.h
@@ -141,6 +141,15 @@ private:
         .reg = CR3,
         .data = this
     };
+
+    drakvuf_trap_t zeropage_trap =
+    {
+        .type = MEMACCESS,
+        .memaccess.gfn = 0,
+        .memaccess.type = PRE,
+        .memaccess.access = VMI_MEMACCESS_W,
+        .data = this
+    };
 };
 
 #endif


### PR DESCRIPTION
Such writes have been used in the past in CVEs like CVE-2014-4113.