### PR TITLE
Use VMI_GET_BIT in procmon

### DIFF
--- a/src/plugins/procmon/winnt.cpp
+++ b/src/plugins/procmon/winnt.cpp
@@ -104,6 +104,7 @@
 
 #include "winnt.h"
 #include <stdio.h>
+#include <libvmi/libvmi.h>
 
 std::string stringify_protection_attributes(uint32_t attributes, char sep)
 {
@@ -117,7 +118,7 @@ std::string stringify_protection_attributes(uint32_t attributes, char sep)
     int num = 0;
     for (size_t i = 0; i < 8 * sizeof(attributes) && attributes; ++i)
     {
-        uint32_t attr = attributes & (1 << i);
+        uint32_t attr = VMI_GET_BIT(attributes, i);
         if (attr == 0)
             continue;
 


### PR DESCRIPTION
Left-shifting signed `1` more then 31-bits is undefined behavior.