### PR TITLE
Harden breakpoints against instruction injection leaks

### DIFF
--- a/src/libdrakvuf/win-processes.c
+++ b/src/libdrakvuf/win-processes.c
@@ -234,12 +234,11 @@ bool win_get_last_error(drakvuf_t drakvuf, drakvuf_trap_info_t* info, uint32_t* 
     if (VMI_SUCCESS != vmi_read_addr_va(vmi, kthread + drakvuf->offsets[KTHREAD_TEB], 0, &teb))
         return false;
 
-    access_context_t ctx =
-    {
-        .translate_mechanism = VMI_TM_PROCESS_DTB,
-        .dtb = cr3,
-        .addr = teb + drakvuf->offsets[TEB_LASTERRORVALUE],
-    };
+    access_context_t ctx;
+    memset(&ctx, 0, sizeof(access_context_t));
+    ctx.translate_mechanism = VMI_TM_PROCESS_DTB;
+    ctx.dtb = cr3;
+    ctx.addr = teb + drakvuf->offsets[TEB_LASTERRORVALUE];
 
     if (VMI_SUCCESS != vmi_read_32(vmi, &ctx, err))
         return false;
@@ -294,11 +293,10 @@ char* win_get_process_commandline(drakvuf_t drakvuf, drakvuf_trap_info_t* info, 
 {
     vmi_instance_t vmi = drakvuf->vmi;
 
-    access_context_t ctx =
-    {
-        .translate_mechanism = VMI_TM_PROCESS_DTB,
-        .dtb = info->regs->cr3,
-    };
+    access_context_t ctx;
+    memset(&ctx, 0, sizeof(access_context_t));
+    ctx.translate_mechanism = VMI_TM_PROCESS_DTB;
+    ctx.dtb = info->regs->cr3;
 
     addr_t peb = 0;
     ctx.addr = eprocess_base + drakvuf->offsets[EPROCESS_PEB];
@@ -342,7 +340,9 @@ int64_t win_get_process_userid(drakvuf_t drakvuf, addr_t eprocess_base)
     addr_t peb;
     addr_t userid;
     vmi_instance_t vmi = drakvuf->vmi;
-    access_context_t ctx = {.translate_mechanism = VMI_TM_PROCESS_DTB};
+    access_context_t ctx;
+    memset(&ctx, 0, sizeof(access_context_t));
+    ctx.translate_mechanism = VMI_TM_PROCESS_DTB;
 
     if (!eprocess_base)
         return -1;
@@ -429,11 +429,10 @@ bool win_get_current_thread_previous_mode(drakvuf_t drakvuf,
 bool win_is_ethread( drakvuf_t drakvuf, addr_t dtb, addr_t ethread_addr )
 {
     dispatcher_object_t dispatcher_type = __DISPATCHER_INVALID_OBJECT;
-    access_context_t ctx =
-    {
-        .translate_mechanism = VMI_TM_PROCESS_DTB,
-        .dtb = dtb,
-    };
+    access_context_t ctx;
+    memset(&ctx, 0, sizeof(access_context_t));
+    ctx.translate_mechanism = VMI_TM_PROCESS_DTB;
+    ctx.dtb = dtb;
 
     ctx.addr = ethread_addr + drakvuf->offsets[ ETHREAD_TCB ] + drakvuf->offsets[ KTHREAD_HEADER ]
                + drakvuf->offsets[ DISPATCHER_TYPE ] ;
@@ -454,12 +453,10 @@ bool win_is_ethread( drakvuf_t drakvuf, addr_t dtb, addr_t ethread_addr )
 bool win_is_eprocess( drakvuf_t drakvuf, addr_t dtb, addr_t eprocess_addr )
 {
     dispatcher_object_t dispatcher_type = __DISPATCHER_INVALID_OBJECT;
-    access_context_t ctx =
-    {
-        .translate_mechanism = VMI_TM_PROCESS_DTB,
-        .dtb = dtb,
-    };
-
+    access_context_t ctx;
+    memset(&ctx, 0, sizeof(access_context_t));
+    ctx.translate_mechanism = VMI_TM_PROCESS_DTB;
+    ctx.dtb = dtb;
     ctx.addr = eprocess_addr + drakvuf->offsets[ EPROCESS_PCB ] + drakvuf->offsets[ KPROCESS_HEADER ]
                + drakvuf->offsets[ DISPATCHER_TYPE ] ;
 
@@ -479,7 +476,9 @@ bool win_get_module_list(drakvuf_t drakvuf, addr_t eprocess_base, addr_t* module
     addr_t ldr=0;
     addr_t modlist=0;
 
-    access_context_t ctx = {.translate_mechanism = VMI_TM_PROCESS_DTB};
+    access_context_t ctx;
+    memset(&ctx, 0, sizeof(access_context_t));
+    ctx.translate_mechanism = VMI_TM_PROCESS_DTB;
 
     if (!eprocess_base)
         return false;
@@ -721,12 +720,10 @@ bool win_get_wow_context(drakvuf_t drakvuf, addr_t ethread, addr_t* wow_ctx)
 {
     addr_t teb_ptr;
 
-    access_context_t ctx =
-    {
-        .translate_mechanism = VMI_TM_PROCESS_PID,
-        .pid = 0,
-        .addr = ethread + drakvuf->offsets[KTHREAD_TEB]
-    };
+    access_context_t ctx;
+    memset(&ctx, 0, sizeof(access_context_t));
+    ctx.translate_mechanism = VMI_TM_PROCESS_PID;
+    ctx.addr = ethread + drakvuf->offsets[KTHREAD_TEB];
 
     if (vmi_read_addr(drakvuf->vmi, &ctx, &teb_ptr) != VMI_SUCCESS)
         return false;
@@ -783,12 +780,10 @@ bool win_get_user_stack64(drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t* 
     addr_t ptrap_frame;
     uint64_t rsp;
 
-    access_context_t ctx =
-    {
-        .translate_mechanism = VMI_TM_PROCESS_PID,
-        .pid = 0,
-        .addr = win_get_current_thread(drakvuf, info) + drakvuf->offsets[KTHREAD_TRAPFRAME]
-    };
+    access_context_t ctx;
+    memset(&ctx, 0, sizeof(access_context_t));
+    ctx.translate_mechanism = VMI_TM_PROCESS_PID;
+    ctx.addr = win_get_current_thread(drakvuf, info) + drakvuf->offsets[KTHREAD_TRAPFRAME];
 
     if (vmi_read_addr(drakvuf->vmi, &ctx, &ptrap_frame) != VMI_SUCCESS)
         return false;
@@ -816,6 +811,7 @@ bool win_get_user_stack32(drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t* 
         return false;
 
     access_context_t ctx;
+    memset(&ctx, 0, sizeof(access_context_t));
     ctx.translate_mechanism = VMI_TM_PROCESS_DTB;
     ctx.dtb = info->regs->cr3;
     ctx.addr = wow_ctx + drakvuf->wow_offsets[WOW_CONTEXT_ESP];
@@ -1010,6 +1006,7 @@ bool win_find_mmvad(drakvuf_t drakvuf, addr_t eprocess, addr_t vaddr, mmvad_info
         ++depth;
 
         access_context_t ctx;
+        memset(&ctx, 0, sizeof(access_context_t));
         ctx.translate_mechanism = VMI_TM_PROCESS_PID;
         ctx.pid = 4;
         ctx.addr = node_addr + drakvuf->offsets[MMVAD_LEFT_CHILD];

--- a/src/libinjector/win_injector.c
+++ b/src/libinjector/win_injector.c
@@ -468,12 +468,10 @@ static bool injector_set_hijacked(injector_t injector, drakvuf_trap_info_t* info
 
 static void fill_created_process_info(injector_t injector, drakvuf_trap_info_t* info)
 {
-    access_context_t ctx =
-    {
-        .translate_mechanism = VMI_TM_PROCESS_DTB,
-        .dtb = info->regs->cr3,
-        .addr = injector->process_info,
-    };
+    access_context_t ctx = {0};
+    ctx.translate_mechanism = VMI_TM_PROCESS_DTB;
+    ctx.dtb = info->regs->cr3;
+    ctx.addr = injector->process_info;
 
     vmi_instance_t vmi = drakvuf_lock_and_get_vmi(injector->drakvuf);
 
@@ -755,12 +753,10 @@ static event_response_t inject_payload(drakvuf_t drakvuf, drakvuf_trap_info_t* i
 
         injector->binary_addr = injector->payload_addr + injector->payload_size;
 
-        access_context_t ctx =
-        {
-            .translate_mechanism = VMI_TM_PROCESS_DTB,
-            .dtb = info->regs->cr3,
-            .addr = injector->binary_addr,
-        };
+        access_context_t ctx = {0};
+        ctx.translate_mechanism = VMI_TM_PROCESS_DTB;
+        ctx.dtb = info->regs->cr3;
+        ctx.addr = injector->binary_addr;
 
         vmi_instance_t vmi = drakvuf_lock_and_get_vmi(drakvuf);
         bool success = ( VMI_SUCCESS == vmi_write(vmi, &ctx, injector->binary_size, (void*)injector->binary, NULL) );
@@ -789,12 +785,11 @@ static event_response_t inject_payload(drakvuf_t drakvuf, drakvuf_trap_info_t* i
 #endif
 
     // Write payload into guest's memory
-    access_context_t ctx =
-    {
-        .translate_mechanism = VMI_TM_PROCESS_DTB,
-        .dtb = info->regs->cr3,
-        .addr = injector->payload_addr,
-    };
+    access_context_t ctx = {0};
+    ctx.translate_mechanism = VMI_TM_PROCESS_DTB;
+    ctx.dtb = info->regs->cr3;
+    ctx.addr = injector->payload_addr;
+
     vmi_instance_t vmi = drakvuf_lock_and_get_vmi(drakvuf);
     bool success = ( VMI_SUCCESS == vmi_write(vmi, &ctx, injector->payload_size, (void*)injector->payload, NULL) );
     drakvuf_release_vmi(drakvuf);
@@ -1071,12 +1066,11 @@ static event_response_t injector_int3_cb(drakvuf_t drakvuf, drakvuf_trap_info_t*
         addr_t saved_rip = 0;
 
         // Get saved RIP from the stack
-        access_context_t ctx =
-        {
-            .translate_mechanism = VMI_TM_PROCESS_DTB,
-            .dtb = info->regs->cr3,
-            .addr = info->regs->rsp,
-        };
+        access_context_t ctx = {0};
+        ctx.translate_mechanism = VMI_TM_PROCESS_DTB;
+        ctx.dtb = info->regs->cr3;
+        ctx.addr = info->regs->rsp;
+
         vmi_instance_t vmi = drakvuf_lock_and_get_vmi(drakvuf);
         bool success = (VMI_SUCCESS == vmi_read(vmi, &ctx, sizeof(addr_t), &saved_rip, NULL));
         drakvuf_release_vmi(drakvuf);
@@ -1473,7 +1467,9 @@ static addr_t get_function_va(drakvuf_t drakvuf, addr_t eprocess_base, char cons
     if (global_search)
     {
         // First get modules load address to search for other process with same address
-        access_context_t ctx = { .translate_mechanism = VMI_TM_PROCESS_PID, };
+        access_context_t ctx = {0};
+        ctx.translate_mechanism = VMI_TM_PROCESS_PID;
+
         addr_t module_list_head;
         if (drakvuf_get_process_pid(drakvuf, eprocess_base, &ctx.pid) &&
             drakvuf_get_module_list(drakvuf, eprocess_base, &module_list_head) &&

--- a/src/plugins/bsodmon/bsodmon.cpp
+++ b/src/plugins/bsodmon/bsodmon.cpp
@@ -115,6 +115,7 @@ static event_response_t hook_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
     vmi_instance_t vmi = drakvuf_lock_and_get_vmi(drakvuf);
 
     access_context_t ctx;
+    memset(&ctx, 0, sizeof(access_context_t));
     ctx.translate_mechanism = VMI_TM_PROCESS_DTB;
     ctx.dtb = info->regs->cr3;
 

--- a/src/plugins/delaymon/delaymon.cpp
+++ b/src/plugins/delaymon/delaymon.cpp
@@ -14,6 +14,7 @@ static event_response_t trap_NtDelayExecution_cb(drakvuf_t drakvuf, drakvuf_trap
 
     {
         access_context_t ctx;
+        memset(&ctx, 0, sizeof(access_context_t));
         ctx.translate_mechanism = VMI_TM_PROCESS_DTB;
         ctx.dtb = info->regs->cr3;
         ctx.addr = delay_addr;

--- a/src/plugins/exmon/exmon.cpp
+++ b/src/plugins/exmon/exmon.cpp
@@ -213,9 +213,9 @@ static event_response_t cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 
     if (e->pm != VMI_PM_IA32E)
     {
-        reg_t exception_record;
-        reg_t ptrap_frame;
-        reg_t exception_code;
+        reg_t exception_record = 0;
+        reg_t ptrap_frame = 0;
+        reg_t exception_code = 0;
         uint8_t previous_mode;
         uint32_t eip, eax, ebx, ecx, edx, edi, esi, ebp, hwesp;
 
@@ -228,11 +228,11 @@ static event_response_t cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
             goto done;
 
         ctx.addr = info->regs->rsp+16;
-        if ( VMI_FAILURE == vmi_read_8(vmi, &ctx, (uint8_t*)&previous_mode) )
+        if ( VMI_FAILURE == vmi_read_8(vmi, &ctx, &previous_mode) )
             goto done;
 
         ctx.addr = info->regs->rsp+20;
-        if ( VMI_FAILURE == vmi_read_32(vmi, &ctx, (uint32_t*)&first_chance) )
+        if ( VMI_FAILURE == vmi_read_32(vmi, &ctx, &first_chance) )
             goto done;
 
         ctx.addr = ptrap_frame;

--- a/src/plugins/exmon/exmon.cpp
+++ b/src/plugins/exmon/exmon.cpp
@@ -207,6 +207,7 @@ static event_response_t cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
     }
 
     access_context_t ctx;
+    memset(&ctx, 0, sizeof(access_context_t));
     ctx.translate_mechanism = VMI_TM_PROCESS_DTB;
     ctx.dtb = info->regs->cr3;
 

--- a/src/plugins/filedelete/filedelete.cpp
+++ b/src/plugins/filedelete/filedelete.cpp
@@ -179,6 +179,7 @@ static bool get_file_object_flags(drakvuf_t drakvuf, drakvuf_trap_info_t* info, 
     addr_t fileflags = file + f->offsets[FILE_OBJECT_FLAGS];
 
     access_context_t ctx;
+    memset(&ctx, 0, sizeof(access_context_t));
     ctx.translate_mechanism = VMI_TM_PROCESS_DTB;
     ctx.addr = fileflags;
     ctx.dtb = info->regs->cr3;
@@ -215,6 +216,7 @@ static std::string get_file_name(filedelete* f, drakvuf_t drakvuf, vmi_instance_
         *out_filetype = filetype;
 
     access_context_t ctx;
+    memset(&ctx, 0, sizeof(access_context_t));
     ctx.translate_mechanism = VMI_TM_PROCESS_DTB;
     ctx.addr = filetype;
     ctx.dtb = info->regs->cr3;
@@ -949,9 +951,11 @@ static event_response_t setinformation_cb(drakvuf_t drakvuf, drakvuf_trap_info_t
     {
         uint8_t del = 0;
         access_context_t ctx;
+        memset(&ctx, 0, sizeof(access_context_t));
         ctx.translate_mechanism = VMI_TM_PROCESS_DTB;
         ctx.dtb = info->regs->cr3;
         ctx.addr = fileinfo;
+
         if ( VMI_FAILURE == vmi_read_8(vmi, &ctx, &del) )
             goto done;
 

--- a/src/plugins/objmon/objmon.cpp
+++ b/src/plugins/objmon/objmon.cpp
@@ -154,6 +154,7 @@ static event_response_t cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 
     gchar* escaped_pname = NULL;
     access_context_t ctx;
+    memset(&ctx, 0, sizeof(access_context_t));
     ctx.translate_mechanism = VMI_TM_PROCESS_DTB;
     ctx.dtb = info->regs->cr3;
 

--- a/src/plugins/poolmon/poolmon.cpp
+++ b/src/plugins/poolmon/poolmon.cpp
@@ -141,8 +141,8 @@ static event_response_t cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 {
     poolmon* p = (poolmon*)info->trap->data;
     page_mode_t pm = drakvuf_get_page_mode(drakvuf);
-    reg_t pool_type;
-    reg_t size;
+    reg_t pool_type = 0;
+    reg_t size = 0;
     char tag[5] = { [0 ... 4] = '\0' };
     struct pooltag* s = NULL;
     const char* pool_type_str;

--- a/src/plugins/poolmon/poolmon.cpp
+++ b/src/plugins/poolmon/poolmon.cpp
@@ -149,6 +149,7 @@ static event_response_t cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
     gchar* escaped_pname = NULL;
 
     access_context_t ctx;
+    memset(&ctx, 0, sizeof(access_context_t));
     ctx.translate_mechanism = VMI_TM_PROCESS_DTB;
     ctx.dtb = info->regs->cr3;
 

--- a/src/plugins/socketmon/socketmon.cpp
+++ b/src/plugins/socketmon/socketmon.cpp
@@ -431,6 +431,7 @@ static event_response_t udpa_ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info
     socketmon* s = w->s;
 
     access_context_t ctx;
+    memset(&ctx, 0, sizeof(access_context_t));
     ctx.translate_mechanism = VMI_TM_PROCESS_DTB;
     ctx.dtb = info->regs->cr3;
 
@@ -509,6 +510,7 @@ static event_response_t tcpe_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
     char* lip = NULL;
     char* rip = NULL;
     access_context_t ctx;
+    memset(&ctx, 0, sizeof(access_context_t));
     ctx.translate_mechanism = VMI_TM_PROCESS_DTB;
     ctx.dtb = info->regs->cr3;
 
@@ -591,6 +593,7 @@ static event_response_t tcpl_ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info
     addr_t p1 = 0;
     char* lip = NULL;
     access_context_t ctx;
+    memset(&ctx, 0, sizeof(access_context_t));
     ctx.translate_mechanism = VMI_TM_PROCESS_DTB;
     ctx.dtb = info->regs->cr3;
 
@@ -794,6 +797,7 @@ static event_response_t trap_DnsQuery_A_cb(drakvuf_t drakvuf, drakvuf_trap_info_
     addr_t domain_name_addr = drakvuf_get_function_argument(drakvuf, info, 1);
 
     access_context_t ctx;
+    memset(&ctx, 0, sizeof(access_context_t));
     ctx.translate_mechanism = VMI_TM_PROCESS_DTB;
     ctx.dtb = info->regs->cr3;
     ctx.addr = domain_name_addr;
@@ -818,6 +822,7 @@ static event_response_t trap_DnsQuery_W_cb(drakvuf_t drakvuf, drakvuf_trap_info_
     unicode_string_t* domain_name_us = nullptr;
 
     access_context_t ctx;
+    memset(&ctx, 0, sizeof(access_context_t));
     ctx.translate_mechanism = VMI_TM_PROCESS_DTB;
     ctx.dtb = info->regs->cr3;
     ctx.addr = domain_name_addr;
@@ -853,6 +858,7 @@ static event_response_t trap_DnsQueryExW_cb(drakvuf_t drakvuf, drakvuf_trap_info
         uint32_t struct_size = sizeof(function_specific_string);
 
         access_context_t ctx;
+        memset(&ctx, 0, sizeof(access_context_t));
         ctx.translate_mechanism = VMI_TM_PROCESS_DTB;
         ctx.dtb = info->regs->cr3;
         ctx.addr = domain_name_addr;
@@ -892,6 +898,7 @@ static event_response_t trap_DnsQueryExA_cb(drakvuf_t drakvuf, drakvuf_trap_info
     addr_t domain_name_addr = drakvuf_get_function_argument(drakvuf, info, 1);
 
     access_context_t ctx;
+    memset(&ctx, 0, sizeof(access_context_t));
     ctx.translate_mechanism = VMI_TM_PROCESS_DTB;
     ctx.dtb = info->regs->cr3;
     ctx.addr = domain_name_addr;
@@ -919,6 +926,7 @@ static event_response_t trap_DnsQueryEx_cb(drakvuf_t drakvuf, drakvuf_trap_info_
     addr_t query_name_addr = 0;
 
     access_context_t ctx;
+    memset(&ctx, 0, sizeof(access_context_t));
     ctx.translate_mechanism = VMI_TM_PROCESS_DTB;
     ctx.dtb = info->regs->cr3;
     ctx.addr = query_request_addr + drakvuf_get_address_width(drakvuf);
@@ -1019,7 +1027,7 @@ static void register_module_trap( drakvuf_t drakvuf, drakvuf_trap_t* trap,
                                   const char* module_name, const char* function_name,
                                   event_response_t(*hook_cb)( drakvuf_t drakvuf, drakvuf_trap_info_t* info ) )
 {
-    struct module_trap_context_t visitor_ctx;
+    struct module_trap_context_t visitor_ctx = {0};
     visitor_ctx.module_name = module_name;
     visitor_ctx.function_name = function_name;
     visitor_ctx.trap = trap;

--- a/src/plugins/syscalls/syscalls.cpp
+++ b/src/plugins/syscalls/syscalls.cpp
@@ -496,6 +496,7 @@ static event_response_t win_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
     vmi_instance_t vmi = drakvuf_lock_and_get_vmi(drakvuf);
 
     access_context_t ctx;
+    memset(&ctx, 0, sizeof(access_context_t));
     ctx.translate_mechanism = VMI_TM_PROCESS_DTB;
     ctx.dtb = info->regs->cr3;
 


### PR DESCRIPTION
Examine breakpoint location to ensure that no instructions preceding it
can leak the breakpoint during execution. Certain instructions can fetch
subsequent memory and store it in registers, thus potentially revealing
the presence of the breakpoint. This is due to the fetch being performed
as part of the instruction and thus no read-access is performed.

This is an extra hardening step against code that may try to detect the
presence of DRAKVUF. When it is deemed unsafe to use the breakpoint
instruction itself, DRAKVUF reverts to a fallback mode using
memory permission based monitor and simulated int3 events. This backup
mode is a bit slower then using actual breakpoints but otherwise should
work without any sideeffect or the libdrakvuf caller having to know
where and when it is safe to use breakpoints.

We employ a whitelist of instructions that are allowed to precede the
breakpoint based on empiricial observation. This is overly cautious and
we may easily have excluded instructions that would be no problem. But
for now this list is working and can be extended in the future in case
anyone has a need for it.