### PR TITLE
fix for ProcMon CommandLine Parse Problem

### DIFF
--- a/src/plugins/procmon/procmon.cpp
+++ b/src/plugins/procmon/procmon.cpp
@@ -164,10 +164,12 @@ static char* read_cmd_line(vmi_instance_t vmi, drakvuf_trap_info_t* info, addr_t
         {
             ctx2.addr = buffer_adr;
             char *buf_ret;
-            buf_ret = (char*)g_malloc0(cmd_len+1);
+            buf_ret = (char*)g_try_malloc0(cmd_len+1);
+            if (!buf_ret) return NULL;
             if(VMI_SUCCESS == vmi_read(vmi,&ctx2,cmd_len,buf_ret,NULL))
             {
-                cmd = (char*)g_malloc0(cmd_len+1);
+                cmd = (char*)g_try_malloc0(cmd_len+1);
+                if (!cmd) return NULL;
                 int i;
                 for(i = 0;i<cmd_len;i++)
                 {

--- a/src/plugins/procmon/procmon.cpp
+++ b/src/plugins/procmon/procmon.cpp
@@ -169,7 +169,11 @@ static char* read_cmd_line(vmi_instance_t vmi, drakvuf_trap_info_t* info, addr_t
             if(VMI_SUCCESS == vmi_read(vmi,&ctx2,cmd_len,buf_ret,NULL))
             {
                 cmd = (char*)g_try_malloc0(cmd_len+1);
-                if (!cmd) return NULL;
+                if (!cmd){
+                    g_free(buf_ret);
+                    g_free(cmd);
+                    return NULL;
+                }
                 int i;
                 for(i = 0;i<cmd_len;i++)
                 {

--- a/src/plugins/procmon/procmon.cpp
+++ b/src/plugins/procmon/procmon.cpp
@@ -178,7 +178,6 @@ static char* readcmdline(vmi_instance_t vmi, drakvuf_trap_info_t* info, addr_t a
     }
     return cmd;
 }
-
 static void print_process_creation_result(
     procmon* f, drakvuf_t drakvuf, drakvuf_trap_info_t* info,
     reg_t status, vmi_pid_t new_pid, addr_t user_process_parameters_addr)
@@ -200,8 +199,7 @@ static void print_process_creation_result(
     gchar* escaped_curdir = NULL;
 
     vmi_lock_guard vmi_lg(drakvuf);
-    char *cmd = readcmdline(vmi_lg.vmi,info,cmdline_addr);
-    
+    char *cmd = readcmdline(vmi_lg.vmi,info,cmdline_addr);    
     access_context_t ctx =
     {
         .translate_mechanism = VMI_TM_PROCESS_DTB,

--- a/src/plugins/procmon/procmon.cpp
+++ b/src/plugins/procmon/procmon.cpp
@@ -174,8 +174,9 @@ static char* read_cmd_line(vmi_instance_t vmi, drakvuf_trap_info_t* info, addr_t
                 for(i = 0;i<cmd_len;i++)
                 {
                     strncat(cmd,&buf_ret[i],1);
-                }
+                }                
             }
+            g_free(buf_ret);
         }
     }
     return cmd;

--- a/src/plugins/procmon/procmon.cpp
+++ b/src/plugins/procmon/procmon.cpp
@@ -174,7 +174,7 @@ static char* read_cmd_line(vmi_instance_t vmi, drakvuf_trap_info_t* info, addr_t
                 for(i = 0;i<cmd_len;i++)
                 {
                     strncat(cmd,&buf_ret[i],1);
-                }                
+                }
             }
             g_free(buf_ret);
         }

--- a/src/plugins/procmon/procmon.cpp
+++ b/src/plugins/procmon/procmon.cpp
@@ -171,7 +171,6 @@ static char* read_cmd_line(vmi_instance_t vmi, drakvuf_trap_info_t* info, addr_t
                 cmd = (char*)g_try_malloc0(cmd_len+1);
                 if (!cmd){
                     g_free(buf_ret);
-                    g_free(cmd);
                     return NULL;
                 }
                 int i;

--- a/src/plugins/procmon/procmon.cpp
+++ b/src/plugins/procmon/procmon.cpp
@@ -145,7 +145,7 @@ struct process_visitor_ctx
 
 } // namespace
 
-static char* readcmdline(vmi_instance_t vmi, drakvuf_trap_info_t* info, addr_t addr)
+static char* read_cmd_line(vmi_instance_t vmi, drakvuf_trap_info_t* info, addr_t addr)
 {
     char *cmd = NULL;
     access_context_t ctx2 =
@@ -158,16 +158,16 @@ static char* readcmdline(vmi_instance_t vmi, drakvuf_trap_info_t* info, addr_t a
     uint16_t cmd_len = 0;
     if(VMI_SUCCESS == vmi_read_16(vmi,&ctx2,&cmd_len))
     {
-        ctx2.addr = cmdline_addr+8;
+        ctx2.addr = cmdline_addr+8; // _UNICODE_STRING->Buffer
         addr_t buffer_adr = 0;
         if(VMI_SUCCESS == vmi_read_addr(vmi,&ctx2,&buffer_adr))
         {
             ctx2.addr = buffer_adr;
             char *buf_ret;
-            buf_ret = (char*)malloc(cmd_len+1);
+            buf_ret = (char*)g_malloc0(cmd_len+1);
             if(VMI_SUCCESS == vmi_read(vmi,&ctx2,cmd_len,buf_ret,NULL))
             {
-                cmd = (char*)malloc(cmd_len+1);
+                cmd = (char*)g_malloc0(cmd_len+1);
                 int i;
                 for(i = 0;i<cmd_len;i++)
                 {
@@ -199,7 +199,7 @@ static void print_process_creation_result(
     gchar* escaped_curdir = NULL;
 
     vmi_lock_guard vmi_lg(drakvuf);
-    char *cmd = readcmdline(vmi_lg.vmi,info,cmdline_addr);
+    char *cmd = read_cmd_line(vmi_lg.vmi,info,cmdline_addr);
     access_context_t ctx =
     {
         .translate_mechanism = VMI_TM_PROCESS_DTB,
@@ -297,7 +297,7 @@ static void print_process_creation_result(
 
     g_free(cmdline);
     g_free(curdir);
-    free(cmd);
+    g_free(cmd);
     if (cmdline_us)
         vmi_free_unicode_str(cmdline_us);
 

--- a/src/plugins/procmon/procmon.cpp
+++ b/src/plugins/procmon/procmon.cpp
@@ -145,6 +145,41 @@ struct process_visitor_ctx
 
 } // namespace
 
+static char* readcmdline(vmi_instance_t vmi, drakvuf_trap_info_t* info, addr_t addr)
+{
+    char *cmd = NULL;
+    access_context_t ctx2 =
+            {
+                    .translate_mechanism = VMI_TM_PROCESS_DTB,
+                    .dtb = info->regs->cr3,
+                    .addr = addr,
+            };
+    addr_t cmdline_addr = ctx2.addr;
+    uint16_t cmd_len = 0;
+    if(VMI_SUCCESS == vmi_read_16(vmi,&ctx2,&cmd_len))
+    {
+        ctx2.addr = cmdline_addr+8;
+        addr_t buffer_adr = 0;
+        if(VMI_SUCCESS == vmi_read_addr(vmi,&ctx2,&buffer_adr))
+        {
+            ctx2.addr = buffer_adr;
+            size_t bytes_read;
+            char *buf_ret;
+            buf_ret = (char*)malloc(cmd_len+1);
+            if(VMI_SUCCESS == vmi_read(vmi,&ctx2,cmd_len,buf_ret,NULL))
+            {
+                cmd = (char*)malloc(cmd_len+1);
+                int i;
+                for(i = 0;i<cmd_len;i++)
+                {
+                    strncat(cmd,&buf_ret[i],1);
+                }
+            }
+        }
+    }
+    return cmd;
+}
+
 static void print_process_creation_result(
     procmon* f, drakvuf_t drakvuf, drakvuf_trap_info_t* info,
     reg_t status, vmi_pid_t new_pid, addr_t user_process_parameters_addr)
@@ -166,6 +201,8 @@ static void print_process_creation_result(
     gchar* escaped_curdir = NULL;
 
     vmi_lock_guard vmi_lg(drakvuf);
+    char *cmd = readcmdline(vmi_lg.vmi,info,cmdline_addr);
+    
     access_context_t ctx =
     {
         .translate_mechanism = VMI_TM_PROCESS_DTB,
@@ -191,7 +228,7 @@ static void print_process_creation_result(
             curdir = g_strdup("");
     }
 
-    gchar* cmdline = g_strescape(cmdline_us ? reinterpret_cast<char const*>(cmdline_us->contents) : "", NULL);
+    gchar* cmdline = g_strescape(cmdline_us ? reinterpret_cast<char const*>(cmdline_us->contents) : cmd, NULL);
     char const* imagepath = imagepath_us ? reinterpret_cast<char const*>(imagepath_us->contents) : "";
     char const* dllpath = dllpath_us ? reinterpret_cast<char const*>(dllpath_us->contents) : "";
 

--- a/src/plugins/procmon/procmon.cpp
+++ b/src/plugins/procmon/procmon.cpp
@@ -297,6 +297,7 @@ static void print_process_creation_result(
 
     g_free(cmdline);
     g_free(curdir);
+    free(cmd);
     if (cmdline_us)
         vmi_free_unicode_str(cmdline_us);
 

--- a/src/plugins/procmon/procmon.cpp
+++ b/src/plugins/procmon/procmon.cpp
@@ -199,7 +199,7 @@ static void print_process_creation_result(
     gchar* escaped_curdir = NULL;
 
     vmi_lock_guard vmi_lg(drakvuf);
-    char *cmd = readcmdline(vmi_lg.vmi,info,cmdline_addr);    
+    char *cmd = readcmdline(vmi_lg.vmi,info,cmdline_addr);
     access_context_t ctx =
     {
         .translate_mechanism = VMI_TM_PROCESS_DTB,

--- a/src/plugins/procmon/procmon.cpp
+++ b/src/plugins/procmon/procmon.cpp
@@ -163,7 +163,6 @@ static char* readcmdline(vmi_instance_t vmi, drakvuf_trap_info_t* info, addr_t a
         if(VMI_SUCCESS == vmi_read_addr(vmi,&ctx2,&buffer_adr))
         {
             ctx2.addr = buffer_adr;
-            size_t bytes_read;
             char *buf_ret;
             buf_ret = (char*)malloc(cmd_len+1);
             if(VMI_SUCCESS == vmi_read(vmi,&ctx2,cmd_len,buf_ret,NULL))


### PR DESCRIPTION
Normally, ProcMon tries to read the commandline information of the new created Process as "Unicode" via the "CommandLine" address from OS JSON Profile.

    _EPROCESS->_PEB->ProcessParameters(_RTL_USER_PROCESS_PARAMETERS)->CommandLine
    addr_t cmdline_addr = user_process_parameters_addr + f->command_line;
uses this way

However, in the OS JSON Profile file, CommandLine looks like a single field.
Normally, ProcMon does not have a problem and prints the CommandLine information, but if the CommandLine of the Process is long data, ProcMon cannot read and process it.(related to libvmi)

An error related to this was reported
#821

CommandLine(_UNICODE_STRING) has 3 fields on Windows systems.

      0xAAAAA0    Length                          [unsigned short:Length]: 0x1882
      0xAAAAA2    MaximumLength                   [unsigned short:MaximumLength]: 0x1884
      0xAAAAA8    Buffer                         <UnicodeString Pointer to [0x4d2608] (Buffer)>

The first 2 bytes show Buffer's length.

This patch processes and displays the data with the length of the CommandLine.


Without patch
![Before](https://i.imgur.com/6G8BkdB.png)

With patch
![After](https://i.imgur.com/JpeENuH.png)