### PR TITLE
libinjector: return injection status

### DIFF
--- a/src/drakvuf.cpp
+++ b/src/drakvuf.cpp
@@ -216,7 +216,7 @@ void drakvuf_c::resume()
     drakvuf_resume(drakvuf);
 }
 
-int drakvuf_c::inject_cmd(vmi_pid_t injection_pid,
+injector_status_t drakvuf_c::inject_cmd(vmi_pid_t injection_pid,
                           uint32_t injection_tid,
                           const char* inject_cmd,
                           const char* cwd,
@@ -231,7 +231,7 @@ int drakvuf_c::inject_cmd(vmi_pid_t injection_pid,
 {
     GThread* timeout_thread = startup_timer(this, timeout);
 
-    int rc = injector_start_app(drakvuf,
+    auto rc = injector_start_app(drakvuf,
                                 injection_pid,
                                 injection_tid,
                                 inject_cmd,
@@ -247,7 +247,7 @@ int drakvuf_c::inject_cmd(vmi_pid_t injection_pid,
                                 args);
 
 
-    if (!rc)
+    if (INJECTOR_SUCCEEDED != rc)
         fprintf(stderr, "Process startup failed\n");
 
     cleanup_timer(this, timeout_thread);

--- a/src/drakvuf.h
+++ b/src/drakvuf.h
@@ -160,7 +160,7 @@ public:
     void loop(int duration);
     void pause();
     void resume();
-    int inject_cmd(vmi_pid_t injection_pid,
+    injector_status_t inject_cmd(vmi_pid_t injection_pid,
                    uint32_t injection_tid,
                    const char* inject_cmd,
                    const char* cwd,

--- a/src/libinjector/injector.c
+++ b/src/libinjector/injector.c
@@ -105,7 +105,7 @@
 #include <libinjector/libinjector.h>
 #include "private.h"
 
-int injector_start_app(
+injector_status_t injector_start_app(
     drakvuf_t drakvuf,
     vmi_pid_t pid,
     uint32_t tid,

--- a/src/libinjector/libinjector.h
+++ b/src/libinjector/libinjector.h
@@ -120,6 +120,13 @@ typedef struct injector* injector_t;
 
 typedef enum
 {
+    INJECTOR_FAILED,
+    INJECTOR_FAILED_WITH_ERROR_CODE,
+    INJECTOR_SUCCEEDED,
+} injector_status_t;
+
+typedef enum
+{
     // win
     INJECT_METHOD_CREATEPROC,
     INJECT_METHOD_SHELLEXEC,
@@ -188,7 +195,7 @@ bool setup_stack_locked(drakvuf_t drakvuf,
                         struct argument args[],
                         int nb_args) NOEXCEPT;
 
-int injector_start_app(drakvuf_t drakvuf,
+injector_status_t injector_start_app(drakvuf_t drakvuf,
                        vmi_pid_t pid,
                        uint32_t tid, // optional, if tid=0 the first thread that gets scheduled is used
                        const char* app,

--- a/src/libinjector/linux_injector.c
+++ b/src/libinjector/linux_injector.c
@@ -160,7 +160,7 @@ struct injector
     GSList* memtraps;
 
     // Results:
-    int rc;
+    injector_status_t rc;
     inject_result_t result;
     struct
     {
@@ -372,7 +372,7 @@ static event_response_t wait_for_injected_process_cb_linux(drakvuf_t drakvuf, dr
         if (info->regs->rax == ~0u)
         {
             printf("Process start failed!! Exec returned -1 \n");
-            injector->rc = 0;
+            injector->rc = INJECTOR_FAILED;
             injector->detected = false;
             drakvuf_remove_trap(drakvuf, injector->int3_trap, NULL);
             drakvuf_remove_trap(drakvuf, info->trap, (drakvuf_trap_free_t)free);
@@ -394,7 +394,7 @@ static event_response_t wait_for_injected_process_cb_linux(drakvuf_t drakvuf, dr
     drakvuf_remove_trap(drakvuf, info->trap, (drakvuf_trap_free_t)free);
     drakvuf_interrupt(drakvuf, SIGINT);
 
-    injector->rc = 1;
+    injector->rc = INJECTOR_SUCCEEDED;
     injector->detected = true;
 
     return 0;
@@ -560,7 +560,7 @@ static event_response_t wait_for_process_in_userspace(drakvuf_t drakvuf, drakvuf
         if (info->regs->rax == ~0u)
         {
             PRINT_DEBUG("Process start failed!!, As exec returned -1 \n");
-            injector->rc = 0;
+            injector->rc = INJECTOR_FAILED;
             injector->detected = false;
             drakvuf_remove_trap(drakvuf, injector->cr3_trap, NULL);
             drakvuf_remove_trap(drakvuf, info->trap,  (drakvuf_trap_free_t)free);
@@ -575,7 +575,7 @@ static event_response_t wait_for_process_in_userspace(drakvuf_t drakvuf, drakvuf
     if (injector->method == INJECT_METHOD_SHELLCODE_LINUX && injector->status == STATUS_EXEC_OK)
     {
         printf("Shellcode executed successfully\n");
-        injector->rc = 1;
+        injector->rc = INJECTOR_SUCCEEDED;
     }
 
     // Unexpected state
@@ -888,7 +888,7 @@ static bool initialize_linux_injector_functions(injector_t injector)
     return true;
 }
 
-int injector_start_app_on_linux(
+injector_status_t injector_start_app_on_linux(
     drakvuf_t drakvuf,
     vmi_pid_t pid,
     uint32_t tid,

--- a/src/libinjector/private.h
+++ b/src/libinjector/private.h
@@ -127,7 +127,7 @@ extern bool verbose;
 
 #endif
 
-int injector_start_app_on_linux(drakvuf_t drakvuf,
+injector_status_t injector_start_app_on_linux(drakvuf_t drakvuf,
                                 vmi_pid_t pid,
                                 uint32_t tid, // optional, if tid=0 the first thread that gets scheduled is used i.e, tid = pid
                                 const char* app,
@@ -137,7 +137,7 @@ int injector_start_app_on_linux(drakvuf_t drakvuf,
                                 const char* args[]);
 
 
-int injector_start_app_on_win(drakvuf_t drakvuf,
+injector_status_t injector_start_app_on_win(drakvuf_t drakvuf,
                               vmi_pid_t pid,
                               uint32_t tid,
                               const char* app,

--- a/src/libinjector/win_injector.c
+++ b/src/libinjector/win_injector.c
@@ -173,7 +173,7 @@ struct injector
     size_t offsets[OFFSET_MAX];
 
     // Results:
-    int rc;
+    injector_status_t rc;
     inject_result_t result;
     struct
     {
@@ -527,8 +527,8 @@ static event_response_t mem_callback(drakvuf_t drakvuf, drakvuf_trap_info_t* inf
 
     if ( info->proc_data.pid != injector->target_pid || ( injector->target_tid && (uint32_t)info->proc_data.tid != injector->target_tid ))
     {
-        PRINT_DEBUG("MemX received but PID (%u) doesn't match target process (%u)\n",
-                    info->proc_data.pid, injector->target_pid);
+        PRINT_DEBUG("MemX received but PID:TID (%u:%u) doesn't match target process (%u:%u)\n",
+                    info->proc_data.pid, info->proc_data.tid, injector->target_pid, injector->target_tid);
         return 0;
     }
 
@@ -583,7 +583,7 @@ static event_response_t wait_for_crash_of_target_process(drakvuf_t drakvuf, drak
     vmi_pid_t crashed_pid = 0;
     if (drakvuf_is_crashreporter(drakvuf, info, &crashed_pid) && crashed_pid == injector->target_pid)
     {
-        injector->rc = 0;
+        injector->rc = INJECTOR_FAILED;
         injector->detected = false;
 
         drakvuf_interrupt(drakvuf, SIGDRAKVUFCRASH);
@@ -713,7 +713,7 @@ static event_response_t wait_for_injected_process_cb(drakvuf_t drakvuf, drakvuf_
     PRINT_DEBUG("Process start detected %i -> 0x%lx\n", injector->pid, info->regs->cr3);
     drakvuf_remove_trap(drakvuf, info->trap, (drakvuf_trap_free_t)free);
 
-    injector->rc = 1;
+    injector->rc = INJECTOR_SUCCEEDED;
     injector->detected = true;
 
     if ( injector->break_loop_on_detection )
@@ -889,7 +889,7 @@ static event_response_t injector_int3_cb(drakvuf_t drakvuf, drakvuf_trap_info_t*
             {
                 // TODO Retrieve PID and TID
                 PRINT_DEBUG("Injected\n");
-                injector->rc = 1;
+                injector->rc = INJECTOR_SUCCEEDED;
             }
 
             memcpy(info->regs, &injector->saved_regs, sizeof(x86_registers_t));
@@ -901,14 +901,17 @@ static event_response_t injector_int3_cb(drakvuf_t drakvuf, drakvuf_trap_info_t*
             // We are now in the return path from CreateProcessW called from mem_callback
 
             if (info->regs->rax)
+            {
+                injector->rc = INJECTOR_SUCCEEDED;
                 fill_created_process_info(injector, info);
+            }
             else
             {
+                injector->rc = INJECTOR_FAILED_WITH_ERROR_CODE;
                 injector->error_code.valid = true;
                 drakvuf_get_last_error(injector->drakvuf, info, &injector->error_code.code, &injector->error_code.string);
             }
 
-            injector->rc = info->regs->rax;
             memcpy(info->regs, &injector->saved_regs, sizeof(x86_registers_t));
 
             if (injector->pid && injector->tid)
@@ -934,7 +937,6 @@ static event_response_t injector_int3_cb(drakvuf_t drakvuf, drakvuf_trap_info_t*
             else
             {
                 PRINT_DEBUG("Failed to inject\n");
-                injector->rc = 0;
 
                 drakvuf_remove_trap(drakvuf, info->trap, NULL);
                 drakvuf_interrupt(drakvuf, SIGDRAKVUFERROR);
@@ -954,17 +956,21 @@ static event_response_t injector_int3_cb(drakvuf_t drakvuf, drakvuf_trap_info_t*
 
         drakvuf_remove_trap(drakvuf, info->trap, NULL);
 
-        injector->rc = info->regs->rax;
+        if (info->regs->rax == 1)
+            injector->rc = INJECTOR_SUCCEEDED;
+        else
+            injector->rc = INJECTOR_FAILED;
+
         memcpy(info->regs, &injector->saved_regs, sizeof(x86_registers_t));
 
-        if (injector->rc == 1)
+        if (injector->rc == INJECTOR_SUCCEEDED)
         {
             PRINT_DEBUG("Resumed\n");
         }
         else
         {
             PRINT_DEBUG("Failed to resume\n");
-            injector->rc = 0;
+            injector->rc = INJECTOR_FAILED;
 
             drakvuf_interrupt(drakvuf, SIGDRAKVUFERROR);
         }
@@ -1108,14 +1114,17 @@ static event_response_t injector_int3_cb(drakvuf_t drakvuf, drakvuf_trap_info_t*
         // We are now in the return path from CreateProcessW
 
         if (info->regs->rax)
+        {
+            injector->rc = INJECTOR_SUCCEEDED;
             fill_created_process_info(injector, info);
+        }
         else
         {
             injector->error_code.valid = true;
+            injector->rc = INJECTOR_FAILED_WITH_ERROR_CODE;
             drakvuf_get_last_error(injector->drakvuf, info, &injector->error_code.code, &injector->error_code.string);
         }
 
-        injector->rc = info->regs->rax;
         memcpy(info->regs, &injector->saved_regs, sizeof(x86_registers_t));
 
         if (injector->pid && injector->tid)
@@ -1141,7 +1150,6 @@ static event_response_t injector_int3_cb(drakvuf_t drakvuf, drakvuf_trap_info_t*
         else
         {
             PRINT_DEBUG("Failed to inject\n");
-            injector->rc = 0;
         }
     }
     // For some reason ShellExecute could return ERROR_FILE_NOT_FOUND while
@@ -1150,12 +1158,12 @@ static event_response_t injector_int3_cb(drakvuf_t drakvuf, drakvuf_trap_info_t*
     {
         // TODO Retrieve PID and TID
         PRINT_DEBUG("Injected\n");
-        injector->rc = 1;
+        injector->rc = INJECTOR_SUCCEEDED;
     }
     else if ( (INJECT_METHOD_SHELLCODE == injector->method || INJECT_METHOD_DOPP == injector->method) && STATUS_EXEC_OK == injector->status)
     {
         PRINT_DEBUG("Shellcode executed\n");
-        injector->rc = 1;
+        injector->rc = INJECTOR_SUCCEEDED;
     }
 
     drakvuf_remove_trap(drakvuf, info->trap, NULL);
@@ -1544,7 +1552,7 @@ static bool initialize_injector_functions(drakvuf_t drakvuf, injector_t injector
     return injector->exec_func != 0;
 }
 
-int injector_start_app_on_win(
+injector_status_t injector_start_app_on_win(
     drakvuf_t drakvuf,
     vmi_pid_t pid,
     uint32_t tid,
@@ -1558,7 +1566,7 @@ int injector_start_app_on_win(
     injector_t* to_be_freed_later,
     bool global_search)
 {
-    int rc = 0;
+    injector_status_t rc = 0;
     PRINT_DEBUG("Target PID %u to start '%s'\n", pid, file);
 
     unicode_string_t* target_file_us = convert_utf8_to_utf16(file);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -547,9 +547,17 @@ int main(int argc, char** argv)
     if (injection_pid > 0 && inject_file)
     {
         PRINT_DEBUG("Starting injection with PID %i(%i) for %s\n", injection_pid, injection_thread, inject_file);
-        int ret = drakvuf->inject_cmd(injection_pid, injection_thread, inject_file, inject_cwd, injection_method, output, binary_path, target_process, injection_timeout, injection_global_search, args_count, args);
-        if (!ret)
+        injector_status_t ret = drakvuf->inject_cmd(injection_pid, injection_thread, inject_file, inject_cwd, injection_method, output, binary_path, target_process, injection_timeout, injection_global_search, args_count, args);
+        switch (ret)
+        {
+        case INJECTOR_FAILED_WITH_ERROR_CODE:
+            rc = 0;
+        case INJECTOR_FAILED:
             goto exit;
+        case INJECTOR_SUCCEEDED:
+        default:
+            break;
+        }
     }
 
     PRINT_DEBUG("Starting plugins\n");

--- a/src/plugins/filedelete/filedelete.cpp
+++ b/src/plugins/filedelete/filedelete.cpp
@@ -396,7 +396,14 @@ static void save_file_metadata(filedelete* f,
         return;
 
     json_object *jobj = json_object_new_object();
-    json_object_object_add(jobj, "FileName", json_object_new_string(filename ?: "<UNKNOWN>"));
+    if (!jobj)
+    {
+        fclose(fp);
+        return;
+    }
+
+    filename = filename ?: "<UNKNOWN>";
+    json_object_object_add(jobj, "FileName", json_object_new_string(filename));
     json_object_object_add(jobj, "FileSize", json_object_new_int64(file_size));
     json_object_object_add(jobj, "FileFlags", json_object_new_string_fmt("0x%lx (%s)", fo_flags, parse_flags(fo_flags, fo_flags_map, OUTPUT_DEFAULT, "0").c_str()));
     json_object_object_add(jobj, "SequenceNumber", json_object_new_int(sequence_number));

--- a/src/plugins/memdump/memdump.cpp
+++ b/src/plugins/memdump/memdump.cpp
@@ -370,6 +370,7 @@ done:
     free(file);
     free(file_path);
     free(tmp_file_path);
+    free(metafile);
     g_free(access_ptrs);
 
     return ret;

--- a/src/plugins/memdump/memdump.cpp
+++ b/src/plugins/memdump/memdump.cpp
@@ -392,10 +392,11 @@ bool inspect_stack_ptr(drakvuf_t drakvuf, drakvuf_trap_info_t* info, memdump* pl
 
     vmi_read(vmi, &ctx, 512, buf, &bytes_read);
 
-    for (size_t i = 0; i < bytes_read; i++)
+    size_t stack_width = is_32bit ? 4 : 8;
+    for (size_t i = 0; i < bytes_read; i += stack_width)
     {
         uint64_t stack_val = 0;
-        memcpy(&stack_val, buf+i, is_32bit ? 4 : 8);
+        memcpy(&stack_val, buf+i, stack_width);
 
         mmvad_info_t mmvad;
         if (!drakvuf_find_mmvad(drakvuf, info->proc_data.base_addr, stack_val, &mmvad))


### PR DESCRIPTION
Sometimes drakvuf fails to inject because of invalid sample (e.g. x64 sample
for x86 VM). This allows to distinguish such situations.