### PR TITLE
fix HOOK_FAIL lookup in CoW

### DIFF
--- a/src/plugins/memdump/userhook.cpp
+++ b/src/plugins/memdump/userhook.cpp
@@ -757,10 +757,12 @@ static event_response_t copy_on_write_handler(drakvuf_t drakvuf, drakvuf_trap_in
     {
         for (auto& hook : dll.targets)
         {
-            addr_t hook_addr = hook.trap->breakpoint.addr;
-            if (hook_addr >> 12 == pa >> 12)
+            if (hook.state == HOOK_OK)
             {
-                hooks.push_back(&hook);
+                addr_t hook_addr = hook.trap->breakpoint.addr;
+                if (hook_addr >> 12 == pa >> 12) {
+                    hooks.push_back(&hook);
+                }
             }
         }
     }

--- a/src/plugins/memdump/userhook.cpp
+++ b/src/plugins/memdump/userhook.cpp
@@ -760,7 +760,8 @@ static event_response_t copy_on_write_handler(drakvuf_t drakvuf, drakvuf_trap_in
             if (hook.state == HOOK_OK)
             {
                 addr_t hook_addr = hook.trap->breakpoint.addr;
-                if (hook_addr >> 12 == pa >> 12) {
+                if (hook_addr >> 12 == pa >> 12)
+                {
                     hooks.push_back(&hook);
                 }
             }


### PR DESCRIPTION
If there were failed hooks, "trap" was NULL causing crashes.