### PR TITLE
vmi: use vmi_slat_set_domain_state

### DIFF
--- a/src/libdrakvuf/vmi.c
+++ b/src/libdrakvuf/vmi.c
@@ -1457,10 +1457,13 @@ bool init_vmi(drakvuf_t drakvuf, bool libvmi_conf)
         return 0;
     }
 
-    bool altp2m = xen_enable_altp2m(drakvuf->xen, drakvuf->domID);
-    PRINT_DEBUG("Altp2m enabled? %i\n", altp2m);
-    if (!altp2m)
+    status = vmi_slat_set_domain_state(drakvuf->vmi, true);
+    if (VMI_FAILURE == status)
+    {
+        PRINT_DEBUG("Failed to enable altp2m\n");
         return 0;
+    }
+    PRINT_DEBUG("Altp2m enabled\n");
 
     /*
      * Create altp2m view

--- a/src/xen_helper/xen_helper.c
+++ b/src/xen_helper/xen_helper.c
@@ -342,31 +342,3 @@ void xen_force_resume(xen_interface_t* xen, domid_t domID)
 
     } while (1);
 }
-
-bool xen_enable_altp2m(xen_interface_t* xen, domid_t domID)
-{
-    uint64_t param_altp2m;
-
-    int rc = xc_hvm_param_get(xen->xc, domID, HVM_PARAM_ALTP2M, &param_altp2m);
-    if (rc < 0)
-    {
-        fprintf(stderr, "Failed to get HVM_PARAM_ALTP2M, RC: %i\n", rc);
-        return 0;
-    }
-
-    if (param_altp2m != XEN_ALTP2M_external)
-    {
-        rc = xc_hvm_param_set(xen->xc, domID, HVM_PARAM_ALTP2M, XEN_ALTP2M_external);
-        if (rc < 0)
-        {
-            fprintf(stderr, "Failed to set HVM_PARAM_ALTP2M, RC: %i\n", rc);
-            return 0;
-        }
-    }
-
-    rc = xc_altp2m_set_domain_state(xen->xc, domID, 1);
-    if (rc < 0)
-        return 0;
-
-    return 1;
-}

--- a/src/xen_helper/xen_helper.h
+++ b/src/xen_helper/xen_helper.h
@@ -138,6 +138,5 @@ void print_sharing_info(xen_interface_t* xen, domid_t domID);
 bool xen_pause(xen_interface_t* xen, domid_t domID);
 void xen_resume(xen_interface_t* xen, domid_t domID);
 void xen_force_resume(xen_interface_t* xen, domid_t domID);
-bool xen_enable_altp2m(xen_interface_t* xen, domid_t domID);
 
 #endif


### PR DESCRIPTION
This PR goes with https://github.com/libvmi/libvmi/pull/816

Moving the enforcement of ALTP2M_external in Libvmi, and using `vmi_slat_set_domain_state`.

Helps for #679 