### PR TITLE
rekall: fix rekall_get_os_type when ProfileClass value is just "Nt"

### DIFF
--- a/src/libdrakvuf/rekall-profile.c
+++ b/src/libdrakvuf/rekall-profile.c
@@ -363,6 +363,8 @@ os_t rekall_get_os_type(json_object* rekall_profile_json)
         ret = VMI_OS_WINDOWS;
     else if ( !strcmp(kernel, "Ntkrpamp") )
         ret = VMI_OS_WINDOWS;
+    else if ( !strcmp(kernel, "Nt") )
+        ret = VMI_OS_WINDOWS;
 
 err_exit:
 


### PR DESCRIPTION
Som rekall profiles from https://github.com/google/rekall-profiles have a `ProfileClass` that contains only `Nt`.

You can `gunzip -d` the first one from this list to confirm (`0018A9A7F0334E8D965F310D1653A5452.gz`):
https://github.com/google/rekall-profiles/tree/gh-pages/v1.0/nt/GUID