### PR TITLE
fix OUTPUT_JSON for various plugins

### DIFF
--- a/src/plugins/apimon/apimon.cpp
+++ b/src/plugins/apimon/apimon.cpp
@@ -180,14 +180,15 @@ static event_response_t usermode_return_hook_cb(drakvuf_t drakvuf, drakvuf_trap_
                     "\"UserId\": %" PRIu64 ", "
                     "\"PID\": %d, "
                     "\"PPID\": %d, "
+                    "\"TID\": %d, "
                     "\"Method\": \"%s\", "
-                    "\"CalledFrom\": 0x%" PRIx64 ", "
-                    "\"ReturnValue\": 0x%" PRIx64 ", "
+                    "\"CalledFrom\": \"0x%" PRIx64 "\", "
+                    "\"ReturnValue\": \"0x%" PRIx64 "\", "
                     "\"Arguments\": ",
                     UNPACK_TIMEVAL(info->timestamp),
                     escaped_pname,
                     USERIDSTR(drakvuf), info->proc_data.userid,
-                    info->proc_data.pid, info->proc_data.ppid,
+                    info->proc_data.pid, info->proc_data.ppid, info->proc_data.tid,
                     info->trap->name,
                     info->regs->rip,
                     info->regs->rax);

--- a/src/plugins/dkommon/dkommon.cpp
+++ b/src/plugins/dkommon/dkommon.cpp
@@ -154,7 +154,7 @@ static void print_hidden_process_information(drakvuf_t drakvuf, drakvuf_trap_inf
                     "\"UserId\": %" PRIu64 ","
                     "\"PID\" : %d,"
                     "\"PPID\": %d,"
-                    "\"Message\": \"Hidden Process\","
+                    "\"Message\": \"Hidden Process\""
                     "}\n",
                     UNPACK_TIMEVAL(info->timestamp),
                     escaped_pname,
@@ -242,7 +242,7 @@ static event_response_t notify_zero_page_write(drakvuf_t drakvuf, drakvuf_trap_i
                     "\"UserId\": %" PRIu64 ","
                     "\"PID\" : %d,"
                     "\"PPID\": %d,"
-                    "\"Message\": \"Zero Page Write\","
+                    "\"Message\": \"Zero Page Write\""
                     "}\n",
                     UNPACK_TIMEVAL(info->timestamp),
                     escaped_pname,
@@ -288,7 +288,7 @@ static void print_driver(drakvuf_t drakvuf, drakvuf_trap_info_t* info, output_fo
                     "\"PID\" : %d,"
                     "\"PPID\": %d,"
                     "\"Message\": \"%s\","
-                    "\"DriverName\": \"%s\","
+                    "\"DriverName\": \"%s\""
                     "}\n",
                     UNPACK_TIMEVAL(info->timestamp),
                     escaped_pname,

--- a/src/plugins/filedelete/filedelete.cpp
+++ b/src/plugins/filedelete/filedelete.cpp
@@ -318,6 +318,7 @@ static void print_file_info(filedelete* f, drakvuf_t drakvuf, drakvuf_trap_info_
                     "\"UserId\": %" PRIu64 ","
                     "\"PID\" : %d,"
                     "\"PPID\": %d,"
+                    "\"TID\": %d,"
                     "\"Method\" : \"%s\","
                     "\"FileName\" : %s"
                     "%s"
@@ -325,7 +326,7 @@ static void print_file_info(filedelete* f, drakvuf_t drakvuf, drakvuf_trap_info_
                     prefix, UNPACK_TIMEVAL(info->timestamp),
                     escaped_pname,
                     USERIDSTR(drakvuf), info->proc_data.userid,
-                    info->proc_data.pid, info->proc_data.ppid,
+                    info->proc_data.pid, info->proc_data.ppid, info->proc_data.tid,
                     info->trap->name, escaped_fname, data);
             g_free(escaped_fname);
             g_free(escaped_pname);

--- a/src/plugins/filetracer/filetracer.cpp
+++ b/src/plugins/filetracer/filetracer.cpp
@@ -186,13 +186,14 @@ static void print_file_obj_info(drakvuf_t drakvuf,
                     "\"UserId\": %" PRIu64 ","
                     "\"PID\" : %d,"
                     "\"PPID\": %d,"
+                    "\"TID\": %d,"
                     "\"Method\": \"%s\","
                     "\"FileName\": %s,"
                     "\"Handle\": \"0x%" PRIx32 "\"",
                     UNPACK_TIMEVAL(info->timestamp),
                     escaped_pname,
                     USERIDSTR(drakvuf), info->proc_data.userid,
-                    info->proc_data.pid, info->proc_data.ppid,
+                    info->proc_data.pid, info->proc_data.ppid, info->proc_data.tid,
                     info->trap->name, escaped_fname, handle);
 
             if (!file_attr.empty())
@@ -427,6 +428,7 @@ static void print_delete_file_info(vmi_instance_t vmi, drakvuf_t drakvuf, drakvu
                     "\"UserId\": %" PRIu64 ","
                     "\"PID\" : %d,"
                     "\"PPID\": %d,"
+                    "\"TID\": %d,"
                     "\"Method\" : \"%s\","
                     "\"Operation\" : \"%s\","
                     "\"FileName\" : %s,"
@@ -435,7 +437,7 @@ static void print_delete_file_info(vmi_instance_t vmi, drakvuf_t drakvuf, drakvu
                     UNPACK_TIMEVAL(info->timestamp),
                     escaped_pname,
                     USERIDSTR(drakvuf), info->proc_data.userid,
-                    info->proc_data.pid, info->proc_data.ppid,
+                    info->proc_data.pid, info->proc_data.ppid, info->proc_data.tid,
                     syscall_name, operation_name, escaped_fname, handle);
 
             g_free(escaped_fname);
@@ -537,6 +539,7 @@ static void print_rename_file_info(vmi_instance_t vmi, drakvuf_t drakvuf, drakvu
                     "\"UserId\": %" PRIu64 ","
                     "\"PID\" : %d,"
                     "\"PPID\": %d,"
+                    "\"TID\": %d,"
                     "\"Method\" : \"%s\","
                     "\"Operation\" : \"%s\","
                     "\"SrcFileName\" : %s,"
@@ -546,7 +549,7 @@ static void print_rename_file_info(vmi_instance_t vmi, drakvuf_t drakvuf, drakvu
                     UNPACK_TIMEVAL(info->timestamp),
                     escaped_pname,
                     USERIDSTR(drakvuf), info->proc_data.userid,
-                    info->proc_data.pid, info->proc_data.ppid,
+                    info->proc_data.pid, info->proc_data.ppid, info->proc_data.tid,
                     syscall_name, operation_name, escaped_fname_src, escaped_fname_dst, src_file_handle );
 
             g_free(escaped_fname_dst);
@@ -639,6 +642,7 @@ static event_response_t create_file_ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_
                     "\"UserId\": %" PRIu64 ","
                     "\"PID\" : %d,"
                     "\"PPID\": %d,"
+                    "\"TID\": %d,"
                     "\"Method\": \"%s\","
                     "\"FileName\": %s,"
                     "\"Handle\": \"0x%x\","
@@ -650,7 +654,7 @@ static event_response_t create_file_ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_
                     UNPACK_TIMEVAL(info->timestamp),
                     escaped_pname,
                     USERIDSTR(drakvuf), info->proc_data.userid,
-                    info->proc_data.pid, info->proc_data.ppid,
+                    info->proc_data.pid, info->proc_data.ppid, info->proc_data.tid,
                     info->trap->name, escaped_fname, handle,
                     w->access.c_str(), w->attrs.c_str(), w->share.c_str(), w->disp.c_str(), w->opts.c_str());
 

--- a/src/plugins/procmon/procmon.cpp
+++ b/src/plugins/procmon/procmon.cpp
@@ -224,6 +224,7 @@ static void print_process_creation_result(
                     "\"UserId\": %" PRIu64 ","
                     "\"PID\" : %d,"
                     "\"PPID\": %d,"
+                    "\"TID\": %d,"
                     "\"Method\" : \"%s\","
                     "\"Status\" : %" PRIu64 ","
                     "\"NewPid\" : %d,"
@@ -235,7 +236,7 @@ static void print_process_creation_result(
                     UNPACK_TIMEVAL(info->timestamp),
                     escaped_pname,
                     USERIDSTR(drakvuf), info->proc_data.userid,
-                    info->proc_data.pid, info->proc_data.ppid,
+                    info->proc_data.pid, info->proc_data.ppid, info->proc_data.tid,
                     info->trap->name, status, new_pid,
                     escaped_cmdline,
                     escaped_ipath,

--- a/src/plugins/regmon/regmon.cpp
+++ b/src/plugins/regmon/regmon.cpp
@@ -175,12 +175,13 @@ static void print_registry_call_info(drakvuf_t drakvuf, drakvuf_trap_info_t* inf
                     "\"UserId\": %" PRIu64 ","
                     "\"PID\" : %d,"
                     "\"PPID\": %d,"
+                    "\"TID\": %d,"
                     "\"Method\" : \"%s\","
                     "\"Key\" : %s",
                     UNPACK_TIMEVAL(info->timestamp),
                     escaped_pname,
                     USERIDSTR(drakvuf), info->proc_data.userid,
-                    info->proc_data.pid, info->proc_data.ppid,
+                    info->proc_data.pid, info->proc_data.ppid, info->proc_data.tid,
                     info->trap->name,
                     escaped_key);
             if (value_name)

--- a/src/plugins/syscalls/syscalls.cpp
+++ b/src/plugins/syscalls/syscalls.cpp
@@ -173,13 +173,14 @@ static void print_header(output_format_t format, drakvuf_t drakvuf, const drakvu
                     "\"UserId\": %" PRIu64 ","
                     "\"PID\" : %d,"
                     "\"PPID\": %d,"
+                    "\"TID\": %d,"
                     "\"Module\": \"%s\","
                     "\"Method\": \"%s\","
                     "\"Args\": [",
                     UNPACK_TIMEVAL(info->timestamp),
                     info->vcpu, info->regs->cr3, escaped_pname,
                     USERIDSTR(drakvuf), info->proc_data.userid,
-                    info->proc_data.pid, info->proc_data.ppid,
+                    info->proc_data.pid, info->proc_data.ppid, info->proc_data.tid,
                     info->trap->breakpoint.module, info->trap->name);
             g_free(escaped_pname);
             break;


### PR DESCRIPTION
* Fix syntax errors when outputting `OUTPUT_JSON` from `apimon` plugin
* Introduce `TID` in printouts of some plugins