### PR TITLE
Add JSON output mode in injector

### DIFF
--- a/src/libinjector/injector.c
+++ b/src/libinjector/injector.c
@@ -1287,6 +1287,7 @@ static void print_injection_info(output_format_t format, const char* file, injec
         arguments = "";
     }
 
+    char* escaped_pname = g_strescape(process_name, NULL);
     char* escaped_arguments = g_strescape(arguments, NULL);
 
     switch (injector->result)
@@ -1302,6 +1303,19 @@ static void print_injection_info(output_format_t format, const char* file, injec
                 case OUTPUT_KV:
                     printf("inject Time=" FORMAT_TIMEVAL ",Status=Success,PID=%u,ProcessName=\"%s\",Arguments=\"%s\",InjectedPid=%u,InjectedTid=%u\n",
                            UNPACK_TIMEVAL(t), injector->target_pid, process_name, escaped_arguments, injector->pid, injector->tid);
+                    break;
+
+                case OUTPUT_JSON:
+                    printf( "{"
+                            "\"Plugin\": \"inject\", "
+                            "\"TimeStamp\": \"" FORMAT_TIMEVAL "\", "
+                            "\"Status\": \"Success\", "
+                            "\"ProcessName\": \"%s\", "
+                            "\"Arguments\": \"%s\", "
+                            "\"InjectedPid\": %d, "
+                            "\"InjectedTid\": %d"
+                            "}\n",
+                            UNPACK_TIMEVAL(t), escaped_pname, escaped_arguments, injector->pid, injector->tid);
                     break;
 
                 default:
@@ -1322,6 +1336,14 @@ static void print_injection_info(output_format_t format, const char* file, injec
                     printf("inject Time=" FORMAT_TIMEVAL ",Status=Timeout\n", UNPACK_TIMEVAL(t));
                     break;
 
+                case OUTPUT_JSON:
+                    printf( "{"
+                            "\"Plugin\": \"inject\", "
+                            "\"TimeStamp\": \"" FORMAT_TIMEVAL "\", "
+                            "\"Status\": \"Timeout\""
+                            "}\n", UNPACK_TIMEVAL(t));
+                    break;
+
                 default:
                 case OUTPUT_DEFAULT:
                     printf("[INJECT] TIME:" FORMAT_TIMEVAL " STATUS:Timeout\n", UNPACK_TIMEVAL(t));
@@ -1339,6 +1361,14 @@ static void print_injection_info(output_format_t format, const char* file, injec
                     printf("inject Time=" FORMAT_TIMEVAL ",Status=Crash\n", UNPACK_TIMEVAL(t));
                     break;
 
+                case OUTPUT_JSON:
+                    printf( "{"
+                            "\"Plugin\": \"inject\", "
+                            "\"TimeStamp\": \"" FORMAT_TIMEVAL "\", "
+                            "\"Status\": \"Crash\""
+                            "}\n", UNPACK_TIMEVAL(t));
+                    break;
+
                 default:
                 case OUTPUT_DEFAULT:
                     printf("[INJECT] TIME:" FORMAT_TIMEVAL " STATUS:Crash\n", UNPACK_TIMEVAL(t));
@@ -1354,6 +1384,14 @@ static void print_injection_info(output_format_t format, const char* file, injec
 
                 case OUTPUT_KV:
                     printf("inject Time=" FORMAT_TIMEVAL ",Status=PrematureBreak\n", UNPACK_TIMEVAL(t));
+                    break;
+
+                case OUTPUT_JSON:
+                    printf( "{"
+                            "\"Plugin\": \"inject\", "
+                            "\"TimeStamp\": \"" FORMAT_TIMEVAL "\", "
+                            "\"Status\": \"PrematureBreak\""
+                            "}\n", UNPACK_TIMEVAL(t));
                     break;
 
                 default:
@@ -1375,6 +1413,17 @@ static void print_injection_info(output_format_t format, const char* file, injec
                            UNPACK_TIMEVAL(t), injector->error_code.code, injector->error_code.string);
                     break;
 
+                case OUTPUT_JSON:
+                    printf( "{"
+                            "\"Plugin\": \"inject\", "
+                            "\"TimeStamp\": \"" FORMAT_TIMEVAL "\", "
+                            "\"Status\": \"Error\", "
+                            "\"ErrorCode\": %d, "
+                            "\"Error\": \"%s\""
+                            "}\n",
+                            UNPACK_TIMEVAL(t), injector->error_code.code, injector->error_code.string);
+                    break;
+
                 default:
                 case OUTPUT_DEFAULT:
                     printf("[INJECT] TIME:" FORMAT_TIMEVAL " STATUS:Error ERROR_CODE:%d ERROR:\"%s\"\n",
@@ -1384,6 +1433,7 @@ static void print_injection_info(output_format_t format, const char* file, injec
             break;
     }
 
+    g_free(escaped_pname);
     g_free(escaped_arguments);
     g_strfreev(split_results);
 }


### PR DESCRIPTION
Currently, with `-o json` injector outputs log lines in default format, which may be inconvenient. This PR adds JSON output format.