### PR TITLE
memdump: Dumps based on stack inspection

### DIFF
--- a/src/libdrakvuf/drakvuf.c
+++ b/src/libdrakvuf/drakvuf.c
@@ -552,6 +552,16 @@ json_object* drakvuf_get_rekall_profile_json(drakvuf_t drakvuf)
     return drakvuf->rekall_profile_json;
 }
 
+const char* drakvuf_get_rekall_wow_profile(drakvuf_t drakvuf)
+{
+    return drakvuf->rekall_wow_profile;
+}
+
+json_object* drakvuf_get_rekall_wow_profile_json(drakvuf_t drakvuf)
+{
+    return drakvuf->rekall_wow_profile_json;
+}
+
 addr_t drakvuf_get_kernel_base(drakvuf_t drakvuf)
 {
     return drakvuf->kernbase;

--- a/src/libdrakvuf/libdrakvuf.h
+++ b/src/libdrakvuf/libdrakvuf.h
@@ -364,6 +364,8 @@ page_mode_t drakvuf_get_page_mode(drakvuf_t drakvuf);
 int drakvuf_get_address_width(drakvuf_t drakvuf);
 const char* drakvuf_get_rekall_profile(drakvuf_t drakvuf);
 json_object* drakvuf_get_rekall_profile_json(drakvuf_t drakvuf);
+const char* drakvuf_get_rekall_wow_profile(drakvuf_t drakvuf);
+json_object* drakvuf_get_rekall_wow_profile_json(drakvuf_t drakvuf);
 
 addr_t drakvuf_get_kernel_base(drakvuf_t drakvuf);
 
@@ -413,6 +415,7 @@ typedef struct _mmvad_info
 
 bool drakvuf_find_mmvad(drakvuf_t drakvuf, addr_t eprocess, addr_t vaddr, mmvad_info_t* out_mmvad);
 
+addr_t drakvuf_get_wow_peb(drakvuf_t drakvuf, access_context_t* ctx, addr_t eprocess);
 bool drakvuf_get_wow_context(drakvuf_t drakvuf, addr_t ethread, addr_t* wow_ctx);
 bool drakvuf_get_user_stack32(drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t* stack_ptr, addr_t* frame_ptr);
 bool drakvuf_get_user_stack64(drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t* stack_ptr);
@@ -479,6 +482,11 @@ bool drakvuf_is_crashreporter(drakvuf_t drakvuf,
 bool drakvuf_get_module_list(drakvuf_t drakvuf,
                              addr_t process_base,
                              addr_t* module_list);
+
+bool drakvuf_get_module_list_wow(drakvuf_t drakvuf,
+                                 access_context_t* ctx,
+                                 addr_t wow_peb,
+                                 addr_t* module_list);
 
 // ObReferenceObjectByHandle
 bool drakvuf_obj_ref_by_handle(drakvuf_t drakvuf,

--- a/src/libdrakvuf/os.c
+++ b/src/libdrakvuf/os.c
@@ -251,6 +251,14 @@ bool drakvuf_get_module_list(drakvuf_t drakvuf, addr_t process_base, addr_t* mod
     return 0;
 }
 
+bool drakvuf_get_module_list_wow( drakvuf_t drakvuf, access_context_t* ctx, addr_t wow_peb, addr_t* module_list )
+{
+    if ( drakvuf->osi.get_module_list_wow )
+        return drakvuf->osi.get_module_list_wow(drakvuf, ctx, wow_peb, module_list);
+
+    return 0;
+}
+
 bool drakvuf_find_process(drakvuf_t drakvuf, vmi_pid_t find_pid, const char* find_procname, addr_t* process_addr)
 {
     if ( drakvuf->osi.find_process )
@@ -403,6 +411,14 @@ bool drakvuf_get_user_stack64(drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr
 {
     if ( drakvuf->osi.get_user_stack64 )
         return drakvuf->osi.get_user_stack64(drakvuf, info, stack_ptr);
+
+    return 0;
+}
+
+addr_t drakvuf_get_wow_peb(drakvuf_t drakvuf, access_context_t* ctx, addr_t eprocess)
+{
+    if ( drakvuf->osi.get_wow_peb )
+        return drakvuf->osi.get_wow_peb(drakvuf, ctx, eprocess);
 
     return 0;
 }

--- a/src/libdrakvuf/os.h
+++ b/src/libdrakvuf/os.h
@@ -154,6 +154,9 @@ typedef struct os_interface
     bool (*get_module_list)
     (drakvuf_t drakvuf, addr_t process_base, addr_t* module_list);
 
+    bool (*get_module_list_wow)
+    (drakvuf_t drakvuf, access_context_t* ctx, addr_t wow_peb, addr_t* module_list);
+
     bool (*find_process)
     (drakvuf_t drakvuf, vmi_pid_t find_pid, const char* find_procname, addr_t* process_addr);
 
@@ -210,6 +213,9 @@ typedef struct os_interface
 
     bool (*get_user_stack64)
     (drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t* stack_ptr);
+
+    addr_t (*get_wow_peb)
+    (drakvuf_t drakvuf, access_context_t* ctx, addr_t eprocess);
 
 } os_interface_t;
 

--- a/src/libdrakvuf/win-processes.c
+++ b/src/libdrakvuf/win-processes.c
@@ -130,10 +130,8 @@ typedef enum dispatcher_object
     DISPATCHER_THREAD_OBJECT  = 6
 } dispatcher_object_t ;
 
-bool win_get_module_list_wow( drakvuf_t drakvuf, access_context_t* ctx, addr_t wow_peb, addr_t* module_list );
 bool win_search_modules( drakvuf_t drakvuf, const char* module_name, bool (*visitor_func)(drakvuf_t drakvuf, const module_info_t* module_info, void* visitor_ctx), void* visitor_ctx, addr_t eprocess_addr, addr_t wow_process, vmi_pid_t pid, access_context_t* ctx );
 bool win_search_modules_wow( drakvuf_t drakvuf, const char* module_name, bool (*visitor_func)(drakvuf_t drakvuf, const module_info_t* module_info, void* visitor_ctx), void* visitor_ctx, addr_t eprocess_addr, addr_t wow_peb, vmi_pid_t pid, access_context_t* ctx );
-addr_t win_get_wow_peb( drakvuf_t drakvuf, access_context_t* ctx, addr_t wow_process );
 
 addr_t win_get_current_thread(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 {

--- a/src/libdrakvuf/win.c
+++ b/src/libdrakvuf/win.c
@@ -458,6 +458,7 @@ bool set_os_windows(drakvuf_t drakvuf)
     drakvuf->osi.is_process = win_is_eprocess;
     drakvuf->osi.is_thread = win_is_ethread;
     drakvuf->osi.get_module_list = win_get_module_list;
+    drakvuf->osi.get_module_list_wow = win_get_module_list_wow;
     drakvuf->osi.find_process = win_find_eprocess;
     drakvuf->osi.inject_traps_modules = win_inject_traps_modules;
     drakvuf->osi.exportksym_to_va = ksym2va;
@@ -476,6 +477,7 @@ bool set_os_windows(drakvuf_t drakvuf)
     drakvuf->osi.get_wow_context = win_get_wow_context;
     drakvuf->osi.get_user_stack32 = win_get_user_stack32;
     drakvuf->osi.get_user_stack64 = win_get_user_stack64;
+    drakvuf->osi.get_wow_peb = win_get_wow_peb;
 
     return true;
 }

--- a/src/libdrakvuf/win.h
+++ b/src/libdrakvuf/win.h
@@ -141,6 +141,7 @@ bool win_is_ethread(drakvuf_t drakvuf, addr_t dtb, addr_t ethread_addr);
 bool win_is_eprocess(drakvuf_t drakvuf, addr_t dtb, addr_t eprocess_addr);
 
 bool win_get_module_list(drakvuf_t drakvuf, addr_t eprocess_base, addr_t* module_list);
+bool win_get_module_list_wow( drakvuf_t drakvuf, access_context_t* ctx, addr_t wow_peb, addr_t* module_list );
 
 bool win_get_module_base_addr(drakvuf_t drakvuf, addr_t module_list_head, const char* module_name, addr_t* base_addr_out);
 bool win_get_module_base_addr_ctx(drakvuf_t drakvuf, addr_t module_list_head, access_context_t* ctx, const char* module_name, addr_t* base_addr_out);
@@ -170,6 +171,7 @@ bool win_find_mmvad(drakvuf_t drakvuf, addr_t eprocess, addr_t vaddr, mmvad_info
 
 bool win_get_pid_from_handle(drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t handle, vmi_pid_t* pid);
 
+addr_t win_get_wow_peb(drakvuf_t drakvuf, access_context_t* ctx, addr_t eprocess);
 bool win_get_wow_context(drakvuf_t drakvuf, addr_t ethread, addr_t* wow_ctx);
 bool win_get_user_stack32(drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t* stack_ptr, addr_t* frame_ptr);
 bool win_get_user_stack64(drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t* stack_ptr);

--- a/src/plugins/Makefile.am
+++ b/src/plugins/Makefile.am
@@ -191,7 +191,7 @@ sources += wmimon/wmimon.cpp
 endif
 
 if PLUGIN_MEMDUMP
-sources += memdump/memdump.cpp memdump/userhook.cpp
+sources += memdump/memdump.cpp memdump/userhook.cpp memdump/stack_util.cpp
 endif
 
 ###############################################################################

--- a/src/plugins/memdump/memdump.cpp
+++ b/src/plugins/memdump/memdump.cpp
@@ -291,6 +291,122 @@ done:
     return ret;
 }
 
+static event_response_t terminate_process_hook_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
+{
+    // HANDLE ProcessHandle
+    uint64_t process_handle = drakvuf_get_function_argument(drakvuf, info, 1);
+
+    if (process_handle != 0xffffffffffffffffULL)
+    {
+        PRINT_DEBUG("[MEMDUMP] Process handle not pointing to self, ignore\n");
+        return VMI_EVENT_RESPONSE_NONE;
+    }
+
+    auto plugin = get_trap_plugin<memdump>(info);
+    if (!plugin)
+        return VMI_EVENT_RESPONSE_NONE;
+
+    vmi_instance_t vmi = drakvuf_lock_and_get_vmi(drakvuf);
+    access_context_t ctx =
+    {
+        .translate_mechanism = VMI_TM_PROCESS_DTB,
+        .dtb = info->regs->cr3
+    };
+
+    bool is_32bit;
+    addr_t stack_ptr;
+    addr_t frame_ptr;
+
+    if (drakvuf_get_user_stack32(drakvuf, info, &stack_ptr, &frame_ptr))
+    {
+        is_32bit = true;
+    }
+    else if (drakvuf_get_user_stack64(drakvuf, info, &stack_ptr))
+    {
+        is_32bit = false;
+    }
+    else
+    {
+        PRINT_DEBUG("[MEMDUMP] Failed to get stack pointer\n");
+        drakvuf_release_vmi(drakvuf);
+        return VMI_EVENT_RESPONSE_NONE;
+    }
+
+    PRINT_DEBUG("[MEMDUMP] Got stack pointer: %llx\n", (unsigned long long)stack_ptr);
+
+    size_t bytes_read = 0;
+    uint8_t buf[512];
+    ctx.addr = stack_ptr;
+    vmi_read(vmi, &ctx, 512, buf, &bytes_read);
+
+    for (size_t i = 0; i < bytes_read; i++)
+    {
+        addr_t stack_val = 0;
+        memcpy(&stack_val, buf+i, is_32bit ? 4 : 8);
+
+        mmvad_info_t mmvad;
+        if (drakvuf_find_mmvad(drakvuf, info->proc_data.base_addr, stack_val, &mmvad))
+        {
+            addr_t begin = mmvad.starting_vpn << 12;
+            size_t len = (mmvad.ending_vpn - mmvad.starting_vpn + 1) << 12;
+
+            page_info_t p_info = {0};
+
+            if (vmi_pagetable_lookup_extended(vmi, info->regs->cr3, stack_val, &p_info) == VMI_SUCCESS)
+            {
+                bool page_valid = p_info.x86_ia32e.pte_value & (1UL << 0);
+                //bool page_write = p_info.x86_ia32e.pte_value & (1UL << 1);
+                bool page_execute = (~p_info.x86_ia32e.pte_value) & (1UL << 63);
+
+                if (page_valid && page_execute && mmvad.file_name_ptr)
+                {
+                    sptr_type_t res = check_module_linked(drakvuf, vmi, plugin, info, mmvad.starting_vpn << 12);
+
+                    if (res == ERROR)
+                    {
+                        PRINT_DEBUG("[MEMDUMP] Something is corrupted\n");
+                        continue;
+                    }
+
+                    if (res == LINKED)
+                    {
+                        PRINT_DEBUG("[MEMDUMP] Linked stack entry %llx\n", (unsigned long long)stack_val);
+                        continue;
+                    }
+                    else if (res == UNLINKED)
+                    {
+                        PRINT_DEBUG("[MEMDUMP] UNLINKED stack entry %llx\n", (unsigned long long)stack_val);
+                    }
+                    else if (res == MAIN)
+                    {
+                        PRINT_DEBUG("[MEMDUMP] MAIN stack entry %llx\n", (unsigned long long)stack_val);
+                    }
+                }
+
+                if (page_valid && page_execute)
+                {
+                    PRINT_DEBUG("[MEMDUMP] VX stack entry %llx\n", (unsigned long long)stack_val);
+
+                    ctx.addr = begin;
+
+                    if (!dump_memory_region(drakvuf, vmi, info, plugin, &ctx, len, "NtTerminateProcess called",
+                                            nullptr, nullptr))
+                    {
+                        PRINT_DEBUG("[MEMDUMP] Failed to save memory dump - internal error\n");
+                    }
+
+                    break;
+                }
+            }
+        }
+    }
+
+    PRINT_DEBUG("[MEMDUMP] Done stack walk\n");
+
+    drakvuf_release_vmi(drakvuf);
+    return VMI_EVENT_RESPONSE_NONE;
+}
+
 static event_response_t free_virtual_memory_hook_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 {
     // HANDLE ProcessHandle
@@ -457,8 +573,21 @@ memdump::memdump(drakvuf_t drakvuf, const memdump_config* c, output_format_t out
     this->memdump_dir = c->memdump_dir;
     this->memdump_counter = 0;
 
+    if (!drakvuf_get_struct_member_rva(drakvuf, "_LDR_DATA_TABLE_ENTRY", "DllBase", &this->dll_base_rva))
+    {
+        throw -1;
+    }
+
+    json_object* rekall_wow_profile = drakvuf_get_rekall_wow_profile_json(drakvuf);
+
+    if (!rekall_get_struct_member_rva(rekall_wow_profile, "_LDR_DATA_TABLE_ENTRY", "DllBase", &this->dll_base_wow_rva))
+    {
+        throw -1;
+    }
+
     breakpoint_in_system_process_searcher bp;
-    if (!register_trap<memdump>(drakvuf, nullptr, this, free_virtual_memory_hook_cb, bp.for_syscall_name("NtFreeVirtualMemory")) ||
+    if (!register_trap<memdump>(drakvuf, nullptr, this, free_virtual_memory_hook_cb,  bp.for_syscall_name("NtFreeVirtualMemory")) ||
+        !register_trap<memdump>(drakvuf, nullptr, this, terminate_process_hook_cb,    bp.for_syscall_name("NtTerminateProcess")) ||
         !register_trap<memdump>(drakvuf, nullptr, this, write_virtual_memory_hook_cb, bp.for_syscall_name("NtWriteVirtualMemory")))
     {
         throw -1;

--- a/src/plugins/memdump/memdump.cpp
+++ b/src/plugins/memdump/memdump.cpp
@@ -147,6 +147,8 @@ bool dump_memory_region(
     size_t len_remainder;
     size_t num_pages;
 
+    size_t tmp_len_bytes = len_bytes;
+
     plugin->memdump_counter++;
 
     if (plugin->memdump_dir)
@@ -200,7 +202,7 @@ bool dump_memory_region(
     for (size_t i = 0; i < num_pages; i++)
     {
         // sometimes we are supposed to write less than the whole page
-        size_t write_length = len_bytes >= VMI_PS_4KB ? VMI_PS_4KB : len_bytes;
+        size_t write_length = tmp_len_bytes >= VMI_PS_4KB ? VMI_PS_4KB : tmp_len_bytes;
 
         if (access_ptrs[i])
         {
@@ -216,7 +218,7 @@ bool dump_memory_region(
 
         // this applies only to the first page
         intra_page_offset = 0;
-        len_bytes -= write_length;
+        tmp_len_bytes -= write_length;
     }
 
     fclose(fp);

--- a/src/plugins/memdump/memdump.cpp
+++ b/src/plugins/memdump/memdump.cpp
@@ -366,31 +366,40 @@ static event_response_t terminate_process_hook_cb(drakvuf_t drakvuf, drakvuf_tra
         //bool page_write = p_info.x86_ia32e.pte_value & (1UL << 1);
         bool page_execute = (~p_info.x86_ia32e.pte_value) & (1UL << 63);
 
-        if (page_valid && page_execute && mmvad.file_name_ptr) {
+        if (page_valid && page_execute && mmvad.file_name_ptr)
+        {
             sptr_type_t res = check_module_linked(drakvuf, vmi, plugin, info, mmvad.starting_vpn << 12);
 
-            if (res == ERROR) {
+            if (res == ERROR)
+            {
                 PRINT_DEBUG("[MEMDUMP] Something is corrupted\n");
                 continue;
             }
 
-            if (res == LINKED) {
+            if (res == LINKED)
+            {
                 PRINT_DEBUG("[MEMDUMP] Linked stack entry %llx\n", (unsigned long long) stack_val);
                 continue;
-            } else if (res == UNLINKED) {
+            }
+            else if (res == UNLINKED)
+            {
                 PRINT_DEBUG("[MEMDUMP] UNLINKED stack entry %llx\n", (unsigned long long) stack_val);
-            } else if (res == MAIN) {
+            }
+            else if (res == MAIN)
+            {
                 PRINT_DEBUG("[MEMDUMP] MAIN stack entry %llx\n", (unsigned long long) stack_val);
             }
         }
 
-        if (page_valid && page_execute) {
+        if (page_valid && page_execute)
+        {
             PRINT_DEBUG("[MEMDUMP] VX stack entry %llx\n", (unsigned long long) stack_val);
 
             ctx.addr = begin;
 
             if (!dump_memory_region(drakvuf, vmi, info, plugin, &ctx, len, "NtTerminateProcess called",
-                                    nullptr, nullptr)) {
+                                    nullptr, nullptr))
+            {
                 PRINT_DEBUG("[MEMDUMP] Failed to save memory dump - internal error\n");
             }
 

--- a/src/plugins/memdump/memdump.h
+++ b/src/plugins/memdump/memdump.h
@@ -177,6 +177,27 @@ typedef struct target_config_entry
     std::string function_name;
 } target_config_entry_t;
 
+// type of a pointer residing on stack
+enum sptr_type_t
+{
+    ERROR,   // problem with stack inspection
+    MAIN,    // pointer to a main module
+    LINKED,  // pointer to some linked DLL module
+    UNLINKED // pointer to some non-legit memory
+};
+
+sptr_type_t check_module_linked_wow(drakvuf_t drakvuf,
+                                    vmi_instance_t vmi,
+                                    memdump* plugin,
+                                    drakvuf_trap_info_t* info,
+                                    addr_t dll_base);
+
+sptr_type_t check_module_linked(drakvuf_t drakvuf,
+                                vmi_instance_t vmi,
+                                memdump* plugin,
+                                drakvuf_trap_info_t* info,
+                                addr_t dll_base);
+
 struct memdump_config
 {
     const char* memdump_dir;
@@ -189,6 +210,8 @@ public:
     // for memdump.cpp
     const char* memdump_dir;
     int memdump_counter;
+    addr_t dll_base_rva;
+    addr_t dll_base_wow_rva;
 
     // for userhook.cpp
     std::vector<target_config_entry_t> wanted_hooks;

--- a/src/plugins/memdump/memdump.h
+++ b/src/plugins/memdump/memdump.h
@@ -140,15 +140,4 @@ public:
     void load_wanted_targets(const memdump_config* c);
 };
 
-bool dump_memory_region(
-    drakvuf_t drakvuf,
-    vmi_instance_t vmi,
-    drakvuf_trap_info_t* info,
-    memdump* plugin,
-    access_context_t* ctx,
-    size_t len_bytes,
-    const char* reason,
-    void* extras,
-    void (*printout_extras)(drakvuf_t drakvuf, output_format_t format, void* extras));
-
 #endif

--- a/src/plugins/memdump/memdump.h
+++ b/src/plugins/memdump/memdump.h
@@ -106,103 +106,20 @@
 #define MEMDUMP_H
 
 #include <vector>
+#include <memory>
 
 #include <glib.h>
 #include "plugins/private.h"
 #include "plugins/plugins_ex.h"
-
-template<typename T>
-struct copy_on_write_result_t: public call_result_t<T>
-{
-    copy_on_write_result_t(T* src) : call_result_t<T>(src), vaddr(), pte(), old_cow_pa() {}
-
-    addr_t vaddr;
-    addr_t pte;
-    addr_t old_cow_pa;
-};
-
-template<typename T>
-struct map_view_of_section_result_t: public call_result_t<T>
-{
-    map_view_of_section_result_t(T* src) : call_result_t<T>(src), section_handle(), process_handle(), base_address_ptr() {}
-
-    uint64_t section_handle;
-    uint64_t process_handle;
-    addr_t base_address_ptr;
-};
-
-enum target_hook_state
-{
-    HOOK_FIRST_TRY,
-    HOOK_PAGEFAULT_RETRY,
-    HOOK_FAILED,
-    HOOK_OK
-};
-
-typedef event_response_t (*callback_t)(drakvuf_t drakvuf, drakvuf_trap_info* info);
-class memdump;
-
-typedef struct hook_target_entry
-{
-    vmi_pid_t pid;
-    std::string target_name;
-    callback_t callback;
-    target_hook_state state;
-    drakvuf_trap_t* trap;
-    memdump* plugin;
-
-    hook_target_entry(std::string target_name, callback_t callback, memdump* plugin)
-        : target_name(target_name), callback(callback), state(HOOK_FIRST_TRY), plugin(plugin) {}
-} hook_target_entry_t;
-
-typedef struct user_dll
-{
-    // relevant while loading
-    addr_t dtb;
-    uint32_t thread_id;
-    addr_t real_dll_base;
-    bool is_hooked;
-
-    // internal, for page faults
-    addr_t pf_current_addr;
-    addr_t pf_max_addr;
-
-    // one entry per hooked function
-    std::vector<hook_target_entry_t> targets;
-} user_dll_t;
-
-typedef struct target_config_entry
-{
-    std::string dll_name;
-    std::string function_name;
-} target_config_entry_t;
-
-// type of a pointer residing on stack
-enum sptr_type_t
-{
-    ERROR,   // problem with stack inspection
-    MAIN,    // pointer to a main module
-    LINKED,  // pointer to some linked DLL module
-    UNLINKED // pointer to some non-legit memory
-};
-
-sptr_type_t check_module_linked_wow(drakvuf_t drakvuf,
-                                    vmi_instance_t vmi,
-                                    memdump* plugin,
-                                    drakvuf_trap_info_t* info,
-                                    addr_t dll_base);
-
-sptr_type_t check_module_linked(drakvuf_t drakvuf,
-                                vmi_instance_t vmi,
-                                memdump* plugin,
-                                drakvuf_trap_info_t* info,
-                                addr_t dll_base);
 
 struct memdump_config
 {
     const char* memdump_dir;
     const char* dll_hooks_list;
 };
+
+struct target_config_entry_t;
+struct user_dll_t;
 
 class memdump: public pluginex
 {

--- a/src/plugins/memdump/private.h
+++ b/src/plugins/memdump/private.h
@@ -192,4 +192,15 @@ sptr_type_t check_module_linked(drakvuf_t drakvuf,
                                 drakvuf_trap_info_t* info,
                                 addr_t dll_base);
 
+bool dump_memory_region(
+        drakvuf_t drakvuf,
+        vmi_instance_t vmi,
+        drakvuf_trap_info_t* info,
+        memdump* plugin,
+        access_context_t* ctx,
+        size_t len_bytes,
+        const char* reason,
+        void* extras,
+        void (*printout_extras)(drakvuf_t drakvuf, output_format_t format, void* extras));
+
 #endif

--- a/src/plugins/memdump/private.h
+++ b/src/plugins/memdump/private.h
@@ -146,7 +146,7 @@ struct hook_target_entry_t
     memdump* plugin;
 
     hook_target_entry_t(std::string target_name, callback_t callback, memdump* plugin)
-            : target_name(target_name), callback(callback), state(HOOK_FIRST_TRY), plugin(plugin) {}
+        : target_name(target_name), callback(callback), state(HOOK_FIRST_TRY), plugin(plugin) {}
 };
 
 struct user_dll_t
@@ -193,14 +193,14 @@ sptr_type_t check_module_linked(drakvuf_t drakvuf,
                                 addr_t dll_base);
 
 bool dump_memory_region(
-        drakvuf_t drakvuf,
-        vmi_instance_t vmi,
-        drakvuf_trap_info_t* info,
-        memdump* plugin,
-        access_context_t* ctx,
-        size_t len_bytes,
-        const char* reason,
-        void* extras,
-        void (*printout_extras)(drakvuf_t drakvuf, output_format_t format, void* extras));
+    drakvuf_t drakvuf,
+    vmi_instance_t vmi,
+    drakvuf_trap_info_t* info,
+    memdump* plugin,
+    access_context_t* ctx,
+    size_t len_bytes,
+    const char* reason,
+    void* extras,
+    void (*printout_extras)(drakvuf_t drakvuf, output_format_t format, void* extras));
 
 #endif

--- a/src/plugins/memdump/private.h
+++ b/src/plugins/memdump/private.h
@@ -102,127 +102,94 @@
  *                                                                         *
  ***************************************************************************/
 
-#include <config.h>
-#include <libvmi/libvmi.h>
+#ifndef MEMDUMP_PRIVATE_H
+#define MEMDUMP_PRIVATE_H
 
-#include "memdump.h"
-#include "private.h"
+template<typename T>
+struct copy_on_write_result_t: public call_result_t<T>
+{
+    copy_on_write_result_t(T* src) : call_result_t<T>(src), vaddr(), pte(), old_cow_pa() {}
+
+    addr_t vaddr;
+    addr_t pte;
+    addr_t old_cow_pa;
+};
+
+template<typename T>
+struct map_view_of_section_result_t: public call_result_t<T>
+{
+    map_view_of_section_result_t(T* src) : call_result_t<T>(src), section_handle(), process_handle(), base_address_ptr() {}
+
+    uint64_t section_handle;
+    uint64_t process_handle;
+    addr_t base_address_ptr;
+};
+
+enum target_hook_state
+{
+    HOOK_FIRST_TRY,
+    HOOK_PAGEFAULT_RETRY,
+    HOOK_FAILED,
+    HOOK_OK
+};
+
+typedef event_response_t (*callback_t)(drakvuf_t drakvuf, drakvuf_trap_info* info);
+class memdump;
+
+struct hook_target_entry_t
+{
+    vmi_pid_t pid;
+    std::string target_name;
+    callback_t callback;
+    target_hook_state state;
+    drakvuf_trap_t* trap;
+    memdump* plugin;
+
+    hook_target_entry_t(std::string target_name, callback_t callback, memdump* plugin)
+            : target_name(target_name), callback(callback), state(HOOK_FIRST_TRY), plugin(plugin) {}
+};
+
+struct user_dll_t
+{
+    // relevant while loading
+    addr_t dtb;
+    uint32_t thread_id;
+    addr_t real_dll_base;
+    bool is_hooked;
+
+    // internal, for page faults
+    addr_t pf_current_addr;
+    addr_t pf_max_addr;
+
+    // one entry per hooked function
+    std::vector<hook_target_entry_t> targets;
+};
+
+struct target_config_entry_t
+{
+    std::string dll_name;
+    std::string function_name;
+};
+
+// type of a pointer residing on stack
+enum sptr_type_t
+{
+    ERROR,   // problem with stack inspection
+    MAIN,    // pointer to a main module
+    LINKED,  // pointer to some linked DLL module
+    UNLINKED // pointer to some non-legit memory
+};
 
 sptr_type_t check_module_linked_wow(drakvuf_t drakvuf,
                                     vmi_instance_t vmi,
                                     memdump* plugin,
                                     drakvuf_trap_info_t* info,
-                                    addr_t dll_base)
-{
-    access_context_t ctx =
-    {
-        .translate_mechanism = VMI_TM_PROCESS_DTB,
-        .dtb = info->regs->cr3
-    };
-
-    addr_t wow_peb = drakvuf_get_wow_peb(drakvuf, &ctx, info->proc_data.base_addr);
-
-    if (!wow_peb)
-        return ERROR;
-
-    addr_t module_list_head;
-
-    if (!drakvuf_get_module_list_wow(drakvuf, &ctx, wow_peb, &module_list_head))
-        return ERROR;
-
-    addr_t next_module = module_list_head;
-    bool is_first = true;
-    sptr_type_t ret = UNLINKED;
-
-    while (1)
-    {
-        uint32_t tmp_next = 0;
-        ctx.addr = next_module;
-        if (VMI_FAILURE == vmi_read_32(vmi, &ctx, &tmp_next))
-        {
-            ret = ERROR;
-            break;
-        }
-
-        if (module_list_head == (addr_t)tmp_next || !tmp_next)
-            break;
-
-        uint32_t tmp_dll_base;
-        ctx.addr = next_module + plugin->dll_base_wow_rva;
-        if (vmi_read_32(vmi, &ctx, &tmp_dll_base) == VMI_SUCCESS)
-        {
-            if (dll_base == (addr_t)tmp_dll_base)
-            {
-                ret = LINKED;
-                break;
-            }
-        }
-
-        next_module = (addr_t)tmp_next;
-        is_first = false;
-    }
-
-    if (is_first && ret == LINKED)
-        ret = MAIN;
-
-    return ret;
-}
+                                    addr_t dll_base);
 
 sptr_type_t check_module_linked(drakvuf_t drakvuf,
                                 vmi_instance_t vmi,
                                 memdump* plugin,
                                 drakvuf_trap_info_t* info,
-                                addr_t dll_base)
-{
-    sptr_type_t sub_ret = check_module_linked_wow(drakvuf, vmi, plugin, info, dll_base);
+                                addr_t dll_base);
 
-    if (sub_ret != ERROR && sub_ret != UNLINKED)
-        return sub_ret;
-
-    addr_t module_list_head;
-    if (!drakvuf_get_module_list(drakvuf, info->proc_data.base_addr, &module_list_head))
-        return ERROR;
-
-    addr_t next_module = module_list_head;
-    access_context_t ctx =
-    {
-        .translate_mechanism = VMI_TM_PROCESS_DTB,
-        .dtb = info->regs->cr3
-    };
-
-    bool is_first = true;
-    sptr_type_t ret = UNLINKED;
-
-    while (1)
-    {
-        addr_t tmp_next = 0;
-        ctx.addr = next_module;
-        if (VMI_FAILURE == vmi_read_addr(vmi, &ctx, &tmp_next))
-        {
-            ret = ERROR;
-            break;
-        }
-
-        if (module_list_head == tmp_next || !tmp_next)
-            break;
-
-        addr_t tmp_dll_base;
-        ctx.addr = next_module + plugin->dll_base_rva;
-        if (vmi_read_addr(vmi, &ctx, &tmp_dll_base) == VMI_SUCCESS)
-        {
-            if (dll_base == tmp_dll_base)
-            {
-                ret = LINKED;
-                break;
-            }
-        }
-
-        is_first = false;
-        next_module = tmp_next;
-    }
-
-    if (is_first && ret == LINKED)
-        ret = MAIN;
-
-    return ret;
-}
+#endif

--- a/src/plugins/memdump/stack_util.cpp
+++ b/src/plugins/memdump/stack_util.cpp
@@ -1,0 +1,123 @@
+#include <config.h>
+#include <libvmi/libvmi.h>
+
+#include "memdump.h"
+
+sptr_type_t check_module_linked_wow(drakvuf_t drakvuf,
+                                    vmi_instance_t vmi,
+                                    memdump* plugin,
+                                    drakvuf_trap_info_t* info,
+                                    addr_t dll_base)
+{
+    access_context_t ctx =
+    {
+        .translate_mechanism = VMI_TM_PROCESS_DTB,
+        .dtb = info->regs->cr3
+    };
+
+    addr_t wow_peb = drakvuf_get_wow_peb(drakvuf, &ctx, info->proc_data.base_addr);
+
+    if (!wow_peb)
+        return ERROR;
+
+    addr_t module_list_head;
+
+    if (!drakvuf_get_module_list_wow(drakvuf, &ctx, wow_peb, &module_list_head))
+        return ERROR;
+
+    addr_t next_module = module_list_head;
+    bool is_first = true;
+    sptr_type_t ret = UNLINKED;
+
+    while (1)
+    {
+        uint32_t tmp_next = 0;
+        ctx.addr = next_module;
+        if (VMI_FAILURE == vmi_read_32(vmi, &ctx, &tmp_next))
+        {
+            ret = ERROR;
+            break;
+        }
+
+        if (module_list_head == (addr_t)tmp_next || !tmp_next)
+            break;
+
+        uint32_t tmp_dll_base;
+        ctx.addr = next_module + plugin->dll_base_wow_rva;
+        if (vmi_read_32(vmi, &ctx, &tmp_dll_base) == VMI_SUCCESS)
+        {
+            if (dll_base == (addr_t)tmp_dll_base)
+            {
+                ret = LINKED;
+                break;
+            }
+        }
+
+        next_module = (addr_t)tmp_next;
+        is_first = false;
+    }
+
+    if (is_first && ret == LINKED)
+        ret = MAIN;
+
+    return ret;
+}
+
+sptr_type_t check_module_linked(drakvuf_t drakvuf,
+                                vmi_instance_t vmi,
+                                memdump* plugin,
+                                drakvuf_trap_info_t* info,
+                                addr_t dll_base)
+{
+    sptr_type_t sub_ret = check_module_linked_wow(drakvuf, vmi, plugin, info, dll_base);
+
+    if (sub_ret != ERROR && sub_ret != UNLINKED)
+        return sub_ret;
+
+    addr_t module_list_head;
+    if (!drakvuf_get_module_list(drakvuf, info->proc_data.base_addr, &module_list_head))
+        return ERROR;
+
+    addr_t next_module = module_list_head;
+    access_context_t ctx =
+    {
+        .translate_mechanism = VMI_TM_PROCESS_DTB,
+        .dtb = info->regs->cr3
+    };
+
+    bool is_first = true;
+    sptr_type_t ret = UNLINKED;
+
+    while (1)
+    {
+        addr_t tmp_next = 0;
+        ctx.addr = next_module;
+        if (VMI_FAILURE == vmi_read_addr(vmi, &ctx, &tmp_next))
+        {
+            ret = ERROR;
+            break;
+        }
+
+        if (module_list_head == tmp_next || !tmp_next)
+            break;
+
+        addr_t tmp_dll_base;
+        ctx.addr = next_module + plugin->dll_base_rva;
+        if (vmi_read_addr(vmi, &ctx, &tmp_dll_base) == VMI_SUCCESS)
+        {
+            if (dll_base == tmp_dll_base)
+            {
+                ret = LINKED;
+                break;
+            }
+        }
+
+        is_first = false;
+        next_module = tmp_next;
+    }
+
+    if (is_first && ret == LINKED)
+        ret = MAIN;
+
+    return ret;
+}

--- a/src/plugins/memdump/userhook.cpp
+++ b/src/plugins/memdump/userhook.cpp
@@ -123,11 +123,13 @@
 #include <libvmi/libvmi.h>
 #include <libvmi/peparse.h>
 #include <assert.h>
+
 #include "memdump.h"
+#include "private.h"
 
 static event_response_t usermode_hook_cb(drakvuf_t drakvuf, drakvuf_trap_info* info)
 {
-    hook_target_entry* target = (hook_target_entry*)info->trap->data;
+    hook_target_entry_t* target = (hook_target_entry_t*)info->trap->data;
 
     if (target->pid != info->proc_data.pid)
         return VMI_EVENT_RESPONSE_NONE;
@@ -337,7 +339,7 @@ static user_dll_t* create_dll_meta(drakvuf_t drakvuf, drakvuf_trap_info* info, m
     return &it->second.back();
 }
 
-static bool make_trap(drakvuf_t drakvuf, drakvuf_trap_info* info, hook_target_entry* target, addr_t exec_func)
+static bool make_trap(drakvuf_t drakvuf, drakvuf_trap_info* info, hook_target_entry_t* target, addr_t exec_func)
 {
     target->pid = info->proc_data.pid;
 


### PR DESCRIPTION
When process does an interesting syscall, walks the usermode stack to get some information about the cause. Dumps the offending code fragments if they appear to be interesting.