### PR TITLE
memdump: CoW hooks

### DIFF
--- a/src/plugins/memdump/private.h
+++ b/src/plugins/memdump/private.h
@@ -126,7 +126,7 @@ enum target_hook_state
 typedef event_response_t (*callback_t)(drakvuf_t drakvuf, drakvuf_trap_info* info);
 class memdump;
 
-typedef struct hook_target_entry
+struct hook_target_entry_t
 {
     vmi_pid_t pid;
     std::string target_name;
@@ -137,7 +137,7 @@ typedef struct hook_target_entry
 
     hook_target_entry(std::string target_name, callback_t callback, memdump* plugin)
             : target_name(target_name), callback(callback), state(HOOK_FIRST_TRY), plugin(plugin) {}
-} hook_target_entry_t;
+};
 
 template<typename T>
 struct copy_on_write_result_t: public call_result_t<T>
@@ -150,7 +150,7 @@ struct copy_on_write_result_t: public call_result_t<T>
     std::vector<hook_target_entry_t*> hooks;
 };
 
-typedef struct user_dll
+struct user_dll_t
 {
     // relevant while loading
     addr_t dtb;
@@ -164,13 +164,13 @@ typedef struct user_dll
 
     // one entry per hooked function
     std::vector<hook_target_entry_t> targets;
-} user_dll_t;
+};
 
-typedef struct target_config_entry
+struct target_config_entry_t
 {
     std::string dll_name;
     std::string function_name;
-} target_config_entry_t;
+};
 
 // type of a pointer residing on stack
 enum sptr_type_t

--- a/src/plugins/memdump/private.h
+++ b/src/plugins/memdump/private.h
@@ -135,7 +135,7 @@ struct hook_target_entry_t
     drakvuf_trap_t* trap;
     memdump* plugin;
 
-    hook_target_entry(std::string target_name, callback_t callback, memdump* plugin)
+    hook_target_entry_t(std::string target_name, callback_t callback, memdump* plugin)
             : target_name(target_name), callback(callback), state(HOOK_FIRST_TRY), plugin(plugin) {}
 };
 

--- a/src/plugins/memdump/private.h
+++ b/src/plugins/memdump/private.h
@@ -136,7 +136,7 @@ struct hook_target_entry_t
     memdump* plugin;
 
     hook_target_entry_t(std::string target_name, callback_t callback, memdump* plugin)
-            : target_name(target_name), callback(callback), state(HOOK_FIRST_TRY), plugin(plugin) {}
+        : target_name(target_name), callback(callback), state(HOOK_FIRST_TRY), plugin(plugin) {}
 };
 
 template<typename T>

--- a/src/plugins/memdump/userhook.cpp
+++ b/src/plugins/memdump/userhook.cpp
@@ -765,7 +765,7 @@ static event_response_t copy_on_write_ret_cb(drakvuf_t drakvuf, drakvuf_trap_inf
 
     PRINT_DEBUG("[MEMDUMP-USER] new PA %lx\n", pa);
 
-    for(auto& ook : data->hooks)
+    for (auto& hook : data->hooks)
     {
         addr_t hook_va = ((data->vaddr >> 12) << 12) + (hook->trap->breakpoint.addr & 0xFFF);
         PRINT_DEBUG("adding hook at %lx\n", hook_va);
@@ -806,7 +806,7 @@ static event_response_t copy_on_write_handler(drakvuf_t drakvuf, drakvuf_trap_in
     std::vector < hook_target_entry_t* > hooks;
     for (auto& dll : plugin->loaded_dlls[info->regs->cr3])
     {
-        for(auto &hook : dll.targets)
+        for (auto& hook : dll.targets)
         {
             addr_t hook_addr = hook.trap->breakpoint.addr;
             if (hook_addr >> 12 == pa >> 12)

--- a/src/plugins/memdump/userhook.cpp
+++ b/src/plugins/memdump/userhook.cpp
@@ -748,7 +748,7 @@ static event_response_t copy_on_write_ret_cb(drakvuf_t drakvuf, drakvuf_trap_inf
     vmi_instance_t vmi = drakvuf_lock_and_get_vmi(drakvuf);
 
     // sometimes the physical address was incorrectly cached in this moment, so we need to flush it
-    vmi_v2pcache_flush(vmi);
+    vmi_v2pcache_flush(vmi, info->regs->cr3);
     addr_t pa;
 
     if (vmi_pagetable_lookup(vmi, info->regs->cr3, data->vaddr, &pa) != VMI_SUCCESS)

--- a/src/plugins/memdump/userhook.cpp
+++ b/src/plugins/memdump/userhook.cpp
@@ -352,7 +352,7 @@ static bool make_trap(vmi_instance_t vmi, drakvuf_t drakvuf, drakvuf_trap_info* 
     page_info pageInfo;
     int ret = vmi_pagetable_lookup_extended(vmi, info->regs->cr3, exec_func, &pageInfo);
 
-    if(ret != VMI_SUCCESS)
+    if (ret != VMI_SUCCESS)
     {
         goto fail;
     }
@@ -367,7 +367,7 @@ static bool make_trap(vmi_instance_t vmi, drakvuf_t drakvuf, drakvuf_trap_info* 
         return true;
     }
 
-    fail:
+fail:
     PRINT_DEBUG("[MEMDUMP-USER] Failed to add trap :(\n");
     return false;
 }
@@ -765,7 +765,7 @@ static event_response_t copy_on_write_ret_cb(drakvuf_t drakvuf, drakvuf_trap_inf
 
     PRINT_DEBUG("[MEMDUMP-USER] new PA %lx\n", pa);
 
-    for(auto &hook : data->hooks)
+    for(auto& ook : data->hooks)
     {
         addr_t hook_va = ((data->vaddr >> 12) << 12) + (hook->trap->breakpoint.addr & 0xFFF);
         PRINT_DEBUG("adding hook at %lx\n", hook_va);
@@ -773,7 +773,7 @@ static event_response_t copy_on_write_ret_cb(drakvuf_t drakvuf, drakvuf_trap_inf
         make_trap(vmi, drakvuf, info, hook, hook_va);
     }
 
-    end:
+end:
     drakvuf_release_vmi(drakvuf);
     return VMI_EVENT_RESPONSE_NONE;
 }
@@ -804,10 +804,12 @@ static event_response_t copy_on_write_handler(drakvuf_t drakvuf, drakvuf_trap_in
 
 
     std::vector < hook_target_entry_t* > hooks;
-    for (auto &dll : plugin->loaded_dlls[info->regs->cr3]) {
-        for(auto &hook : dll.targets) {
+    for (auto& dll : plugin->loaded_dlls[info->regs->cr3])
+    {
+        for(auto &hook : dll.targets)
+        {
             addr_t hook_addr = hook.trap->breakpoint.addr;
-            if(hook_addr >> 12 == pa >> 12)
+            if (hook_addr >> 12 == pa >> 12)
             {
                 hooks.push_back(&hook);
             }
@@ -817,16 +819,16 @@ static event_response_t copy_on_write_handler(drakvuf_t drakvuf, drakvuf_trap_in
     PRINT_DEBUG("[MEMDUMP-USER] copy on write called: vaddr: %llx pte: %llx, pid: %d, cr3: %llx\n", (unsigned long long)vaddr, (unsigned long long)pte, info->proc_data.pid, (unsigned long long)info->regs->cr3);
     PRINT_DEBUG("[MEMDUMP-USER] old CoW PA: %llx\n", (unsigned long long)pa);
 
-    if(!hooks.empty())
+    if (!hooks.empty())
     {
         PRINT_DEBUG("MEMDUMP-USER] Found %zu hooks on CoW page, registering return trap\n", hooks.size());
 
         auto trap = plugin->register_trap<memdump, copy_on_write_result_t<memdump>>(
-                drakvuf,
-                info,
-                plugin,
-                copy_on_write_ret_cb,
-                breakpoint_by_pid_searcher());
+                        drakvuf,
+                        info,
+                        plugin,
+                        copy_on_write_ret_cb,
+                        breakpoint_by_pid_searcher());
         if (!trap)
             return VMI_EVENT_RESPONSE_NONE;
 

--- a/src/plugins/memdump/userhook.cpp
+++ b/src/plugins/memdump/userhook.cpp
@@ -339,7 +339,7 @@ static user_dll_t* create_dll_meta(drakvuf_t drakvuf, drakvuf_trap_info* info, m
     return &it->second.back();
 }
 
-static bool make_trap(vmi_instance_t vmi, drakvuf_t drakvuf, drakvuf_trap_info* info, hook_target_entry* target, addr_t exec_func)
+static bool make_trap(vmi_instance_t vmi, drakvuf_t drakvuf, drakvuf_trap_info* info, hook_target_entry_t* target, addr_t exec_func)
 {
     target->pid = info->proc_data.pid;
 

--- a/src/plugins/memdump/userhook.cpp
+++ b/src/plugins/memdump/userhook.cpp
@@ -351,9 +351,9 @@ static bool make_trap(vmi_instance_t vmi, drakvuf_t drakvuf, drakvuf_trap_info* 
 
     // during CoW we need to find all traps placed on the same physical page
     // that's why we'll manually resolve vaddr and strore paddr under trap->breakpoint.addr
-    addr_t pa = vmi_pagetable_lookup(vmi, info->regs->cr3, exec_func);
+    addr_t pa;
 
-    if (pa == 0)
+    if (vmi_pagetable_lookup(vmi, info->regs->cr3, exec_func, &pa) != VMI_SUCCESS)
     {
         goto fail;
     }
@@ -749,9 +749,9 @@ static event_response_t copy_on_write_ret_cb(drakvuf_t drakvuf, drakvuf_trap_inf
 
     // sometimes the physical address was incorrectly cached in this moment, so we need to flush it
     vmi_v2pcache_flush(vmi);
-    addr_t pa = vmi_pagetable_lookup(vmi, info->regs->cr3, data->vaddr);
+    addr_t pa;
 
-    if (pa == 0)
+    if (vmi_pagetable_lookup(vmi, info->regs->cr3, data->vaddr, &pa) != VMI_SUCCESS)
     {
         PRINT_DEBUG("[MEMDUMP-USER] failed to get pa");
         goto end;
@@ -791,9 +791,9 @@ static event_response_t copy_on_write_handler(drakvuf_t drakvuf, drakvuf_trap_in
 
     vmi_instance_t vmi = drakvuf_lock_and_get_vmi(drakvuf);
 
-    addr_t pa = vmi_pagetable_lookup(vmi, info->regs->cr3, vaddr);
+    addr_t pa;
 
-    if (pa == 0)
+    if (vmi_pagetable_lookup(vmi, info->regs->cr3, vaddr, &pa) != VMI_SUCCESS)
     {
         PRINT_DEBUG("[MEMDUMP-USER] failed to get pa");
         drakvuf_release_vmi(drakvuf);

--- a/src/plugins/memdump/userhook.cpp
+++ b/src/plugins/memdump/userhook.cpp
@@ -757,8 +757,6 @@ static event_response_t copy_on_write_ret_cb(drakvuf_t drakvuf, drakvuf_trap_inf
         goto end;
     }
 
-    pa = pinfo.paddr;
-
     if (data->old_cow_pa == pa)
     {
         PRINT_DEBUG("[MEMDUMP-USER] PA after CoW remained the same, wtf? Nothing to do here...\n");


### PR DESCRIPTION
As hooks are added per physical address, any write access to the page with the hook causes loss of it due to copy on write. This PR hooks MiCopyOnWrite function and re-adds hooks after moving hooked function to another physical address.