### PR TITLE
Extends syscalls plugin to be able to dump input buffer of NtWriteVirtualMemory

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -226,6 +226,8 @@ int main(int argc, char** argv)
 #endif
 #ifdef ENABLE_PLUGIN_SYSCALLS
                 "\t -S <syscalls filter>      File with list of syscalls for trap in syscalls plugin (trap all if parameter is absent)\n"
+                "\t -E <memory write dump folder>\n"
+                "\t                           Folder where virtual memory write should be stored\n"
 #endif
 #ifdef ENABLE_PLUGIN_BSODMON
                 "\t -b                        Exit from execution as soon as a BSoD is detected\n"
@@ -292,7 +294,7 @@ int main(int argc, char** argv)
         {"rekall-wow-ole32", required_argument, NULL, opt_rekall_wow_ole32},
         {NULL, 0, NULL, 0}
     };
-    const char* opts = "r:d:i:I:e:m:t:D:o:vx:a:spT:S:Mc:nblgj:w:W:";
+    const char* opts = "r:d:i:I:e:m:t:D:o:vx:a:spT:S:E:Mc:nblgj:w:W:";
 
     while ((c = getopt_long (argc, argv, opts, long_opts, &long_index)) != -1)
         switch (c)
@@ -385,6 +387,9 @@ int main(int argc, char** argv)
 #endif
             case 'S':
                 options.syscalls_filter_file = optarg;
+                break;
+            case 'E':
+                options.syscalls_virtual_memory_write = optarg;
                 break;
             case 'M':
                 options.dump_modified_files = true;

--- a/src/plugins/plugins.cpp
+++ b/src/plugins/plugins.cpp
@@ -158,6 +158,7 @@ int drakvuf_plugins::start(const drakvuf_plugin_t plugin_id,
                     syscalls_config config =
                     {
                         .syscalls_filter_file = options->syscalls_filter_file,
+                        .syscalls_virtual_memory_write = options->syscalls_virtual_memory_write,
                     };
                     this->plugins[plugin_id] = new syscalls(this->drakvuf, &config, this->output);
                     break;

--- a/src/plugins/plugins.h
+++ b/src/plugins/plugins.h
@@ -126,6 +126,7 @@ struct plugins_options
     const char* iphlpapi_profile;       // PLUGIN_ENVMON
     const char* mpr_profile;            // PLUGIN_ENVMON
     const char* syscalls_filter_file;   // PLUGIN_SYSCALLS
+    const char* syscalls_virtual_memory_write; //PLUGIN_SYSCALLS
     bool abort_on_bsod;                 // PLUGIN_BSODMON
     const char* ntdll_profile;          // PLUGIN_LIBRARYMON
     const char* ole32_profile;          // PLUGIN_WMIMON

--- a/src/plugins/syscalls/syscalls.h
+++ b/src/plugins/syscalls/syscalls.h
@@ -112,6 +112,7 @@
 struct syscalls_config
 {
     const char* syscalls_filter_file;
+    const char* syscalls_virtual_memory_write;
 };
 
 class syscalls: public plugin
@@ -124,6 +125,7 @@ public:
     uint8_t reg_size;
     output_format_t format;
     os_t os;
+    const char* syscalls_virtual_memory_write;
 
     syscalls(drakvuf_t drakvuf, const syscalls_config* config, output_format_t output);
     ~syscalls();


### PR DESCRIPTION
This adds the possibility to the syscalls plugin to dump content of memory written by the NtWriteVirtualMemory syscall.
This option could be enabled by adding "-E" when launching drakvuf.