### PR TITLE
Fix cppcheck warning

### DIFF
--- a/src/libdrakvuf/rekall-profile.c
+++ b/src/libdrakvuf/rekall-profile.c
@@ -377,7 +377,7 @@ int drakvuf_get_os_build_date(drakvuf_t drakvuf)
     int year = 0;
     int month = 0;
     int day = 0;
-    char junk[15] = {'\0'};
+    char junk[16] = {'\0'};
     char build_date[10] = {'\0'};
 
     if (!drakvuf->rekall_profile_json)


### PR DESCRIPTION
`[src/libdrakvuf/rekall-profile.c:406]: (error) Width 15 given in format string (no. 6) is larger than destination buffer 'junk[15]', use %14s to prevent overflowing it.`