### PR TITLE
memdump: initialize properly even if WOW64 NTDLL profile is not provided

### DIFF
--- a/src/libdrakvuf/win-processes.c
+++ b/src/libdrakvuf/win-processes.c
@@ -809,6 +809,9 @@ bool win_get_user_stack32(drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t* 
 
     addr_t wow_ctx;
 
+    if (!drakvuf->wow_offsets)
+        return false;
+
     if (!win_get_wow_context(drakvuf, win_get_current_thread(drakvuf, info), &wow_ctx))
         return false;
 

--- a/src/plugins/memdump/memdump.cpp
+++ b/src/plugins/memdump/memdump.cpp
@@ -590,15 +590,16 @@ memdump::memdump(drakvuf_t drakvuf, const memdump_config* c, output_format_t out
 
     json_object* rekall_wow_profile = drakvuf_get_rekall_wow_profile_json(drakvuf);
 
-    if ( !rekall_wow_profile )
+    if (rekall_wow_profile)
     {
-        PRINT_DEBUG("Memdump plugin requires the Rekall profile for WoW64 NTDLL (-w)\n");
-        return;
+        if (!rekall_get_struct_member_rva(rekall_wow_profile, "_LDR_DATA_TABLE_ENTRY", "DllBase", &this->dll_base_wow_rva))
+        {
+            throw -1;
+        }
     }
-
-    if (!rekall_get_struct_member_rva(rekall_wow_profile, "_LDR_DATA_TABLE_ENTRY", "DllBase", &this->dll_base_wow_rva))
+    else
     {
-        throw -1;
+        PRINT_DEBUG("Memdump works better when there is a Rekall profile for WoW64 NTDLL (-w)\n");
     }
 
     breakpoint_in_system_process_searcher bp;

--- a/src/plugins/memdump/stack_util.cpp
+++ b/src/plugins/memdump/stack_util.cpp
@@ -114,6 +114,10 @@ sptr_type_t check_module_linked_wow(drakvuf_t drakvuf,
                                     drakvuf_trap_info_t* info,
                                     addr_t dll_base)
 {
+    // WOW64 NTDLL profile not provided
+    if (!plugin->dll_base_wow_rva)
+        return ERROR;
+
     access_context_t ctx =
     {
         .translate_mechanism = VMI_TM_PROCESS_DTB,


### PR DESCRIPTION
[Work in progress] Fix `memdump` so it doesn't require WOW64 NTDLL profile to be provided at all times.