### PR TITLE
add -k switch that allows to provide KPGD value manually

### DIFF
--- a/src/drakvuf.cpp
+++ b/src/drakvuf.cpp
@@ -167,10 +167,11 @@ drakvuf_c::drakvuf_c(const char* domain,
                      output_format_t output,
                      bool verbose,
                      bool leave_paused,
-                     bool libvmi_conf)
+                     bool libvmi_conf,
+                     addr_t kpgd)
     : leave_paused{ leave_paused }
 {
-    if (!drakvuf_init(&drakvuf, domain, json_kernel_path, json_wow_path, verbose, libvmi_conf))
+    if (!drakvuf_init(&drakvuf, domain, json_kernel_path, json_wow_path, verbose, libvmi_conf, kpgd))
     {
         drakvuf_close(drakvuf, leave_paused);
         throw std::runtime_error("drakvuf_init() failed");

--- a/src/drakvuf.h
+++ b/src/drakvuf.h
@@ -151,7 +151,8 @@ public:
               output_format_t output,
               bool verbose,
               bool leave_paused,
-              bool libvmi_conf);
+              bool libvmi_conf,
+              addr_t kpgd);
     ~drakvuf_c();
 
     int is_initialized();

--- a/src/injector.c
+++ b/src/injector.c
@@ -235,7 +235,7 @@ int main(int argc, char** argv)
                 libvmi_conf = true;
                 break;
             case 'k':
-                kpgd = strtol(optarg, NULL, 0);
+                kpgd = strtoull(optarg, NULL, 0);
                 break;
             default:
                 fprintf(stderr, "Unrecognized option: %c\n", c);

--- a/src/injector.c
+++ b/src/injector.c
@@ -130,6 +130,7 @@ static inline void print_help(void)
             "\t -e <inject_file>          The executable to start with injection\n"
             "Optional inputs:\n"
             "\t -l                        Use libvmi.conf\n"
+            "\t -k <kpgd value>           Use provided KPGD value for faster and more robust startup (advanced)\n"
             "\t -m <inject_method>        The injection method [WIN] (createproc (32 and 64-bit), shellexec, shellcode or doppelganging (Win10) for Windows amd64 only)\n"
             "\t -f <args for exec>        [LINUX] - Arguments specified for exec to include (requires -m execproc)\n"
             "\t                           [LINUX] (execproc -> int execlp(const char *file, const char *arg0, ..., const char *argn, (char *)0); for Linux kernel 4.18+, 64bit only) (Maximum 10 args)\n"
@@ -161,6 +162,7 @@ int main(int argc, char** argv)
     bool libvmi_conf = false;
     const char* args[10] = {};
     int args_count = 0;
+    addr_t kpgd = 0;
 
     fprintf(stderr, "%s %s v%s Copyright (C) 2014-2020 Tamas K Lengyel\n",
             PACKAGE_NAME, argv[0], PACKAGE_VERSION);
@@ -171,7 +173,7 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    while ((c = getopt (argc, argv, "r:d:i:I:e:m:B:P:f:vlg")) != -1)
+    while ((c = getopt (argc, argv, "r:d:i:I:e:m:B:P:f:k:vlg")) != -1)
         switch (c)
         {
             case 'r':
@@ -232,6 +234,9 @@ int main(int argc, char** argv)
             case 'l':
                 libvmi_conf = true;
                 break;
+            case 'k':
+                kpgd = strtol(optarg, NULL, 0);
+                break;
             default:
                 fprintf(stderr, "Unrecognized option: %c\n", c);
                 return rc;
@@ -270,7 +275,7 @@ int main(int argc, char** argv)
     sigaction(SIGINT, &act, NULL);
     sigaction(SIGALRM, &act, NULL);
 
-    if (!drakvuf_init(&drakvuf, domain, json_kernel_path, NULL, verbose, libvmi_conf))
+    if (!drakvuf_init(&drakvuf, domain, json_kernel_path, NULL, verbose, libvmi_conf, kpgd))
     {
         fprintf(stderr, "Failed to initialize on domain %s\n", domain);
         return 1;

--- a/src/libdrakvuf/drakvuf.c
+++ b/src/libdrakvuf/drakvuf.c
@@ -155,7 +155,7 @@ void drakvuf_close(drakvuf_t drakvuf, const bool pause)
     g_free(drakvuf);
 }
 
-bool drakvuf_init(drakvuf_t* drakvuf, const char* domain, const char* json_kernel_path, const char* json_wow_path, bool _verbose, bool libvmi_conf)
+bool drakvuf_init(drakvuf_t* drakvuf, const char* domain, const char* json_kernel_path, const char* json_wow_path, bool _verbose, bool libvmi_conf, addr_t kpgd)
 {
 
     if ( !domain || !json_kernel_path )
@@ -176,6 +176,8 @@ bool drakvuf_init(drakvuf_t* drakvuf, const char* domain, const char* json_kerne
     }
     else
         PRINT_DEBUG("drakvuf_init: Rekall WoW64 profile not used\n");
+
+    (*drakvuf)->kpgd = kpgd;
 
     g_mutex_init(&(*drakvuf)->vmi_lock);
 

--- a/src/libdrakvuf/libdrakvuf.h
+++ b/src/libdrakvuf/libdrakvuf.h
@@ -353,7 +353,8 @@ bool drakvuf_init (drakvuf_t* drakvuf,
                    const char* json_profile,
                    const char* json_wow_profile,
                    const bool verbose,
-                   const bool libvmi_conf) NOEXCEPT;
+                   const bool libvmi_conf,
+                   const addr_t kpgd) NOEXCEPT;
 void drakvuf_close (drakvuf_t drakvuf, const bool pause) NOEXCEPT;
 bool drakvuf_add_trap(drakvuf_t drakvuf,
                       drakvuf_trap_t* trap) NOEXCEPT;

--- a/src/libdrakvuf/private.h
+++ b/src/libdrakvuf/private.h
@@ -208,6 +208,7 @@ struct drakvuf
     xen_pfn_t max_gpfn;
     addr_t kernbase;
     addr_t kdtb;
+    addr_t kpgd;
 
     int address_width;
 

--- a/src/libdrakvuf/vmi.c
+++ b/src/libdrakvuf/vmi.c
@@ -1379,6 +1379,10 @@ bool init_vmi(drakvuf_t drakvuf, bool libvmi_conf)
     {
         GHashTable* config = g_hash_table_new(g_str_hash, g_str_equal);
         g_hash_table_insert(config, "volatility_ist", drakvuf->json_kernel_path);
+        if (drakvuf->kpgd)
+        {
+            g_hash_table_insert(config, "kpgd", &drakvuf->kpgd);
+        }
         drakvuf->os = vmi_init_os(drakvuf->vmi, VMI_CONFIG_GHASHTABLE, config, NULL);
         g_hash_table_destroy(config);
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -429,7 +429,7 @@ int main(int argc, char** argv)
                 libvmi_conf = true;
                 break;
             case 'k':
-                kpgd = strtol(optarg, NULL, 0);
+                kpgd = strtoull(optarg, NULL, 0);
                 break;
             case 'w':
                 json_wow_path = optarg;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -155,6 +155,7 @@ static void print_usage()
             "\t -d <domain ID or name>    The domain's ID or name\n"
             "Optional inputs:\n"
             "\t -l                        Use libvmi.conf\n"
+            "\t -k <kpgd value>           Use provided KPGD value for faster and more robust startup (advanced)\n"
             "\t -i <injection pid>        The PID of the process to hijack for injection\n"
             "\t -I <injection thread>     The ThreadID in the process to hijack for injection (requires -i)\n"
             "\t -e <inject_file>          The executable to start with injection\n"
@@ -256,6 +257,7 @@ int main(int argc, char** argv)
     bool verbose = false;
     bool leave_paused = false;
     bool libvmi_conf = false;
+    addr_t kpgd = 0;
     plugins_options options = {};
     bool disabled_all = false; // Used to disable all plugin once
     const char* args[10] = {};
@@ -312,7 +314,7 @@ int main(int argc, char** argv)
         {"dll-hooks-list", required_argument, NULL, opt_dll_hooks_list},
         {NULL, 0, NULL, 0}
     };
-    const char* opts = "r:d:i:I:e:m:t:D:o:vx:a:f:spT:S:Mc:nblgj:w:W:h";
+    const char* opts = "r:d:i:I:e:m:t:D:o:vx:a:f:spT:S:Mc:nblgj:k:w:W:h";
 
     while ((c = getopt_long (argc, argv, opts, long_opts, &long_index)) != -1)
         switch (c)
@@ -426,6 +428,9 @@ int main(int argc, char** argv)
             case 'l':
                 libvmi_conf = true;
                 break;
+            case 'k':
+                kpgd = strtol(optarg, NULL, 0);
+                break;
             case 'w':
                 json_wow_path = optarg;
                 break;
@@ -502,7 +507,7 @@ int main(int argc, char** argv)
 
     try
     {
-        drakvuf = new drakvuf_c(domain, json_kernel_path, json_wow_path, output, verbose, leave_paused, libvmi_conf);
+        drakvuf = new drakvuf_c(domain, json_kernel_path, json_wow_path, output, verbose, leave_paused, libvmi_conf, kpgd);
     }
     catch (const std::exception& e)
     {

--- a/src/proc_stat.cpp
+++ b/src/proc_stat.cpp
@@ -174,7 +174,7 @@ int main(int argc, char** argv)
 
 
     /* initialize the Drakvuf library */
-    if (!drakvuf_init(&drakvuf, domain, profile, NULL, false, false))
+    if (!drakvuf_init(&drakvuf, domain, profile, NULL, false, false, 0))
     {
         printf("Failed to initialize Drakvuf\n");
         goto done;


### PR DESCRIPTION
In some situations, LibVMI doesn't always detect KPGD value in robust way. If somebody is operating in conditions where KPGD is well-known (e.g. DRAKVUF is continously being ran against VM with the same snapshot), the value may manually forced using `-k <kpgd value>` switch.