### PR TITLE
Package build: allow to specify version manually

### DIFF
--- a/package/build.sh
+++ b/package/build.sh
@@ -9,7 +9,7 @@ mkdir -p package/log
 
 if [ ! -f "package/cache/xen-intermediate-$XEN_HASH.tar.gz" ]
 then
-    echo Building Xen intermediate...
+    echo Building Xen intermediate $XEN_HASH...
     docker build -f package/Dockerfile-xen -t xen-intermediate . 2>&1 >package/log/xen-build.log
     if [ $? -ne 0 ]; then echo Xen intermediate image build failed, build log tail below ; tail -n 200 package/log/xen-build.log ; exit 1 ; fi
     echo Removing old Xen intermediate image...
@@ -18,11 +18,11 @@ then
     docker save xen-intermediate | gzip -c > "package/cache/xen-intermediate-$XEN_HASH.tar.gz"
     if [ $? -ne 0 ]; then echo Failed to save Xen intermediate image ; rm package/cache/xen-intermediate-*.tar.gz ; exit 1 ; fi
 else
-    echo Loading cached Xen intermediate...
+    echo Loading cached Xen intermediate $XEN_HASH...
     docker load < "package/cache/xen-intermediate-$XEN_HASH.tar.gz"
     if [ $? -ne 0 ]; then echo Failed to load Xen intermediate image ; exit 1 ; fi
 fi
 
 echo Building final image...
-docker build -f package/Dockerfile-final -t deb-build . && docker run -v $(pwd)/package/out:/out deb-build
+docker build -f package/Dockerfile-final -t deb-build . && docker run -v $(pwd)/package/out:/out deb-build ./package/mkdeb $@
 if [ $? -ne 0 ]; then echo Failed to build package ; exit 1 ; fi

--- a/package/mkdeb
+++ b/package/mkdeb
@@ -4,16 +4,28 @@
 
 set -e
 
-distro=$1
+distro="$1"
 
 if [ "$distro" = "" ]
 then
     distro=generic
 fi
 
-version=$(grep 'PACKAGE_VERSION=' 'autom4te.cache/output.1' | head -n 1 | cut -f2 "-d'")
+if [ "$2" = "" ]
+then
+    version=$(grep 'PACKAGE_VERSION' 'src/Makefile' | head -n 1 | cut -f2 "-d=" | xargs echo -n)
+    echo "Auto-detected version: $version"
 
-# map the architecture, if necessary
+    if [ "$version" = "" ]
+    then
+        echo "Unable to recognize package version automatically, please provide it explicitly by the command line:"
+       echo "package/mkdeb <distro> <version>"
+    fi
+else
+    version="$2"
+    echo "Using version: $version"
+fi
+
 arch=amd64
 
 # Prepare the directory to package
@@ -62,7 +74,7 @@ cp package/extra/etc/modules-load.d/xen.conf deb/etc/modules-load.d/
 
 # Package it up
 chown -R root:root deb
-dpkg-deb --build -z0 deb drakvuf-bundle-$version-$distro.deb
+dpkg-deb --build -z0 deb "drakvuf-bundle-$version-$distro.deb"
 mv drakvuf-bundle*.deb /out
 rm -rf deb
 


### PR DESCRIPTION
More robust package version detection && possibility to specify it manually if it's not detected (happens in some environments).