### PR TITLE
memdump/filedelete: change metadata format to JSON

### DIFF
--- a/src/libdrakvuf/Makefile.am
+++ b/src/libdrakvuf/Makefile.am
@@ -102,12 +102,12 @@
 #                                                                         #
 #*************************************************************************#
 
-h_sources = libdrakvuf.h json-profile.h os.h private.h vmi.h \
+h_sources = libdrakvuf.h json-profile.h json-util.h os.h private.h vmi.h \
             win.h win-error-codes.h win-exports.h win-handles.h win-offsets.h \
             win-offsets-map.h win-wow-offsets.h win-wow-offsets-map.h \
             ntstatus.h \
             linux.h linux-exports.h linux-offsets.h linux-offsets-map.h
-c_sources = drakvuf.c json-profile.c os.c vmi.c \
+c_sources = drakvuf.c json-profile.c json-util.c os.c vmi.c \
             win.c win-exports.c win-handles.c win-processes.c win-registry.c \
             win-files.c \
             linux.c linux-processes.c linux-exports.c

--- a/src/libdrakvuf/json-util.c
+++ b/src/libdrakvuf/json-util.c
@@ -121,7 +121,8 @@ struct json_object* json_object_new_string_fmt(const char* format, ...)
 
     va_end(args);
 
-    if (string) {
+    if (string)
+    {
         ret = json_object_new_string(string);
         free(string);
     }

--- a/src/libdrakvuf/json-util.c
+++ b/src/libdrakvuf/json-util.c
@@ -1,0 +1,129 @@
+/*********************IMPORTANT DRAKVUF LICENSE TERMS***********************
+*                                                                         *
+* DRAKVUF (C) 2014-2020 Tamas K Lengyel.                                  *
+* Tamas K Lengyel is hereinafter referred to as the author.               *
+* This program is free software; you may redistribute and/or modify it    *
+* under the terms of the GNU General Public License as published by the   *
+* Free Software Foundation; Version 2 ("GPL"), BUT ONLY WITH ALL OF THE   *
+* CLARIFICATIONS AND EXCEPTIONS DESCRIBED HEREIN.  This guarantees your   *
+* right to use, modify, and redistribute this software under certain      *
+* conditions.  If you wish to embed DRAKVUF technology into proprietary   *
+* software, alternative licenses can be aquired from the author.          *
+*                                                                         *
+* Note that the GPL places important restrictions on "derivative works",  *
+* yet it does not provide a detailed definition of that term.  To avoid   *
+* misunderstandings, we interpret that term as broadly as copyright law   *
+* allows.  For example, we consider an application to constitute a        *
+* derivative work for the purpose of this license if it does any of the   *
+* following with any software or content covered by this license          *
+* ("Covered Software"):                                                   *
+*                                                                         *
+* o Integrates source code from Covered Software.                         *
+*                                                                         *
+* o Reads or includes copyrighted data files.                             *
+*                                                                         *
+* o Is designed specifically to execute Covered Software and parse the    *
+* results (as opposed to typical shell or execution-menu apps, which will *
+* execute anything you tell them to).                                     *
+*                                                                         *
+* o Includes Covered Software in a proprietary executable installer.  The *
+* installers produced by InstallShield are an example of this.  Including *
+* DRAKVUF with other software in compressed or archival form does not     *
+* trigger this provision, provided appropriate open source decompression  *
+* or de-archiving software is widely available for no charge.  For the    *
+* purposes of this license, an installer is considered to include Covered *
+* Software even if it actually retrieves a copy of Covered Software from  *
+* another source during runtime (such as by downloading it from the       *
+* Internet).                                                              *
+*                                                                         *
+* o Links (statically or dynamically) to a library which does any of the  *
+* above.                                                                  *
+*                                                                         *
+* o Executes a helper program, module, or script to do any of the above.  *
+*                                                                         *
+* This list is not exclusive, but is meant to clarify our interpretation  *
+* of derived works with some common examples.  Other people may interpret *
+* the plain GPL differently, so we consider this a special exception to   *
+* the GPL that we apply to Covered Software.  Works which meet any of     *
+* these conditions must conform to all of the terms of this license,      *
+* particularly including the GPL Section 3 requirements of providing      *
+* source code and allowing free redistribution of the work as a whole.    *
+*                                                                         *
+* Any redistribution of Covered Software, including any derived works,    *
+* must obey and carry forward all of the terms of this license, including *
+* obeying all GPL rules and restrictions.  For example, source code of    *
+* the whole work must be provided and free redistribution must be         *
+* allowed.  All GPL references to "this License", are to be treated as    *
+* including the terms and conditions of this license text as well.        *
+*                                                                         *
+* Because this license imposes special exceptions to the GPL, Covered     *
+* Work may not be combined (even as part of a larger work) with plain GPL *
+* software.  The terms, conditions, and exceptions of this license must   *
+* be included as well.  This license is incompatible with some other open *
+* source licenses as well.  In some cases we can relicense portions of    *
+* DRAKVUF or grant special permissions to use it in other open source     *
+* software.  Please contact tamas.k.lengyel@gmail.com with any such       *
+* requests.  Similarly, we don't incorporate incompatible open source     *
+* software into Covered Software without special permission from the      *
+* copyright holders.                                                      *
+*                                                                         *
+* If you have any questions about the licensing restrictions on using     *
+* DRAKVUF in other works, are happy to help.  As mentioned above,         *
+* alternative license can be requested from the author to integrate       *
+* DRAKVUF into proprietary applications and appliances.  Please email     *
+* tamas.k.lengyel@gmail.com for further information.                      *
+*                                                                         *
+* If you have received a written license agreement or contract for        *
+* Covered Software stating terms other than these, you may choose to use  *
+* and redistribute Covered Software under those terms instead of these.   *
+*                                                                         *
+* Source is provided to this software because we believe users have a     *
+* right to know exactly what a program is going to do before they run it. *
+* This also allows you to audit the software for security holes.          *
+*                                                                         *
+* Source code also allows you to port DRAKVUF to new platforms, fix bugs, *
+* and add new features.  You are highly encouraged to submit your changes *
+* on https://github.com/tklengyel/drakvuf, or by other methods.           *
+* By sending these changes, it is understood (unless you specify          *
+* otherwise) that you are offering unlimited, non-exclusive right to      *
+* reuse, modify, and relicense the code.  DRAKVUF will always be          *
+* available Open Source, but this is important because the inability to   *
+* relicense code has caused devastating problems for other Free Software  *
+* projects (such as KDE and NASM).                                        *
+* To specify special license conditions of your contributions, just say   *
+* so when you send them.                                                  *
+*                                                                         *
+* This program is distributed in the hope that it will be useful, but     *
+* WITHOUT ANY WARRANTY; without even the implied warranty of              *
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the DRAKVUF   *
+* license file for more details (it's in a COPYING file included with     *
+* DRAKVUF, and also available from                                        *
+* https://github.com/tklengyel/drakvuf/COPYING)                           *
+*                                                                         *
+***************************************************************************/
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdarg.h>
+#include <json-c/json.h>
+#include "json-util.h"
+
+struct json_object* json_object_new_string_fmt(const char* format, ...)
+{
+    struct json_object* ret;
+    char* string;
+    va_list args;
+
+    va_start(args, format);
+
+    if (vasprintf(&string, format, args) < 0)
+    {
+        return NULL;
+    }
+
+    va_end(args);
+
+    ret = json_object_new_string(string);
+    free(string);
+    return ret;
+}

--- a/src/libdrakvuf/json-util.c
+++ b/src/libdrakvuf/json-util.c
@@ -110,20 +110,21 @@
 
 struct json_object* json_object_new_string_fmt(const char* format, ...)
 {
-    struct json_object* ret;
+    struct json_object* ret = NULL;
     char* string;
     va_list args;
 
     va_start(args, format);
 
     if (vasprintf(&string, format, args) < 0)
-    {
-        return NULL;
-    }
+        string = NULL;
 
     va_end(args);
 
-    ret = json_object_new_string(string);
-    free(string);
+    if (string) {
+        ret = json_object_new_string(string);
+        free(string);
+    }
+
     return ret;
 }

--- a/src/libdrakvuf/json-util.h
+++ b/src/libdrakvuf/json-util.h
@@ -1,0 +1,118 @@
+/*********************IMPORTANT DRAKVUF LICENSE TERMS***********************
+*                                                                         *
+* DRAKVUF (C) 2014-2020 Tamas K Lengyel.                                  *
+* Tamas K Lengyel is hereinafter referred to as the author.               *
+* This program is free software; you may redistribute and/or modify it    *
+* under the terms of the GNU General Public License as published by the   *
+* Free Software Foundation; Version 2 ("GPL"), BUT ONLY WITH ALL OF THE   *
+* CLARIFICATIONS AND EXCEPTIONS DESCRIBED HEREIN.  This guarantees your   *
+* right to use, modify, and redistribute this software under certain      *
+* conditions.  If you wish to embed DRAKVUF technology into proprietary   *
+* software, alternative licenses can be aquired from the author.          *
+*                                                                         *
+* Note that the GPL places important restrictions on "derivative works",  *
+* yet it does not provide a detailed definition of that term.  To avoid   *
+* misunderstandings, we interpret that term as broadly as copyright law   *
+* allows.  For example, we consider an application to constitute a        *
+* derivative work for the purpose of this license if it does any of the   *
+* following with any software or content covered by this license          *
+* ("Covered Software"):                                                   *
+*                                                                         *
+* o Integrates source code from Covered Software.                         *
+*                                                                         *
+* o Reads or includes copyrighted data files.                             *
+*                                                                         *
+* o Is designed specifically to execute Covered Software and parse the    *
+* results (as opposed to typical shell or execution-menu apps, which will *
+* execute anything you tell them to).                                     *
+*                                                                         *
+* o Includes Covered Software in a proprietary executable installer.  The *
+* installers produced by InstallShield are an example of this.  Including *
+* DRAKVUF with other software in compressed or archival form does not     *
+* trigger this provision, provided appropriate open source decompression  *
+* or de-archiving software is widely available for no charge.  For the    *
+* purposes of this license, an installer is considered to include Covered *
+* Software even if it actually retrieves a copy of Covered Software from  *
+* another source during runtime (such as by downloading it from the       *
+* Internet).                                                              *
+*                                                                         *
+* o Links (statically or dynamically) to a library which does any of the  *
+* above.                                                                  *
+*                                                                         *
+* o Executes a helper program, module, or script to do any of the above.  *
+*                                                                         *
+* This list is not exclusive, but is meant to clarify our interpretation  *
+* of derived works with some common examples.  Other people may interpret *
+* the plain GPL differently, so we consider this a special exception to   *
+* the GPL that we apply to Covered Software.  Works which meet any of     *
+* these conditions must conform to all of the terms of this license,      *
+* particularly including the GPL Section 3 requirements of providing      *
+* source code and allowing free redistribution of the work as a whole.    *
+*                                                                         *
+* Any redistribution of Covered Software, including any derived works,    *
+* must obey and carry forward all of the terms of this license, including *
+* obeying all GPL rules and restrictions.  For example, source code of    *
+* the whole work must be provided and free redistribution must be         *
+* allowed.  All GPL references to "this License", are to be treated as    *
+* including the terms and conditions of this license text as well.        *
+*                                                                         *
+* Because this license imposes special exceptions to the GPL, Covered     *
+* Work may not be combined (even as part of a larger work) with plain GPL *
+* software.  The terms, conditions, and exceptions of this license must   *
+* be included as well.  This license is incompatible with some other open *
+* source licenses as well.  In some cases we can relicense portions of    *
+* DRAKVUF or grant special permissions to use it in other open source     *
+* software.  Please contact tamas.k.lengyel@gmail.com with any such       *
+* requests.  Similarly, we don't incorporate incompatible open source     *
+* software into Covered Software without special permission from the      *
+* copyright holders.                                                      *
+*                                                                         *
+* If you have any questions about the licensing restrictions on using     *
+* DRAKVUF in other works, are happy to help.  As mentioned above,         *
+* alternative license can be requested from the author to integrate       *
+* DRAKVUF into proprietary applications and appliances.  Please email     *
+* tamas.k.lengyel@gmail.com for further information.                      *
+*                                                                         *
+* If you have received a written license agreement or contract for        *
+* Covered Software stating terms other than these, you may choose to use  *
+* and redistribute Covered Software under those terms instead of these.   *
+*                                                                         *
+* Source is provided to this software because we believe users have a     *
+* right to know exactly what a program is going to do before they run it. *
+* This also allows you to audit the software for security holes.          *
+*                                                                         *
+* Source code also allows you to port DRAKVUF to new platforms, fix bugs, *
+* and add new features.  You are highly encouraged to submit your changes *
+* on https://github.com/tklengyel/drakvuf, or by other methods.           *
+* By sending these changes, it is understood (unless you specify          *
+* otherwise) that you are offering unlimited, non-exclusive right to      *
+* reuse, modify, and relicense the code.  DRAKVUF will always be          *
+* available Open Source, but this is important because the inability to   *
+* relicense code has caused devastating problems for other Free Software  *
+* projects (such as KDE and NASM).                                        *
+* To specify special license conditions of your contributions, just say   *
+* so when you send them.                                                  *
+*                                                                         *
+* This program is distributed in the hope that it will be useful, but     *
+* WITHOUT ANY WARRANTY; without even the implied warranty of              *
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the DRAKVUF   *
+* license file for more details (it's in a COPYING file included with     *
+* DRAKVUF, and also available from                                        *
+* https://github.com/tklengyel/drakvuf/COPYING)                           *
+*                                                                         *
+***************************************************************************/
+
+#ifndef JSON_UTIL_H
+#define JSON_UTIL_H
+
+#include <json-c/json.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+    struct json_object* json_object_new_string_fmt(const char *format, ...) __attribute__ ((format (printf, 1, 2)));
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/plugins/filedelete/filedelete.cpp
+++ b/src/plugins/filedelete/filedelete.cpp
@@ -259,16 +259,28 @@ static void save_file_metadata(filedelete* f,
     if (!fp)
         return;
 
-    fprintf(fp, "FileName: \"%s\"\n", filename ?: "<UNKNOWN>");
-    fprintf(fp, "FileSize: %zu\n", file_size);
-    fprintf(fp, "FileFlags: 0x%lx (%s)\n", fo_flags, parse_flags(fo_flags, fo_flags_map, OUTPUT_DEFAULT, "0").c_str());
-    fprintf(fp, "SequenceNumber: %d\n", sequence_number);
-    fprintf(fp, "ControlArea: 0x%lx\n", control_area);
-    fprintf(fp, "PID: %" PRIu64 "\n", static_cast<uint64_t>(info->proc_data.pid));
-    fprintf(fp, "PPID: %" PRIu64 "\n", static_cast<uint64_t>(info->proc_data.ppid));
-    fprintf(fp, "ProcessName: \"%s\"\n", info->proc_data.name);
-    if (ntstatus)
-        fprintf(fp, "WARNING: The file have been read partially with status 0x%x\n", ntstatus);
+    // TODO string escaping
+    fprintf(fp, "{\n");
+    fprintf(fp, "  \"FileName\": \"%s\",\n", filename ?: "<UNKNOWN>");
+    fprintf(fp, "  \"FileSize\": %zu,\n", file_size);
+    fprintf(fp, "  \"FileFlags\": \"0x%lx (%s)\",\n", fo_flags, parse_flags(fo_flags, fo_flags_map, OUTPUT_DEFAULT, "0").c_str());
+    fprintf(fp, "  \"SequenceNumber\": %d,\n", sequence_number);
+    fprintf(fp, "  \"ControlArea\": \"0x%lx\",\n", control_area);
+    fprintf(fp, "  \"PID\": %" PRIu64 ",\n", static_cast<uint64_t>(info->proc_data.pid));
+    fprintf(fp, "  \"PPID\": %" PRIu64 ",\n", static_cast<uint64_t>(info->proc_data.ppid));
+    fprintf(fp, "  \"ProcessName\": \"%s\",\n", info->proc_data.name);
+    if (!ntstatus)
+    {
+        fprintf(fp, "  \"FullReadSuccess\": true\n");
+    }
+    else
+    {
+        fprintf(fp, "  \"FullReadSuccess\": false,\n");
+        // if the file have been read partially, also note what was the NTSTATUS of failing operation
+        fprintf(fp, "  \"ReadNtStatus\": %d\n", ntstatus);
+    }
+
+    fprintf(fp, "}\n");
 
     fclose(fp);
 }

--- a/src/plugins/filedelete/filedelete.cpp
+++ b/src/plugins/filedelete/filedelete.cpp
@@ -278,7 +278,7 @@ static void save_file_metadata(filedelete* f,
     {
         json_object_object_add(jobj, "FullReadSuccess", json_object_new_boolean(FALSE));
         // if the file have been read partially, also note what was the NTSTATUS of failing operation
-        json_object_object_add(jobj, "ProcessName", json_object_new_int(ntstatus));
+        json_object_object_add(jobj, "ReadNTStatus", json_object_new_int(ntstatus));
     }
 
     fprintf(fp, "%s\n", json_object_get_string(jobj));

--- a/src/plugins/filedelete/filedelete.cpp
+++ b/src/plugins/filedelete/filedelete.cpp
@@ -116,6 +116,7 @@
 #include "private.h"
 
 #include <libinjector/libinjector.h>
+#include <libdrakvuf/json-util.h>
 
 using std::ostringstream;
 using std::string;
@@ -259,30 +260,31 @@ static void save_file_metadata(filedelete* f,
     if (!fp)
         return;
 
-    // TODO string escaping
-    fprintf(fp, "{\n");
-    fprintf(fp, "  \"FileName\": \"%s\",\n", filename ?: "<UNKNOWN>");
-    fprintf(fp, "  \"FileSize\": %zu,\n", file_size);
-    fprintf(fp, "  \"FileFlags\": \"0x%lx (%s)\",\n", fo_flags, parse_flags(fo_flags, fo_flags_map, OUTPUT_DEFAULT, "0").c_str());
-    fprintf(fp, "  \"SequenceNumber\": %d,\n", sequence_number);
-    fprintf(fp, "  \"ControlArea\": \"0x%lx\",\n", control_area);
-    fprintf(fp, "  \"PID\": %" PRIu64 ",\n", static_cast<uint64_t>(info->proc_data.pid));
-    fprintf(fp, "  \"PPID\": %" PRIu64 ",\n", static_cast<uint64_t>(info->proc_data.ppid));
-    fprintf(fp, "  \"ProcessName\": \"%s\",\n", info->proc_data.name);
+    json_object *jobj = json_object_new_object();
+    json_object_object_add(jobj, "FileName", json_object_new_string(filename ?: "<UNKNOWN>"));
+    json_object_object_add(jobj, "FileSize", json_object_new_int64(file_size));
+    json_object_object_add(jobj, "FileFlags", json_object_new_string_fmt("0x%lx (%s)", fo_flags, parse_flags(fo_flags, fo_flags_map, OUTPUT_DEFAULT, "0").c_str()));
+    json_object_object_add(jobj, "SequenceNumber", json_object_new_int(sequence_number));
+    json_object_object_add(jobj, "ControlArea", json_object_new_string_fmt("0x%lx", control_area));
+    json_object_object_add(jobj, "PID", json_object_new_int64(static_cast<uint64_t>(info->proc_data.pid)));
+    json_object_object_add(jobj, "PPID", json_object_new_int64(static_cast<uint64_t>(info->proc_data.ppid)));
+    json_object_object_add(jobj, "ProcessName", json_object_new_string(info->proc_data.name));
+
     if (!ntstatus)
     {
-        fprintf(fp, "  \"FullReadSuccess\": true\n");
+        json_object_object_add(jobj, "FullReadSuccess", json_object_new_boolean(TRUE));
     }
     else
     {
-        fprintf(fp, "  \"FullReadSuccess\": false,\n");
+        json_object_object_add(jobj, "FullReadSuccess", json_object_new_boolean(FALSE));
         // if the file have been read partially, also note what was the NTSTATUS of failing operation
-        fprintf(fp, "  \"ReadNtStatus\": %d\n", ntstatus);
+        json_object_object_add(jobj, "ProcessName", json_object_new_int(ntstatus));
     }
 
-    fprintf(fp, "}\n");
-
+    fprintf(fp, "%s\n", json_object_get_string(jobj));
     fclose(fp);
+
+    json_object_put(jobj);
 }
 
 static void print_file_info(filedelete* f, drakvuf_t drakvuf, drakvuf_trap_info_t* info, const string& filename_s, const string& prefix_s, const string& data_s)

--- a/src/plugins/memdump/memdump.cpp
+++ b/src/plugins/memdump/memdump.cpp
@@ -132,20 +132,24 @@ static void save_file_metadata(const drakvuf_trap_info_t* info,
     if (!fp)
         return;
 
-    fprintf(fp, "Method: \"%s\"\n", method);
-    fprintf(fp, "DumpReason: \"%s\"\n", dump_reason);
-    fprintf(fp, "DumpAddress: 0x%" PRIx64 "\n", dump_address);
-    fprintf(fp, "DumpSize: 0x%" PRIx64 "\n", dump_size);
-    fprintf(fp, "PID: %" PRId32 "\n", info->proc_data.pid);
-    fprintf(fp, "PPID: %" PRId32 "\n", info->proc_data.ppid);
-    fprintf(fp, "ProcessName: \"%s\"\n", info->proc_data.name);
+    // TODO string escaping?
+
+    fprintf(fp, "{\n");
+    fprintf(fp, "  \"Method\": \"%s\",\n", method);
+    fprintf(fp, "  \"DumpReason\": \"%s\",\n", dump_reason);
+    fprintf(fp, "  \"DumpAddress\": \"0x%" PRIx64 "\",\n", dump_address);
+    fprintf(fp, "  \"DumpSize\": \"0x%" PRIx64 "\",\n", dump_size);
+    fprintf(fp, "  \"PID\": %" PRId32 ",\n", info->proc_data.pid);
+    fprintf(fp, "  \"PPID\": %" PRId32 ",\n", info->proc_data.ppid);
+    fprintf(fp, "  \"ProcessName\": \"%s\",\n", info->proc_data.name);
     if (extras && extras->type == WriteVirtualMemoryExtras)
     {
-        fprintf(fp, "TargetPID: %" PRId32 "\n", extras->write_virtual_memory_extras.target_pid);
-        fprintf(fp, "TargetProcessName: \"%s\"\n", extras->write_virtual_memory_extras.target_name);
-        fprintf(fp, "TargetBaseAddress: %" PRIx64 "\n", extras->write_virtual_memory_extras.base_address);
+        fprintf(fp, "  \"TargetPID\": %" PRId32 ",\n", extras->write_virtual_memory_extras.target_pid);
+        fprintf(fp, "  \"TargetProcessName\": \"%s\",\n", extras->write_virtual_memory_extras.target_name);
+        fprintf(fp, "  \"TargetBaseAddress\": \"0x%" PRIx64 "\",\n", extras->write_virtual_memory_extras.base_address);
     }
-    fprintf(fp, "DataFileName: \"%s\"\n", data_file_name);
+    fprintf(fp, "  \"DataFileName\": \"%s\"\n", data_file_name);
+    fprintf(fp, "}\n");
 
     fclose(fp);
 }

--- a/src/plugins/memdump/memdump.cpp
+++ b/src/plugins/memdump/memdump.cpp
@@ -108,6 +108,7 @@
 #include <libvmi/libvmi.h>
 #include <libvmi/peparse.h>
 #include <assert.h>
+#include <libdrakvuf/json-util.h>
 
 #include "memdump.h"
 #include "private.h"
@@ -132,26 +133,28 @@ static void save_file_metadata(const drakvuf_trap_info_t* info,
     if (!fp)
         return;
 
-    // TODO string escaping?
+    json_object *jobj = json_object_new_object();
+    json_object_object_add(jobj, "Method", json_object_new_string(method));
+    json_object_object_add(jobj, "DumpReason", json_object_new_string(dump_reason));
+    json_object_object_add(jobj, "DumpAddress", json_object_new_string_fmt("0x%" PRIx64, dump_address));
+    json_object_object_add(jobj, "DumpSize", json_object_new_string_fmt("0x%" PRIx64, dump_size));
+    json_object_object_add(jobj, "PID", json_object_new_int(info->proc_data.pid));
+    json_object_object_add(jobj, "PPID", json_object_new_int(info->proc_data.ppid));
+    json_object_object_add(jobj, "ProcessName", json_object_new_string(info->proc_data.name));
 
-    fprintf(fp, "{\n");
-    fprintf(fp, "  \"Method\": \"%s\",\n", method);
-    fprintf(fp, "  \"DumpReason\": \"%s\",\n", dump_reason);
-    fprintf(fp, "  \"DumpAddress\": \"0x%" PRIx64 "\",\n", dump_address);
-    fprintf(fp, "  \"DumpSize\": \"0x%" PRIx64 "\",\n", dump_size);
-    fprintf(fp, "  \"PID\": %" PRId32 ",\n", info->proc_data.pid);
-    fprintf(fp, "  \"PPID\": %" PRId32 ",\n", info->proc_data.ppid);
-    fprintf(fp, "  \"ProcessName\": \"%s\",\n", info->proc_data.name);
     if (extras && extras->type == WriteVirtualMemoryExtras)
     {
-        fprintf(fp, "  \"TargetPID\": %" PRId32 ",\n", extras->write_virtual_memory_extras.target_pid);
-        fprintf(fp, "  \"TargetProcessName\": \"%s\",\n", extras->write_virtual_memory_extras.target_name);
-        fprintf(fp, "  \"TargetBaseAddress\": \"0x%" PRIx64 "\",\n", extras->write_virtual_memory_extras.base_address);
+        json_object_object_add(jobj, "TargetPID", json_object_new_string_fmt("%" PRId32, extras->write_virtual_memory_extras.target_pid));
+        json_object_object_add(jobj, "TargetProcessName", json_object_new_string(extras->write_virtual_memory_extras.target_name));
+        json_object_object_add(jobj, "TargetBaseAddress", json_object_new_string_fmt("0x%" PRIx64, extras->write_virtual_memory_extras.base_address));
     }
-    fprintf(fp, "  \"DataFileName\": \"%s\"\n", data_file_name);
-    fprintf(fp, "}\n");
 
+    json_object_object_add(jobj, "DataFileName", json_object_new_string(data_file_name));
+
+    fprintf(fp, "%s\n", json_object_get_string(jobj));
     fclose(fp);
+
+    json_object_put(jobj);
 }
 
 /**

--- a/src/plugins/memdump/memdump.cpp
+++ b/src/plugins/memdump/memdump.cpp
@@ -144,7 +144,7 @@ static void save_file_metadata(const drakvuf_trap_info_t* info,
 
     if (extras && extras->type == WriteVirtualMemoryExtras)
     {
-        json_object_object_add(jobj, "TargetPID", json_object_new_string_fmt("%" PRId32, extras->write_virtual_memory_extras.target_pid));
+        json_object_object_add(jobj, "TargetPID", json_object_new_int(extras->write_virtual_memory_extras.target_pid));
         json_object_object_add(jobj, "TargetProcessName", json_object_new_string(extras->write_virtual_memory_extras.target_name));
         json_object_object_add(jobj, "TargetBaseAddress", json_object_new_string_fmt("0x%" PRIx64, extras->write_virtual_memory_extras.base_address));
     }


### PR DESCRIPTION
Store JSON metadata together with files dumped by `filedelete` plugin and memory dumps created by `memdump`. Add some util to make JSON-C usage easier.

resolve #779