### PR TITLE
plugins/wmimon: use correct dll to find CoCreateInstance

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -220,6 +220,8 @@ static void print_usage()
             "\t                           The JSON profile for ole32.dll\n"
             "\t --json-wow-ole32 <path to json>\n"
             "\t                           The JSON profile for SysWOW64/ole32.dll\n"
+            "\t --json-combase <path to json>\n"
+            "\t                           The JSON profile for combase.dll\n"
 #endif
 #ifdef ENABLE_PLUGIN_MEMDUMP
             "\t --memdump-dir <directory>\n"
@@ -284,6 +286,7 @@ int main(int argc, char** argv)
         opt_json_mpr,
         opt_json_ole32,
         opt_json_wow_ole32,
+        opt_json_combase,
         opt_memdump_dir,
         opt_dll_hooks_list,
     };
@@ -305,6 +308,7 @@ int main(int argc, char** argv)
         {"help", no_argument, NULL, 'h'},
         {"json-ole32", required_argument, NULL, opt_json_ole32},
         {"json-wow-ole32", required_argument, NULL, opt_json_wow_ole32},
+        {"json-combase", required_argument, NULL, opt_json_combase},
         {"memdump-dir", required_argument, NULL, opt_memdump_dir},
         {"dll-hooks-list", required_argument, NULL, opt_dll_hooks_list},
         {NULL, 0, NULL, 0}
@@ -453,6 +457,9 @@ int main(int argc, char** argv)
                 break;
             case opt_json_wow_ole32:
                 options.wow_ole32_profile = optarg;
+                break;
+            case opt_json_combase:
+                options.combase_profile = optarg;
                 break;
 #endif
 #ifdef ENABLE_PLUGIN_MEMDUMP

--- a/src/plugins/plugins.cpp
+++ b/src/plugins/plugins.cpp
@@ -309,6 +309,7 @@ int drakvuf_plugins::start(const drakvuf_plugin_t plugin_id,
                     {
                         .ole32_profile = options->ole32_profile,
                         .wow_ole32_profile = options->wow_ole32_profile,
+                        .combase_profile = options->combase_profile,
                     };
                     this->plugins[plugin_id] = new wmimon(this->drakvuf, &config, this->output);
                     break;

--- a/src/plugins/plugins.h
+++ b/src/plugins/plugins.h
@@ -130,6 +130,7 @@ struct plugins_options
     const char* ntdll_profile;          // PLUGIN_LIBRARYMON
     const char* ole32_profile;          // PLUGIN_WMIMON
     const char* wow_ole32_profile;      // PLUGIN_WMIMON
+    const char* combase_profile;        // PLUGIN_WMIMON
     const char* memdump_dir;            // PLUGIN_MEMDUMP
     const char* dll_hooks_list;         // PLUGIN_MEMDUMP
 };

--- a/src/plugins/wmimon/private.h
+++ b/src/plugins/wmimon/private.h
@@ -107,6 +107,7 @@
 
 #include <sstream>
 #include <iomanip>
+#include <vector>
 
 using uuid_t = unsigned char[16];
 

--- a/src/plugins/wmimon/wmimon.h
+++ b/src/plugins/wmimon/wmimon.h
@@ -113,6 +113,7 @@ struct wmimon_config
 {
     const char* ole32_profile;
     const char* wow_ole32_profile;
+    const char* combase_profile;
 };
 
 class wmimon: public pluginex


### PR DESCRIPTION
Starting from Windows 8 the CoCreateInstance functions resides in combase.dll.
The WoW is an exception.

Read WMI vtables based on OS arch