### PR TITLE
build: remove Wstrict-prototypes and Wmissing-prototypes for cpp

### DIFF
--- a/src/plugins/Makefile.am
+++ b/src/plugins/Makefile.am
@@ -224,9 +224,8 @@ AM_CXXFLAGS += -Wno-missing-field-initializers -Wno-unused-parameter
 AM_CXXFLAGS += -Wno-initializer-overrides
 AM_CXXFLAGS += -Wcast-qual -Wcast-align -Wstrict-aliasing \
                -Wpointer-arith -Winit-self -Wshadow \
-               -Wstrict-prototypes \
-               -Wmissing-prototypes -Wredundant-decls \
-               -Wfloat-equal -Wundef -Wvla
+               -Wredundant-decls -Wfloat-equal -Wundef \
+               -Wvla
 # Note that -pg is incompatible with HARDENING
 if !HARDENING
 AM_CXXFLAGS += -pg


### PR DESCRIPTION
This PR removes useless CPP flags, since the C++ compiler will always show warnings for missing prototypes.
source: https://stackoverflow.com/a/2389184/3017219

