### PR TITLE
Don't automatically trap on MOV-TO-CR3

### DIFF
--- a/src/libdrakvuf/drakvuf.c
+++ b/src/libdrakvuf/drakvuf.c
@@ -348,6 +348,9 @@ bool inject_trap_reg(drakvuf_t drakvuf, drakvuf_trap_t* trap)
 {
     if (CR3 == trap->reg)
     {
+        if ( !drakvuf->cr3 && !control_cr3_trap(drakvuf, 1) )
+            return 0;
+
         drakvuf->cr3 = g_slist_prepend(drakvuf->cr3, trap);
         return 1;
     }
@@ -572,9 +575,9 @@ int drakvuf_get_address_width(drakvuf_t drakvuf)
     return drakvuf->address_width;
 }
 
-bool drakvuf_get_current_process_data(drakvuf_t drakvuf, uint64_t vcpu_id, proc_data_priv_t* proc_data)
+bool drakvuf_get_current_process_data(drakvuf_t drakvuf, drakvuf_trap_info_t *info, proc_data_priv_t* proc_data)
 {
-    addr_t process_base = drakvuf_get_current_process(drakvuf, vcpu_id);
+    addr_t process_base = drakvuf_get_current_process(drakvuf, info);
     return drakvuf_get_process_data_priv(drakvuf, process_base, proc_data);
 }
 

--- a/src/libdrakvuf/drakvuf.c
+++ b/src/libdrakvuf/drakvuf.c
@@ -575,7 +575,7 @@ int drakvuf_get_address_width(drakvuf_t drakvuf)
     return drakvuf->address_width;
 }
 
-bool drakvuf_get_current_process_data(drakvuf_t drakvuf, drakvuf_trap_info_t *info, proc_data_priv_t* proc_data)
+bool drakvuf_get_current_process_data(drakvuf_t drakvuf, drakvuf_trap_info_t* info, proc_data_priv_t* proc_data)
 {
     addr_t process_base = drakvuf_get_current_process(drakvuf, info);
     return drakvuf_get_process_data_priv(drakvuf, process_base, proc_data);

--- a/src/libdrakvuf/libdrakvuf.h
+++ b/src/libdrakvuf/libdrakvuf.h
@@ -362,17 +362,13 @@ json_object* drakvuf_get_rekall_profile_json(drakvuf_t drakvuf);
 
 addr_t drakvuf_get_kernel_base(drakvuf_t drakvuf);
 
-/*
- * Specify either vcpu_id and/or regs. If regs don't have the required info
- * (for example Xen 4.6 doesn't actually send fs_base/gs_base), it falls back
- * on the vcpu id so it's best to specify both.
- */
 addr_t drakvuf_get_current_process(drakvuf_t drakvuf,
-                                   uint64_t vcpu_id);
+                                   drakvuf_trap_info_t *info);
+
 addr_t drakvuf_get_current_thread(drakvuf_t drakvuf,
-                                  uint64_t vcpu_id);
+                                  drakvuf_trap_info_t *info);
 status_t drakvuf_get_last_error(drakvuf_t drakvuf,
-                                uint64_t vcpu_id,
+                                drakvuf_trap_info_t *info,
                                 uint32_t* err,
                                 const char** err_str);
 
@@ -400,7 +396,7 @@ bool drakvuf_get_process_data(drakvuf_t drakvuf,
                               proc_data_t* proc_data);
 
 bool drakvuf_get_current_thread_id(drakvuf_t drakvuf,
-                                   uint64_t vcpu_id,
+                                   drakvuf_trap_info_t *info,
                                    uint32_t* thread_id);
 
 addr_t drakvuf_exportksym_to_va(drakvuf_t drakvuf,
@@ -413,7 +409,7 @@ addr_t drakvuf_exportsym_to_va(drakvuf_t drakvuf, addr_t process_addr,
 // Microsoft PreviousMode KTHREAD explanation:
 // https://msdn.microsoft.com/en-us/library/windows/hardware/ff559860(v=vs.85).aspx
 bool drakvuf_get_current_thread_previous_mode(drakvuf_t drakvuf,
-        uint64_t vcpu_id,
+        drakvuf_trap_info_t *info,
         privilege_mode_t* previous_mode);
 
 bool drakvuf_get_thread_previous_mode(drakvuf_t drakvuf,

--- a/src/libdrakvuf/libdrakvuf.h
+++ b/src/libdrakvuf/libdrakvuf.h
@@ -363,12 +363,12 @@ json_object* drakvuf_get_rekall_profile_json(drakvuf_t drakvuf);
 addr_t drakvuf_get_kernel_base(drakvuf_t drakvuf);
 
 addr_t drakvuf_get_current_process(drakvuf_t drakvuf,
-                                   drakvuf_trap_info_t *info);
+                                   drakvuf_trap_info_t* info);
 
 addr_t drakvuf_get_current_thread(drakvuf_t drakvuf,
-                                  drakvuf_trap_info_t *info);
+                                  drakvuf_trap_info_t* info);
 status_t drakvuf_get_last_error(drakvuf_t drakvuf,
-                                drakvuf_trap_info_t *info,
+                                drakvuf_trap_info_t* info,
                                 uint32_t* err,
                                 const char** err_str);
 
@@ -396,7 +396,7 @@ bool drakvuf_get_process_data(drakvuf_t drakvuf,
                               proc_data_t* proc_data);
 
 bool drakvuf_get_current_thread_id(drakvuf_t drakvuf,
-                                   drakvuf_trap_info_t *info,
+                                   drakvuf_trap_info_t* info,
                                    uint32_t* thread_id);
 
 addr_t drakvuf_exportksym_to_va(drakvuf_t drakvuf,
@@ -409,7 +409,7 @@ addr_t drakvuf_exportsym_to_va(drakvuf_t drakvuf, addr_t process_addr,
 // Microsoft PreviousMode KTHREAD explanation:
 // https://msdn.microsoft.com/en-us/library/windows/hardware/ff559860(v=vs.85).aspx
 bool drakvuf_get_current_thread_previous_mode(drakvuf_t drakvuf,
-        drakvuf_trap_info_t *info,
+        drakvuf_trap_info_t* info,
         privilege_mode_t* previous_mode);
 
 bool drakvuf_get_thread_previous_mode(drakvuf_t drakvuf,

--- a/src/libdrakvuf/linux-processes.c
+++ b/src/libdrakvuf/linux-processes.c
@@ -119,7 +119,7 @@
 #define STACK_SIZE_16K 0x3fff
 #define MIN_KERNEL_BOUNDARY 0x80000000
 
-addr_t linux_get_current_process(drakvuf_t drakvuf, drakvuf_trap_info_t *info)
+addr_t linux_get_current_process(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 {
     addr_t process = 0;
     vmi_instance_t vmi = drakvuf->vmi;
@@ -158,7 +158,7 @@ addr_t linux_get_current_process(drakvuf_t drakvuf, drakvuf_trap_info_t *info)
 /*
  * Threads are really just processes on Linux.
  */
-addr_t linux_get_current_thread(drakvuf_t drakvuf, drakvuf_trap_info_t *info)
+addr_t linux_get_current_thread(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 {
     return linux_get_current_process(drakvuf, info);
 }
@@ -192,7 +192,7 @@ status_t linux_get_process_pid(drakvuf_t drakvuf, addr_t process_base, vmi_pid_t
     return vmi_read_32(drakvuf->vmi, &ctx, (uint32_t*)pid);
 }
 
-char* linux_get_current_process_name(drakvuf_t drakvuf, drakvuf_trap_info_t *info, bool fullpath)
+char* linux_get_current_process_name(drakvuf_t drakvuf, drakvuf_trap_info_t* info, bool fullpath)
 {
     UNUSED(fullpath);
     addr_t process_base = linux_get_current_process(drakvuf, info);
@@ -230,7 +230,7 @@ int64_t linux_get_process_userid(drakvuf_t drakvuf, addr_t process_base)
     return uid;
 };
 
-int64_t linux_get_current_process_userid(drakvuf_t drakvuf, drakvuf_trap_info_t *info)
+int64_t linux_get_current_process_userid(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 {
     addr_t process_base = linux_get_current_process(drakvuf, info);
     if ( !process_base )
@@ -255,7 +255,7 @@ int64_t linux_get_current_process_userid(drakvuf_t drakvuf, drakvuf_trap_info_t 
     return uid;
 }
 
-bool linux_get_current_thread_id( drakvuf_t drakvuf, drakvuf_trap_info_t *info, uint32_t* thread_id )
+bool linux_get_current_thread_id( drakvuf_t drakvuf, drakvuf_trap_info_t* info, uint32_t* thread_id )
 {
     /*
      * On Linux PID is actually the thread ID....... ... ...

--- a/src/libdrakvuf/linux-processes.c
+++ b/src/libdrakvuf/linux-processes.c
@@ -119,7 +119,7 @@
 #define STACK_SIZE_16K 0x3fff
 #define MIN_KERNEL_BOUNDARY 0x80000000
 
-addr_t linux_get_current_process(drakvuf_t drakvuf, uint64_t vcpu_id)
+addr_t linux_get_current_process(drakvuf_t drakvuf, drakvuf_trap_info_t *info)
 {
     addr_t process = 0;
     vmi_instance_t vmi = drakvuf->vmi;
@@ -127,8 +127,8 @@ addr_t linux_get_current_process(drakvuf_t drakvuf, uint64_t vcpu_id)
     access_context_t ctx =
     {
         .translate_mechanism = VMI_TM_PROCESS_DTB,
-        .dtb = drakvuf->regs[vcpu_id]->cr3,
-        .addr = drakvuf->regs[vcpu_id]->gs_base + drakvuf->offsets[CURRENT_TASK],
+        .dtb = info->regs->cr3,
+        .addr = info->regs->gs_base + drakvuf->offsets[CURRENT_TASK],
     };
 
     if ( VMI_FAILURE == vmi_read_addr(vmi, &ctx, &process) || process < MIN_KERNEL_BOUNDARY )
@@ -143,10 +143,10 @@ addr_t linux_get_current_process(drakvuf_t drakvuf, uint64_t vcpu_id)
          * something that resembles a kernel-address.
          * See https://www.cs.columbia.edu/~smb/classes/s06-4118/l06.pdf for more info.
          */
-        ctx.addr = drakvuf->kpcr[vcpu_id] & ~STACK_SIZE_16K;
+        ctx.addr = info->regs->rsp & ~STACK_SIZE_16K;
         if ( VMI_FAILURE == vmi_read_addr(vmi, &ctx, &process) || process < MIN_KERNEL_BOUNDARY )
         {
-            ctx.addr = drakvuf->kpcr[vcpu_id] & ~STACK_SIZE_8K;
+            ctx.addr = info->regs->rsp & ~STACK_SIZE_8K;
             if ( VMI_FAILURE == vmi_read_addr(vmi, &ctx, &process) || process < MIN_KERNEL_BOUNDARY )
                 process = 0;
         }
@@ -158,9 +158,9 @@ addr_t linux_get_current_process(drakvuf_t drakvuf, uint64_t vcpu_id)
 /*
  * Threads are really just processes on Linux.
  */
-addr_t linux_get_current_thread(drakvuf_t drakvuf, uint64_t vcpu_id)
+addr_t linux_get_current_thread(drakvuf_t drakvuf, drakvuf_trap_info_t *info)
 {
-    return linux_get_current_process(drakvuf, vcpu_id);
+    return linux_get_current_process(drakvuf, info);
 }
 
 char* linux_get_process_name(drakvuf_t drakvuf, addr_t process_base, bool fullpath)
@@ -192,17 +192,17 @@ status_t linux_get_process_pid(drakvuf_t drakvuf, addr_t process_base, vmi_pid_t
     return vmi_read_32(drakvuf->vmi, &ctx, (uint32_t*)pid);
 }
 
-char* linux_get_current_process_name(drakvuf_t drakvuf, uint64_t vcpu_id, bool fullpath)
+char* linux_get_current_process_name(drakvuf_t drakvuf, drakvuf_trap_info_t *info, bool fullpath)
 {
     UNUSED(fullpath);
-    addr_t process_base = linux_get_current_process(drakvuf, vcpu_id);
+    addr_t process_base = linux_get_current_process(drakvuf, info);
     if ( !process_base )
         return NULL;
 
     access_context_t ctx =
     {
         .translate_mechanism = VMI_TM_PROCESS_DTB,
-        .dtb = drakvuf->regs[vcpu_id]->cr3,
+        .dtb = info->regs->cr3,
         .addr = process_base + drakvuf->offsets[TASK_STRUCT_COMM]
     };
 
@@ -230,16 +230,16 @@ int64_t linux_get_process_userid(drakvuf_t drakvuf, addr_t process_base)
     return uid;
 };
 
-int64_t linux_get_current_process_userid(drakvuf_t drakvuf, uint64_t vcpu_id)
+int64_t linux_get_current_process_userid(drakvuf_t drakvuf, drakvuf_trap_info_t *info)
 {
-    addr_t process_base = linux_get_current_process(drakvuf, vcpu_id);
+    addr_t process_base = linux_get_current_process(drakvuf, info);
     if ( !process_base )
         return -1;
 
     access_context_t ctx =
     {
         .translate_mechanism = VMI_TM_PROCESS_DTB,
-        .dtb = drakvuf->regs[vcpu_id]->cr3,
+        .dtb = info->regs->cr3,
         .addr = process_base + drakvuf->offsets[TASK_STRUCT_CRED]
     };
 
@@ -255,19 +255,19 @@ int64_t linux_get_current_process_userid(drakvuf_t drakvuf, uint64_t vcpu_id)
     return uid;
 }
 
-bool linux_get_current_thread_id( drakvuf_t drakvuf, uint64_t vcpu_id, uint32_t* thread_id )
+bool linux_get_current_thread_id( drakvuf_t drakvuf, drakvuf_trap_info_t *info, uint32_t* thread_id )
 {
     /*
      * On Linux PID is actually the thread ID....... ... ...
      */
-    addr_t process_base = linux_get_current_process(drakvuf, vcpu_id);
+    addr_t process_base = linux_get_current_process(drakvuf, info);
     if ( !process_base )
         return false;
 
     access_context_t ctx =
     {
         .translate_mechanism = VMI_TM_PROCESS_DTB,
-        .dtb = drakvuf->regs[vcpu_id]->cr3,
+        .dtb = info->regs->cr3,
         .addr = process_base + drakvuf->offsets[TASK_STRUCT_PID]
     };
     uint32_t _thread_id;

--- a/src/libdrakvuf/linux.h
+++ b/src/libdrakvuf/linux.h
@@ -108,21 +108,21 @@
 #include <libvmi/libvmi.h>
 #include "libdrakvuf.h"
 
-addr_t linux_get_current_thread(drakvuf_t drakvuf, uint64_t vcpu_id);
+addr_t linux_get_current_thread(drakvuf_t drakvuf, drakvuf_trap_info_t *info);
 
-addr_t linux_get_current_process(drakvuf_t drakvuf, uint64_t vcpu_id);
+addr_t linux_get_current_process(drakvuf_t drakvuf, drakvuf_trap_info_t *info);
 
 char* linux_get_process_name(drakvuf_t drakvuf, addr_t process_base, bool fullpath);
 
 status_t linux_get_process_pid(drakvuf_t drakvuf, addr_t process_base, vmi_pid_t* pid);
 
-char* linux_get_current_process_name(drakvuf_t drakvuf, uint64_t vcpu_id, bool fullpath);
+char* linux_get_current_process_name(drakvuf_t drakvuf, drakvuf_trap_info_t *info, bool fullpath);
 
 int64_t linux_get_process_userid(drakvuf_t drakvuf, addr_t process_base);
 
-int64_t linux_get_current_process_userid(drakvuf_t drakvuf, uint64_t vcpu_id);
+int64_t linux_get_current_process_userid(drakvuf_t drakvuf, drakvuf_trap_info_t *info);
 
-bool linux_get_current_thread_id(drakvuf_t drakvuf, uint64_t vcpu_id, uint32_t* thread_id);
+bool linux_get_current_thread_id(drakvuf_t drakvuf, drakvuf_trap_info_t *info, uint32_t* thread_id);
 
 status_t linux_get_process_ppid( drakvuf_t drakvuf, addr_t process_base, vmi_pid_t* ppid );
 

--- a/src/libdrakvuf/linux.h
+++ b/src/libdrakvuf/linux.h
@@ -108,21 +108,21 @@
 #include <libvmi/libvmi.h>
 #include "libdrakvuf.h"
 
-addr_t linux_get_current_thread(drakvuf_t drakvuf, drakvuf_trap_info_t *info);
+addr_t linux_get_current_thread(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
 
-addr_t linux_get_current_process(drakvuf_t drakvuf, drakvuf_trap_info_t *info);
+addr_t linux_get_current_process(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
 
 char* linux_get_process_name(drakvuf_t drakvuf, addr_t process_base, bool fullpath);
 
 status_t linux_get_process_pid(drakvuf_t drakvuf, addr_t process_base, vmi_pid_t* pid);
 
-char* linux_get_current_process_name(drakvuf_t drakvuf, drakvuf_trap_info_t *info, bool fullpath);
+char* linux_get_current_process_name(drakvuf_t drakvuf, drakvuf_trap_info_t* info, bool fullpath);
 
 int64_t linux_get_process_userid(drakvuf_t drakvuf, addr_t process_base);
 
-int64_t linux_get_current_process_userid(drakvuf_t drakvuf, drakvuf_trap_info_t *info);
+int64_t linux_get_current_process_userid(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
 
-bool linux_get_current_thread_id(drakvuf_t drakvuf, drakvuf_trap_info_t *info, uint32_t* thread_id);
+bool linux_get_current_thread_id(drakvuf_t drakvuf, drakvuf_trap_info_t* info, uint32_t* thread_id);
 
 status_t linux_get_process_ppid( drakvuf_t drakvuf, addr_t process_base, vmi_pid_t* ppid );
 

--- a/src/libdrakvuf/os.c
+++ b/src/libdrakvuf/os.c
@@ -128,7 +128,7 @@ bool fill_offsets_from_rekall(drakvuf_t drakvuf, size_t size, const char* names 
     return 1;
 }
 
-addr_t drakvuf_get_current_thread(drakvuf_t drakvuf, drakvuf_trap_info_t *info)
+addr_t drakvuf_get_current_thread(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 {
     if ( drakvuf->osi.get_current_thread )
         return drakvuf->osi.get_current_thread(drakvuf, info);
@@ -136,7 +136,7 @@ addr_t drakvuf_get_current_thread(drakvuf_t drakvuf, drakvuf_trap_info_t *info)
     return 0;
 }
 
-status_t drakvuf_get_last_error(drakvuf_t drakvuf, drakvuf_trap_info_t *info, uint32_t* err, const char** err_str)
+status_t drakvuf_get_last_error(drakvuf_t drakvuf, drakvuf_trap_info_t* info, uint32_t* err, const char** err_str)
 {
     if ( drakvuf->osi.get_last_error )
         return drakvuf->osi.get_last_error(drakvuf, info, err, err_str);
@@ -144,7 +144,7 @@ status_t drakvuf_get_last_error(drakvuf_t drakvuf, drakvuf_trap_info_t *info, ui
     return VMI_FAILURE;
 }
 
-addr_t drakvuf_get_current_process(drakvuf_t drakvuf, drakvuf_trap_info_t *info)
+addr_t drakvuf_get_current_process(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 {
     if ( drakvuf->osi.get_current_process )
         return drakvuf->osi.get_current_process(drakvuf, info);
@@ -176,7 +176,7 @@ status_t drakvuf_get_process_pid(drakvuf_t drakvuf, addr_t process_base, vmi_pid
     return VMI_FAILURE;
 }
 
-char* drakvuf_get_current_process_name(drakvuf_t drakvuf, drakvuf_trap_info_t *info, bool fullpath)
+char* drakvuf_get_current_process_name(drakvuf_t drakvuf, drakvuf_trap_info_t* info, bool fullpath)
 {
     if ( drakvuf->osi.get_current_process_name )
         return drakvuf->osi.get_current_process_name(drakvuf, info, fullpath);
@@ -192,7 +192,7 @@ int64_t drakvuf_get_process_userid(drakvuf_t drakvuf, addr_t process_base)
     return ~0l;
 }
 
-int64_t drakvuf_get_current_process_userid(drakvuf_t drakvuf, drakvuf_trap_info_t *info)
+int64_t drakvuf_get_current_process_userid(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 {
     if ( drakvuf->osi.get_current_process_userid )
         return drakvuf->osi.get_current_process_userid(drakvuf, info);
@@ -200,7 +200,7 @@ int64_t drakvuf_get_current_process_userid(drakvuf_t drakvuf, drakvuf_trap_info_
     return ~0l;
 }
 
-bool drakvuf_get_current_thread_id( drakvuf_t drakvuf, drakvuf_trap_info_t *info, uint32_t* thread_id )
+bool drakvuf_get_current_thread_id( drakvuf_t drakvuf, drakvuf_trap_info_t* info, uint32_t* thread_id )
 {
     if ( drakvuf->osi.get_current_thread_id )
         return drakvuf->osi.get_current_thread_id(drakvuf, info, thread_id);
@@ -218,7 +218,7 @@ bool drakvuf_get_thread_previous_mode( drakvuf_t drakvuf, addr_t kthread, privil
 }
 
 bool drakvuf_get_current_thread_previous_mode( drakvuf_t drakvuf,
-        drakvuf_trap_info_t *info,
+        drakvuf_trap_info_t* info,
         privilege_mode_t* previous_mode )
 {
     if ( drakvuf->osi.get_current_thread_previous_mode )

--- a/src/libdrakvuf/os.c
+++ b/src/libdrakvuf/os.c
@@ -128,26 +128,26 @@ bool fill_offsets_from_rekall(drakvuf_t drakvuf, size_t size, const char* names 
     return 1;
 }
 
-addr_t drakvuf_get_current_thread(drakvuf_t drakvuf, uint64_t vcpu_id)
+addr_t drakvuf_get_current_thread(drakvuf_t drakvuf, drakvuf_trap_info_t *info)
 {
     if ( drakvuf->osi.get_current_thread )
-        return drakvuf->osi.get_current_thread(drakvuf, vcpu_id);
+        return drakvuf->osi.get_current_thread(drakvuf, info);
 
     return 0;
 }
 
-status_t drakvuf_get_last_error(drakvuf_t drakvuf, uint64_t vcpu_id, uint32_t* err, const char** err_str)
+status_t drakvuf_get_last_error(drakvuf_t drakvuf, drakvuf_trap_info_t *info, uint32_t* err, const char** err_str)
 {
     if ( drakvuf->osi.get_last_error )
-        return drakvuf->osi.get_last_error(drakvuf, vcpu_id, err, err_str);
+        return drakvuf->osi.get_last_error(drakvuf, info, err, err_str);
 
     return VMI_FAILURE;
 }
 
-addr_t drakvuf_get_current_process(drakvuf_t drakvuf, uint64_t vcpu_id)
+addr_t drakvuf_get_current_process(drakvuf_t drakvuf, drakvuf_trap_info_t *info)
 {
     if ( drakvuf->osi.get_current_process )
-        return drakvuf->osi.get_current_process(drakvuf, vcpu_id);
+        return drakvuf->osi.get_current_process(drakvuf, info);
 
     return 0;
 }
@@ -176,10 +176,10 @@ status_t drakvuf_get_process_pid(drakvuf_t drakvuf, addr_t process_base, vmi_pid
     return VMI_FAILURE;
 }
 
-char* drakvuf_get_current_process_name(drakvuf_t drakvuf, uint64_t vcpu_id, bool fullpath)
+char* drakvuf_get_current_process_name(drakvuf_t drakvuf, drakvuf_trap_info_t *info, bool fullpath)
 {
     if ( drakvuf->osi.get_current_process_name )
-        return drakvuf->osi.get_current_process_name(drakvuf, vcpu_id, fullpath);
+        return drakvuf->osi.get_current_process_name(drakvuf, info, fullpath);
 
     return NULL;
 }
@@ -192,18 +192,18 @@ int64_t drakvuf_get_process_userid(drakvuf_t drakvuf, addr_t process_base)
     return ~0l;
 }
 
-int64_t drakvuf_get_current_process_userid(drakvuf_t drakvuf, uint64_t vcpu_id)
+int64_t drakvuf_get_current_process_userid(drakvuf_t drakvuf, drakvuf_trap_info_t *info)
 {
     if ( drakvuf->osi.get_current_process_userid )
-        return drakvuf->osi.get_current_process_userid(drakvuf, vcpu_id);
+        return drakvuf->osi.get_current_process_userid(drakvuf, info);
 
     return ~0l;
 }
 
-bool drakvuf_get_current_thread_id( drakvuf_t drakvuf, uint64_t vcpu_id, uint32_t* thread_id )
+bool drakvuf_get_current_thread_id( drakvuf_t drakvuf, drakvuf_trap_info_t *info, uint32_t* thread_id )
 {
     if ( drakvuf->osi.get_current_thread_id )
-        return drakvuf->osi.get_current_thread_id(drakvuf, vcpu_id, thread_id);
+        return drakvuf->osi.get_current_thread_id(drakvuf, info, thread_id);
 
     return 0;
 }
@@ -218,11 +218,11 @@ bool drakvuf_get_thread_previous_mode( drakvuf_t drakvuf, addr_t kthread, privil
 }
 
 bool drakvuf_get_current_thread_previous_mode( drakvuf_t drakvuf,
-        uint64_t vcpu_id,
+        drakvuf_trap_info_t *info,
         privilege_mode_t* previous_mode )
 {
     if ( drakvuf->osi.get_current_thread_previous_mode )
-        return drakvuf->osi.get_current_thread_previous_mode(drakvuf, vcpu_id, previous_mode);
+        return drakvuf->osi.get_current_thread_previous_mode(drakvuf, info, previous_mode);
 
     return 0;
 }

--- a/src/libdrakvuf/os.h
+++ b/src/libdrakvuf/os.h
@@ -110,13 +110,13 @@ typedef struct process_data_priv proc_data_priv_t;
 typedef struct os_interface
 {
     addr_t (*get_current_thread)
-    (drakvuf_t drakvuf, drakvuf_trap_info_t *info);
+    (drakvuf_t drakvuf, drakvuf_trap_info_t* info);
 
     addr_t (*get_current_process)
-    (drakvuf_t drakvuf, drakvuf_trap_info_t *info);
+    (drakvuf_t drakvuf, drakvuf_trap_info_t* info);
 
     status_t (*get_last_error)
-    (drakvuf_t drakvuf, drakvuf_trap_info_t *info, uint32_t* err, const char** err_str);
+    (drakvuf_t drakvuf, drakvuf_trap_info_t* info, uint32_t* err, const char** err_str);
 
     char* (*get_process_name)
     (drakvuf_t drakvuf, addr_t process_base, bool fullpath);
@@ -125,7 +125,7 @@ typedef struct os_interface
     (drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t eprocess_base);
 
     char* (*get_current_process_name)
-    (drakvuf_t drakvuf, drakvuf_trap_info_t *info, bool fullpath);
+    (drakvuf_t drakvuf, drakvuf_trap_info_t* info, bool fullpath);
 
     int64_t (*get_process_userid)
     (drakvuf_t drakvuf, addr_t process_base);
@@ -134,16 +134,16 @@ typedef struct os_interface
     (drakvuf_t drakvuf, addr_t process_base, vmi_pid_t* pid);
 
     int64_t (*get_current_process_userid)
-    (drakvuf_t drakvuf, drakvuf_trap_info_t *info);
+    (drakvuf_t drakvuf, drakvuf_trap_info_t* info);
 
     bool (*get_current_thread_id)
-    (drakvuf_t drakvuf, drakvuf_trap_info_t *info, uint32_t* thread_id);
+    (drakvuf_t drakvuf, drakvuf_trap_info_t* info, uint32_t* thread_id);
 
     bool (*get_thread_previous_mode)
     (drakvuf_t drakvuf, addr_t kthread, privilege_mode_t* previous_mode);
 
     bool (*get_current_thread_previous_mode)
-    (drakvuf_t drakvuf, drakvuf_trap_info_t *info, privilege_mode_t* previous_mode);
+    (drakvuf_t drakvuf, drakvuf_trap_info_t* info, privilege_mode_t* previous_mode);
 
     bool (*is_process)
     (drakvuf_t drakvuf, addr_t dtb, addr_t process_addr);

--- a/src/libdrakvuf/os.h
+++ b/src/libdrakvuf/os.h
@@ -110,13 +110,13 @@ typedef struct process_data_priv proc_data_priv_t;
 typedef struct os_interface
 {
     addr_t (*get_current_thread)
-    (drakvuf_t drakvuf, uint64_t vcpu_id);
+    (drakvuf_t drakvuf, drakvuf_trap_info_t *info);
 
     addr_t (*get_current_process)
-    (drakvuf_t drakvuf, uint64_t vcpu_id);
+    (drakvuf_t drakvuf, drakvuf_trap_info_t *info);
 
     status_t (*get_last_error)
-    (drakvuf_t drakvuf, uint64_t vcpu_id, uint32_t* err, const char** err_str);
+    (drakvuf_t drakvuf, drakvuf_trap_info_t *info, uint32_t* err, const char** err_str);
 
     char* (*get_process_name)
     (drakvuf_t drakvuf, addr_t process_base, bool fullpath);
@@ -125,7 +125,7 @@ typedef struct os_interface
     (drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t eprocess_base);
 
     char* (*get_current_process_name)
-    (drakvuf_t drakvuf, uint64_t vcpu_id, bool fullpath);
+    (drakvuf_t drakvuf, drakvuf_trap_info_t *info, bool fullpath);
 
     int64_t (*get_process_userid)
     (drakvuf_t drakvuf, addr_t process_base);
@@ -134,16 +134,16 @@ typedef struct os_interface
     (drakvuf_t drakvuf, addr_t process_base, vmi_pid_t* pid);
 
     int64_t (*get_current_process_userid)
-    (drakvuf_t drakvuf, uint64_t vcpu_id);
+    (drakvuf_t drakvuf, drakvuf_trap_info_t *info);
 
     bool (*get_current_thread_id)
-    (drakvuf_t drakvuf, uint64_t vcpu_id, uint32_t* thread_id);
+    (drakvuf_t drakvuf, drakvuf_trap_info_t *info, uint32_t* thread_id);
 
     bool (*get_thread_previous_mode)
     (drakvuf_t drakvuf, addr_t kthread, privilege_mode_t* previous_mode);
 
     bool (*get_current_thread_previous_mode)
-    (drakvuf_t drakvuf, uint64_t vcpu_id, privilege_mode_t* previous_mode);
+    (drakvuf_t drakvuf, drakvuf_trap_info_t *info, privilege_mode_t* previous_mode);
 
     bool (*is_process)
     (drakvuf_t drakvuf, addr_t dtb, addr_t process_addr);

--- a/src/libdrakvuf/private.h
+++ b/src/libdrakvuf/private.h
@@ -142,6 +142,15 @@ extern bool verbose;
 
 #define UNUSED(x) (void)(x)
 
+/*
+ * How often should the VMI caches be flushed?
+ *
+ * TODO: develop intelligent cache-flush system that
+ *       catches the events that actually make flushes
+ *       necessary.
+ */
+#define VMI_FLUSH_RATE 100
+
 struct fd_info
 {
     int fd;
@@ -168,6 +177,7 @@ struct drakvuf
     xen_pfn_t zero_page_gfn;
 
     // VMI
+    unsigned long flush_counter;
     GMutex vmi_lock;
     vmi_instance_t vmi;
 

--- a/src/libdrakvuf/private.h
+++ b/src/libdrakvuf/private.h
@@ -296,7 +296,7 @@ struct memcb_pass
 void drakvuf_force_resume (drakvuf_t drakvuf);
 
 bool drakvuf_get_current_process_data(drakvuf_t drakvuf,
-                                      drakvuf_trap_info_t *info,
+                                      drakvuf_trap_info_t* info,
                                       proc_data_priv_t* proc_data);
 
 bool drakvuf_get_process_data_priv(drakvuf_t drakvuf,
@@ -304,11 +304,11 @@ bool drakvuf_get_process_data_priv(drakvuf_t drakvuf,
                                    proc_data_priv_t* proc_data);
 
 char* drakvuf_get_current_process_name(drakvuf_t drakvuf,
-                                       drakvuf_trap_info_t *info,
+                                       drakvuf_trap_info_t* info,
                                        bool fullpath);
 
 int64_t drakvuf_get_current_process_userid(drakvuf_t drakvuf,
-        drakvuf_trap_info_t *info);
+        drakvuf_trap_info_t* info);
 
 bool inject_trap_breakpoint(drakvuf_t drakvuf, drakvuf_trap_t* trap);
 bool inject_trap_reg(drakvuf_t drakvuf, drakvuf_trap_t* trap);

--- a/src/libdrakvuf/private.h
+++ b/src/libdrakvuf/private.h
@@ -201,9 +201,6 @@ struct drakvuf
 
     int address_width;
 
-    x86_registers_t* regs[16]; // vCPU specific registers recorded during the last event
-    addr_t kpcr[16]; // vCPU specific kpcr recorded on mov-to-cr3
-
     GHashTable* remapped_gfns; // Key: gfn
     // val: remapped gfn
 
@@ -289,7 +286,7 @@ struct memcb_pass
 void drakvuf_force_resume (drakvuf_t drakvuf);
 
 bool drakvuf_get_current_process_data(drakvuf_t drakvuf,
-                                      uint64_t vcpu_id,
+                                      drakvuf_trap_info_t *info,
                                       proc_data_priv_t* proc_data);
 
 bool drakvuf_get_process_data_priv(drakvuf_t drakvuf,
@@ -297,11 +294,11 @@ bool drakvuf_get_process_data_priv(drakvuf_t drakvuf,
                                    proc_data_priv_t* proc_data);
 
 char* drakvuf_get_current_process_name(drakvuf_t drakvuf,
-                                       uint64_t vcpu_id,
+                                       drakvuf_trap_info_t *info,
                                        bool fullpath);
 
 int64_t drakvuf_get_current_process_userid(drakvuf_t drakvuf,
-        uint64_t vcpu_id);
+        drakvuf_trap_info_t *info);
 
 bool inject_trap_breakpoint(drakvuf_t drakvuf, drakvuf_trap_t* trap);
 bool inject_trap_reg(drakvuf_t drakvuf, drakvuf_trap_t* trap);

--- a/src/libdrakvuf/vmi.c
+++ b/src/libdrakvuf/vmi.c
@@ -350,7 +350,8 @@ event_response_t pre_mem_cb(vmi_instance_t vmi, vmi_event_t* event)
     g_get_current_time(&timestamp);
 
     proc_data_priv_t proc_data = {0};
-    drakvuf_trap_info_t trap_info = {0};
+    drakvuf_trap_info_t trap_info;
+    memset(&trap_info, 0, sizeof(drakvuf_trap_info_t));
 
     trap_info.regs = event->x86_regs;
     trap_info.vcpu = event->vcpu_id;
@@ -526,7 +527,8 @@ event_response_t int3_cb(vmi_instance_t vmi, vmi_event_t* event)
     g_get_current_time(&timestamp);
 
     proc_data_priv_t proc_data = {0};
-    drakvuf_trap_info_t trap_info = {0};
+    drakvuf_trap_info_t trap_info;
+    memset(&trap_info, 0, sizeof(drakvuf_trap_info_t));
 
     trap_info.regs = event->x86_regs;
     trap_info.vcpu = event->vcpu_id;
@@ -609,7 +611,8 @@ event_response_t cr3_cb(vmi_instance_t vmi, vmi_event_t* event)
     g_get_current_time(&timestamp);
 
     proc_data_priv_t proc_data = {0};
-    drakvuf_trap_info_t trap_info = {0};
+    drakvuf_trap_info_t trap_info;
+    memset(&trap_info, 0, sizeof(drakvuf_trap_info_t));
 
     trap_info.regs = event->x86_regs;
     trap_info.vcpu = event->vcpu_id;
@@ -659,7 +662,8 @@ event_response_t debug_cb(vmi_instance_t vmi, vmi_event_t* event)
     g_get_current_time(&timestamp);
 
     proc_data_priv_t proc_data = {0};
-    drakvuf_trap_info_t trap_info = {0};
+    drakvuf_trap_info_t trap_info;
+    memset(&trap_info, 0, sizeof(drakvuf_trap_info_t));
 
     trap_info.regs = event->x86_regs;
     trap_info.vcpu = event->vcpu_id;
@@ -711,7 +715,8 @@ event_response_t cpuid_cb(vmi_instance_t vmi, vmi_event_t* event)
     g_get_current_time(&timestamp);
 
     proc_data_priv_t proc_data = {0};
-    drakvuf_trap_info_t trap_info = {0};
+    drakvuf_trap_info_t trap_info;
+    memset(&trap_info, 0, sizeof(drakvuf_trap_info_t));
 
     trap_info.regs = event->x86_regs;
     trap_info.vcpu = event->vcpu_id;

--- a/src/libdrakvuf/vmi.c
+++ b/src/libdrakvuf/vmi.c
@@ -172,7 +172,6 @@ event_response_t post_mem_cb(vmi_instance_t vmi, vmi_event_t* event)
     event_response_t rsp = 0;
     struct memcb_pass* pass = (struct memcb_pass*)event->data;
     drakvuf_t drakvuf = pass->drakvuf;
-    drakvuf->regs[event->vcpu_id] = event->x86_regs;
 
     /*
      * The trap may have been removed since in another callback,
@@ -305,7 +304,6 @@ event_response_t pre_mem_cb(vmi_instance_t vmi, vmi_event_t* event)
     UNUSED(vmi);
     event_response_t rsp = 0;
     drakvuf_t drakvuf = (drakvuf_t)event->data;
-    drakvuf->regs[event->vcpu_id] = event->x86_regs;
 
     if (event->mem_event.gfn == drakvuf->zero_page_gfn)
     {
@@ -330,12 +328,24 @@ event_response_t pre_mem_cb(vmi_instance_t vmi, vmi_event_t* event)
                 (event->mem_event.out_access & VMI_MEMACCESS_X) ? 'x' : '-'
                );
 
-    proc_data_priv_t proc_data = {0};
-
-    drakvuf_get_current_process_data( drakvuf, event->vcpu_id, &proc_data );
-
     GTimeVal timestamp;
     g_get_current_time(&timestamp);
+
+    proc_data_priv_t proc_data = {0};
+    drakvuf_trap_info_t trap_info = {0};
+
+    trap_info.regs = event->x86_regs;
+    trap_info.vcpu = event->vcpu_id;
+    trap_info.timestamp = timestamp;
+    trap_info.trap_pa = pa;
+
+    drakvuf_get_current_process_data( drakvuf, &trap_info, &proc_data );
+
+    trap_info.proc_data.base_addr = proc_data.base_addr;
+    trap_info.proc_data.name      = proc_data.name;
+    trap_info.proc_data.pid       = proc_data.pid;
+    trap_info.proc_data.ppid      = proc_data.ppid;
+    trap_info.proc_data.userid    = proc_data.userid;
 
     GSList* loop = s->traps;
     drakvuf->in_callback = 1;
@@ -346,20 +356,7 @@ event_response_t pre_mem_cb(vmi_instance_t vmi, vmi_event_t* event)
         if (trap->cb && trap->memaccess.type == PRE &&
                 (trap->memaccess.access & event->mem_event.out_access))
         {
-            drakvuf_trap_info_t trap_info =
-            {
-                .trap = trap,
-                .proc_data.base_addr = proc_data.base_addr,
-                .proc_data.name      = proc_data.name,
-                .proc_data.pid       = proc_data.pid,
-                .proc_data.ppid      = proc_data.ppid,
-                .proc_data.userid    = proc_data.userid,
-                .timestamp           = timestamp,
-                .trap_pa = pa,
-                .regs = event->x86_regs,
-                .vcpu = event->vcpu_id,
-            };
-
+            trap_info.trap = trap;
             rsp |= trap->cb(drakvuf, &trap_info);
         }
 
@@ -379,23 +376,10 @@ event_response_t pre_mem_cb(vmi_instance_t vmi, vmi_event_t* event)
             loop = sbp->traps;
             while (loop)
             {
-                drakvuf_trap_t* trap = (drakvuf_trap_t*)loop->data;
-                drakvuf_trap_info_t trap_info =
-                {
-                    .trap = trap,
-                    .proc_data.base_addr = proc_data.base_addr,
-                    .proc_data.name      = proc_data.name,
-                    .proc_data.pid       = proc_data.pid,
-                    .proc_data.ppid      = proc_data.ppid,
-                    .proc_data.userid    = proc_data.userid,
-                    .timestamp           = timestamp,
-                    .trap_pa = pa,
-                    .regs = event->x86_regs,
-                    .vcpu = event->vcpu_id,
-                };
+                trap_info.trap = (drakvuf_trap_t*)loop->data;
 
                 loop = loop->next;
-                rsp |= trap->cb(drakvuf, &trap_info);
+                rsp |= trap_info.trap->cb(drakvuf, &trap_info);
             }
         }
     }
@@ -470,7 +454,6 @@ event_response_t int3_cb(vmi_instance_t vmi, vmi_event_t* event)
     UNUSED(vmi);
     event_response_t rsp = 0;
     drakvuf_t drakvuf = (drakvuf_t)event->data;
-    drakvuf->regs[event->vcpu_id] = event->x86_regs;
 
     addr_t pa = (event->interrupt_event.gfn << 12)
                 + event->interrupt_event.offset + event->interrupt_event.insn_length - 1;
@@ -519,34 +502,32 @@ event_response_t int3_cb(vmi_instance_t vmi, vmi_event_t* event)
     else
         event->interrupt_event.reinject = 0;
 
-    proc_data_priv_t proc_data = {0};
-
-    drakvuf_get_current_process_data(drakvuf, event->vcpu_id, &proc_data);
-
     GTimeVal timestamp;
     g_get_current_time(&timestamp);
+
+    proc_data_priv_t proc_data = {0};
+    drakvuf_trap_info_t trap_info = {0};
+
+    trap_info.regs = event->x86_regs;
+    trap_info.vcpu = event->vcpu_id;
+    trap_info.timestamp = timestamp;
+    trap_info.trap_pa = pa;
+
+    drakvuf_get_current_process_data( drakvuf, &trap_info, &proc_data );
+
+    trap_info.proc_data.base_addr = proc_data.base_addr;
+    trap_info.proc_data.name      = proc_data.name;
+    trap_info.proc_data.pid       = proc_data.pid;
+    trap_info.proc_data.ppid      = proc_data.ppid;
+    trap_info.proc_data.userid    = proc_data.userid;
 
     drakvuf->in_callback = 1;
     GSList* loop = s->traps;
     while (loop)
     {
-        drakvuf_trap_t* trap = (drakvuf_trap_t*)loop->data;
-        drakvuf_trap_info_t trap_info =
-        {
-            .trap = trap,
-            .proc_data.base_addr = proc_data.base_addr,
-            .proc_data.name      = proc_data.name,
-            .proc_data.pid       = proc_data.pid,
-            .proc_data.ppid      = proc_data.ppid,
-            .proc_data.userid    = proc_data.userid,
-            .timestamp           = timestamp,
-            .trap_pa = pa,
-            .regs = event->x86_regs,
-            .vcpu = event->vcpu_id,
-        };
-
+        trap_info.trap = (drakvuf_trap_t*)loop->data;
+        rsp |= trap_info.trap->cb(drakvuf, &trap_info);
         loop = loop->next;
-        rsp |= trap->cb(drakvuf, &trap_info);
     }
     drakvuf->in_callback = 0;
 
@@ -574,7 +555,6 @@ event_response_t cr3_cb(vmi_instance_t vmi, vmi_event_t* event)
     UNUSED(vmi);
     event_response_t rsp = 0;
     drakvuf_t drakvuf = (drakvuf_t)event->data;
-    drakvuf->regs[event->vcpu_id] = event->x86_regs;
 
 #ifdef DRAKVUF_DEBUG
     /* This is very verbose and always on so we only print debug information
@@ -586,7 +566,7 @@ event_response_t cr3_cb(vmi_instance_t vmi, vmi_event_t* event)
     event->x86_regs->cr3 = event->reg_event.value;
 
     /* Flush the LibVMI caches */
-    vmi_v2pcache_flush(drakvuf->vmi, event->reg_event.previous);
+    /*vmi_v2pcache_flush(drakvuf->vmi, event->reg_event.previous);
     vmi_pidcache_flush(drakvuf->vmi);
     vmi_rvacache_flush(drakvuf->vmi);
     vmi_symcache_flush(drakvuf->vmi);
@@ -601,35 +581,33 @@ event_response_t cr3_cb(vmi_instance_t vmi, vmi_event_t* event)
     else
     {
         drakvuf->kpcr[event->vcpu_id] = event->x86_regs->rsp;
-    }
-
-    proc_data_priv_t proc_data = {0};
-
-    drakvuf_get_current_process_data( drakvuf, event->vcpu_id, &proc_data );
+    }*/
 
     GTimeVal timestamp;
     g_get_current_time(&timestamp);
+
+    proc_data_priv_t proc_data = {0};
+    drakvuf_trap_info_t trap_info = {0};
+
+    trap_info.regs = event->x86_regs;
+    trap_info.vcpu = event->vcpu_id;
+    trap_info.timestamp = timestamp;
+
+    drakvuf_get_current_process_data( drakvuf, &trap_info, &proc_data );
+
+    trap_info.proc_data.base_addr = proc_data.base_addr;
+    trap_info.proc_data.name      = proc_data.name;
+    trap_info.proc_data.pid       = proc_data.pid;
+    trap_info.proc_data.ppid      = proc_data.ppid;
+    trap_info.proc_data.userid    = proc_data.userid;
 
     drakvuf->in_callback = 1;
     GSList* loop = drakvuf->cr3;
     while (loop)
     {
-        drakvuf_trap_t* trap = (drakvuf_trap_t*)loop->data;
-        drakvuf_trap_info_t trap_info =
-        {
-            .trap = trap,
-            .proc_data.base_addr = proc_data.base_addr,
-            .proc_data.name      = proc_data.name,
-            .proc_data.pid       = proc_data.pid,
-            .proc_data.ppid      = proc_data.ppid,
-            .proc_data.userid    = proc_data.userid,
-            .timestamp           = timestamp,
-            .regs = event->x86_regs,
-            .vcpu = event->vcpu_id,
-        };
-
+        trap_info.trap = (drakvuf_trap_t*)loop->data;
+        rsp |= trap_info.trap->cb(drakvuf, &trap_info);
         loop = loop->next;
-        rsp |= trap->cb(drakvuf, &trap_info);
     }
     drakvuf->in_callback = 0;
 
@@ -645,7 +623,6 @@ event_response_t debug_cb(vmi_instance_t vmi, vmi_event_t* event)
     UNUSED(vmi);
     event_response_t rsp = 0;
     drakvuf_t drakvuf = (drakvuf_t)event->data;
-    drakvuf->regs[event->vcpu_id] = event->x86_regs;
 
 #ifdef DEBUG
     addr_t pa = (event->debug_event.gfn << 12) + event->debug_event.offset;
@@ -654,34 +631,32 @@ event_response_t debug_cb(vmi_instance_t vmi, vmi_event_t* event)
                 event->debug_event.gla, event->debug_event.insn_length);
 #endif
 
-    proc_data_priv_t proc_data = {0};
-
-    drakvuf_get_current_process_data( drakvuf, event->vcpu_id, &proc_data );
-
     GTimeVal timestamp;
     g_get_current_time(&timestamp);
+
+    proc_data_priv_t proc_data = {0};
+    drakvuf_trap_info_t trap_info = {0};
+
+    trap_info.regs = event->x86_regs;
+    trap_info.vcpu = event->vcpu_id;
+    trap_info.timestamp = timestamp;
+    trap_info.debug = &event->debug_event;
+
+    drakvuf_get_current_process_data( drakvuf, &trap_info, &proc_data );
+
+    trap_info.proc_data.base_addr = proc_data.base_addr;
+    trap_info.proc_data.name      = proc_data.name;
+    trap_info.proc_data.pid       = proc_data.pid;
+    trap_info.proc_data.ppid      = proc_data.ppid;
+    trap_info.proc_data.userid    = proc_data.userid;
 
     drakvuf->in_callback = 1;
     GSList* loop = drakvuf->debug;
     while (loop)
     {
-        drakvuf_trap_t* trap = (drakvuf_trap_t*)loop->data;
-        drakvuf_trap_info_t trap_info =
-        {
-            .trap = trap,
-            .proc_data.base_addr = proc_data.base_addr,
-            .proc_data.name      = proc_data.name,
-            .proc_data.pid       = proc_data.pid,
-            .proc_data.ppid      = proc_data.ppid,
-            .proc_data.userid    = proc_data.userid,
-            .timestamp           = timestamp,
-            .regs = event->x86_regs,
-            .vcpu = event->vcpu_id,
-            .debug = &event->debug_event
-        };
-
+        trap_info.trap = (drakvuf_trap_t*)loop->data;
+        rsp |= trap_info.trap->cb(drakvuf, &trap_info);
         loop = loop->next;
-        rsp |= trap->cb(drakvuf, &trap_info);
     }
     drakvuf->in_callback = 0;
 
@@ -699,41 +674,39 @@ event_response_t cpuid_cb(vmi_instance_t vmi, vmi_event_t* event)
     UNUSED(vmi);
     event_response_t rsp = 0;
     drakvuf_t drakvuf = (drakvuf_t)event->data;
-    drakvuf->regs[event->vcpu_id] = event->x86_regs;
 
     PRINT_DEBUG("CPUID event vCPU %u altp2m:%u CR3: 0x%"PRIx64" RIP=0x%"PRIx64". Insn_length: %u\n",
                 event->vcpu_id, event->slat_id, event->x86_regs->cr3,
                 event->x86_regs->rip, event->cpuid_event.insn_length);
 
     reg_t rip = event->x86_regs->rip;
-    proc_data_priv_t proc_data = {0};
-
-    drakvuf_get_current_process_data( drakvuf, event->vcpu_id, &proc_data );
 
     GTimeVal timestamp;
     g_get_current_time(&timestamp);
+
+    proc_data_priv_t proc_data = {0};
+    drakvuf_trap_info_t trap_info = {0};
+
+    trap_info.regs = event->x86_regs;
+    trap_info.vcpu = event->vcpu_id;
+    trap_info.timestamp = timestamp;
+    trap_info.cpuid = &event->cpuid_event;
+
+    drakvuf_get_current_process_data( drakvuf, &trap_info, &proc_data );
+
+    trap_info.proc_data.base_addr = proc_data.base_addr;
+    trap_info.proc_data.name      = proc_data.name;
+    trap_info.proc_data.pid       = proc_data.pid;
+    trap_info.proc_data.ppid      = proc_data.ppid;
+    trap_info.proc_data.userid    = proc_data.userid;
 
     drakvuf->in_callback = 1;
     GSList* loop = drakvuf->cpuid;
     while (loop)
     {
-        drakvuf_trap_t* trap = (drakvuf_trap_t*)loop->data;
-        drakvuf_trap_info_t trap_info =
-        {
-            .trap = trap,
-            .proc_data.base_addr = proc_data.base_addr,
-            .proc_data.name      = proc_data.name,
-            .proc_data.pid       = proc_data.pid,
-            .proc_data.ppid      = proc_data.ppid,
-            .proc_data.userid    = proc_data.userid,
-            .timestamp           = timestamp,
-            .regs = event->x86_regs,
-            .vcpu = event->vcpu_id,
-            .cpuid = &event->cpuid_event
-        };
-
+        trap_info.trap = (drakvuf_trap_t*)loop->data;
+        rsp |= trap_info.trap->cb(drakvuf, &trap_info);
         loop = loop->next;
-        rsp |= trap->cb(drakvuf, &trap_info);
     }
     drakvuf->in_callback = 0;
 
@@ -865,9 +838,9 @@ void remove_trap(drakvuf_t drakvuf,
         {
             if (CR3 == trap->reg)
             {
-                /* We don't disable the event itself even if the list is empty
-                   as we may use it to flush the LibVMI cache */
                 drakvuf->cr3 = g_slist_remove(drakvuf->cr3, trap);
+                if ( !drakvuf->cr3 )
+                    control_cr3_trap(drakvuf, 0);
             }
             break;
         }
@@ -1199,6 +1172,35 @@ bool control_debug_trap(drakvuf_t drakvuf, bool toggle)
     return 1;
 }
 
+bool control_cr3_trap(drakvuf_t drakvuf, bool toggle)
+{
+    drakvuf->cr3_event.version = VMI_EVENTS_VERSION;
+    drakvuf->cr3_event.type = VMI_EVENT_REGISTER;
+    drakvuf->cr3_event.reg_event.reg = CR3;
+    drakvuf->cr3_event.reg_event.in_access = VMI_REGACCESS_W;
+    drakvuf->cr3_event.data = drakvuf;
+    drakvuf->cr3_event.callback = cr3_cb;
+
+    if ( toggle )
+    {
+        if (VMI_FAILURE == vmi_register_event(drakvuf->vmi, &drakvuf->cr3_event))
+        {
+            fprintf(stderr, "Failed to register CR3 event\n");
+            return 0;
+        }
+    }
+    else
+    {
+        if (VMI_FAILURE == vmi_clear_event(drakvuf->vmi, &drakvuf->cr3_event, NULL))
+        {
+            fprintf(stderr, "Failed to clear CR3 event\n");
+            return 0;
+        }
+    }
+
+    return 1;
+}
+
 bool control_cpuid_trap(drakvuf_t drakvuf, bool toggle)
 {
     drakvuf->cpuid_event.version = VMI_EVENTS_VERSION;
@@ -1459,15 +1461,6 @@ bool init_vmi(drakvuf_t drakvuf, bool libvmi_conf)
     if (VMI_FAILURE == vmi_register_event(drakvuf->vmi, &drakvuf->interrupt_event))
     {
         fprintf(stderr, "Failed to register interrupt event\n");
-        return 0;
-    }
-
-    SETUP_REG_EVENT(&drakvuf->cr3_event, CR3, VMI_REGACCESS_W, 0, cr3_cb);
-    drakvuf->cr3_event.data = drakvuf;
-
-    if (VMI_FAILURE == vmi_register_event(drakvuf->vmi, &drakvuf->cr3_event))
-    {
-        fprintf(stderr, "Failed to register CR3 event\n");
         return 0;
     }
 

--- a/src/libdrakvuf/vmi.h
+++ b/src/libdrakvuf/vmi.h
@@ -144,6 +144,7 @@ bool inject_traps_modules(drakvuf_t drakvuf,
 void remove_trap(drakvuf_t drakvuf,
                  const drakvuf_trap_t* trap);
 
+bool control_cr3_trap(drakvuf_t drakvuf, bool toggle);
 bool control_debug_trap(drakvuf_t drakvuf, bool toggle);
 bool control_cpuid_trap(drakvuf_t drakvuf, bool toggle);
 

--- a/src/libdrakvuf/win-files.c
+++ b/src/libdrakvuf/win-files.c
@@ -110,7 +110,7 @@
 
 char* win_get_filename_from_handle(drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t handle)
 {
-    addr_t process = drakvuf_get_current_process(drakvuf, info->vcpu);
+    addr_t process = drakvuf_get_current_process(drakvuf, info);
     if (!process) return NULL;
 
     addr_t obj = drakvuf_get_obj_by_handle(drakvuf, process, handle);

--- a/src/libdrakvuf/win-processes.c
+++ b/src/libdrakvuf/win-processes.c
@@ -129,7 +129,7 @@ bool win_search_modules( drakvuf_t drakvuf, const char* module_name, bool (*visi
 bool win_search_modules_wow( drakvuf_t drakvuf, const char* module_name, bool (*visitor_func)(drakvuf_t drakvuf, const module_info_t* module_info, void* visitor_ctx), void* visitor_ctx, addr_t eprocess_addr, addr_t wow_peb, vmi_pid_t pid, access_context_t* ctx );
 addr_t win_get_wow_peb( drakvuf_t drakvuf, access_context_t* ctx, addr_t wow_process );
 
-addr_t win_get_current_thread(drakvuf_t drakvuf, drakvuf_trap_info_t *info)
+addr_t win_get_current_thread(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 {
     vmi_instance_t vmi = drakvuf->vmi;
     addr_t thread;
@@ -157,7 +157,7 @@ addr_t win_get_current_thread(drakvuf_t drakvuf, drakvuf_trap_info_t *info)
     return thread;
 }
 
-addr_t win_get_current_process(drakvuf_t drakvuf, drakvuf_trap_info_t *info)
+addr_t win_get_current_process(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 {
     addr_t thread;
     addr_t process;
@@ -172,7 +172,7 @@ addr_t win_get_current_process(drakvuf_t drakvuf, drakvuf_trap_info_t *info)
     return process;
 }
 
-status_t win_get_last_error(drakvuf_t drakvuf, drakvuf_trap_info_t *info, uint32_t* err, const char** err_str)
+status_t win_get_last_error(drakvuf_t drakvuf, drakvuf_trap_info_t* info, uint32_t* err, const char** err_str)
 {
     if (!err || !err_str)
         return VMI_FAILURE;
@@ -290,7 +290,7 @@ status_t win_get_process_pid(drakvuf_t drakvuf, addr_t eprocess_base, vmi_pid_t*
     return vmi_read_32_va(drakvuf->vmi, eprocess_base + drakvuf->offsets[EPROCESS_PID], 0, (uint32_t*)pid);
 }
 
-char* win_get_current_process_name(drakvuf_t drakvuf, drakvuf_trap_info_t *info, bool fullpath)
+char* win_get_current_process_name(drakvuf_t drakvuf, drakvuf_trap_info_t* info, bool fullpath)
 {
     return win_get_process_name(drakvuf, win_get_current_process(drakvuf, info), fullpath);
 }
@@ -325,7 +325,7 @@ int64_t win_get_process_userid(drakvuf_t drakvuf, addr_t eprocess_base)
     return (int64_t)userid;
 };
 
-int64_t win_get_current_process_userid(drakvuf_t drakvuf, drakvuf_trap_info_t *info)
+int64_t win_get_current_process_userid(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 {
     return win_get_process_userid(drakvuf, win_get_current_process(drakvuf, info));
 }
@@ -333,7 +333,7 @@ int64_t win_get_current_process_userid(drakvuf_t drakvuf, drakvuf_trap_info_t *i
 /////////////////////////////////////////////////////////////////////////////////////////////
 
 
-bool win_get_current_thread_id(drakvuf_t drakvuf, drakvuf_trap_info_t *info, uint32_t* thread_id)
+bool win_get_current_thread_id(drakvuf_t drakvuf, drakvuf_trap_info_t* info, uint32_t* thread_id)
 {
     addr_t p_tid ;
     addr_t ethread = win_get_current_thread(drakvuf, info);
@@ -375,7 +375,7 @@ bool win_get_thread_previous_mode( drakvuf_t drakvuf, addr_t kthread, privilege_
 }
 
 bool win_get_current_thread_previous_mode(drakvuf_t drakvuf,
-        drakvuf_trap_info_t *info,
+        drakvuf_trap_info_t* info,
         privilege_mode_t* previous_mode )
 {
     addr_t kthread = win_get_current_thread(drakvuf, info);

--- a/src/libdrakvuf/win-processes.c
+++ b/src/libdrakvuf/win-processes.c
@@ -129,18 +129,27 @@ bool win_search_modules( drakvuf_t drakvuf, const char* module_name, bool (*visi
 bool win_search_modules_wow( drakvuf_t drakvuf, const char* module_name, bool (*visitor_func)(drakvuf_t drakvuf, const module_info_t* module_info, void* visitor_ctx), void* visitor_ctx, addr_t eprocess_addr, addr_t wow_peb, vmi_pid_t pid, access_context_t* ctx );
 addr_t win_get_wow_peb( drakvuf_t drakvuf, access_context_t* ctx, addr_t wow_process );
 
-addr_t win_get_current_thread(drakvuf_t drakvuf, uint64_t vcpu_id)
+addr_t win_get_current_thread(drakvuf_t drakvuf, drakvuf_trap_info_t *info)
 {
     vmi_instance_t vmi = drakvuf->vmi;
     addr_t thread;
     addr_t prcb;
+    addr_t kpcr;
 
     if (drakvuf->pm == VMI_PM_IA32E)
+    {
         prcb=drakvuf->offsets[KPCR_PRCB];
+
+        vmi_get_vcpureg(drakvuf->vmi, &kpcr, GS_BASE, info->vcpu);
+    }
     else
+    {
         prcb=drakvuf->offsets[KPCR_PRCBDATA];
 
-    if (VMI_SUCCESS != vmi_read_addr_va(vmi, drakvuf->kpcr[vcpu_id] + prcb + drakvuf->offsets[KPRCB_CURRENTTHREAD], 0, &thread))
+        vmi_get_vcpureg(drakvuf->vmi, &kpcr, FS_BASE, info->vcpu);
+    }
+
+    if (VMI_SUCCESS != vmi_read_addr_va(vmi, kpcr + prcb + drakvuf->offsets[KPRCB_CURRENTTHREAD], 0, &thread))
     {
         return 0;
     }
@@ -148,12 +157,12 @@ addr_t win_get_current_thread(drakvuf_t drakvuf, uint64_t vcpu_id)
     return thread;
 }
 
-addr_t win_get_current_process(drakvuf_t drakvuf, uint64_t vcpu_id)
+addr_t win_get_current_process(drakvuf_t drakvuf, drakvuf_trap_info_t *info)
 {
     addr_t thread;
     addr_t process;
 
-    thread=win_get_current_thread(drakvuf,vcpu_id);
+    thread=win_get_current_thread(drakvuf, info);
 
     if (thread == 0 || VMI_SUCCESS != vmi_read_addr_va(drakvuf->vmi, thread + drakvuf->offsets[KTHREAD_PROCESS], 0, &process))
     {
@@ -163,21 +172,21 @@ addr_t win_get_current_process(drakvuf_t drakvuf, uint64_t vcpu_id)
     return process;
 }
 
-status_t win_get_last_error(drakvuf_t drakvuf, uint64_t vcpu_id, uint32_t* err, const char** err_str)
+status_t win_get_last_error(drakvuf_t drakvuf, drakvuf_trap_info_t *info, uint32_t* err, const char** err_str)
 {
     if (!err || !err_str)
         return VMI_FAILURE;
 
     vmi_instance_t vmi = drakvuf->vmi;
 
-    addr_t eprocess = win_get_current_process(drakvuf, vcpu_id);
+    addr_t eprocess = win_get_current_process(drakvuf, info);
     addr_t cr3 = 0;
     vmi_pid_t pid = 0;
     if (eprocess && VMI_SUCCESS == win_get_process_pid(drakvuf, eprocess, &pid))
         if (VMI_SUCCESS != vmi_pid_to_dtb(vmi, pid, &cr3))
             return VMI_FAILURE;
 
-    addr_t kthread = win_get_current_thread(drakvuf, vcpu_id);
+    addr_t kthread = win_get_current_thread(drakvuf, info);
     if (!kthread)
         return VMI_FAILURE;
 
@@ -281,9 +290,9 @@ status_t win_get_process_pid(drakvuf_t drakvuf, addr_t eprocess_base, vmi_pid_t*
     return vmi_read_32_va(drakvuf->vmi, eprocess_base + drakvuf->offsets[EPROCESS_PID], 0, (uint32_t*)pid);
 }
 
-char* win_get_current_process_name(drakvuf_t drakvuf, uint64_t vcpu_id, bool fullpath)
+char* win_get_current_process_name(drakvuf_t drakvuf, drakvuf_trap_info_t *info, bool fullpath)
 {
-    return win_get_process_name(drakvuf, win_get_current_process(drakvuf, vcpu_id), fullpath);
+    return win_get_process_name(drakvuf, win_get_current_process(drakvuf, info), fullpath);
 }
 
 int64_t win_get_process_userid(drakvuf_t drakvuf, addr_t eprocess_base)
@@ -316,18 +325,18 @@ int64_t win_get_process_userid(drakvuf_t drakvuf, addr_t eprocess_base)
     return (int64_t)userid;
 };
 
-int64_t win_get_current_process_userid(drakvuf_t drakvuf, uint64_t vcpu_id)
+int64_t win_get_current_process_userid(drakvuf_t drakvuf, drakvuf_trap_info_t *info)
 {
-    return win_get_process_userid(drakvuf, win_get_current_process(drakvuf, vcpu_id));
+    return win_get_process_userid(drakvuf, win_get_current_process(drakvuf, info));
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////
 
 
-bool win_get_current_thread_id(drakvuf_t drakvuf, uint64_t vcpu_id, uint32_t* thread_id)
+bool win_get_current_thread_id(drakvuf_t drakvuf, drakvuf_trap_info_t *info, uint32_t* thread_id)
 {
     addr_t p_tid ;
-    addr_t ethread = win_get_current_thread(drakvuf, vcpu_id);
+    addr_t ethread = win_get_current_thread(drakvuf, info);
 
     if ( ethread )
     {
@@ -366,10 +375,10 @@ bool win_get_thread_previous_mode( drakvuf_t drakvuf, addr_t kthread, privilege_
 }
 
 bool win_get_current_thread_previous_mode(drakvuf_t drakvuf,
-        uint64_t vcpu_id,
+        drakvuf_trap_info_t *info,
         privilege_mode_t* previous_mode )
 {
-    addr_t kthread = win_get_current_thread(drakvuf, vcpu_id);
+    addr_t kthread = win_get_current_thread(drakvuf, info);
 
     return win_get_thread_previous_mode(drakvuf, kthread, previous_mode);
 }

--- a/src/libdrakvuf/win.h
+++ b/src/libdrakvuf/win.h
@@ -110,11 +110,11 @@
 #include "os.h"
 #include "win-exports.h"
 
-addr_t win_get_current_thread(drakvuf_t drakvuf, uint64_t vcpu_id);
+addr_t win_get_current_thread(drakvuf_t drakvuf, drakvuf_trap_info_t *info);
 
-addr_t win_get_current_process(drakvuf_t drakvuf, uint64_t vcpu_id);
+addr_t win_get_current_process(drakvuf_t drakvuf, drakvuf_trap_info_t *info);
 
-status_t win_get_last_error(drakvuf_t drakvuf, uint64_t vcpu_id, uint32_t* err, const char** err_str);
+status_t win_get_last_error(drakvuf_t drakvuf, drakvuf_trap_info_t *info, uint32_t* err, const char** err_str);
 
 char* win_get_process_name(drakvuf_t drakvuf, addr_t eprocess_base, bool fullpath);
 
@@ -122,18 +122,18 @@ char* win_get_process_commandline(drakvuf_t drakvuf, drakvuf_trap_info_t* info, 
 
 status_t win_get_process_pid(drakvuf_t drakvuf, addr_t eprocess_base, int32_t* pid);
 
-char* win_get_current_process_name(drakvuf_t drakvuf, uint64_t vcpu_id, bool fullpath);
+char* win_get_current_process_name(drakvuf_t drakvuf, drakvuf_trap_info_t *info, bool fullpath);
 
 int64_t win_get_process_userid(drakvuf_t drakvuf, addr_t eprocess_base);
 
-int64_t win_get_current_process_userid(drakvuf_t drakvuf, uint64_t vcpu_id);
+int64_t win_get_current_process_userid(drakvuf_t drakvuf, drakvuf_trap_info_t *info);
 
-bool win_get_current_thread_id(drakvuf_t drakvuf, uint64_t vcpu_id, uint32_t* thread_id);
+bool win_get_current_thread_id(drakvuf_t drakvuf, drakvuf_trap_info_t *info, uint32_t* thread_id);
 
 bool win_get_thread_previous_mode(drakvuf_t drakvuf, addr_t kthread, privilege_mode_t* previous_mode);
 
 bool win_get_current_thread_previous_mode(drakvuf_t drakvuf,
-        uint64_t vcpu_id,
+        drakvuf_trap_info_t *info,
         privilege_mode_t* previous_mode);
 
 bool win_is_ethread(drakvuf_t drakvuf, addr_t dtb, addr_t ethread_addr);

--- a/src/libdrakvuf/win.h
+++ b/src/libdrakvuf/win.h
@@ -110,11 +110,11 @@
 #include "os.h"
 #include "win-exports.h"
 
-addr_t win_get_current_thread(drakvuf_t drakvuf, drakvuf_trap_info_t *info);
+addr_t win_get_current_thread(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
 
-addr_t win_get_current_process(drakvuf_t drakvuf, drakvuf_trap_info_t *info);
+addr_t win_get_current_process(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
 
-status_t win_get_last_error(drakvuf_t drakvuf, drakvuf_trap_info_t *info, uint32_t* err, const char** err_str);
+status_t win_get_last_error(drakvuf_t drakvuf, drakvuf_trap_info_t* info, uint32_t* err, const char** err_str);
 
 char* win_get_process_name(drakvuf_t drakvuf, addr_t eprocess_base, bool fullpath);
 
@@ -122,18 +122,18 @@ char* win_get_process_commandline(drakvuf_t drakvuf, drakvuf_trap_info_t* info, 
 
 status_t win_get_process_pid(drakvuf_t drakvuf, addr_t eprocess_base, int32_t* pid);
 
-char* win_get_current_process_name(drakvuf_t drakvuf, drakvuf_trap_info_t *info, bool fullpath);
+char* win_get_current_process_name(drakvuf_t drakvuf, drakvuf_trap_info_t* info, bool fullpath);
 
 int64_t win_get_process_userid(drakvuf_t drakvuf, addr_t eprocess_base);
 
-int64_t win_get_current_process_userid(drakvuf_t drakvuf, drakvuf_trap_info_t *info);
+int64_t win_get_current_process_userid(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
 
-bool win_get_current_thread_id(drakvuf_t drakvuf, drakvuf_trap_info_t *info, uint32_t* thread_id);
+bool win_get_current_thread_id(drakvuf_t drakvuf, drakvuf_trap_info_t* info, uint32_t* thread_id);
 
 bool win_get_thread_previous_mode(drakvuf_t drakvuf, addr_t kthread, privilege_mode_t* previous_mode);
 
 bool win_get_current_thread_previous_mode(drakvuf_t drakvuf,
-        drakvuf_trap_info_t *info,
+        drakvuf_trap_info_t* info,
         privilege_mode_t* previous_mode);
 
 bool win_is_ethread(drakvuf_t drakvuf, addr_t dtb, addr_t ethread_addr);

--- a/src/libinjector/injector.c
+++ b/src/libinjector/injector.c
@@ -454,7 +454,7 @@ static bool injector_set_hijacked(injector_t injector, drakvuf_trap_info_t* info
     if (!injector->target_tid)
     {
         uint32_t threadid = 0;
-        if (!drakvuf_get_current_thread_id(injector->drakvuf, info->vcpu, &threadid) || !threadid)
+        if (!drakvuf_get_current_thread_id(injector->drakvuf, info, &threadid) || !threadid)
             return false;
 
         injector->target_tid = threadid;
@@ -601,7 +601,7 @@ static event_response_t wait_for_target_process_cb(drakvuf_t drakvuf, drakvuf_tr
     if (info->proc_data.pid != injector->target_pid)
         return 0;
 
-    addr_t thread = drakvuf_get_current_thread(drakvuf, info->vcpu);
+    addr_t thread = drakvuf_get_current_thread(drakvuf, info);
     if (!thread)
     {
         PRINT_DEBUG("Failed to find current thread\n");
@@ -609,7 +609,7 @@ static event_response_t wait_for_target_process_cb(drakvuf_t drakvuf, drakvuf_tr
     }
 
     uint32_t threadid = 0;
-    if ( !drakvuf_get_current_thread_id(injector->drakvuf, info->vcpu, &threadid) || !threadid )
+    if ( !drakvuf_get_current_thread_id(injector->drakvuf, info, &threadid) || !threadid )
         return 0;
 
     PRINT_DEBUG("Thread @ 0x%lx. ThreadID: %u\n", thread, threadid);
@@ -869,7 +869,7 @@ static event_response_t injector_int3_cb(drakvuf_t drakvuf, drakvuf_trap_info_t*
     if (injector->target_tid)
     {
         uint32_t threadid = 0;
-        if (!drakvuf_get_current_thread_id(drakvuf, info->vcpu, &threadid) || threadid != injector->target_tid)
+        if (!drakvuf_get_current_thread_id(drakvuf, info, &threadid) || threadid != injector->target_tid)
             return 0;
     }
 
@@ -913,7 +913,7 @@ static event_response_t injector_int3_cb(drakvuf_t drakvuf, drakvuf_trap_info_t*
             else
             {
                 injector->error_code.valid = true;
-                drakvuf_get_last_error(injector->drakvuf, info->vcpu, &injector->error_code.code, &injector->error_code.string);
+                drakvuf_get_last_error(injector->drakvuf, info, &injector->error_code.code, &injector->error_code.string);
             }
 
             injector->rc = info->regs->rax;
@@ -1121,7 +1121,7 @@ static event_response_t injector_int3_cb(drakvuf_t drakvuf, drakvuf_trap_info_t*
         else
         {
             injector->error_code.valid = true;
-            drakvuf_get_last_error(injector->drakvuf, info->vcpu, &injector->error_code.code, &injector->error_code.string);
+            drakvuf_get_last_error(injector->drakvuf, info, &injector->error_code.code, &injector->error_code.string);
         }
 
         injector->rc = info->regs->rax;

--- a/src/plugins/filedelete/filedelete.cpp
+++ b/src/plugins/filedelete/filedelete.cpp
@@ -606,7 +606,7 @@ event_response_t readfile_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
         return 0;
 
     uint32_t thread_id = 0;
-    if (!drakvuf_get_current_thread_id(drakvuf, info->vcpu, &thread_id))
+    if (!drakvuf_get_current_thread_id(drakvuf, info, &thread_id))
         return 0;
 
     if (thread_id != injector->target_thread_id)
@@ -726,7 +726,7 @@ event_response_t exallocatepool_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
     if (info->regs->cr3 != injector->target_cr3)
         goto done;
 
-    if ( !drakvuf_get_current_thread_id(drakvuf, info->vcpu, &thread_id) ||
+    if ( !drakvuf_get_current_thread_id(drakvuf, info, &thread_id) ||
             !injector->target_thread_id || thread_id != injector->target_thread_id )
         goto done;
 
@@ -768,7 +768,7 @@ event_response_t queryobject_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
     if (info->regs->cr3 != injector->target_cr3)
         return 0;
 
-    if ( !drakvuf_get_current_thread_id(drakvuf, info->vcpu, &thread_id) ||
+    if ( !drakvuf_get_current_thread_id(drakvuf, info, &thread_id) ||
             !injector->target_thread_id || thread_id != injector->target_thread_id )
         return 0;
 
@@ -854,7 +854,7 @@ static bool start_readfile(drakvuf_t drakvuf, drakvuf_trap_info_t* info, vmi_ins
     }
 
     uint32_t target_thread_id = 0;
-    if ( !drakvuf_get_current_thread_id(drakvuf, info->vcpu, &target_thread_id) ||
+    if ( !drakvuf_get_current_thread_id(drakvuf, info, &target_thread_id) ||
             !target_thread_id )
     {
         PRINT_DEBUG("[FILEDELETE2] Failed to get Thread ID\n");

--- a/src/plugins/librarymon/librarymon.cpp
+++ b/src/plugins/librarymon/librarymon.cpp
@@ -111,7 +111,7 @@
 
 static event_response_t load_library_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 {
-    addr_t thread = drakvuf_get_current_thread(drakvuf, info->vcpu);
+    addr_t thread = drakvuf_get_current_thread(drakvuf, info);
     if (!thread)
         return VMI_EVENT_RESPONSE_NONE;
 

--- a/src/plugins/procmon/procmon.cpp
+++ b/src/plugins/procmon/procmon.cpp
@@ -325,7 +325,7 @@ static event_response_t process_creation_return_hook(drakvuf_t drakvuf, drakvuf_
         return VMI_EVENT_RESPONSE_NONE;
     }
 
-    if (!data->verify_result_call_params(info, drakvuf_get_current_thread(drakvuf, info->vcpu)))
+    if (!data->verify_result_call_params(info, drakvuf_get_current_thread(drakvuf, info)))
         return VMI_EVENT_RESPONSE_NONE;
 
     auto* plugin = data->plugin();
@@ -379,7 +379,7 @@ static event_response_t create_user_process_hook(
         return VMI_EVENT_RESPONSE_NONE;
     }
 
-    data->set_result_call_params(info, drakvuf_get_current_thread(drakvuf, info->vcpu));
+    data->set_result_call_params(info, drakvuf_get_current_thread(drakvuf, info));
     data->new_process_handle_addr = process_handle_addr;
     data->user_process_parameters_addr = user_process_parameters_addr;
     return VMI_EVENT_RESPONSE_NONE;
@@ -476,7 +476,7 @@ static event_response_t open_process_return_hook_cb(drakvuf_t drakvuf, drakvuf_t
         return VMI_EVENT_RESPONSE_NONE;
     }
 
-    if (!data->verify_result_call_params(info, drakvuf_get_current_thread(drakvuf, info->vcpu)))
+    if (!data->verify_result_call_params(info, drakvuf_get_current_thread(drakvuf, info)))
         return VMI_EVENT_RESPONSE_NONE;
 
     plugin->destroy_trap(drakvuf, info->trap);
@@ -579,7 +579,7 @@ static event_response_t open_process_hook_cb(drakvuf_t drakvuf, drakvuf_trap_inf
         return VMI_EVENT_RESPONSE_NONE;
     }
 
-    data->set_result_call_params(info, drakvuf_get_current_thread(drakvuf, info->vcpu));
+    data->set_result_call_params(info, drakvuf_get_current_thread(drakvuf, info));
 
     // PHANDLE ProcessHandle
     data->process_handle_addr = drakvuf_get_function_argument(drakvuf, info, 1);

--- a/src/plugins/wmimon/wmimon.cpp
+++ b/src/plugins/wmimon/wmimon.cpp
@@ -399,7 +399,7 @@ event_response_t ExecMethod_return_handler(drakvuf_t drakvuf, drakvuf_trap_info_
         return VMI_EVENT_RESPONSE_NONE;
     }
 
-    if (!data->verify_result_call_params(info, drakvuf_get_current_thread(drakvuf, info->vcpu)))
+    if (!data->verify_result_call_params(info, drakvuf_get_current_thread(drakvuf, info)))
         return VMI_EVENT_RESPONSE_NONE;
 
     plugin->destroy_trap(drakvuf, info->trap);
@@ -507,7 +507,7 @@ event_response_t ExecMethod_handler(drakvuf_t drakvuf, drakvuf_trap_info_t* info
         return VMI_EVENT_RESPONSE_NONE;
     }
 
-    params->set_result_call_params(info, drakvuf_get_current_thread(drakvuf, info->vcpu));
+    params->set_result_call_params(info, drakvuf_get_current_thread(drakvuf, info));
     params->m_object = drakvuf_get_function_argument(drakvuf, info, 2);
     params->m_method = drakvuf_get_function_argument(drakvuf, info, 3);
     params->m_vtable = drakvuf_get_function_argument(drakvuf, info, 6);
@@ -526,7 +526,7 @@ event_response_t GetObject_return_handler(drakvuf_t drakvuf, drakvuf_trap_info_t
         return VMI_EVENT_RESPONSE_NONE;
     }
 
-    if (!data->verify_result_call_params(info, drakvuf_get_current_thread(drakvuf, info->vcpu)))
+    if (!data->verify_result_call_params(info, drakvuf_get_current_thread(drakvuf, info)))
         return VMI_EVENT_RESPONSE_NONE;
 
     plugin->destroy_trap(drakvuf, info->trap);
@@ -621,7 +621,7 @@ event_response_t GetObject_handler(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
         return VMI_EVENT_RESPONSE_NONE;
     }
 
-    params->set_result_call_params(info, drakvuf_get_current_thread(drakvuf, info->vcpu));
+    params->set_result_call_params(info, drakvuf_get_current_thread(drakvuf, info));
     params->m_object = drakvuf_get_function_argument(drakvuf, info, 2);
     params->m_vtable = drakvuf_get_function_argument(drakvuf, info, 5);
 
@@ -639,7 +639,7 @@ event_response_t ExecQuery_return_handler(drakvuf_t drakvuf, drakvuf_trap_info_t
         return VMI_EVENT_RESPONSE_NONE;
     }
 
-    if (!data->verify_result_call_params(info, drakvuf_get_current_thread(drakvuf, info->vcpu)))
+    if (!data->verify_result_call_params(info, drakvuf_get_current_thread(drakvuf, info)))
         return VMI_EVENT_RESPONSE_NONE;
 
     plugin->destroy_trap(drakvuf, info->trap);
@@ -734,7 +734,7 @@ event_response_t ExecQuery_handler(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
         return VMI_EVENT_RESPONSE_NONE;
     }
 
-    params->set_result_call_params(info, drakvuf_get_current_thread(drakvuf, info->vcpu));
+    params->set_result_call_params(info, drakvuf_get_current_thread(drakvuf, info));
     params->m_command = drakvuf_get_function_argument(drakvuf, info, 3);
     params->m_vtable = drakvuf_get_function_argument(drakvuf, info, 6);
 
@@ -752,7 +752,7 @@ event_response_t ConnectServer_return_handler(drakvuf_t drakvuf, drakvuf_trap_in
         return VMI_EVENT_RESPONSE_NONE;
     }
 
-    if (!data->verify_result_call_params(info, drakvuf_get_current_thread(drakvuf, info->vcpu)))
+    if (!data->verify_result_call_params(info, drakvuf_get_current_thread(drakvuf, info)))
         return VMI_EVENT_RESPONSE_NONE;
 
     plugin->destroy_trap(drakvuf, info->trap);
@@ -867,7 +867,7 @@ event_response_t ConnectServer_handler(drakvuf_t drakvuf, drakvuf_trap_info_t* i
         return VMI_EVENT_RESPONSE_NONE;
     }
 
-    params->set_result_call_params(info, drakvuf_get_current_thread(drakvuf, info->vcpu));
+    params->set_result_call_params(info, drakvuf_get_current_thread(drakvuf, info));
     params->m_resource = drakvuf_get_function_argument(drakvuf, info, 2);
     params->m_vtable = drakvuf_get_function_argument(drakvuf, info, 9);
 
@@ -886,7 +886,7 @@ event_response_t CoCreateInstanse_return_handler(drakvuf_t drakvuf, drakvuf_trap
         return VMI_EVENT_RESPONSE_NONE;
     }
 
-    if (!data->verify_result_call_params(info, drakvuf_get_current_thread(drakvuf, info->vcpu)) || FAILED(info->regs->rax))
+    if (!data->verify_result_call_params(info, drakvuf_get_current_thread(drakvuf, info)) || FAILED(info->regs->rax))
         return VMI_EVENT_RESPONSE_NONE;
 
     plugin->destroy_trap(drakvuf, info->trap);
@@ -959,7 +959,7 @@ event_response_t CoCreateInstanse_handler(drakvuf_t drakvuf, drakvuf_trap_info_t
         return VMI_EVENT_RESPONSE_NONE;
     }
 
-    params->set_result_call_params(info, drakvuf_get_current_thread(drakvuf, info->vcpu));
+    params->set_result_call_params(info, drakvuf_get_current_thread(drakvuf, info));
     params->CLSID = drakvuf_get_function_argument(drakvuf, info, 1);
     params->IID = drakvuf_get_function_argument(drakvuf, info, 4);
     params->m_vtable = drakvuf_get_function_argument(drakvuf, info, 5);


### PR DESCRIPTION
It can create severe overhead on certain systems.

Fixes #621 