### PR TITLE
memdump: refactor usermode hooking into core DRAKVUF

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -542,6 +542,7 @@ AC_CONFIG_FILES([Makefile src/Makefile
                  src/xen_helper/Makefile
                  src/plugins/Makefile
                  src/dirwatch/Makefile
+				 src/libusermode/Makefile
                ])
 
 AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -542,7 +542,7 @@ AC_CONFIG_FILES([Makefile src/Makefile
                  src/xen_helper/Makefile
                  src/plugins/Makefile
                  src/dirwatch/Makefile
-				 src/libusermode/Makefile
+                 src/libusermode/Makefile
                ])
 
 AC_OUTPUT

--- a/src/libdrakvuf/Makefile.am
+++ b/src/libdrakvuf/Makefile.am
@@ -112,7 +112,7 @@ c_sources = drakvuf.c json-profile.c os.c vmi.c \
             win-files.c \
             linux.c linux-processes.c linux-exports.c
 
-AM_CPPFLAGS = -I$(top_srcdir) -I$(top_srcdir)/src -I$(srcdir)
+AM_CPPFLAGS = -I$(top_srcdir)
 AM_CPPFLAGS += $(CPPFLAGS)
 AM_CPPFLAGS += $(VMI_CFLAGS)
 AM_CPPFLAGS += $(GLIB_CFLAGS)

--- a/src/libdrakvuf/Makefile.am
+++ b/src/libdrakvuf/Makefile.am
@@ -112,7 +112,7 @@ c_sources = drakvuf.c json-profile.c os.c vmi.c \
             win-files.c \
             linux.c linux-processes.c linux-exports.c
 
-AM_CPPFLAGS = -I$(top_srcdir)
+AM_CPPFLAGS = -I$(top_srcdir) -I$(top_srcdir)/src -I$(srcdir)
 AM_CPPFLAGS += $(CPPFLAGS)
 AM_CPPFLAGS += $(VMI_CFLAGS)
 AM_CPPFLAGS += $(GLIB_CFLAGS)

--- a/src/libdrakvuf/private.h
+++ b/src/libdrakvuf/private.h
@@ -160,6 +160,7 @@ struct fd_info
 };
 typedef struct fd_info* fd_info_t;
 
+
 struct drakvuf
 {
     char* dom_name;

--- a/src/libdrakvuf/private.h
+++ b/src/libdrakvuf/private.h
@@ -160,7 +160,6 @@ struct fd_info
 };
 typedef struct fd_info* fd_info_t;
 
-
 struct drakvuf
 {
     char* dom_name;

--- a/src/libusermode/Makefile.am
+++ b/src/libusermode/Makefile.am
@@ -102,65 +102,44 @@
 #                                                                         #
 #*************************************************************************#
 
-bin_PROGRAMS = drakvuf xen_memclone injector proc_stat
+sources = userhook.cpp userhook.h
 
-SUBDIRS = xen_helper libdrakvuf libinjector plugins dirwatch libusermode
-
-drakvuf_SOURCES = main.cpp drakvuf.cpp drakvuf.h
-xen_memclone_SOURCES  = xen_memclone.c
-injector_SOURCES = injector.c
-proc_stat_SOURCES = proc_stat.cpp
-
-AM_CPPFLAGS = $(CPPFLAGS)
+AM_CPPFLAGS = -I$(top_srcdir) -I$(top_srcdir)/src -I$(srcdir)
+AM_CPPFLAGS += $(CPPFLAGS)
 AM_CPPFLAGS += $(VMI_CFLAGS)
 AM_CPPFLAGS += $(GLIB_CFLAGS)
-AM_CPPFLAGS += $(JSON_CFLAGS)
-AM_CPPFLAGS += -I$(top_srcdir) -I$(srcdir)
+AM_CPPFLAGS += $(JSONC_CFLAGS)
 
 AM_LDFLAGS =  $(LDFLAGS)
-AM_LDFLAGS += $(VMI_LIBS)
 AM_LDFLAGS += $(GLIB_LIBS)
+AM_LDFLAGS += $(VMI_LIBS)
 AM_LDFLAGS += $(JSONC_LIBS)
 
-AM_CFLAGS = $(CFLAGS)
 AM_CXXFLAGS = $(CXXFLAGS)
-
 if HARDENING
-AM_CFLAGS += $(HARDEN_CFLAGS) -DHARDENING
 AM_CXXFLAGS += $(HARDEN_CFLAGS) -DHARDENING
 endif
 
 if SANITIZE
-AM_CFLAGS += $(SANITIZE_CFLAGS)
 AM_CXXFLAGS += $(SANITIZE_CFLAGS)
 AM_LDFLAGS += $(SANITIZE_LDFLAGS)
 endif
 
-# Note that -pg is incompatible with HARDENING
 if DEBUG
-AM_CFLAGS += -DDRAKVUF_DEBUG -Werror -Wall -Wextra -g -ggdb3
-AM_CFLAGS += -Wno-missing-field-initializers
 AM_CXXFLAGS += -DDRAKVUF_DEBUG -Werror -Wall -Wextra -g -ggdb3
-AM_CXXFLAGS += -Wno-missing-field-initializers -Wno-unknown-warning-option -Wno-c99-designator -ferror-limit=0
+AM_CXXFLAGS += -Wno-missing-field-initializers -Wno-unused-parameter
+AM_CXXFLAGS += -Wno-initializer-overrides -Wno-unknown-warning-option
+AM_CXXFLAGS += -Wno-c99-designator -ferror-limit=0 -Wno-reorder-init-list
+AM_CXXFLAGS += -Wcast-qual -Wcast-align -Wstrict-aliasing \
+               -Wpointer-arith -Winit-self -Wshadow \
+               -Wredundant-decls -Wfloat-equal -Wundef \
+               -Wvla
+# Note that -pg is incompatible with HARDENING
 if !HARDENING
-AM_CFLAGS += -pg
 AM_CXXFLAGS += -pg
 endif
 endif
 
-drakvuf_LDADD = libdrakvuf/libdrakvuf.la
-drakvuf_LDADD += xen_helper/libxenhelper.la
-drakvuf_LDADD += plugins/libdrakvufplugins.la
-drakvuf_LDADD += libinjector/libinjector.la
-drakvuf_LDADD += libusermode/libusermode.la
-
-if HARDENING
-drakvuf_LDADD += $(HARDEN_LDFLAGS)
-endif
-
-injector_LDADD = libdrakvuf/libdrakvuf.la
-injector_LDADD += libinjector/libinjector.la
-
-proc_stat_LDADD = libdrakvuf/libdrakvuf.la
-
-xen_memclone_LDADD = xen_helper/libxenhelper.la
+noinst_LTLIBRARIES= libusermode.la
+libusermode_la_SOURCES= $(sources)
+libusermode_la_LIBADD = ../libdrakvuf/libdrakvuf.la

--- a/src/libusermode/Makefile.am
+++ b/src/libusermode/Makefile.am
@@ -102,7 +102,7 @@
 #                                                                         #
 #*************************************************************************#
 
-sources = userhook.cpp userhook.h
+sources = userhook.cpp
 
 AM_CPPFLAGS = -I$(top_srcdir) -I$(top_srcdir)/src -I$(srcdir)
 AM_CPPFLAGS += $(CPPFLAGS)

--- a/src/libusermode/Makefile.am
+++ b/src/libusermode/Makefile.am
@@ -129,7 +129,6 @@ if DEBUG
 AM_CXXFLAGS += -DDRAKVUF_DEBUG -Werror -Wall -Wextra -g -ggdb3
 AM_CXXFLAGS += -Wno-missing-field-initializers -Wno-unused-parameter
 AM_CXXFLAGS += -Wno-initializer-overrides -Wno-unknown-warning-option
-AM_CXXFLAGS += -Wno-c99-designator -ferror-limit=0 -Wno-reorder-init-list
 AM_CXXFLAGS += -Wcast-qual -Wcast-align -Wstrict-aliasing \
                -Wpointer-arith -Winit-self -Wshadow \
                -Wredundant-decls -Wfloat-equal -Wundef \

--- a/src/libusermode/Makefile.am
+++ b/src/libusermode/Makefile.am
@@ -127,8 +127,7 @@ endif
 
 if DEBUG
 AM_CXXFLAGS += -DDRAKVUF_DEBUG -Werror -Wall -Wextra -g -ggdb3
-AM_CXXFLAGS += -Wno-missing-field-initializers -Wno-unused-parameter
-AM_CXXFLAGS += -Wno-initializer-overrides -Wno-unknown-warning-option
+AM_CXXFLAGS += -Wno-unused-parameter
 AM_CXXFLAGS += -Wcast-qual -Wcast-align -Wstrict-aliasing \
                -Wpointer-arith -Winit-self -Wshadow \
                -Wredundant-decls -Wfloat-equal -Wundef \

--- a/src/libusermode/userhook.cpp
+++ b/src/libusermode/userhook.cpp
@@ -276,9 +276,7 @@ static bool make_trap(vmi_instance_t vmi, drakvuf_t drakvuf, drakvuf_trap_info *
     addr_t pa;
 
     if (vmi_pagetable_lookup(vmi, info->regs->cr3, exec_func, &pa) != VMI_SUCCESS)
-    {
         goto fail;
-    }
 
     trap->breakpoint.lookup_type = LOOKUP_NONE;
     trap->breakpoint.addr_type = ADDR_PA;

--- a/src/libusermode/userhook.cpp
+++ b/src/libusermode/userhook.cpp
@@ -353,6 +353,7 @@ static event_response_t internal_perform_hooking(drakvuf_t drakvuf, drakvuf_trap
                     if (vmi_request_page_fault(lg.vmi, info->vcpu, exec_func, 0) == VMI_SUCCESS)
                     {
                         target.state = HOOK_PAGEFAULT_RETRY;
+                        return VMI_EVENT_RESPONSE_NONE;
                     }
                 }
                 else

--- a/src/libusermode/userhook.cpp
+++ b/src/libusermode/userhook.cpp
@@ -1,0 +1,837 @@
+/*********************IMPORTANT DRAKVUF LICENSE TERMS***********************
+ *                                                                         *
+ * DRAKVUF (C) 2014-2020 Tamas K Lengyel.                                  *
+ * Tamas K Lengyel is hereinafter referred to as the author.               *
+ * This program is free software; you may redistribute and/or modify it    *
+ * under the terms of the GNU General Public License as published by the   *
+ * Free Software Foundation; Version 2 ("GPL"), BUT ONLY WITH ALL OF THE   *
+ * CLARIFICATIONS AND EXCEPTIONS DESCRIBED HEREIN.  This guarantees your   *
+ * right to use, modify, and redistribute this software under certain      *
+ * conditions.  If you wish to embed DRAKVUF technology into proprietary   *
+ * software, alternative licenses can be aquired from the author.          *
+ *                                                                         *
+ * Note that the GPL places important restrictions on "derivative works",  *
+ * yet it does not provide a detailed definition of that term.  To avoid   *
+ * misunderstandings, we interpret that term as broadly as copyright law   *
+ * allows.  For example, we consider an application to constitute a        *
+ * derivative work for the purpose of this license if it does any of the   *
+ * following with any software or content covered by this license          *
+ * ("Covered Software"):                                                   *
+ *                                                                         *
+ * o Integrates source code from Covered Software.                         *
+ *                                                                         *
+ * o Reads or includes copyrighted data files.                             *
+ *                                                                         *
+ * o Is designed specifically to execute Covered Software and parse the    *
+ * results (as opposed to typical shell or execution-menu apps, which will *
+ * execute anything you tell them to).                                     *
+ *                                                                         *
+ * o Includes Covered Software in a proprietary executable installer.  The *
+ * installers produced by InstallShield are an example of this.  Including *
+ * DRAKVUF with other software in compressed or archival form does not     *
+ * trigger this provision, provided appropriate open source decompression  *
+ * or de-archiving software is widely available for no charge.  For the    *
+ * purposes of this license, an installer is considered to include Covered *
+ * Software even if it actually retrieves a copy of Covered Software from  *
+ * another source during runtime (such as by downloading it from the       *
+ * Internet).                                                              *
+ *                                                                         *
+ * o Links (statically or dynamically) to a library which does any of the  *
+ * above.                                                                  *
+ *                                                                         *
+ * o Executes a helper program, module, or script to do any of the above.  *
+ *                                                                         *
+ * This list is not exclusive, but is meant to clarify our interpretation  *
+ * of derived works with some common examples.  Other people may interpret *
+ * the plain GPL differently, so we consider this a special exception to   *
+ * the GPL that we apply to Covered Software.  Works which meet any of     *
+ * these conditions must conform to all of the terms of this license,      *
+ * particularly including the GPL Section 3 requirements of providing      *
+ * source code and allowing free redistribution of the work as a whole.    *
+ *                                                                         *
+ * Any redistribution of Covered Software, including any derived works,    *
+ * must obey and carry forward all of the terms of this license, including *
+ * obeying all GPL rules and restrictions.  For example, source code of    *
+ * the whole work must be provided and free redistribution must be         *
+ * allowed.  All GPL references to "this License", are to be treated as    *
+ * including the terms and conditions of this license text as well.        *
+ *                                                                         *
+ * Because this license imposes special exceptions to the GPL, Covered     *
+ * Work may not be combined (even as part of a larger work) with plain GPL *
+ * software.  The terms, conditions, and exceptions of this license must   *
+ * be included as well.  This license is incompatible with some other open *
+ * source licenses as well.  In some cases we can relicense portions of    *
+ * DRAKVUF or grant special permissions to use it in other open source     *
+ * software.  Please contact tamas.k.lengyel@gmail.com with any such       *
+ * requests.  Similarly, we don't incorporate incompatible open source     *
+ * software into Covered Software without special permission from the      *
+ * copyright holders.                                                      *
+ *                                                                         *
+ * If you have any questions about the licensing restrictions on using     *
+ * DRAKVUF in other works, are happy to help.  As mentioned above,         *
+ * alternative license can be requested from the author to integrate       *
+ * DRAKVUF into proprietary applications and appliances.  Please email     *
+ * tamas.k.lengyel@gmail.com for further information.                      *
+ *                                                                         *
+ * If you have received a written license agreement or contract for        *
+ * Covered Software stating terms other than these, you may choose to use  *
+ * and redistribute Covered Software under those terms instead of these.   *
+ *                                                                         *
+ * Source is provided to this software because we believe users have a     *
+ * right to know exactly what a program is going to do before they run it. *
+ * This also allows you to audit the software for security holes.          *
+ *                                                                         *
+ * Source code also allows you to port DRAKVUF to new platforms, fix bugs, *
+ * and add new features.  You are highly encouraged to submit your changes *
+ * on https://github.com/tklengyel/drakvuf, or by other methods.           *
+ * By sending these changes, it is understood (unless you specify          *
+ * otherwise) that you are offering unlimited, non-exclusive right to      *
+ * reuse, modify, and relicense the code.  DRAKVUF will always be          *
+ * available Open Source, but this is important because the inability to   *
+ * relicense code has caused devastating problems for other Free Software  *
+ * projects (such as KDE and NASM).                                        *
+ * To specify special license conditions of your contributions, just say   *
+ * so when you send them.                                                  *
+ *                                                                         *
+ * This program is distributed in the hope that it will be useful, but     *
+ * WITHOUT ANY WARRANTY; without even the implied warranty of              *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the DRAKVUF   *
+ * license file for more details (it's in a COPYING file included with     *
+ * DRAKVUF, and also available from                                        *
+ * https://github.com/tklengyel/drakvuf/COPYING)                           *
+ *                                                                         *
+ ***************************************************************************/
+
+ /**
+  * User mode hooking module of MEMDUMP plugin.
+  *
+  * (1) Observes when a process is loading a new DLL through the side effects
+  * of NtMapViewOfSection or NtProtectVirtualMemory being called.
+  * (2) Finds the DLL export information and checks if it's fully readable,
+  * if not, triggers a page fault to force system to load it into memory.
+  * (3) Translates given export symbols to virtual addresses, checks if
+  * the underlying memory is available (if not, again triggers page fault)
+  * and finally adds a standard DRAKVUF trap.
+  */
+
+#include <fstream>
+#include <sstream>
+#include <map>
+#include <string>
+
+#include <config.h>
+#include <glib.h>
+#include <inttypes.h>
+#include <libvmi/libvmi.h>
+#include <libvmi/peparse.h>
+#include <libdrakvuf/libdrakvuf.h>
+#include <assert.h>
+
+#include "userhook.hpp"
+
+
+userhook* instance = nullptr;
+
+
+/**
+ * Check if this thread is currently in process of loading a DLL.
+ * If so, return a pointer to the associated metadata.
+ */
+static user_dll_t* get_pending_dll(drakvuf_t drakvuf, drakvuf_trap_info * info, userhook * plugin)
+{
+	uint32_t thread_id;
+	if (!drakvuf_get_current_thread_id(drakvuf, info, &thread_id))
+		return nullptr;
+
+	auto vec_it = plugin->loaded_dlls.find(info->regs->cr3);
+
+	if (vec_it == plugin->loaded_dlls.end())
+		return nullptr;
+
+	for (auto& dll_meta : vec_it->second)
+	{
+		if (!dll_meta.is_hooked && dll_meta.thread_id == thread_id)
+			return &dll_meta;
+	}
+
+	return nullptr;
+}
+
+/**
+ * Check if DLL is interesting, if so, build a "hooking context" of a DLL. Such context is needed,
+ * because user mode hooking is a stateful operation which requires a VM to be un-paused many times.
+ */
+static user_dll_t* create_dll_meta(drakvuf_t drakvuf, drakvuf_trap_info * info, userhook * plugin, addr_t dll_base)
+{
+	mmvad_info_t mmvad;
+	if (!drakvuf_find_mmvad(drakvuf, info->proc_data.base_addr, dll_base, &mmvad))
+		return nullptr;
+
+	if (mmvad.file_name_ptr == 0)
+		return nullptr;
+
+	auto vec_it = plugin->loaded_dlls.find(info->regs->cr3);
+
+	if (vec_it != plugin->loaded_dlls.end())
+	{
+		for (auto const& dll_meta : vec_it->second)
+		{
+			if (dll_meta.real_dll_base == mmvad.starting_vpn << 12)
+			{
+				PRINT_DEBUG("[USERHOOK] DLL %d!%llx is already hooked\n", info->proc_data.pid, (unsigned long long)mmvad.starting_vpn << 12);
+				return nullptr;
+			}
+		}
+	}
+
+	uint32_t thread_id;
+	if (!drakvuf_get_current_thread_id(drakvuf, info, &thread_id))
+		return nullptr;
+
+	user_dll_t dll_meta =
+	{
+		.dtb = info->regs->cr3,
+		.thread_id = thread_id,
+		.real_dll_base = (mmvad.starting_vpn << 12),
+		.is_hooked = false
+	};
+
+    dll_t dll = {
+        .dtb = info->regs->cr3,
+        .pid = info->proc_data.pid,
+        .thread_id = thread_id,
+        .real_dll_base = (mmvad.starting_vpn << 12),
+        .mmvad = &mmvad
+    };
+
+	for (auto &reg : plugin->plugins) {
+		reg.cb(drakvuf, &dll, reg.extra);
+	}
+
+    // FIXME
+    dll_meta.targets = std::move(dll.targets);
+
+	if (dll_meta.targets.empty()) {
+		return nullptr;
+	}
+
+	printf("[USERHOOK] Found DLL which is worth processing %llx\n", (unsigned long long)mmvad.starting_vpn << 12);
+	addr_t vad_start = mmvad.starting_vpn << 12;
+	size_t vad_length = (mmvad.ending_vpn - mmvad.starting_vpn + 1) << 12;
+
+	access_context_t ctx =
+	{
+		.translate_mechanism = VMI_TM_PROCESS_DTB,
+		.dtb = info->regs->cr3,
+		.addr = vad_start
+	};
+
+	addr_t export_header_rva = 0;
+	size_t export_header_size = 0;
+
+	constexpr int MAX_HEADER_BYTES = 1024;   // keep under 1 page
+	uint8_t image[MAX_HEADER_BYTES];
+
+	vmi_instance_t vmi = drakvuf_lock_and_get_vmi(drakvuf);
+	bool status = (VMI_SUCCESS == peparse_get_image(vmi, &ctx, MAX_HEADER_BYTES, image));
+	drakvuf_release_vmi(drakvuf);
+
+	if (!status)
+		return nullptr;
+
+	void* optional_header = NULL;
+	uint16_t magic = 0;
+
+	peparse_assign_headers(image, NULL, NULL, &magic, &optional_header, NULL, NULL);
+	export_header_rva = peparse_get_idd_rva(IMAGE_DIRECTORY_ENTRY_EXPORT, &magic, optional_header, NULL, NULL);
+	export_header_size = peparse_get_idd_size(IMAGE_DIRECTORY_ENTRY_EXPORT, &magic, optional_header, NULL, NULL);
+
+	if (export_header_rva >= vad_length)
+	{
+		PRINT_DEBUG("[USERHOOK] Export header RVA is forwarded outside VAD\n");
+		return nullptr;
+	}
+	else if (export_header_size >= vad_length - export_header_rva)
+	{
+		PRINT_DEBUG("[USERHOOK] Export header size is forwarded outside VAD\n");
+		return nullptr;
+	}
+
+	dll_meta.pf_current_addr = vad_start + export_header_rva & ~(VMI_PS_4KB - 1);
+	dll_meta.pf_max_addr = vad_start + export_header_rva + export_header_size;
+
+	if (dll_meta.pf_max_addr & VMI_PS_4KB)
+	{
+		dll_meta.pf_max_addr += VMI_PS_4KB;
+		dll_meta.pf_max_addr = dll_meta.pf_max_addr & ~(VMI_PS_4KB - 1);
+	}
+
+	auto it = plugin->loaded_dlls.emplace(info->regs->cr3, std::vector<user_dll_t>()).first;
+	it->second.push_back(std::move(dll_meta));
+	return &it->second.back();
+}
+
+static bool make_trap(vmi_instance_t vmi, drakvuf_t drakvuf, drakvuf_trap_info * info, hook_target_entry_t * target, addr_t exec_func)
+{
+	target->pid = info->proc_data.pid;
+
+	drakvuf_trap_t* trap = new drakvuf_trap_t;
+	trap->type = BREAKPOINT;
+	trap->name = target->target_name.c_str();
+	trap->cb = target->callback;
+	trap->data = target;
+
+	// during CoW we need to find all traps placed on the same physical page
+	// that's why we'll manually resolve vaddr and strore paddr under trap->breakpoint.addr
+	addr_t pa;
+
+	if (vmi_pagetable_lookup(vmi, info->regs->cr3, exec_func, &pa) != VMI_SUCCESS)
+	{
+		goto fail;
+	}
+
+	trap->breakpoint.lookup_type = LOOKUP_NONE;
+	trap->breakpoint.addr_type = ADDR_PA;
+	trap->breakpoint.addr = pa;
+
+	if (drakvuf_add_trap(drakvuf, trap))
+	{
+		target->trap = trap;
+		return true;
+	}
+
+fail:
+	PRINT_DEBUG("[USERHOOK] Failed to add trap :(\n");
+	delete trap;
+	return false;
+}
+
+static event_response_t perform_hooking(drakvuf_t drakvuf, drakvuf_trap_info * info, userhook * plugin, user_dll_t * dll_meta)
+{
+	vmi_instance_t vmi = drakvuf_lock_and_get_vmi(drakvuf);
+
+	// we have to make sure that addresses between [pf_current_addr, pf_max_addr]
+	// are available for reading otherwise vmi_translate_sym2v will fail unconditionally
+	// and we will be unable to add hooks
+
+	while (dll_meta->pf_current_addr <= dll_meta->pf_max_addr)
+	{
+		page_info_t pinfo;
+		addr_t pa;
+		if (vmi_pagetable_lookup_extended(vmi, info->regs->cr3, dll_meta->pf_current_addr, &pinfo) == VMI_SUCCESS)
+		{
+			PRINT_DEBUG("[USERHOOK] Export info accessible OK %llx\n", (unsigned long long)dll_meta->pf_current_addr);
+			dll_meta->pf_current_addr += VMI_PS_4KB;
+			continue;
+		}
+
+		pa = pinfo.paddr;
+
+		if (vmi_request_page_fault(vmi, info->vcpu, dll_meta->pf_current_addr, 0) == VMI_SUCCESS)
+		{
+			PRINT_DEBUG("[USERHOOK] Export info not accessible, page fault %llx\n", (unsigned long long)dll_meta->pf_current_addr);
+			dll_meta->pf_current_addr += VMI_PS_4KB;
+		}
+		else
+		{
+			PRINT_DEBUG("[USERHOOK] Failed to request page fault for DTB %llx, address %llx\n", (unsigned long long)info->regs->cr3, (unsigned long long)dll_meta->pf_current_addr);
+		}
+
+		drakvuf_release_vmi(drakvuf);
+		return VMI_EVENT_RESPONSE_NONE;
+	}
+
+	// export info should be available, try hooking DLLs
+	for (auto& target : dll_meta->targets)
+	{
+		if (target.state == HOOK_FIRST_TRY || target.state == HOOK_PAGEFAULT_RETRY)
+		{
+			addr_t exec_func;
+			access_context_t ctx =
+			{
+				.translate_mechanism = VMI_TM_PROCESS_DTB,
+				.dtb = info->regs->cr3,
+				.addr = dll_meta->real_dll_base
+			};
+
+			status_t translate_ret = vmi_translate_sym2v(vmi, &ctx, target.target_name.c_str(), &exec_func);
+
+			if (translate_ret == VMI_SUCCESS && target.state == HOOK_FIRST_TRY)
+			{
+				target.state = HOOK_FAILED;
+
+				page_info_t pinfo;
+				if (vmi_pagetable_lookup_extended(vmi, info->regs->cr3, exec_func, &pinfo) != VMI_SUCCESS)
+				{
+					if (vmi_request_page_fault(vmi, info->vcpu, exec_func, 0) == VMI_SUCCESS)
+					{
+						target.state = HOOK_PAGEFAULT_RETRY;
+						drakvuf_release_vmi(drakvuf);
+						return VMI_EVENT_RESPONSE_NONE;
+					}
+				}
+				else
+				{
+					if (make_trap(vmi, drakvuf, info, &target, exec_func))
+						target.state = HOOK_OK;
+				}
+			}
+			else if (translate_ret == VMI_SUCCESS && target.state == HOOK_PAGEFAULT_RETRY)
+			{
+				target.state = HOOK_FAILED;
+				page_info_t pinfo;
+
+				if (vmi_pagetable_lookup_extended(vmi, info->regs->cr3, exec_func, &pinfo) == VMI_SUCCESS)
+				{
+					if (make_trap(vmi, drakvuf, info, &target, exec_func))
+						target.state = HOOK_OK;
+				}
+			}
+			else
+			{
+				target.state = HOOK_FAILED;
+			}
+
+			PRINT_DEBUG("[USERHOOK] Hook %s (vaddr = 0x%llx, dll_base = 0x%llx, result = %s)\n",
+				target.target_name.c_str(),
+				(unsigned long long)exec_func,
+				(unsigned long long)dll_meta->real_dll_base,
+				target.state == HOOK_OK ? "OK" : "FAIL");
+		}
+	}
+
+	drakvuf_release_vmi(drakvuf);
+	PRINT_DEBUG("[USERHOOK] Done, flag DLL as hooked\n");
+	dll_meta->is_hooked = true;
+	return VMI_EVENT_RESPONSE_NONE;
+}
+
+/**
+ * This is used in order to observe when SysWOW64 process is loading a new DLL.
+ * If the DLL is interesting, we perform further investigation and try to equip user mode hooks.
+ */
+static event_response_t protect_virtual_memory_hook_cb(drakvuf_t drakvuf, drakvuf_trap_info_t * info)
+{
+	// IN HANDLE ProcessHandle
+	uint64_t process_handle = drakvuf_get_function_argument(drakvuf, info, 1);
+	// IN OUT PVOID *BaseAddress
+	addr_t base_address_ptr = drakvuf_get_function_argument(drakvuf, info, 2);
+
+	if (process_handle != ~0ULL)
+		return VMI_EVENT_RESPONSE_NONE;
+
+	auto plugin = get_trap_plugin<userhook>(info);
+	if (!plugin)
+		return VMI_EVENT_RESPONSE_NONE;
+
+	user_dll_t * dll_meta = get_pending_dll(drakvuf, info, plugin);
+
+	if (!dll_meta)
+	{
+		addr_t base_address;
+
+		access_context_t ctx =
+		{
+			.translate_mechanism = VMI_TM_PROCESS_DTB,
+			.dtb = info->regs->cr3,
+			.addr = base_address_ptr
+		};
+
+		vmi_instance_t vmi = drakvuf_lock_and_get_vmi(drakvuf);
+		bool success = (VMI_SUCCESS == vmi_read_addr(vmi, &ctx, &base_address));
+		drakvuf_release_vmi(drakvuf);
+
+		if (!success)
+			return VMI_EVENT_RESPONSE_NONE;
+
+		dll_meta = create_dll_meta(drakvuf, info, plugin, base_address);
+	}
+
+	if (dll_meta)
+		return perform_hooking(drakvuf, info, plugin, dll_meta);
+
+	return VMI_EVENT_RESPONSE_NONE;
+}
+
+/**
+ * This is used in order to observe when 64 bit process is loading a new DLL.
+ * If the DLL is interesting, we perform further investigation and try to equip user mode hooks.
+ */
+static event_response_t map_view_of_section_ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t * info)
+{
+	auto data = get_trap_params<userhook, map_view_of_section_result_t<userhook>>(info);
+	userhook* plugin = data->plugin();
+	if (!data || !plugin)
+	{
+		PRINT_DEBUG("[USERHOOK] map_view_of_section_ret_cb invalid trap params!\n");
+		drakvuf_remove_trap(drakvuf, info->trap, nullptr);
+		return VMI_EVENT_RESPONSE_NONE;
+	}
+
+	if (!data->verify_result_call_params(info, drakvuf_get_current_thread(drakvuf, info)))
+		return VMI_EVENT_RESPONSE_NONE;
+
+	user_dll_t* dll_meta = get_pending_dll(drakvuf, info, plugin);
+
+	if (!dll_meta)
+	{
+		addr_t base_address;
+
+		access_context_t ctx =
+		{
+			.translate_mechanism = VMI_TM_PROCESS_DTB,
+			.dtb = info->regs->cr3,
+			.addr = data->base_address_ptr
+		};
+
+		vmi_instance_t vmi = drakvuf_lock_and_get_vmi(drakvuf);
+		bool success = (VMI_SUCCESS == vmi_read_addr(vmi, &ctx, &base_address));
+		drakvuf_release_vmi(drakvuf);
+
+		if (!success)
+			return VMI_EVENT_RESPONSE_NONE;
+
+		dll_meta = create_dll_meta(drakvuf, info, plugin, base_address);
+	}
+
+	if (dll_meta)
+		return perform_hooking(drakvuf, info, plugin, dll_meta);
+
+	plugin->destroy_trap(drakvuf, info->trap);
+	return VMI_EVENT_RESPONSE_NONE;
+}
+
+static event_response_t map_view_of_section_hook_cb(drakvuf_t drakvuf, drakvuf_trap_info_t * info)
+{
+	auto plugin = get_trap_plugin<userhook>(info);
+	if (!plugin)
+		return VMI_EVENT_RESPONSE_NONE;
+
+	auto trap = plugin->register_trap<userhook, map_view_of_section_result_t<userhook>>(
+		drakvuf,
+		info,
+		plugin,
+		map_view_of_section_ret_cb,
+		breakpoint_by_pid_searcher());
+	if (!trap)
+		return VMI_EVENT_RESPONSE_NONE;
+
+	auto data = get_trap_params<userhook, map_view_of_section_result_t<userhook>>(trap);
+	if (!data)
+	{
+		plugin->destroy_plugin_params(plugin->detach_plugin_params(trap));
+		return VMI_EVENT_RESPONSE_NONE;
+	}
+
+	data->set_result_call_params(info, drakvuf_get_current_thread(drakvuf, info));
+
+	// IN HANDLE SectionHandle
+	data->section_handle = drakvuf_get_function_argument(drakvuf, info, 1);
+	// IN HANDLE ProcessHandle
+	data->process_handle = drakvuf_get_function_argument(drakvuf, info, 2);
+	// IN OUT PVOID *BaseAddress
+	data->base_address_ptr = drakvuf_get_function_argument(drakvuf, info, 3);
+
+	return VMI_EVENT_RESPONSE_NONE;
+}
+
+/**
+ * As we may accidentally trigger an exception in the kernel by using vmi_request_page_fault,
+ * we hook KiSystemServiceHandler to account for that situation. Inside this hook,
+ * we check if it was "our fault" and if so, we forcefully return EXCEPTION_CONTINUE_EXECUTION.
+ * In any other case, we just pass the control to the original exception handler.
+ */
+static event_response_t system_service_handler_hook_cb(drakvuf_t drakvuf, drakvuf_trap_info_t * info)
+{
+	PRINT_DEBUG("[USERHOOK] Entered system service handler\n");
+
+	auto plugin = get_trap_plugin<userhook>(info);
+	if (!plugin)
+		return VMI_EVENT_RESPONSE_NONE;
+
+	uint32_t thread_id;
+
+	if (!drakvuf_get_current_thread_id(drakvuf, info, &thread_id))
+	{
+		PRINT_DEBUG("[USERHOOK] Failed to get thread id in system service handler!\n");
+		return VMI_EVENT_RESPONSE_NONE;
+	}
+
+	bool our_fault = false;
+
+	auto vec_it = plugin->loaded_dlls.find(info->regs->cr3);
+
+	if (vec_it != plugin->loaded_dlls.end())
+	{
+		for (auto const& dll_meta : vec_it->second)
+		{
+			if (dll_meta.dtb == info->regs->cr3 && dll_meta.thread_id == thread_id)
+			{
+				our_fault = true;
+				break;
+			}
+		}
+	}
+
+	if (!our_fault)
+	{
+		PRINT_DEBUG("[USERHOOK] Not suppressing service exception - not our fault\n");
+		return VMI_EVENT_RESPONSE_NONE;
+	}
+
+	// emulate `ret` instruction
+	addr_t saved_rip = 0;
+	access_context_t ctx =
+	{
+		.translate_mechanism = VMI_TM_PROCESS_DTB,
+		.dtb = info->regs->cr3,
+		.addr = info->regs->rsp,
+	};
+
+	vmi_instance_t vmi = drakvuf_lock_and_get_vmi(drakvuf);
+	bool success = (VMI_SUCCESS == vmi_read(vmi, &ctx, sizeof(addr_t), &saved_rip, NULL));
+	drakvuf_release_vmi(drakvuf);
+
+	if (!success)
+	{
+		PRINT_DEBUG("[USERHOOK] Error while reading the saved RIP in system service handler\n");
+		return VMI_EVENT_RESPONSE_NONE;
+	}
+
+	constexpr int EXCEPTION_CONTINUE_EXECUTION = 0;
+	info->regs->rip = saved_rip;
+	info->regs->rsp += sizeof(addr_t);
+	info->regs->rax = EXCEPTION_CONTINUE_EXECUTION;
+	return VMI_EVENT_RESPONSE_SET_REGISTERS;
+}
+
+/**
+ * Observe process exit and remove all user mode hooks
+ */
+static event_response_t terminate_process_hook_cb(drakvuf_t drakvuf, drakvuf_trap_info_t * info)
+{
+	auto plugin = get_trap_plugin<userhook>(info);
+	if (!plugin)
+		return VMI_EVENT_RESPONSE_NONE;
+
+	auto vec_it = plugin->loaded_dlls.find(info->regs->cr3);
+
+	if (vec_it == plugin->loaded_dlls.end())
+		return VMI_EVENT_RESPONSE_NONE;
+
+	for (auto& it : vec_it->second)
+	{
+		for (auto& target : it.targets)
+		{
+			if (target.state == HOOK_OK)
+			{
+				PRINT_DEBUG("[USERHOOK] Erased trap for pid %d %s\n", info->proc_data.pid,
+					target.target_name.c_str());
+				drakvuf_remove_trap(drakvuf, target.trap, NULL);
+			}
+		}
+	}
+
+	plugin->loaded_dlls.erase(vec_it);
+	return VMI_EVENT_RESPONSE_NONE;
+}
+
+static event_response_t copy_on_write_ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t * info)
+{
+	auto data = get_trap_params<userhook, copy_on_write_result_t<userhook>>(info);
+	userhook* plugin = data->plugin();
+	if (!data || !plugin)
+	{
+		PRINT_DEBUG("[USERHOOK] copy_on_write_ret_cb invalid trap params!\n");
+		drakvuf_remove_trap(drakvuf, info->trap, nullptr);
+		return VMI_EVENT_RESPONSE_NONE;
+	}
+
+	if (!data->verify_result_call_params(info, drakvuf_get_current_thread(drakvuf, info)))
+		return VMI_EVENT_RESPONSE_NONE;
+
+	plugin->destroy_trap(drakvuf, info->trap);
+
+	vmi_instance_t vmi = drakvuf_lock_and_get_vmi(drakvuf);
+
+	// sometimes the physical address was incorrectly cached in this moment, so we need to flush it
+	vmi_v2pcache_flush(vmi, info->regs->cr3);
+	addr_t pa;
+
+	if (vmi_pagetable_lookup(vmi, info->regs->cr3, data->vaddr, &pa) != VMI_SUCCESS)
+	{
+		PRINT_DEBUG("[USERHOOK] failed to get pa\n");
+		goto end;
+	}
+
+	if (data->old_cow_pa == pa)
+	{
+		PRINT_DEBUG("[USERHOOK] PA after CoW remained the same, wtf? Nothing to do here...\n");
+		goto end;
+	}
+
+	for (auto& hook : data->hooks)
+	{
+		addr_t hook_va = ((data->vaddr >> 12) << 12) + (hook->trap->breakpoint.addr & 0xFFF);
+		PRINT_DEBUG("adding hook at %lx\n", hook_va);
+
+		if (hook->trap)
+		{
+			drakvuf_remove_trap(drakvuf, hook->trap, nullptr);
+			delete hook->trap;
+			hook->state = HOOK_FAILED;
+			hook->trap = nullptr;
+		}
+
+		make_trap(vmi, drakvuf, info, hook, hook_va);
+	}
+
+end:
+	drakvuf_release_vmi(drakvuf);
+	return VMI_EVENT_RESPONSE_NONE;
+}
+
+static event_response_t copy_on_write_handler(drakvuf_t drakvuf, drakvuf_trap_info_t * info)
+{
+	auto plugin = get_trap_plugin<userhook>(info);
+	if (!plugin)
+		return VMI_EVENT_RESPONSE_NONE;
+
+	addr_t vaddr = drakvuf_get_function_argument(drakvuf, info, 1);
+	addr_t pte = drakvuf_get_function_argument(drakvuf, info, 2);
+
+	vmi_instance_t vmi = drakvuf_lock_and_get_vmi(drakvuf);
+
+	addr_t pa;
+
+	if (vmi_pagetable_lookup(vmi, info->regs->cr3, vaddr, &pa) != VMI_SUCCESS)
+	{
+		PRINT_DEBUG("[USERHOOK] failed to get pa");
+		drakvuf_release_vmi(drakvuf);
+		return VMI_EVENT_RESPONSE_NONE;
+	}
+
+	drakvuf_release_vmi(drakvuf);
+
+	std::vector < hook_target_entry_t* > hooks;
+	for (auto& dll : plugin->loaded_dlls[info->regs->cr3])
+	{
+		for (auto& hook : dll.targets)
+		{
+			if (hook.state == HOOK_OK)
+			{
+				addr_t hook_addr = hook.trap->breakpoint.addr;
+				if (hook_addr >> 12 == pa >> 12)
+				{
+					hooks.push_back(&hook);
+				}
+			}
+		}
+	}
+
+	PRINT_DEBUG("[USERHOOK] copy on write called: vaddr: %llx pte: %llx, pid: %d, cr3: %llx\n", (unsigned long long)vaddr, (unsigned long long)pte, info->proc_data.pid, (unsigned long long)info->regs->cr3);
+	PRINT_DEBUG("[USERHOOK] old CoW PA: %llx\n", (unsigned long long)pa);
+
+	if (!hooks.empty())
+	{
+		PRINT_DEBUG("USERHOOK] Found %zu hooks on CoW page, registering return trap\n", hooks.size());
+
+		auto trap = plugin->register_trap<userhook, copy_on_write_result_t<userhook>>(
+			drakvuf,
+			info,
+			plugin,
+			copy_on_write_ret_cb,
+			breakpoint_by_pid_searcher());
+		if (!trap)
+			return VMI_EVENT_RESPONSE_NONE;
+
+		auto data = get_trap_params<userhook, copy_on_write_result_t<userhook>>(trap);
+		if (!data)
+		{
+			plugin->destroy_plugin_params(plugin->detach_plugin_params(trap));
+			return VMI_EVENT_RESPONSE_NONE;
+		}
+
+		data->set_result_call_params(info, drakvuf_get_current_thread(drakvuf, info));
+
+		data->vaddr = vaddr;
+		data->pte = pte;
+		data->old_cow_pa = pa;
+		data->hooks = hooks;
+	}
+
+	return VMI_EVENT_RESPONSE_NONE;
+}
+
+bool userhook::init(drakvuf_t drakvuf)
+{
+	page_mode_t pm = drakvuf_get_page_mode(drakvuf);
+
+	if (pm != VMI_PM_IA32E)
+	{
+		PRINT_DEBUG("[USERHOOK] Usermode hooking is not yet supported on this architecture/bitness.\n");
+		return 0;
+	}
+
+	breakpoint_in_system_process_searcher bp;
+	if (!register_trap<userhook>(drakvuf, nullptr, this, protect_virtual_memory_hook_cb, bp.for_syscall_name("NtProtectVirtualMemory")) ||
+		!register_trap<userhook>(drakvuf, nullptr, this, map_view_of_section_hook_cb, bp.for_syscall_name("NtMapViewOfSection")) ||
+		!register_trap<userhook>(drakvuf, nullptr, this, system_service_handler_hook_cb, bp.for_syscall_name("KiSystemServiceHandler")) ||
+		!register_trap<userhook>(drakvuf, nullptr, this, terminate_process_hook_cb, bp.for_syscall_name("NtTerminateProcess")) ||
+		!register_trap<userhook>(drakvuf, nullptr, this, copy_on_write_handler, bp.for_syscall_name("MiCopyOnWrite")))
+	{
+		return 0;
+	}
+
+	return 1;
+}
+
+bool userhook::register_plugin(drakvuf_t drakvuf, usermode_cb_registration reg)
+{
+	if (!this->initialized) {
+		printf("initialize userhook\n");
+		if (!this->init(drakvuf)) {
+			return false;
+		}
+	}
+
+	printf("Pushing registration\n");
+	this->plugins.push_back(reg);
+	return true;
+}
+
+userhook::~userhook()
+{
+	for (auto& it : this->loaded_dlls)
+	{
+		for (auto& loaded_dll : it.second)
+		{
+			for (auto& target : loaded_dll.targets)
+			{
+				if (target.state == HOOK_OK)
+				{
+					delete target.trap;
+				}
+			}
+		}
+	}
+}
+
+bool drakvuf_register_usermode_callback(drakvuf_t drakvuf, usermode_cb_registration* reg)
+{
+    if (!instance) {
+        instance = new userhook(drakvuf);
+    }
+
+    if (!instance->initialized) {
+        if (!instance->init(drakvuf)) {
+            return false;
+        }
+    }
+
+    if (!instance->register_plugin(drakvuf, *reg)) {
+        return false;
+    }
+
+    return true;
+}

--- a/src/libusermode/userhook.cpp
+++ b/src/libusermode/userhook.cpp
@@ -761,6 +761,7 @@ static event_response_t copy_on_write_handler(drakvuf_t drakvuf, drakvuf_trap_in
 bool userhook::init(drakvuf_t drakvuf)
 {
     page_mode_t pm = drakvuf_get_page_mode(drakvuf);
+    this->initialized = true;
 
     if (pm != VMI_PM_IA32E)
     {
@@ -781,16 +782,9 @@ bool userhook::init(drakvuf_t drakvuf)
     return 1;
 }
 
-bool userhook::register_plugin(drakvuf_t drakvuf, usermode_cb_registration reg)
+void userhook::register_plugin(drakvuf_t drakvuf, usermode_cb_registration reg)
 {
-    if (!this->initialized) {
-        if (!this->init(drakvuf)) {
-            return false;
-        }
-    }
-
     this->plugins.push_back(reg);
-    return true;
 }
 
 userhook::~userhook()
@@ -822,9 +816,6 @@ bool drakvuf_register_usermode_callback(drakvuf_t drakvuf, usermode_cb_registrat
         }
     }
 
-    if (!instance->register_plugin(drakvuf, *reg)) {
-        return false;
-    }
-
+    instance->register_plugin(drakvuf, *reg);
     return true;
 }

--- a/src/libusermode/userhook.cpp
+++ b/src/libusermode/userhook.cpp
@@ -686,11 +686,10 @@ static event_response_t copy_on_write_handler(drakvuf_t drakvuf, drakvuf_trap_in
 
     addr_t vaddr = drakvuf_get_function_argument(drakvuf, info, 1);
     addr_t pte = drakvuf_get_function_argument(drakvuf, info, 2);
+    addr_t pa;
 
     { // using vmi
         vmi_lock_guard lg(drakvuf);
-
-        addr_t pa;
 
         if (vmi_pagetable_lookup(lg.vmi, info->regs->cr3, vaddr, &pa) != VMI_SUCCESS)
         {

--- a/src/libusermode/userhook.cpp
+++ b/src/libusermode/userhook.cpp
@@ -454,10 +454,10 @@ static event_response_t map_view_of_section_ret_cb(drakvuf_t drakvuf, drakvuf_tr
 {
     auto data = get_trap_params<userhook, map_view_of_section_result_t<userhook>>(info);
     userhook* plugin = data->plugin();
+
     if (!data || !plugin)
     {
         PRINT_DEBUG("[USERHOOK] map_view_of_section_ret_cb invalid trap params!\n");
-        drakvuf_remove_trap(drakvuf, info->trap, nullptr);
         return VMI_EVENT_RESPONSE_NONE;
     }
 
@@ -633,10 +633,10 @@ static event_response_t copy_on_write_ret_cb(drakvuf_t drakvuf, drakvuf_trap_inf
 {
     auto data = get_trap_params<userhook, copy_on_write_result_t<userhook>>(info);
     userhook* plugin = data->plugin();
+
     if (!data || !plugin)
     {
         PRINT_DEBUG("[USERHOOK] copy_on_write_ret_cb invalid trap params!\n");
-        drakvuf_remove_trap(drakvuf, info->trap, nullptr);
         return VMI_EVENT_RESPONSE_NONE;
     }
 

--- a/src/libusermode/userhook.hpp
+++ b/src/libusermode/userhook.hpp
@@ -219,7 +219,7 @@ public:
     ~userhook();
 
     bool init(drakvuf_t drakvuf);
-    bool register_plugin(drakvuf_t drakvuf, usermode_cb_registration reg);
+    void register_plugin(drakvuf_t drakvuf, usermode_cb_registration reg);
 };
 
 extern userhook* instance;

--- a/src/libusermode/userhook.hpp
+++ b/src/libusermode/userhook.hpp
@@ -202,7 +202,13 @@ struct usermode_cb_registration {
     void* extra;
 };
 
-bool drakvuf_register_usermode_callback(drakvuf_t drakvuf, usermode_cb_registration* reg);
+typedef enum usermode_reg_status {
+    USERMODE_REGISTER_ERROR,
+    USERMODE_REGISTER_SUCCESS,
+    USERMODE_ARCH_UNSUPPORTED,
+} usermode_reg_status_t;
+
+usermode_reg_status_t drakvuf_register_usermode_callback(drakvuf_t drakvuf, usermode_cb_registration* reg);
 
 class userhook : public pluginex
 {

--- a/src/libusermode/userhook.hpp
+++ b/src/libusermode/userhook.hpp
@@ -102,77 +102,132 @@
  *                                                                         *
  ***************************************************************************/
 
-#ifndef MEMDUMP_PRIVATE_H
-#define MEMDUMP_PRIVATE_H
+#ifndef WIN_USERHOOK_H
+#define WIN_USERHOOK_H
 
 #include <vector>
-#include <list>
+#include <memory>
 
-typedef enum
-  {
-   INVALID,
-   WriteVirtualMemoryExtras,
-   __MAX_EXTRAX__
-  } extras_type_t;
+#include <glib.h>
+#include "plugins/private.h"
+#include "plugins/plugins_ex.h"
 
-typedef struct
+typedef event_response_t(*callback_t)(drakvuf_t drakvuf, drakvuf_trap_info* info);
+
+enum target_hook_state
 {
-  extras_type_t type;
-  union
-  {
-    struct
-    {
-      vmi_pid_t target_pid;
-      char* target_name;
-      addr_t base_address;
-    } write_virtual_memory_extras;
-  };
-} extras_t;
-
-class memdump;
-
-// type of a pointer residing on stack
-enum sptr_type_t
-{
-    ERROR,   // problem with stack inspection
-    MAIN,    // pointer to a main module
-    LINKED,  // pointer to some linked DLL module
-    UNLINKED // pointer to some non-legit memory
+	HOOK_FIRST_TRY,
+	HOOK_PAGEFAULT_RETRY,
+	HOOK_FAILED,
+	HOOK_OK
 };
 
-sptr_type_t check_module_linked_wow(drakvuf_t drakvuf,
-                                    vmi_instance_t vmi,
-                                    memdump* plugin,
-                                    drakvuf_trap_info_t* info,
-                                    addr_t dll_base);
+struct hook_target_entry_t
+{
+	vmi_pid_t pid;
+	std::string target_name;
+	callback_t callback;
+	size_t args_num;
+	target_hook_state state;
+	drakvuf_trap_t* trap;
+	void* plugin;
 
-sptr_type_t check_module_linked(drakvuf_t drakvuf,
-                                vmi_instance_t vmi,
-                                memdump* plugin,
-                                drakvuf_trap_info_t* info,
-                                addr_t dll_base);
+	hook_target_entry_t(std::string target_name, callback_t callback, size_t args_num, void* plugin)
+		: target_name(target_name), callback(callback), args_num(args_num), state(HOOK_FIRST_TRY), plugin(plugin) {}
+};
 
-bool dump_memory_region(
-    drakvuf_t drakvuf,
-    vmi_instance_t vmi,
-    drakvuf_trap_info_t* info,
-    memdump* plugin,
-    access_context_t* ctx,
-    size_t len_bytes,
-    const char* reason,
-    extras_t* extras,
-    void (*printout_extras)(drakvuf_t drakvuf, output_format_t format, extras_t* extras));
+struct return_hook_target_entry_t
+{
+	vmi_pid_t pid;
+	drakvuf_trap_t* trap;
+	void* plugin;
+	std::vector < uint64_t > arguments;
+};
 
-bool inspect_stack_ptr(
-    drakvuf_t drakvuf,
-    drakvuf_trap_info_t* info,
-    memdump* plugin,
-    bool is_32bit,
-    addr_t stack_ptr);
+template<typename T>
+struct map_view_of_section_result_t : public call_result_t<T>
+{
+	map_view_of_section_result_t(T* src) : call_result_t<T>(src), section_handle(), process_handle(), base_address_ptr() {}
 
-bool dump_from_stack(
-    drakvuf_t drakvuf,
-    drakvuf_trap_info_t* info,
-    memdump* plugin);
+	uint64_t section_handle;
+	uint64_t process_handle;
+	addr_t base_address_ptr;
+};
+
+template<typename T>
+struct copy_on_write_result_t : public call_result_t<T>
+{
+	copy_on_write_result_t(T* src) : call_result_t<T>(src), vaddr(), pte(), old_cow_pa() {}
+
+	addr_t vaddr;
+	addr_t pte;
+	addr_t old_cow_pa;
+	std::vector<hook_target_entry_t*> hooks;
+};
+
+struct user_dll_t
+{
+	// relevant while loading
+	addr_t dtb;
+	uint32_t thread_id;
+	addr_t real_dll_base;
+	bool is_hooked;
+
+	// internal, for page faults
+	addr_t pf_current_addr;
+	addr_t pf_max_addr;
+
+	// one entry per hooked function
+	std::vector<hook_target_entry_t> targets;
+};
+
+struct target_config_entry_t
+{
+	std::string dll_name;
+	std::string function_name;
+	size_t args_num;
+
+	target_config_entry_t() : dll_name(), function_name(), args_num() {}
+	target_config_entry_t(std::string&& dll_name, std::string&& function_name, size_t args_num)
+		: dll_name(std::move(dll_name)), function_name(std::move(function_name)), args_num(args_num) {}
+};
+
+struct dll_t {
+    addr_t dtb;
+    vmi_pid_t pid;
+    uint32_t thread_id;
+    addr_t real_dll_base;
+    mmvad_info_t* mmvad;
+    std::vector<hook_target_entry_t> targets;
+};
+
+typedef void (*dll_discover_cb)(drakvuf_t, dll_t*, void*);
+
+struct usermode_cb_registration {
+    dll_discover_cb cb;
+    void* extra;
+};
+
+bool drakvuf_register_usermode_callback(drakvuf_t drakvuf, usermode_cb_registration* reg);
+
+class userhook : public pluginex
+{
+public:
+    int initialized;
+
+	std::vector<usermode_cb_registration> plugins;
+
+	std::vector<target_config_entry_t> wanted_hooks;
+	// map dtb -> list of hooked dlls
+	std::map<addr_t, std::vector<user_dll_t>> loaded_dlls;
+
+	userhook(drakvuf_t drakvuf) : pluginex(drakvuf, OUTPUT_DEFAULT), initialized(0) {}
+    ~userhook();
+
+	bool init(drakvuf_t drakvuf);
+	bool register_plugin(drakvuf_t drakvuf, usermode_cb_registration reg);
+};
+
+extern userhook* instance;
 
 #endif

--- a/src/libusermode/userhook.hpp
+++ b/src/libusermode/userhook.hpp
@@ -224,7 +224,7 @@ public:
     userhook(drakvuf_t drakvuf) : pluginex(drakvuf, OUTPUT_DEFAULT), initialized(0) {}
     ~userhook();
 
-    bool init(drakvuf_t drakvuf);
+    usermode_reg_status_t init(drakvuf_t drakvuf);
     void register_plugin(drakvuf_t drakvuf, usermode_cb_registration reg);
 };
 

--- a/src/plugins/memdump/memdump.h
+++ b/src/plugins/memdump/memdump.h
@@ -113,6 +113,17 @@
 #include "plugins/private.h"
 #include "plugins/plugins_ex.h"
 
+struct target_config_entry_t
+{
+    std::string dll_name;
+    std::string function_name;
+    size_t args_num;
+
+    target_config_entry_t() : dll_name(), function_name(), args_num() {}
+    target_config_entry_t(std::string&& dll_name, std::string&& function_name, size_t args_num)
+        : dll_name(std::move(dll_name)), function_name(std::move(function_name)), args_num(args_num) {}
+};
+
 struct memdump_config
 {
     const char* memdump_dir;

--- a/src/plugins/memdump/memdump.h
+++ b/src/plugins/memdump/memdump.h
@@ -128,7 +128,7 @@ public:
     addr_t dll_base_rva;
     addr_t dll_base_wow_rva;
 
-	std::vector<target_config_entry_t> wanted_hooks;
+    std::vector<target_config_entry_t> wanted_hooks;
 
     memdump(drakvuf_t drakvuf, const memdump_config* config, output_format_t output);
     ~memdump();

--- a/src/plugins/memdump/memdump.h
+++ b/src/plugins/memdump/memdump.h
@@ -109,6 +109,7 @@
 #include <memory>
 
 #include <glib.h>
+#include <libusermode/userhook.hpp>
 #include "plugins/private.h"
 #include "plugins/plugins_ex.h"
 
@@ -117,9 +118,6 @@ struct memdump_config
     const char* memdump_dir;
     const char* dll_hooks_list;
 };
-
-struct target_config_entry_t;
-struct user_dll_t;
 
 class memdump: public pluginex
 {
@@ -130,10 +128,7 @@ public:
     addr_t dll_base_rva;
     addr_t dll_base_wow_rva;
 
-    // for userhook.cpp
-    std::vector<target_config_entry_t> wanted_hooks;
-    // map dtb -> list of hooked dlls
-    std::map<addr_t, std::vector<user_dll_t>> loaded_dlls;
+	std::vector<target_config_entry_t> wanted_hooks;
 
     memdump(drakvuf_t drakvuf, const memdump_config* config, output_format_t output);
     ~memdump();

--- a/src/plugins/memdump/userhook.cpp
+++ b/src/plugins/memdump/userhook.cpp
@@ -171,16 +171,16 @@ static event_response_t usermode_return_hook_cb(drakvuf_t drakvuf, drakvuf_trap_
     switch (plugin->m_output_format)
     {
         case OUTPUT_CSV:
-            printf("memdump-userhok," FORMAT_TIMEVAL ",%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64 ",\"%s\",0x%" PRIx64 ",\"",
+            printf("memdump-userhok," FORMAT_TIMEVAL ",%" PRIu32 ",0x%" PRIx64 ",\"%s\",%" PRIi64 ",\"%s\",0x%" PRIx64 ",0x%" PRIx64 ",\"",
                    UNPACK_TIMEVAL(info->timestamp), info->vcpu, info->regs->cr3, info->proc_data.name,
-                   info->proc_data.userid, info->trap->name, info->regs->rip);
+                   info->proc_data.userid, info->trap->name, info->regs->rax, info->regs->rip);
             print_arguments(ret_target->arguments);
             printf("\"");
             break;
         case OUTPUT_KV:
-            printf("memdump, Time=" FORMAT_TIMEVAL ",VCPU=%" PRIu32 ",CR3=0x%" PRIx64 ",ProcessName=\"%s\",UserID=%" PRIi64 ",Method=\"%s\",CalledFrom=0x%" PRIx64 ",Arguments=\"",
+            printf("memdump, Time=" FORMAT_TIMEVAL ",VCPU=%" PRIu32 ",CR3=0x%" PRIx64 ",ProcessName=\"%s\",UserID=%" PRIi64 ",Method=\"%s\",CalledFrom=0x%" PRIx64 ",ReturnValue=0x%" PRIx64 ",Arguments=\"",
                    UNPACK_TIMEVAL(info->timestamp), info->vcpu, info->regs->cr3, info->proc_data.name,
-                   info->proc_data.userid, info->trap->name, info->regs->rip);
+                   info->proc_data.userid, info->trap->name, info->regs->rip, info->regs->rax);
             print_arguments(ret_target->arguments);
             printf("\"");
             break;
@@ -196,13 +196,15 @@ static event_response_t usermode_return_hook_cb(drakvuf_t drakvuf, drakvuf_trap_
                     "\"PPID\": %d, "
                     "\"Method\": \"%s\", "
                     "\"CalledFrom\": 0x%" PRIx64 ", "
+                    "\"ReturnValue\": 0x%" PRIx64 ", "
                     "\"Arguments\": [",
                     UNPACK_TIMEVAL(info->timestamp),
                     escaped_pname,
                     USERIDSTR(drakvuf), info->proc_data.userid,
                     info->proc_data.pid, info->proc_data.ppid,
                     info->trap->name,
-                    info->regs->rip);
+                    info->regs->rip,
+                    info->regs->rax);
 
             print_arguments(ret_target->arguments);
             printf("], "
@@ -213,9 +215,9 @@ static event_response_t usermode_return_hook_cb(drakvuf_t drakvuf, drakvuf_trap_
             break;
         default:
         case OUTPUT_DEFAULT:
-            printf("[MEMDUMP-USERHOOK] TIME:" FORMAT_TIMEVAL " VCPU:%" PRIu32 " CR3:0x%" PRIx64 " ProcessName:\"%s\" UserID:%" PRIi64 " Method:\"%s\" CalledFrom:0x%" PRIx64 " Arguments:\"",
+            printf("[MEMDUMP-USERHOOK] TIME:" FORMAT_TIMEVAL " VCPU:%" PRIu32 " CR3:0x%" PRIx64 " ProcessName:\"%s\" UserID:%" PRIi64 " Method:\"%s\" CalledFrom:0x%" PRIx64 " ReturnValue:0x%" PRIx64 " Arguments:\"",
                    UNPACK_TIMEVAL(info->timestamp), info->vcpu, info->regs->cr3, info->proc_data.name,
-                   info->proc_data.userid, info->trap->name, info->regs->rip);
+                   info->proc_data.userid, info->trap->name, info->regs->rax, info->regs->rip);
             print_arguments(ret_target->arguments);
             printf("\"");
             break;

--- a/src/plugins/memdump/userhook.cpp
+++ b/src/plugins/memdump/userhook.cpp
@@ -317,7 +317,7 @@ static event_response_t usermode_hook_cb(drakvuf_t drakvuf, drakvuf_trap_info* i
     return VMI_EVENT_RESPONSE_NONE;
 }
 
-void on_dll_discovered(drakvuf_t drakvuf, dll_t* dll, void* extra)
+void on_dll_discovered(drakvuf_t drakvuf, const dll_view_t* dll, void* extra)
 {
     memdump* plugin = (memdump*)extra;
 
@@ -329,9 +329,7 @@ void on_dll_discovered(drakvuf_t drakvuf, dll_t* dll, void* extra)
         for (auto const& wanted_hook : plugin->wanted_hooks)
         {
             if (strstr((const char*)dll_name->contents, wanted_hook.dll_name.c_str()) != 0)
-            {
-                dll->targets.emplace_back(wanted_hook.function_name.c_str(), usermode_hook_cb, wanted_hook.args_num, plugin);
-            }
+                drakvuf_request_usermode_hook(drakvuf, dll, wanted_hook.function_name.c_str(), usermode_hook_cb, wanted_hook.args_num, plugin);
         }
     }
 
@@ -341,7 +339,7 @@ void on_dll_discovered(drakvuf_t drakvuf, dll_t* dll, void* extra)
     drakvuf_release_vmi(drakvuf);
 }
 
-void on_dll_hooked(drakvuf_t drakvuf, dll_t* dll, void* extra)
+void on_dll_hooked(drakvuf_t drakvuf, const dll_view_t* dll, void* extra)
 {
     PRINT_DEBUG("[MEMDUMP] DLL hooked - done\n");
 }

--- a/src/plugins/memdump/userhook.cpp
+++ b/src/plugins/memdump/userhook.cpp
@@ -410,7 +410,11 @@ void memdump::userhook_init(drakvuf_t drakvuf, const memdump_config* c, output_f
         .extra = (void *)this
     };
 
-    if (!drakvuf_register_usermode_callback(drakvuf, &reg)) {
+    usermode_reg_status_t status = drakvuf_register_usermode_callback(drakvuf, &reg);
+
+    if (status == USERMODE_ARCH_UNSUPPORTED) {
+        PRINT_DEBUG("[MEMDUMP] Usermode hooking is not supported on this architecture/bitness, these features will be disabled\n");
+    } else if (status != USERMODE_REGISTER_SUCCESS) {
         PRINT_DEBUG("[MEMDUMP] Failed to subscribe to libusermode\n");
         throw -1;
     }

--- a/src/plugins/memdump/userhook.cpp
+++ b/src/plugins/memdump/userhook.cpp
@@ -125,6 +125,7 @@
 #include <libvmi/libvmi.h>
 #include <libvmi/peparse.h>
 #include <libdrakvuf/private.h>
+#include <libusermode/userhook.hpp>
 #include <assert.h>
 
 #include "memdump.h"
@@ -159,7 +160,7 @@ static event_response_t usermode_return_hook_cb(drakvuf_t drakvuf, drakvuf_trap_
     if (info->proc_data.pid != ret_target->pid)
         return VMI_EVENT_RESPONSE_NONE;
 
-    auto plugin = ret_target->plugin;
+    auto plugin = (memdump*)ret_target->plugin;
 
     std::map < std::string, std::string > extra_data;
 
@@ -233,7 +234,7 @@ static event_response_t usermode_hook_cb(drakvuf_t drakvuf, drakvuf_trap_info* i
     if (target->pid != info->proc_data.pid)
         return VMI_EVENT_RESPONSE_NONE;
 
-    dump_from_stack(drakvuf, info, target->plugin);
+    dump_from_stack(drakvuf, info, (memdump*)target->plugin);
 
     auto vmi = drakvuf_lock_and_get_vmi(drakvuf);
     vmi_v2pcache_flush(vmi, info->regs->cr3);
@@ -314,514 +315,28 @@ static event_response_t usermode_hook_cb(drakvuf_t drakvuf, drakvuf_trap_info* i
     return VMI_EVENT_RESPONSE_NONE;
 }
 
-/**
- * Check if this thread is currently in process of loading a DLL.
- * If so, return a pointer to the associated metadata.
- */
-static user_dll_t* get_pending_dll(drakvuf_t drakvuf, drakvuf_trap_info* info, memdump* plugin)
+void on_dll_discovered(drakvuf_t drakvuf, dll_t* dll, void* extra)
 {
-    uint32_t thread_id;
-    if (!drakvuf_get_current_thread_id(drakvuf, info, &thread_id))
-        return nullptr;
-
-    auto vec_it = plugin->loaded_dlls.find(info->regs->cr3);
-
-    if (vec_it == plugin->loaded_dlls.end())
-        return nullptr;
-
-    for (auto& dll_meta : vec_it->second)
-    {
-        if (!dll_meta.is_hooked && dll_meta.thread_id == thread_id)
-            return &dll_meta;
-    }
-
-    return nullptr;
-}
-
-static bool populate_hook_targets(drakvuf_t drakvuf, memdump* plugin, const mmvad_info_t& mmvad, user_dll_t* dll_meta)
-{
-    vmi_instance_t vmi = drakvuf_lock_and_get_vmi(drakvuf);
-    unicode_string_t* dll_name = drakvuf_read_unicode_va(vmi, mmvad.file_name_ptr, 0);
-
-    if (dll_name && dll_name->contents)
-    {
-        for (auto const& wanted_hook : plugin->wanted_hooks)
-        {
-            if (strstr((const char*) dll_name->contents, wanted_hook.dll_name.c_str()) != 0)
-            {
-                dll_meta->targets.emplace_back(wanted_hook.function_name.c_str(), usermode_hook_cb, wanted_hook.args_num, plugin);
-            }
-        }
-    }
-
-    if (dll_name)
-        vmi_free_unicode_str(dll_name);
-
-    drakvuf_release_vmi(drakvuf);
-    return !dll_meta->targets.empty();
-}
-
-/**
- * Check if DLL is interesting, if so, build a "hooking context" of a DLL. Such context is needed,
- * because user mode hooking is a stateful operation which requires a VM to be un-paused many times.
- */
-static user_dll_t* create_dll_meta(drakvuf_t drakvuf, drakvuf_trap_info* info, memdump* plugin, addr_t dll_base)
-{
-    mmvad_info_t mmvad;
-    if (!drakvuf_find_mmvad(drakvuf, info->proc_data.base_addr, dll_base, &mmvad))
-        return nullptr;
-
-    if (mmvad.file_name_ptr == 0)
-        return nullptr;
-
-    auto vec_it = plugin->loaded_dlls.find(info->regs->cr3);
-
-    if (vec_it != plugin->loaded_dlls.end())
-    {
-        for (auto const& dll_meta : vec_it->second)
-        {
-            if (dll_meta.real_dll_base == mmvad.starting_vpn << 12)
-            {
-                PRINT_DEBUG("[MEMDUMP-USER] DLL %d!%llx is already hooked\n", info->proc_data.pid, (unsigned long long)mmvad.starting_vpn << 12);
-                return nullptr;
-            }
-        }
-    }
-
-    uint32_t thread_id;
-    if (!drakvuf_get_current_thread_id(drakvuf, info, &thread_id))
-        return nullptr;
-
-    user_dll_t dll_meta =
-    {
-        .dtb = info->regs->cr3,
-        .thread_id = thread_id,
-        .real_dll_base = (mmvad.starting_vpn << 12),
-        .is_hooked = false
-    };
-
-    if (!populate_hook_targets(drakvuf, plugin, mmvad, &dll_meta))
-        return nullptr;
-
-    PRINT_DEBUG("[MEMDUMP-USER] Found DLL which is worth processing %llx\n", (unsigned long long)mmvad.starting_vpn << 12);
-    addr_t vad_start = mmvad.starting_vpn << 12;
-    size_t vad_length = (mmvad.ending_vpn - mmvad.starting_vpn + 1) << 12;
-
-    access_context_t ctx =
-    {
-        .translate_mechanism = VMI_TM_PROCESS_DTB,
-        .dtb = info->regs->cr3,
-        .addr = vad_start
-    };
-
-    addr_t export_header_rva = 0;
-    size_t export_header_size = 0;
-
-    constexpr int MAX_HEADER_BYTES = 1024;   // keep under 1 page
-    uint8_t image[MAX_HEADER_BYTES];
-
-    vmi_instance_t vmi = drakvuf_lock_and_get_vmi(drakvuf);
-    bool status = (VMI_SUCCESS == peparse_get_image(vmi, &ctx, MAX_HEADER_BYTES, image));
-    drakvuf_release_vmi(drakvuf);
-
-    if (!status)
-        return nullptr;
-
-    void* optional_header = NULL;
-    uint16_t magic = 0;
-
-    peparse_assign_headers(image, NULL, NULL, &magic, &optional_header, NULL, NULL);
-    export_header_rva = peparse_get_idd_rva(IMAGE_DIRECTORY_ENTRY_EXPORT, &magic, optional_header, NULL, NULL);
-    export_header_size = peparse_get_idd_size(IMAGE_DIRECTORY_ENTRY_EXPORT, &magic, optional_header, NULL, NULL);
-
-    if (export_header_rva >= vad_length)
-    {
-        PRINT_DEBUG("[MEMDUMP-USER] Export header RVA is forwarded outside VAD\n");
-        return nullptr;
-    }
-    else if (export_header_size >= vad_length - export_header_rva)
-    {
-        PRINT_DEBUG("[MEMDUMP-USER] Export header size is forwarded outside VAD\n");
-        return nullptr;
-    }
-
-    dll_meta.pf_current_addr = vad_start + export_header_rva & ~(VMI_PS_4KB - 1);
-    dll_meta.pf_max_addr = vad_start + export_header_rva + export_header_size;
-
-    if (dll_meta.pf_max_addr & VMI_PS_4KB)
-    {
-        dll_meta.pf_max_addr += VMI_PS_4KB;
-        dll_meta.pf_max_addr = dll_meta.pf_max_addr & ~(VMI_PS_4KB - 1);
-    }
-
-    auto it = plugin->loaded_dlls.emplace(info->regs->cr3, std::vector<user_dll_t>()).first;
-    it->second.push_back(std::move(dll_meta));
-    return &it->second.back();
-}
-
-static bool make_trap(vmi_instance_t vmi, drakvuf_t drakvuf, drakvuf_trap_info* info, hook_target_entry_t* target, addr_t exec_func)
-{
-    target->pid = info->proc_data.pid;
-
-    drakvuf_trap_t* trap = new drakvuf_trap_t;
-    trap->type = BREAKPOINT;
-    trap->name = target->target_name.c_str();
-    trap->cb = target->callback;
-    trap->data = target;
-
-    // during CoW we need to find all traps placed on the same physical page
-    // that's why we'll manually resolve vaddr and strore paddr under trap->breakpoint.addr
-    addr_t pa;
-
-    if (vmi_pagetable_lookup(vmi, info->regs->cr3, exec_func, &pa) != VMI_SUCCESS)
-    {
-        goto fail;
-    }
-
-    trap->breakpoint.lookup_type = LOOKUP_NONE;
-    trap->breakpoint.addr_type = ADDR_PA;
-    trap->breakpoint.addr = pa;
-
-    if (drakvuf_add_trap(drakvuf, trap))
-    {
-        target->trap = trap;
-        return true;
-    }
-
-fail:
-    PRINT_DEBUG("[MEMDUMP-USER] Failed to add trap :(\n");
-    delete trap;
-    return false;
-}
-
-static event_response_t perform_hooking(drakvuf_t drakvuf, drakvuf_trap_info* info, memdump* plugin, user_dll_t* dll_meta)
-{
-    vmi_instance_t vmi = drakvuf_lock_and_get_vmi(drakvuf);
-
-    // we have to make sure that addresses between [pf_current_addr, pf_max_addr]
-    // are available for reading otherwise vmi_translate_sym2v will fail unconditionally
-    // and we will be unable to add hooks
-
-    while (dll_meta->pf_current_addr <= dll_meta->pf_max_addr)
-    {
-        page_info_t pinfo;
-        addr_t pa;
-        if (vmi_pagetable_lookup_extended(vmi, info->regs->cr3, dll_meta->pf_current_addr, &pinfo) == VMI_SUCCESS)
-        {
-            PRINT_DEBUG("[MEMDUMP-USER] Export info accessible OK %llx\n", (unsigned long long)dll_meta->pf_current_addr);
-            dll_meta->pf_current_addr += VMI_PS_4KB;
-            continue;
-        }
-
-        pa = pinfo.paddr;
-
-        if (vmi_request_page_fault(vmi, info->vcpu, dll_meta->pf_current_addr, 0) == VMI_SUCCESS)
-        {
-            PRINT_DEBUG("[MEMDUMP-USER] Export info not accessible, page fault %llx\n", (unsigned long long)dll_meta->pf_current_addr);
-            dll_meta->pf_current_addr += VMI_PS_4KB;
-        }
-        else
-        {
-            PRINT_DEBUG("[MEMDUMP-USER] Failed to request page fault for DTB %llx, address %llx\n", (unsigned long long)info->regs->cr3, (unsigned long long)dll_meta->pf_current_addr);
-        }
-
-        drakvuf_release_vmi(drakvuf);
-        return VMI_EVENT_RESPONSE_NONE;
-    }
-
-    // export info should be available, try hooking DLLs
-    for (auto& target : dll_meta->targets)
-    {
-        if (target.state == HOOK_FIRST_TRY || target.state == HOOK_PAGEFAULT_RETRY)
-        {
-            addr_t exec_func;
-            access_context_t ctx =
-            {
-                .translate_mechanism = VMI_TM_PROCESS_DTB,
-                .dtb = info->regs->cr3,
-                .addr = dll_meta->real_dll_base
-            };
-
-            status_t translate_ret = vmi_translate_sym2v(vmi, &ctx, target.target_name.c_str(), &exec_func);
-
-            if (translate_ret == VMI_SUCCESS && target.state == HOOK_FIRST_TRY)
-            {
-                target.state = HOOK_FAILED;
-
-                page_info_t pinfo;
-                if (vmi_pagetable_lookup_extended(vmi, info->regs->cr3, exec_func, &pinfo) != VMI_SUCCESS)
-                {
-                    if (vmi_request_page_fault(vmi, info->vcpu, exec_func, 0) == VMI_SUCCESS)
-                    {
-                        target.state = HOOK_PAGEFAULT_RETRY;
-                        drakvuf_release_vmi(drakvuf);
-                        return VMI_EVENT_RESPONSE_NONE;
-                    }
-                }
-                else
-                {
-                    if (make_trap(vmi, drakvuf, info, &target, exec_func))
-                        target.state = HOOK_OK;
-                }
-            }
-            else if (translate_ret == VMI_SUCCESS && target.state == HOOK_PAGEFAULT_RETRY)
-            {
-                target.state = HOOK_FAILED;
-                page_info_t pinfo;
-
-                if (vmi_pagetable_lookup_extended(vmi, info->regs->cr3, exec_func, &pinfo) == VMI_SUCCESS)
-                {
-                    if (make_trap(vmi, drakvuf, info, &target, exec_func))
-                        target.state = HOOK_OK;
-                }
-            }
-            else
-            {
-                target.state = HOOK_FAILED;
-            }
-
-            PRINT_DEBUG("[MEMDUMP-USER] Hook %s (vaddr = 0x%llx, dll_base = 0x%llx, result = %s)\n",
-                        target.target_name.c_str(),
-                        (unsigned long long)exec_func,
-                        (unsigned long long)dll_meta->real_dll_base,
-                        target.state == HOOK_OK ? "OK" : "FAIL");
-        }
-    }
-
-    drakvuf_release_vmi(drakvuf);
-    PRINT_DEBUG("[MEMDUMP-USER] Done, flag DLL as hooked\n");
-    dll_meta->is_hooked = true;
-    return VMI_EVENT_RESPONSE_NONE;
-}
-
-/**
- * This is used in order to observe when SysWOW64 process is loading a new DLL.
- * If the DLL is interesting, we perform further investigation and try to equip user mode hooks.
- */
-static event_response_t protect_virtual_memory_hook_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
-{
-    // IN HANDLE ProcessHandle
-    uint64_t process_handle = drakvuf_get_function_argument(drakvuf, info, 1);
-    // IN OUT PVOID *BaseAddress
-    addr_t base_address_ptr = drakvuf_get_function_argument(drakvuf, info, 2);
-
-    if (process_handle != ~0ULL)
-        return VMI_EVENT_RESPONSE_NONE;
-
-    auto plugin = get_trap_plugin<memdump>(info);
-    if (!plugin)
-        return VMI_EVENT_RESPONSE_NONE;
-
-    user_dll_t* dll_meta = get_pending_dll(drakvuf, info, plugin);
-
-    if (!dll_meta)
-    {
-        addr_t base_address;
-
-        access_context_t ctx =
-        {
-            .translate_mechanism = VMI_TM_PROCESS_DTB,
-            .dtb = info->regs->cr3,
-            .addr = base_address_ptr
-        };
-
-        vmi_instance_t vmi = drakvuf_lock_and_get_vmi(drakvuf);
-        bool success = (VMI_SUCCESS == vmi_read_addr(vmi, &ctx, &base_address));
-        drakvuf_release_vmi(drakvuf);
-
-        if (!success)
-            return VMI_EVENT_RESPONSE_NONE;
-
-        dll_meta = create_dll_meta(drakvuf, info, plugin, base_address);
-    }
-
-    if (dll_meta)
-        return perform_hooking(drakvuf, info, plugin, dll_meta);
-
-    return VMI_EVENT_RESPONSE_NONE;
-}
-
-/**
- * This is used in order to observe when 64 bit process is loading a new DLL.
- * If the DLL is interesting, we perform further investigation and try to equip user mode hooks.
- */
-static event_response_t map_view_of_section_ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
-{
-    auto data = get_trap_params<memdump, map_view_of_section_result_t<memdump>>(info);
-    memdump* plugin = data->plugin();
-    if (!data || !plugin)
-    {
-        PRINT_DEBUG("[MEMDUMP-USER] map_view_of_section_ret_cb invalid trap params!\n");
-        drakvuf_remove_trap(drakvuf, info->trap, nullptr);
-        return VMI_EVENT_RESPONSE_NONE;
-    }
-
-    if (!data->verify_result_call_params(info, drakvuf_get_current_thread(drakvuf, info)))
-        return VMI_EVENT_RESPONSE_NONE;
-
-    user_dll_t* dll_meta = get_pending_dll(drakvuf, info, plugin);
-
-    if (!dll_meta)
-    {
-        addr_t base_address;
-
-        access_context_t ctx =
-        {
-            .translate_mechanism = VMI_TM_PROCESS_DTB,
-            .dtb = info->regs->cr3,
-            .addr = data->base_address_ptr
-        };
-
-        vmi_instance_t vmi = drakvuf_lock_and_get_vmi(drakvuf);
-        bool success = (VMI_SUCCESS == vmi_read_addr(vmi, &ctx, &base_address));
-        drakvuf_release_vmi(drakvuf);
-
-        if (!success)
-            return VMI_EVENT_RESPONSE_NONE;
-
-        dll_meta = create_dll_meta(drakvuf, info, plugin, base_address);
-    }
-
-    if (dll_meta)
-        return perform_hooking(drakvuf, info, plugin, dll_meta);
-
-    plugin->destroy_trap(drakvuf, info->trap);
-    return VMI_EVENT_RESPONSE_NONE;
-}
-
-static event_response_t map_view_of_section_hook_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
-{
-    auto plugin = get_trap_plugin<memdump>(info);
-    if (!plugin)
-        return VMI_EVENT_RESPONSE_NONE;
-
-    auto trap = plugin->register_trap<memdump, map_view_of_section_result_t<memdump>>(
-                    drakvuf,
-                    info,
-                    plugin,
-                    map_view_of_section_ret_cb,
-                    breakpoint_by_pid_searcher());
-    if (!trap)
-        return VMI_EVENT_RESPONSE_NONE;
-
-    auto data = get_trap_params<memdump, map_view_of_section_result_t<memdump>>(trap);
-    if (!data)
-    {
-        plugin->destroy_plugin_params(plugin->detach_plugin_params(trap));
-        return VMI_EVENT_RESPONSE_NONE;
-    }
-
-    data->set_result_call_params(info, drakvuf_get_current_thread(drakvuf, info));
-
-    // IN HANDLE SectionHandle
-    data->section_handle = drakvuf_get_function_argument(drakvuf, info, 1);
-    // IN HANDLE ProcessHandle
-    data->process_handle = drakvuf_get_function_argument(drakvuf, info, 2);
-    // IN OUT PVOID *BaseAddress
-    data->base_address_ptr = drakvuf_get_function_argument(drakvuf, info, 3);
-
-    return VMI_EVENT_RESPONSE_NONE;
-}
-
-/**
- * As we may accidentally trigger an exception in the kernel by using vmi_request_page_fault,
- * we hook KiSystemServiceHandler to account for that situation. Inside this hook,
- * we check if it was "our fault" and if so, we forcefully return EXCEPTION_CONTINUE_EXECUTION.
- * In any other case, we just pass the control to the original exception handler.
- */
-static event_response_t system_service_handler_hook_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
-{
-    PRINT_DEBUG("[MEMDUMP-USER] Entered system service handler\n");
-
-    auto plugin = get_trap_plugin<memdump>(info);
-    if (!plugin)
-        return VMI_EVENT_RESPONSE_NONE;
-
-    uint32_t thread_id;
-
-    if (!drakvuf_get_current_thread_id(drakvuf, info, &thread_id))
-    {
-        PRINT_DEBUG("[MEMDUMP-USER] Failed to get thread id in system service handler!\n");
-        return VMI_EVENT_RESPONSE_NONE;
-    }
-
-    bool our_fault = false;
-
-    auto vec_it = plugin->loaded_dlls.find(info->regs->cr3);
-
-    if (vec_it != plugin->loaded_dlls.end())
-    {
-        for (auto const& dll_meta : vec_it->second)
-        {
-            if (dll_meta.dtb == info->regs->cr3 && dll_meta.thread_id == thread_id)
-            {
-                our_fault = true;
-                break;
-            }
-        }
-    }
-
-    if (!our_fault)
-    {
-        PRINT_DEBUG("[MEMDUMP-USER] Not suppressing service exception - not our fault\n");
-        return VMI_EVENT_RESPONSE_NONE;
-    }
-
-    // emulate `ret` instruction
-    addr_t saved_rip = 0;
-    access_context_t ctx =
-    {
-        .translate_mechanism = VMI_TM_PROCESS_DTB,
-        .dtb = info->regs->cr3,
-        .addr = info->regs->rsp,
-    };
-
-    vmi_instance_t vmi = drakvuf_lock_and_get_vmi(drakvuf);
-    bool success = (VMI_SUCCESS == vmi_read(vmi, &ctx, sizeof(addr_t), &saved_rip, NULL));
-    drakvuf_release_vmi(drakvuf);
-
-    if ( !success )
-    {
-        PRINT_DEBUG("[MEMDUMP-USER] Error while reading the saved RIP in system service handler\n");
-        return VMI_EVENT_RESPONSE_NONE;
-    }
-
-    constexpr int EXCEPTION_CONTINUE_EXECUTION = 0;
-    info->regs->rip = saved_rip;
-    info->regs->rsp += sizeof(addr_t);
-    info->regs->rax = EXCEPTION_CONTINUE_EXECUTION;
-    return VMI_EVENT_RESPONSE_SET_REGISTERS;
-}
-
-/**
- * Observe process exit and remove all user mode hooks
- */
-static event_response_t terminate_process_hook_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
-{
-    auto plugin = get_trap_plugin<memdump>(info);
-    if (!plugin)
-        return VMI_EVENT_RESPONSE_NONE;
-
-    auto vec_it = plugin->loaded_dlls.find(info->regs->cr3);
-
-    if (vec_it == plugin->loaded_dlls.end())
-        return VMI_EVENT_RESPONSE_NONE;
-
-    for (auto& it : vec_it->second)
-    {
-        for (auto& target : it.targets)
-        {
-            if (target.state == HOOK_OK)
-            {
-                PRINT_DEBUG("[MEMDUMP-USER] Erased trap for pid %d %s\n", info->proc_data.pid,
-                            target.target_name.c_str());
-                drakvuf_remove_trap(drakvuf, target.trap, NULL);
-            }
-        }
-    }
-
-    plugin->loaded_dlls.erase(vec_it);
-    return VMI_EVENT_RESPONSE_NONE;
+	memdump* plugin = (memdump*)extra;
+
+	vmi_instance_t vmi = drakvuf_lock_and_get_vmi(drakvuf);
+	unicode_string_t* dll_name = drakvuf_read_unicode_va(vmi, dll->mmvad->file_name_ptr, 0);
+
+	if (dll_name && dll_name->contents)
+	{
+		for (auto const& wanted_hook : plugin->wanted_hooks)
+		{
+			if (strstr((const char*)dll_name->contents, wanted_hook.dll_name.c_str()) != 0)
+			{
+				dll->targets.emplace_back(wanted_hook.function_name.c_str(), usermode_hook_cb, wanted_hook.args_num, plugin);
+			}
+		}
+	}
+
+	if (dll_name)
+		vmi_free_unicode_str(dll_name);
+
+	drakvuf_release_vmi(drakvuf);
 }
 
 void memdump::load_wanted_targets(const memdump_config* c)
@@ -864,144 +379,8 @@ void memdump::load_wanted_targets(const memdump_config* c)
     }
 }
 
-static event_response_t copy_on_write_ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
-{
-    auto data = get_trap_params<memdump, copy_on_write_result_t<memdump>>(info);
-    memdump* plugin = data->plugin();
-    if (!data || !plugin)
-    {
-        PRINT_DEBUG("[MEMDUMP-USER] copy_on_write_ret_cb invalid trap params!\n");
-        drakvuf_remove_trap(drakvuf, info->trap, nullptr);
-        return VMI_EVENT_RESPONSE_NONE;
-    }
-
-    if (!data->verify_result_call_params(info, drakvuf_get_current_thread(drakvuf, info)))
-        return VMI_EVENT_RESPONSE_NONE;
-
-    plugin->destroy_trap(drakvuf, info->trap);
-
-    vmi_instance_t vmi = drakvuf_lock_and_get_vmi(drakvuf);
-
-    // sometimes the physical address was incorrectly cached in this moment, so we need to flush it
-    vmi_v2pcache_flush(vmi, info->regs->cr3);
-    addr_t pa;
-
-    if (vmi_pagetable_lookup(vmi, info->regs->cr3, data->vaddr, &pa) != VMI_SUCCESS)
-    {
-        PRINT_DEBUG("[MEMDUMP-USER] failed to get pa\n");
-        goto end;
-    }
-
-    if (data->old_cow_pa == pa)
-    {
-        PRINT_DEBUG("[MEMDUMP-USER] PA after CoW remained the same, wtf? Nothing to do here...\n");
-        goto end;
-    }
-
-    for (auto& hook : data->hooks)
-    {
-        addr_t hook_va = ((data->vaddr >> 12) << 12) + (hook->trap->breakpoint.addr & 0xFFF);
-        PRINT_DEBUG("adding hook at %lx\n", hook_va);
-
-        if (hook->trap)
-        {
-            drakvuf_remove_trap(drakvuf, hook->trap, nullptr);
-            delete hook->trap;
-            hook->state = HOOK_FAILED;
-            hook->trap = nullptr;
-        }
-
-        make_trap(vmi, drakvuf, info, hook, hook_va);
-    }
-
-end:
-    drakvuf_release_vmi(drakvuf);
-    return VMI_EVENT_RESPONSE_NONE;
-}
-
-static event_response_t copy_on_write_handler(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
-{
-    auto plugin = get_trap_plugin<memdump>(info);
-    if (!plugin)
-        return VMI_EVENT_RESPONSE_NONE;
-
-    addr_t vaddr = drakvuf_get_function_argument(drakvuf, info, 1);
-    addr_t pte = drakvuf_get_function_argument(drakvuf, info, 2);
-
-    vmi_instance_t vmi = drakvuf_lock_and_get_vmi(drakvuf);
-
-    addr_t pa;
-
-    if (vmi_pagetable_lookup(vmi, info->regs->cr3, vaddr, &pa) != VMI_SUCCESS)
-    {
-        PRINT_DEBUG("[MEMDUMP-USER] failed to get pa");
-        drakvuf_release_vmi(drakvuf);
-        return VMI_EVENT_RESPONSE_NONE;
-    }
-
-    drakvuf_release_vmi(drakvuf);
-
-
-    std::vector < hook_target_entry_t* > hooks;
-    for (auto& dll : plugin->loaded_dlls[info->regs->cr3])
-    {
-        for (auto& hook : dll.targets)
-        {
-            if (hook.state == HOOK_OK)
-            {
-                addr_t hook_addr = hook.trap->breakpoint.addr;
-                if (hook_addr >> 12 == pa >> 12)
-                {
-                    hooks.push_back(&hook);
-                }
-            }
-        }
-    }
-
-    PRINT_DEBUG("[MEMDUMP-USER] copy on write called: vaddr: %llx pte: %llx, pid: %d, cr3: %llx\n", (unsigned long long)vaddr, (unsigned long long)pte, info->proc_data.pid, (unsigned long long)info->regs->cr3);
-    PRINT_DEBUG("[MEMDUMP-USER] old CoW PA: %llx\n", (unsigned long long)pa);
-
-    if (!hooks.empty())
-    {
-        PRINT_DEBUG("MEMDUMP-USER] Found %zu hooks on CoW page, registering return trap\n", hooks.size());
-
-        auto trap = plugin->register_trap<memdump, copy_on_write_result_t<memdump>>(
-                        drakvuf,
-                        info,
-                        plugin,
-                        copy_on_write_ret_cb,
-                        breakpoint_by_pid_searcher());
-        if (!trap)
-            return VMI_EVENT_RESPONSE_NONE;
-
-        auto data = get_trap_params<memdump, copy_on_write_result_t<memdump>>(trap);
-        if (!data)
-        {
-            plugin->destroy_plugin_params(plugin->detach_plugin_params(trap));
-            return VMI_EVENT_RESPONSE_NONE;
-        }
-
-        data->set_result_call_params(info, drakvuf_get_current_thread(drakvuf, info));
-
-        data->vaddr = vaddr;
-        data->pte = pte;
-        data->old_cow_pa = pa;
-        data->hooks = hooks;
-    }
-
-    return VMI_EVENT_RESPONSE_NONE;
-}
-
 void memdump::userhook_init(drakvuf_t drakvuf, const memdump_config* c, output_format_t output)
 {
-    page_mode_t pm = drakvuf_get_page_mode(drakvuf);
-
-    if (pm != VMI_PM_IA32E)
-    {
-        PRINT_DEBUG("[MEMDUMP-USER] Usermode hooking is not yet supported on this architecture/bitness.\n");
-        return;
-    }
-
     try
     {
         this->load_wanted_targets(c);
@@ -1018,30 +397,14 @@ void memdump::userhook_init(drakvuf_t drakvuf, const memdump_config* c, output_f
         return;
     }
 
-    breakpoint_in_system_process_searcher bp;
-    if (!register_trap<memdump>(drakvuf, nullptr, this, protect_virtual_memory_hook_cb, bp.for_syscall_name("NtProtectVirtualMemory")) ||
-        !register_trap<memdump>(drakvuf, nullptr, this, map_view_of_section_hook_cb, bp.for_syscall_name("NtMapViewOfSection")) ||
-        !register_trap<memdump>(drakvuf, nullptr, this, system_service_handler_hook_cb, bp.for_syscall_name("KiSystemServiceHandler")) ||
-        !register_trap<memdump>(drakvuf, nullptr, this, terminate_process_hook_cb, bp.for_syscall_name("NtTerminateProcess")) ||
-        !register_trap<memdump>(drakvuf, nullptr, this, copy_on_write_handler, bp.for_syscall_name("MiCopyOnWrite")))
-    {
-        throw -1;
+    usermode_cb_registration reg = { .cb = on_dll_discovered, .extra = (void *)this };
+    if (!drakvuf_register_usermode_callback(drakvuf, &reg)) {
+        printf("Failed to subscribe to libusermode\n");
+        throw - 1;
     }
 }
 
 void memdump::userhook_destroy(memdump* plugin)
 {
-    for (auto& it : plugin->loaded_dlls)
-    {
-        for (auto& loaded_dll : it.second)
-        {
-            for (auto& target : loaded_dll.targets)
-            {
-                if (target.state == HOOK_OK)
-                {
-                    delete target.trap;
-                }
-            }
-        }
-    }
+
 }

--- a/tools/demangle.py
+++ b/tools/demangle.py
@@ -1,0 +1,188 @@
+#********************IMPORTANT DRAKVUF LICENSE TERMS**********************#
+#                                                                         #
+# DRAKVUF (C) 2014-2020 Tamas K Lengyel.                                  #
+# Tamas K Lengyel is hereinafter referred to as the author.               #
+# This program is free software; you may redistribute and/or modify it    #
+# under the terms of the GNU General Public License as published by the   #
+# Free Software Foundation; Version 2 ("GPL"), BUT ONLY WITH ALL OF THE   #
+# CLARIFICATIONS AND EXCEPTIONS DESCRIBED HEREIN.  This guarantees your   #
+# right to use, modify, and redistribute this software under certain      #
+# conditions.  If you wish to embed DRAKVUF technology into proprietary   #
+# software, alternative licenses can be aquired from the author.          #
+#                                                                         #
+# Note that the GPL places important restrictions on "derivative works' ,  #
+# yet it does not provide a detailed definition of that term.  To avoid   #
+# misunderstandings, we interpret that term as broadly as copyright law   #
+# allows.  For example, we consider an application to constitute a        #
+# derivative work for the purpose of this license if it does any of the   #
+# following with any software or content covered by this license          #
+# ("Covered Software"):                                                   #
+#                                                                         #
+# o Integrates source code from Covered Software.                         #
+#                                                                         #
+# o Reads or includes copyrighted data files.                             #
+#                                                                         #
+# o Is designed specifically to execute Covered Software and parse the    #
+# results (as opposed to typical shell or execution-menu apps, which will #
+# execute anything you tell them to).                                     #
+#                                                                         #
+# o Includes Covered Software in a proprietary executable installer.  The #
+# installers produced by InstallShield are an example of this.  Including #
+# DRAKVUF with other software in compressed or archival form does not     #
+# trigger this provision, provided appropriate open source decompression  #
+# or de-archiving software is widely available for no charge.  For the    #
+# purposes of this license, an installer is considered to include Covered #
+# Software even if it actually retrieves a copy of Covered Software from  #
+# another source during runtime (such as by downloading it from the       #
+# Internet).                                                              #
+#                                                                         #
+# o Links (statically or dynamically) to a library which does any of the  #
+# above.                                                                  #
+#                                                                         #
+# o Executes a helper program, module, or script to do any of the above.  #
+#                                                                         #
+# This list is not exclusive, but is meant to clarify our interpretation  #
+# of derived works with some common examples.  Other people may interpret #
+# the plain GPL differently, so we consider this a special exception to   #
+# the GPL that we apply to Covered Software.  Works which meet any of     #
+# these conditions must conform to all of the terms of this license,      #
+# particularly including the GPL Section 3 requirements of providing      #
+# source code and allowing free redistribution of the work as a whole.    #
+#                                                                         #
+# Any redistribution of Covered Software, including any derived works,    #
+# must obey and carry forward all of the terms of this license, including #
+# obeying all GPL rules and restrictions.  For example, source code of    #
+# the whole work must be provided and free redistribution must be         #
+# allowed.  All GPL references to "this License' , are to be treated as    #
+# including the terms and conditions of this license text as well.        #
+#                                                                         #
+# Because this license imposes special exceptions to the GPL, Covered     #
+# Work may not be combined (even as part of a larger work) with plain GPL #
+# software.  The terms, conditions, and exceptions of this license must   #
+# be included as well.  This license is incompatible with some other open #
+# source licenses as well.  In some cases we can relicense portions of    #
+# DRAKVUF or grant special permissions to use it in other open source     #
+# software.  Please contact tamas.k.lengyel@gmail.com with any such       #
+# requests.  Similarly, we don't incorporate incompatible open source     #
+# software into Covered Software without special permission from the      #
+# copyright holders.                                                      #
+#                                                                         #
+# If you have any questions about the licensing restrictions on using     #
+# DRAKVUF in other works, are happy to help.  As mentioned above,         #
+# alternative license can be requested from the author to integrate       #
+# DRAKVUF into proprietary applications and appliances.  Please email     #
+# tamas.k.lengyel@gmail.com for further information.                      #
+#                                                                         #
+# If you have received a written license agreement or contract for        #
+# Covered Software stating terms other than these, you may choose to use  #
+# and redistribute Covered Software under those terms instead of these.   #
+#                                                                         #
+# Source is provided to this software because we believe users have a     #
+# right to know exactly what a program is going to do before they run it. #
+# This also allows you to audit the software for security holes.          #
+#                                                                         #
+# Source code also allows you to port DRAKVUF to new platforms, fix bugs, #
+# and add new features.  You are highly encouraged to submit your changes #
+# on https://github.com/tklengyel/drakvuf, or by other methods.           #
+# By sending these changes, it is understood (unless you specify          #
+# otherwise) that you are offering unlimited, non-exclusive right to      #
+# reuse, modify, and relicense the code.  DRAKVUF will always be          #
+# available Open Source, but this is important because the inability to   #
+# relicense code has caused devastating problems for other Free Software  #
+# projects (such as KDE and NASM).                                        #
+# To specify special license conditions of your contributions, just say   #
+# so when you send them.                                                  #
+#                                                                         #
+# This program is distributed in the hope that it will be useful, but     #
+# WITHOUT ANY WARRANTY; without even the implied warranty of              #
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the DRAKVUF   #
+# license file for more details (it's in a COPYING file included with     #
+# DRAKVUF, and also available from                                        #
+# https://github.com/tklengyel/drakvuf/COPYING)                           #
+#                                                                         #
+#*************************************************************************#
+
+#
+# Use this tool to post-process Volatility IST JSONs to demangle C++
+# function names. Once the following issue is closed this tool will
+# become obsolete:
+#
+# https://github.com/volatilityfoundation/volatility3/issues/157
+#
+
+import sys
+import json
+
+DEMANGLE_MAP = {
+    '?0'    : ','    ,
+    '?1'    : '/'    ,
+    '?2'    : '\\'   ,
+    '?4'    : '.'    ,
+    '?3'    : ':'    ,
+    '?5'    : ' '    ,
+    '?6'    : ''     ,
+    '?7'    : '"'    ,
+    '?8'    : '\''   ,
+    '?9'    : '-'    ,
+    '?$AA'  : ''     ,
+    '?$AN'  : ''     ,
+    '?$CF'  : '%'    ,
+    '?$EA'  : '@'    ,
+    '?$CD'  : '#'    ,
+    '?$CG'  : '&'    ,
+    '?$HO'  : '~'    ,
+    '?$CI'  : '('    ,
+    '?$CJ'  : ')'    ,
+    '?$DM1' : '</'   ,
+    '?$DMO' : '>'    ,
+    '?$DN'  : '='    ,
+    '?$CK'  : '*'    ,
+    '?$CB'  : '!'    ,
+}
+
+if len(sys.argv) != 2:
+    exit(1)
+
+with open(sys.argv[1], 'r') as json_file:
+    demangled = {}
+    demangled_count = 0
+    data = json.load(json_file)
+
+    for symbol in data["symbols"]:
+        if symbol.startswith("_"):
+            symbol = symbol[1:]
+
+        if not symbol.startswith("??_C@"):
+            continue
+
+        name = symbol.split("@")[3]
+
+        for replace in DEMANGLE_MAP:
+            name = name.replace(replace, DEMANGLE_MAP[replace])
+
+        if not name:
+            continue;
+
+        name = "str:" + name
+        info = {}
+        info["address"] = data["symbols"][symbol]["address"]
+        info["oldname"] = symbol
+
+        test = name
+        count = 0
+        while test in demangled:
+            count = count +1
+            test = name + "_" + str(count)
+        name = test
+
+        demangled[name] = info
+        demangled_count = demangled_count + 1
+
+    for new_symbol in demangled:
+        data["symbols"].pop(demangled[new_symbol]["oldname"])
+        data["symbols"][new_symbol] = {}
+        data["symbols"][new_symbol]["address"] = demangled[new_symbol]["address"]
+
+    if demangled_count:
+        with open(sys.argv[1], 'w') as json_out:
+            json.dump(data, json_out, indent=4)


### PR DESCRIPTION
Move usermode hooking framework from `memdump` plugin to core DRAKVUF.

resolve #787 