### PR TITLE
Add plugin to track and dump NtWriteVirtualMemory calls

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -326,6 +326,16 @@ if test x$plugin_wmimon = xyes; then
   AC_DEFINE_UNQUOTED(ENABLE_PLUGIN_WMIMON, 1, "")
 fi
 
+AC_ARG_ENABLE([plugin_writevirtualmemmon],
+  [AS_HELP_STRING([--disable-plugin-writevirtualmemmon],
+    [Enable the windows kernel bugcheck watching plugin @<:@yes@:>@])],
+  [plugin_writevirtualmemmon="$enableval"],
+  [plugin_writevirtualmemmon="yes"])
+AM_CONDITIONAL([PLUGIN_WRITEVIRTUALMEMMON], [test x$plugin_writevirtualmemmon = xyes])
+if test x$plugin_writevirtualmemmon = xyes; then
+  AC_DEFINE_UNQUOTED(ENABLE_PLUGIN_WRITEVIRTUALMEMMON, 1, "")
+fi
+
 #####################################################
 
 AC_ARG_ENABLE([hardening],
@@ -533,24 +543,25 @@ Build system type: $build
 Installation prefix: $prefix
 -------------------------------------------------------------------------------
 DRAKVUF Plugins
-Syscalls:     $plugin_syscalls
-Poolmon:      $plugin_poolmon
-Filetracer:   $plugin_filetracer
-Filedelete:   $plugin_filedelete
-Objmon:       $plugin_objmon
-Exmon:        $plugin_exmon
-SSDTmon:      $plugin_ssdtmon
-CPUIDmon:     $plugin_cpuidmon
-Debugmon:     $plugin_debugmon
-Socketmon:    $plugin_socketmon
-Regmon:       $plugin_regmon
-Procmon:      $plugin_procmon
-BSODmon:      $plugin_bsodmon
-EnvMon:       $plugin_envmon
-CrashMon:     $plugin_crashmon
-ClipboardMon: $plugin_clipboardmon
-WindowMon:    $plugin_windowmon
-LibraryMon:   $plugin_librarymon
-DKOMmon:      $plugin_dkommon
-WMIMon:       $plugin_wmimon
+Syscalls:           $plugin_syscalls
+Poolmon:            $plugin_poolmon
+Filetracer:         $plugin_filetracer
+Filedelete:         $plugin_filedelete
+Objmon:             $plugin_objmon
+Exmon:              $plugin_exmon
+SSDTmon:            $plugin_ssdtmon
+CPUIDmon:           $plugin_cpuidmon
+Debugmon:           $plugin_debugmon
+Socketmon:          $plugin_socketmon
+Regmon:             $plugin_regmon
+Procmon:            $plugin_procmon
+BSODmon:            $plugin_bsodmon
+EnvMon:             $plugin_envmon
+CrashMon:           $plugin_crashmon
+ClipboardMon:       $plugin_clipboardmon
+WindowMon:          $plugin_windowmon
+LibraryMon:         $plugin_librarymon
+DKOMmon:            $plugin_dkommon
+WMIMon:             $plugin_wmimon
+writevirtualmemmon: $plugin_writevirtualmemmon
 -------------------------------------------------------------------------------])

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -256,6 +256,10 @@ int main(int argc, char** argv)
                 "\t --rekall-wow-ole32 <rekall profile>\n"
                 "\t                           The Rekall profile for SysWOW64/ole32.dll\n"
 #endif
+#ifdef ENABLE_PLUGIN_WRITEVIRTUALMEMMON
+                "\t --virtualmemdump-dir <file dump folder>\n"
+                "\t                           Folder where dumped memory should be stored\n"
+#endif
                );
         return rc;
     }
@@ -272,6 +276,7 @@ int main(int argc, char** argv)
         opt_rekall_mpr,
         opt_rekall_ole32,
         opt_rekall_wow_ole32,
+        opt_virtualmemdump_dir,
     };
     const option long_opts[] =
     {
@@ -290,6 +295,7 @@ int main(int argc, char** argv)
         {"verbose", no_argument, NULL, 'v'},
         {"rekall-ole32", required_argument, NULL, opt_rekall_ole32},
         {"rekall-wow-ole32", required_argument, NULL, opt_rekall_wow_ole32},
+        {"virtualmemdump-dir", required_argument, NULL, opt_virtualmemdump_dir},
         {NULL, 0, NULL, 0}
     };
     const char* opts = "r:d:i:I:e:m:t:D:o:vx:a:spT:S:Mc:nblgj:w:W:";
@@ -430,6 +436,12 @@ int main(int argc, char** argv)
                 options.wow_ole32_profile = optarg;
                 break;
 #endif
+#ifdef ENABLE_PLUGIN_WRITEVIRTUALMEMMON
+            case opt_virtualmemdump_dir:
+                options.virtualmemdump_dir = optarg;
+                break;
+#endif
+
             default:
                 if (isalnum(c))
                     fprintf(stderr, "Unrecognized option: %c\n", c);

--- a/src/plugins/Makefile.am
+++ b/src/plugins/Makefile.am
@@ -190,6 +190,10 @@ if PLUGIN_WMIMON
 sources += wmimon/wmimon.cpp
 endif
 
+if PLUGIN_WRITEVIRTUALMEMMON
+sources +=writevirtualmemmon/writevirtualmemmon.cpp
+endif
+
 ###############################################################################
 sources += plugins.cpp plugins.h plugins_ex.cpp plugins_ex.h plugin_utils.cpp plugin_utils.h
 

--- a/src/plugins/plugins.cpp
+++ b/src/plugins/plugins.cpp
@@ -125,6 +125,7 @@
 #include "librarymon/librarymon.h"
 #include "dkommon/dkommon.h"
 #include "wmimon/wmimon.h"
+#include "writevirtualmemmon/writevirtualmemmon.h"
 
 drakvuf_plugins::drakvuf_plugins(const drakvuf_t _drakvuf, output_format_t _output, os_t _os)
     : drakvuf{ _drakvuf }, output{ _output }, os{ _os }
@@ -312,6 +313,11 @@ int drakvuf_plugins::start(const drakvuf_plugin_t plugin_id,
                     this->plugins[plugin_id] = new wmimon(this->drakvuf, &config, this->output);
                     break;
                 }
+#endif
+#ifdef ENABLE_PLUGIN_WRITEVIRTUALMEMMON
+                case PLUGIN_WRITEVIRTUALMEMMON:
+                    this->plugins[plugin_id] = new writevirtualmemmon(this->drakvuf, this->output);
+                    break;
 #endif
                 case __DRAKVUF_PLUGIN_LIST_MAX: /* fall-through */
                 default:

--- a/src/plugins/plugins.cpp
+++ b/src/plugins/plugins.cpp
@@ -316,8 +316,14 @@ int drakvuf_plugins::start(const drakvuf_plugin_t plugin_id,
 #endif
 #ifdef ENABLE_PLUGIN_WRITEVIRTUALMEMMON
                 case PLUGIN_WRITEVIRTUALMEMMON:
-                    this->plugins[plugin_id] = new writevirtualmemmon(this->drakvuf, this->output);
+                {
+                    writevirtualmemmon_config config =
+                    {
+                        .dump_folder = options->virtualmemdump_dir,
+                    };
+                    this->plugins[plugin_id] = new writevirtualmemmon(this->drakvuf, &config, this->output);
                     break;
+                }
 #endif
                 case __DRAKVUF_PLUGIN_LIST_MAX: /* fall-through */
                 default:

--- a/src/plugins/plugins.h
+++ b/src/plugins/plugins.h
@@ -130,6 +130,7 @@ struct plugins_options
     const char* ntdll_profile;          // PLUGIN_LIBRARYMON
     const char* ole32_profile;          // PLUGIN_WMIMON
     const char* wow_ole32_profile;      // PLUGIN_WMIMON
+    const char* virtualmemdump_dir;     // PLUGIN_WRITEVIRTUALMEMMON
 };
 
 typedef enum drakvuf_plugin

--- a/src/plugins/writevirtualmemmon/writevirtualmemmon.cpp
+++ b/src/plugins/writevirtualmemmon/writevirtualmemmon.cpp
@@ -143,7 +143,7 @@ static void extract_memory_allocation(drakvuf_t drakvuf, const drakvuf_trap_info
         ctx.addr = buffer_val;
         if ( VMI_FAILURE != vmi_read(vmi, &ctx, buffer_size_val, content, NULL )){
             char* filename = NULL;
-            if(asprintf(&filename, "%s/" FORMAT_TIMEVAL "_%lu_write.bin", wvm->dump_folder, UNPACK_TIMEVAL(info->timestamp), buffer_val) >= 0){
+            if(asprintf(&filename, "%s/" FORMAT_TIMEVAL "_%d_write.bin", wvm->dump_folder, UNPACK_TIMEVAL(info->timestamp), info->proc_data.pid) >= 0){
                 FILE* file = fopen(filename, "wb");
                 fwrite(content, 1, buffer_size_val, file);
                 fclose(file);

--- a/src/plugins/writevirtualmemmon/writevirtualmemmon.h
+++ b/src/plugins/writevirtualmemmon/writevirtualmemmon.h
@@ -102,175 +102,31 @@
  *                                                                         *
  ***************************************************************************/
 
-#ifndef DRAKVUF_PLUGINS_H
-#define DRAKVUF_PLUGINS_H
+#ifndef WRITEVIRTUALMEMMON_H
+#define WRITEVIRTUALMEMMON_H
 
-#include <config.h>
-#include <stdlib.h>
-#include <inttypes.h>
-#include <sys/time.h>
-#include <libdrakvuf/libdrakvuf.h>
+#include <glib.h>
+#include "plugins/plugins.h"
+#include "plugins/private.h"
 
-struct plugins_options
+class writevirtualmemmon: public plugin
 {
-    const char* dump_folder;            // PLUGIN_FILEDELETE
-    bool dump_modified_files;           // PLUGIN_FILEDELETE
-    bool filedelete_use_injector;       // PLUGIN_FILEDELETE
-    bool cpuid_stealth;                 // PLUGIN_CPUIDMON
-    const char* tcpip_profile;          // PLUGIN_SOCKETMON
-    const char* win32k_profile;         // PLUGIN_CLIPBOARDMON, PLUGIN_WINDOWMON
-    const char* sspicli_profile;        // PLUGIN_ENVMON
-    const char* kernel32_profile;       // PLUGIN_ENVMON
-    const char* kernelbase_profile;     // PLUGIN_ENVMON
-    const char* wow_kernel32_profile;   // PLUGIN_ENVMON
-    const char* iphlpapi_profile;       // PLUGIN_ENVMON
-    const char* mpr_profile;            // PLUGIN_ENVMON
-    const char* syscalls_filter_file;   // PLUGIN_SYSCALLS
-    bool abort_on_bsod;                 // PLUGIN_BSODMON
-    const char* ntdll_profile;          // PLUGIN_LIBRARYMON
-    const char* ole32_profile;          // PLUGIN_WMIMON
-    const char* wow_ole32_profile;      // PLUGIN_WMIMON
-};
-
-typedef enum drakvuf_plugin
-{
-    PLUGIN_SYSCALLS,
-    PLUGIN_POOLMON,
-    PLUGIN_FILETRACER,
-    PLUGIN_FILEDELETE,
-    PLUGIN_OBJMON,
-    PLUGIN_EXMON,
-    PLUGIN_SSDTMON,
-    PLUGIN_DEBUGMON,
-    PLUGIN_DELAYMON,
-    PLUGIN_CPUIDMON,
-    PLUGIN_SOCKETMON,
-    PLUGIN_REGMON,
-    PLUGIN_PROCMON,
-    PLUGIN_BSODMON,
-    PLUGIN_ENVMON,
-    PLUGIN_CRASHMON,
-    PLUGIN_CLIPBOARDMON,
-    PLUGIN_WINDOWMON,
-    PLUGIN_LIBRARYMON,
-    PLUGIN_DKOMMON,
-    PLUGIN_WMIMON,
-    PLUGIN_WRITEVIRTUALMEMMON,
-    __DRAKVUF_PLUGIN_LIST_MAX
-} drakvuf_plugin_t;
-
-static const char* drakvuf_plugin_names[] =
-{
-    [PLUGIN_SYSCALLS] = "syscalls",
-    [PLUGIN_POOLMON] = "poolmon",
-    [PLUGIN_FILETRACER] = "filetracer",
-    [PLUGIN_FILEDELETE] = "filedelete",
-    [PLUGIN_OBJMON] = "objmon",
-    [PLUGIN_EXMON] = "exmon",
-    [PLUGIN_SSDTMON] = "ssdtmon",
-    [PLUGIN_DEBUGMON] = "debugmon",
-    [PLUGIN_DELAYMON] = "delaymon",
-    [PLUGIN_CPUIDMON] = "cpuidmon",
-    [PLUGIN_SOCKETMON] = "socketmon",
-    [PLUGIN_REGMON] = "regmon",
-    [PLUGIN_PROCMON] = "procmon",
-    [PLUGIN_BSODMON] = "bsodmon",
-    [PLUGIN_ENVMON] = "envmon",
-    [PLUGIN_CRASHMON] = "crashmon",
-    [PLUGIN_CLIPBOARDMON] = "clipboardmon",
-    [PLUGIN_WINDOWMON] = "windowmon",
-    [PLUGIN_LIBRARYMON] = "librarymon",
-    [PLUGIN_DKOMMON] = "dkommon",
-    [PLUGIN_WMIMON] = "wmimon",
-    [PLUGIN_WRITEVIRTUALMEMMON] = "writevirtualmemmon",
-};
-
-static const bool drakvuf_plugin_os_support[__DRAKVUF_PLUGIN_LIST_MAX][VMI_OS_WINDOWS+1] =
-{
-    [PLUGIN_SYSCALLS]                 = { [VMI_OS_WINDOWS] = 1, [VMI_OS_LINUX] = 1 },
-    [PLUGIN_POOLMON]                  = { [VMI_OS_WINDOWS] = 1, [VMI_OS_LINUX] = 0 },
-    [PLUGIN_FILETRACER]               = { [VMI_OS_WINDOWS] = 1, [VMI_OS_LINUX] = 0 },
-    [PLUGIN_FILEDELETE]               = { [VMI_OS_WINDOWS] = 1, [VMI_OS_LINUX] = 0 },
-    [PLUGIN_OBJMON]                   = { [VMI_OS_WINDOWS] = 1, [VMI_OS_LINUX] = 0 },
-    [PLUGIN_EXMON]                    = { [VMI_OS_WINDOWS] = 1, [VMI_OS_LINUX] = 0 },
-    [PLUGIN_SSDTMON]                  = { [VMI_OS_WINDOWS] = 1, [VMI_OS_LINUX] = 0 },
-    [PLUGIN_DEBUGMON]                 = { [VMI_OS_WINDOWS] = 1, [VMI_OS_LINUX] = 1 },
-    [PLUGIN_DELAYMON]                 = { [VMI_OS_WINDOWS] = 1, [VMI_OS_LINUX] = 0 },
-    [PLUGIN_CPUIDMON]                 = { [VMI_OS_WINDOWS] = 1, [VMI_OS_LINUX] = 1 },
-    [PLUGIN_SOCKETMON]                = { [VMI_OS_WINDOWS] = 1, [VMI_OS_LINUX] = 0 },
-    [PLUGIN_REGMON]                   = { [VMI_OS_WINDOWS] = 1, [VMI_OS_LINUX] = 0 },
-    [PLUGIN_PROCMON]                  = { [VMI_OS_WINDOWS] = 1, [VMI_OS_LINUX] = 0 },
-    [PLUGIN_BSODMON]                  = { [VMI_OS_WINDOWS] = 1, [VMI_OS_LINUX] = 0 },
-    [PLUGIN_ENVMON]                   = { [VMI_OS_WINDOWS] = 1, [VMI_OS_LINUX] = 0 },
-    [PLUGIN_CRASHMON]                 = { [VMI_OS_WINDOWS] = 1, [VMI_OS_LINUX] = 0 },
-    [PLUGIN_CLIPBOARDMON]             = { [VMI_OS_WINDOWS] = 1, [VMI_OS_LINUX] = 0 },
-    [PLUGIN_WINDOWMON]                = { [VMI_OS_WINDOWS] = 1, [VMI_OS_LINUX] = 0 },
-    [PLUGIN_LIBRARYMON]               = { [VMI_OS_WINDOWS] = 1, [VMI_OS_LINUX] = 0 },
-    [PLUGIN_DKOMMON]                  = { [VMI_OS_WINDOWS] = 1, [VMI_OS_LINUX] = 0 },
-    [PLUGIN_WMIMON]                   = { [VMI_OS_WINDOWS] = 1, [VMI_OS_LINUX] = 0 },
-    [PLUGIN_WRITEVIRTUALMEMMON]       = { [VMI_OS_WINDOWS] = 1, [VMI_OS_LINUX] = 0 },
-};
-
-class plugin
-{
-public:
-    virtual ~plugin() = default;
-};
-
-class drakvuf_plugins
-{
-private:
-    drakvuf_t drakvuf;
-    output_format_t output;
-    os_t os;
-    plugin* plugins[__DRAKVUF_PLUGIN_LIST_MAX] = { [0 ... __DRAKVUF_PLUGIN_LIST_MAX-1] = nullptr };
 
 public:
-    drakvuf_plugins(drakvuf_t drakvuf, output_format_t output, os_t os);
-    ~drakvuf_plugins();
-    int start(drakvuf_plugin_t plugin, const plugins_options* config);
-};
-
-/***************************************************************************/
-
-struct vmi_lock_guard
-{
-    vmi_lock_guard(drakvuf_t drakvuf_) : drakvuf(drakvuf_), vmi()
+    output_format_t format;
+    drakvuf_trap_t trap =
     {
-        lock();
-    }
+        // TODO: check in depth the lookup type
+        .breakpoint.lookup_type = LOOKUP_PID,
+        .breakpoint.pid = 4,
+        .breakpoint.addr_type = ADDR_RVA,
+        .breakpoint.module = "ntoskrnl.exe",
+        .type = BREAKPOINT,
+        .data = (void*)this
+    };
 
-    vmi_instance_t lock()
-    {
-        if (!vmi)
-            vmi = drakvuf_lock_and_get_vmi(drakvuf);
-
-        return vmi;
-    }
-
-    bool unlock()
-    {
-        if (vmi)
-        {
-            drakvuf_release_vmi(drakvuf);
-            vmi = nullptr;
-            return true;
-        }
-        return false;
-
-    }
-
-    bool is_lock() const { return vmi == nullptr ? true : false; }
-
-    operator vmi_instance_t() const { return vmi; }
-
-    ~vmi_lock_guard()
-    {
-        unlock();
-    }
-
-    drakvuf_t drakvuf;
-    vmi_instance_t vmi;
+    writevirtualmemmon(drakvuf_t drakvuf, output_format_t output);
+    ~writevirtualmemmon();
 };
 
 #endif

--- a/src/plugins/writevirtualmemmon/writevirtualmemmon.h
+++ b/src/plugins/writevirtualmemmon/writevirtualmemmon.h
@@ -109,11 +109,17 @@
 #include "plugins/plugins.h"
 #include "plugins/private.h"
 
+struct writevirtualmemmon_config
+{
+    const char* dump_folder;
+};
+
 class writevirtualmemmon: public plugin
 {
 
 public:
     output_format_t format;
+    const char* dump_folder;
     drakvuf_trap_t trap =
     {
         // TODO: check in depth the lookup type
@@ -125,7 +131,7 @@ public:
         .data = (void*)this
     };
 
-    writevirtualmemmon(drakvuf_t drakvuf, output_format_t output);
+    writevirtualmemmon(drakvuf_t drakvuf, writevirtualmemmon_config* config, output_format_t output);
     ~writevirtualmemmon();
 };
 


### PR DESCRIPTION
Implementation of the feature discussed in #650
This plugin logs and allows to dump the memory written by the NtWriteVirtualMemory system call.
The dump folder is chosen with the  ```--virtualmemdump ``` argument. 