### PR TITLE
Extend memdump plugin: track NtWriteVirtualMemory (integrate alexmocha's code)

### DIFF
--- a/src/libdrakvuf/libdrakvuf.h
+++ b/src/libdrakvuf/libdrakvuf.h
@@ -540,6 +540,8 @@ addr_t drakvuf_get_function_argument(drakvuf_t drakvuf,
                                      drakvuf_trap_info_t* info,
                                      int argument_number);
 
+status_t drakvuf_get_pid_from_handle(drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t handle, vmi_pid_t* pid);
+
 /*---------------------------------------------------------
  * Event FD functions
  */

--- a/src/libdrakvuf/os.c
+++ b/src/libdrakvuf/os.c
@@ -374,3 +374,11 @@ status_t drakvuf_find_mmvad(drakvuf_t drakvuf, addr_t eprocess, addr_t vaddr, mm
 
     return 0;
 }
+
+status_t drakvuf_get_pid_from_handle(drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t handle, vmi_pid_t* pid)
+{
+    if ( drakvuf->osi.get_pid_from_handle )
+        return drakvuf->osi.get_pid_from_handle(drakvuf, info, handle, pid);
+
+    return 0;
+}

--- a/src/libdrakvuf/os.h
+++ b/src/libdrakvuf/os.h
@@ -199,6 +199,9 @@ typedef struct os_interface
     status_t (*find_mmvad)
     (drakvuf_t drakvuf, addr_t eprocess, addr_t vaddr, mmvad_info_t* out_mmvad);
 
+    status_t (*get_pid_from_handle)
+    (drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t handle, vmi_pid_t* pid);
+
 } os_interface_t;
 
 bool set_os_windows(drakvuf_t drakvuf);

--- a/src/libdrakvuf/win-processes.c
+++ b/src/libdrakvuf/win-processes.c
@@ -1016,5 +1016,5 @@ status_t win_get_pid_from_handle(drakvuf_t drakvuf, drakvuf_trap_info_t* info, a
     }
 
     addr_t eprocess_base = obj + drakvuf->offsets[OBJECT_HEADER_BODY];
-    return drakvuf_get_process_pid(drakvuf, eprocess_base, pid) == VMI_SUCCESS;
+    return drakvuf_get_process_pid(drakvuf, eprocess_base, pid);
 }

--- a/src/libdrakvuf/win-processes.c
+++ b/src/libdrakvuf/win-processes.c
@@ -995,3 +995,26 @@ status_t win_find_mmvad(drakvuf_t drakvuf, addr_t eprocess, addr_t vaddr, mmvad_
 
     return VMI_FAILURE;
 }
+
+status_t win_get_pid_from_handle(drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t handle, vmi_pid_t* pid)
+{
+    if (handle == 0 || handle == UINT64_MAX)
+    {
+        *pid = info->proc_data.pid;
+        return VMI_SUCCESS;
+    }
+
+    if (!info->proc_data.base_addr)
+    {
+        return VMI_FAILURE;
+    }
+
+    addr_t obj = drakvuf_get_obj_by_handle(drakvuf, info->proc_data.base_addr, handle);
+    if (!obj)
+    {
+        return VMI_FAILURE;
+    }
+
+    addr_t eprocess_base = obj + drakvuf->offsets[OBJECT_HEADER_BODY];
+    return drakvuf_get_process_pid(drakvuf, eprocess_base, pid) == VMI_SUCCESS;
+}

--- a/src/libdrakvuf/win.c
+++ b/src/libdrakvuf/win.c
@@ -472,6 +472,7 @@ bool set_os_windows(drakvuf_t drakvuf)
     drakvuf->osi.enumerate_processes_with_module = win_enumerate_processes_with_module;
     drakvuf->osi.is_crashreporter = win_is_crashreporter;
     drakvuf->osi.find_mmvad = win_find_mmvad;
+    drakvuf->osi.get_pid_from_handle = win_get_pid_from_handle;
 
     return true;
 }

--- a/src/libdrakvuf/win.h
+++ b/src/libdrakvuf/win.h
@@ -168,4 +168,6 @@ bool win_inject_traps_modules(drakvuf_t drakvuf, drakvuf_trap_t* trap, addr_t li
 
 status_t win_find_mmvad(drakvuf_t drakvuf, addr_t eprocess, addr_t vaddr, mmvad_info_t* out_mmvad);
 
+status_t win_get_pid_from_handle(drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t handle, vmi_pid_t* pid);
+
 #endif

--- a/src/plugins/memdump/memdump.cpp
+++ b/src/plugins/memdump/memdump.cpp
@@ -308,7 +308,8 @@ static event_response_t free_virtual_memory_hook_cb(drakvuf_t drakvuf, drakvuf_t
         return VMI_EVENT_RESPONSE_NONE;
 
     vmi_instance_t vmi = drakvuf_lock_and_get_vmi(drakvuf);
-    access_context_t ctx = {
+    access_context_t ctx =
+    {
         .translate_mechanism = VMI_TM_PROCESS_DTB,
         .dtb = info->regs->cr3,
         .addr = mem_base_address_ptr
@@ -412,7 +413,8 @@ static event_response_t write_virtual_memory_hook_cb(drakvuf_t drakvuf, drakvuf_
         return VMI_EVENT_RESPONSE_NONE;
 
     vmi_instance_t vmi = drakvuf_lock_and_get_vmi(drakvuf);
-    access_context_t ctx = {
+    access_context_t ctx =
+    {
         .translate_mechanism = VMI_TM_PROCESS_DTB,
         .dtb = info->regs->cr3,
         .addr = buffer_ptr

--- a/src/plugins/memdump/memdump.cpp
+++ b/src/plugins/memdump/memdump.cpp
@@ -111,8 +111,6 @@
 
 #define DUMP_NAME_PLACEHOLDER "(not configured)"
 
-// TODO move to common library, this is also used in procmon
-
 /**
  * Dumps the memory specified by access context, from `ctx->addr` (first byte) to `ctx->addr + len_bytes - 1` (last byte).
  * File is stored in a path provided in --memdump-dir command line option and named according to the scheme:

--- a/src/plugins/memdump/memdump.cpp
+++ b/src/plugins/memdump/memdump.cpp
@@ -448,7 +448,7 @@ memdump::memdump(drakvuf_t drakvuf, const memdump_config* c, output_format_t out
 
     breakpoint_in_system_process_searcher bp;
     if (!register_trap<memdump>(drakvuf, nullptr, this, free_virtual_memory_hook_cb, bp.for_syscall_name("NtFreeVirtualMemory")) ||
-            !register_trap<memdump>(drakvuf, nullptr, this, write_virtual_memory_hook_cb, bp.for_syscall_name("NtWriteVirtualMemory")))
+        !register_trap<memdump>(drakvuf, nullptr, this, write_virtual_memory_hook_cb, bp.for_syscall_name("NtWriteVirtualMemory")))
     {
         throw -1;
     }

--- a/src/plugins/memdump/memdump.cpp
+++ b/src/plugins/memdump/memdump.cpp
@@ -308,8 +308,11 @@ static event_response_t free_virtual_memory_hook_cb(drakvuf_t drakvuf, drakvuf_t
         return VMI_EVENT_RESPONSE_NONE;
 
     vmi_instance_t vmi = drakvuf_lock_and_get_vmi(drakvuf);
-    access_context_t ctx = { .translate_mechanism = VMI_TM_PROCESS_DTB, .dtb = info->regs->cr3 };
-    ctx.addr = mem_base_address_ptr;
+    access_context_t ctx = {
+        .translate_mechanism = VMI_TM_PROCESS_DTB,
+        .dtb = info->regs->cr3,
+        .addr = mem_base_address_ptr
+    };
 
     addr_t mem_base_address;
 
@@ -409,8 +412,11 @@ static event_response_t write_virtual_memory_hook_cb(drakvuf_t drakvuf, drakvuf_
         return VMI_EVENT_RESPONSE_NONE;
 
     vmi_instance_t vmi = drakvuf_lock_and_get_vmi(drakvuf);
-    access_context_t ctx = { .translate_mechanism = VMI_TM_PROCESS_DTB, .dtb = info->regs->cr3 };
-    ctx.addr = buffer_ptr;
+    access_context_t ctx = {
+        .translate_mechanism = VMI_TM_PROCESS_DTB,
+        .dtb = info->regs->cr3,
+        .addr = buffer_ptr
+    };
 
     vmi_pid_t target_pid;
     addr_t process_addr = 0;

--- a/src/plugins/memdump/memdump.h
+++ b/src/plugins/memdump/memdump.h
@@ -119,6 +119,7 @@ class memdump: public pluginex
 public:
     const char* memdump_dir;
     int memdump_counter;
+    addr_t object_header_body;
 
     memdump(drakvuf_t drakvuf, const memdump_config* config, output_format_t output);
 };

--- a/src/plugins/memdump/memdump.h
+++ b/src/plugins/memdump/memdump.h
@@ -119,7 +119,6 @@ class memdump: public pluginex
 public:
     const char* memdump_dir;
     int memdump_counter;
-    addr_t object_header_body;
 
     memdump(drakvuf_t drakvuf, const memdump_config* config, output_format_t output);
 };

--- a/src/plugins/procmon/procmon.cpp
+++ b/src/plugins/procmon/procmon.cpp
@@ -294,26 +294,6 @@ static void print_process_creation_result(
         vmi_free_unicode_str(dllpath_us);
 }
 
-static vmi_pid_t get_pid_from_handle(procmon* f, drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t handle)
-{
-    if (handle == 0 || handle == UINT64_MAX)
-        return info->proc_data.pid;
-
-    if (!info->proc_data.base_addr)
-        return 0;
-
-    addr_t obj = drakvuf_get_obj_by_handle(drakvuf, info->proc_data.base_addr, handle);
-    if (!obj)
-        return 0;
-
-    vmi_pid_t pid;
-    addr_t eprocess_base = obj + f->object_header_body;
-    if (VMI_FAILURE == drakvuf_get_process_pid(drakvuf, eprocess_base, &pid))
-        return 0;
-
-    return pid;
-}
-
 static event_response_t process_creation_return_hook(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 {
     auto data = get_trap_params<procmon, process_creation_result_t<procmon>>(info);
@@ -347,7 +327,9 @@ static event_response_t process_creation_return_hook(drakvuf_t drakvuf, drakvuf_
 
     drakvuf_release_vmi(drakvuf);
 
-    vmi_pid_t new_pid = get_pid_from_handle(plugin, drakvuf, info, new_process_handle);
+    vmi_pid_t new_pid;
+    if (drakvuf_get_pid_from_handle(drakvuf, info, new_process_handle, &new_pid) != VMI_SUCCESS)
+        new_pid = 0;
 
     print_process_creation_result(plugin, drakvuf, info, status, new_pid, user_process_parameters_addr);
     return VMI_EVENT_RESPONSE_NONE;
@@ -393,7 +375,9 @@ static event_response_t terminate_process_hook(
     if (!plugin)
         return VMI_EVENT_RESPONSE_NONE;
 
-    vmi_pid_t exit_pid = get_pid_from_handle(plugin, drakvuf, info, process_handle);
+    vmi_pid_t exit_pid;
+    if (drakvuf_get_pid_from_handle(drakvuf, info, process_handle, &exit_pid) != VMI_SUCCESS)
+        exit_pid = 0;
 
     char exit_status_buf[NTSTATUS_MAX_FORMAT_STR_SIZE] = {0};
     const char* exit_status_str = ntstatus_to_string(ntstatus_t(exit_status));
@@ -730,8 +714,6 @@ procmon::procmon(drakvuf_t drakvuf, output_format_t output)
 
     this->current_directory_handle = current_directory_offset + curdir_handle_offset;
     this->current_directory_dospath = current_directory_offset + curdir_dospath_offset;
-    if (!drakvuf_get_struct_member_rva(drakvuf, "_OBJECT_HEADER", "Body", &this->object_header_body))
-        throw -1;
 
     breakpoint_in_system_process_searcher bp;
     if (!register_trap<procmon>(drakvuf, nullptr, this, create_user_process_hook_cb, bp.for_syscall_name("NtCreateUserProcess")) ||

--- a/src/plugins/procmon/procmon.h
+++ b/src/plugins/procmon/procmon.h
@@ -117,7 +117,6 @@ public:
     addr_t dll_path;
     addr_t current_directory_handle;
     addr_t current_directory_dospath;
-    addr_t object_header_body;
 
     procmon(drakvuf_t drakvuf, output_format_t output);
 };


### PR DESCRIPTION
Integrated @alexmocha code from PR #655 into `memdump` plugin.

In case of `NtWriteVirtualMemory` it is very important to log some non-standard parameters like target process PID (to whom the write was done) and target base address. Thus, `dump_memory_region` now accepts `printout_extras` callback, which is capable of adding some syscall-specific things to the printouts.