### PR TITLE
Revert "Fix bug with remapped_gfn not reactivating in breakpoint"

### DIFF
--- a/src/libdrakvuf/vmi.c
+++ b/src/libdrakvuf/vmi.c
@@ -804,8 +804,6 @@ void remove_trap(drakvuf_t drakvuf,
                 remove_trap(drakvuf, &container->breakpoint.guard2);
 
                 g_hash_table_remove(drakvuf->breakpoint_lookup_pa, &container->breakpoint.pa);
-
-                remapped_gfn->active = 0;
             }
 
             break;


### PR DESCRIPTION
Reverts tklengyel/drakvuf#730

I think it was a little bit too fast. I found some cases where this patch is crashing the whole VM badly, I don't know why exactly yet.