### PR TITLE
Store syscall definitions in custom structs

### DIFF
--- a/src/plugins/syscalls/linux.cpp
+++ b/src/plugins/syscalls/linux.cpp
@@ -115,7 +115,7 @@
 // Builds the argument buffer from the current context, returns status
 static status_t linux_build_argbuf(void* buf, vmi_instance_t vmi,
                                    drakvuf_trap_info_t* info, syscalls *s,
-                                   const syscall_definition_t* sc,
+                                   const syscall_t* sc,
                                    addr_t pt_regs_addr)
 {
     int nargs = 0;
@@ -220,7 +220,7 @@ static event_response_t linux_ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* inf
 
     syscalls *s = w->s;
 
-    const syscall_definition_t *sc = w->num <= NUM_SYSCALLS_LINUX ? &linux_syscalls[w->num] : NULL;
+    const syscall_t *sc = w->num < NUM_SYSCALLS_LINUX ? linuxsc::linux_syscalls[w->num] : NULL;
 
     print_header(s->format, drakvuf, false, info, w->num, info->trap->breakpoint.module, sc, info->regs->rax, NULL);
     print_footer(s->format, 0);
@@ -239,7 +239,7 @@ static event_response_t linux_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 
     unsigned int nargs = 0;
     uint8_t buf[sizeof(uint64_t) * 8] = {0};
-    const syscall_definition_t* sc = NULL;
+    const syscall_t* sc = NULL;
     addr_t pt_regs = 0;
 
     addr_t ret = 0, nr = ~0;
@@ -263,7 +263,7 @@ static event_response_t linux_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 
     if ( nr<NUM_SYSCALLS_LINUX )
     {
-        sc = &linux_syscalls[nr];
+        sc = linuxsc::linux_syscalls[nr];
         nargs = sc->num_args;
 
        if ( s->filter && !g_hash_table_lookup(s->filter, sc->name) )

--- a/src/plugins/syscalls/linux.h
+++ b/src/plugins/syscalls/linux.h
@@ -177,373 +177,668 @@ static const char* linux_pt_regs_names[__PT_REGS_MAX] =
     [PT_REGS_SS] = "ss",
 };
 
-// The actual max depends on the arch and actual kernel version
-#define NUM_SYSCALLS_LINUX 313
+namespace linuxsc {
 
-static const syscall_definition_t linux_syscalls[] =
-{
-    [0] =
-    {
-        .name = "read", .ret = LONG,   .num_args = 3, .args =
-        {
-            {.name = "fd",      .dir = DIR_IN, .type = LONG },
-            {.name = "buf",     .dir = DIR_IN, .type = PVOID },
-            {.name = "count",   .dir = DIR_IN, .type = ULONG },
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmissing-braces"
 
-        }
-    },
+SYSCALL(read, LONG, 3,
+            "fd",    "", DIR_IN,    LONG,
+            "buf",   "", DIR_IN,    PVOID,
+            "count", "", DIR_OUT,   ULONG
+         );
+SYSCALL(write, LONG, 3,
+            "fd",    "", DIR_IN,    LONG,
+            "buf",   "", DIR_OUT,   PVOID,
+            "count", "", DIR_OUT,   ULONG
+         );
+SYSCALL(open, LONG, 3,
+            "pathname", "", DIR_IN, PCHAR,
+            "flags",    "", DIR_IN, ULONG,
+            "mode",     "", DIR_IN, ULONG
+         );
+SYSCALL(close, LONG, 1,
+            "fd", "", DIR_IN, LONG,
+         );
+SYSCALL(openat, LONG, 4,
+            "dirfd",    "", DIR_IN, LONG,
+            "pathname", "", DIR_IN, PCHAR,
+            "flags",    "", DIR_IN, ULONG,
+            "mode",     "", DIR_IN, ULONG,
+         );
 
-    [1] =
-    {
-        .name = "write", .ret = LONG,    .num_args = 3, .args =
-        {
-            {.name = "fd",       .dir = DIR_IN,  .type = LONG },
-            {.name = "buf",      .dir = DIR_OUT, .type = PVOID },
-            {.name = "count",    .dir = DIR_OUT, .type = ULONG },
-        },
-    },
+// TODO: fill in missing ret & argument info
+SYSCALL(stat, VOID,0);
+SYSCALL(fstat,VOID,0);
+SYSCALL(lstat,VOID,0);
+SYSCALL(poll,VOID,0);
+SYSCALL(lseek,VOID,0);
+SYSCALL(mmap,VOID,0);
+SYSCALL(mprotect,VOID,0);
+SYSCALL(munmap,VOID,0);
+SYSCALL(brk,VOID,0);
+SYSCALL(rt_sigaction,VOID,0);
+SYSCALL(rt_sigprocmask,VOID,0);
+SYSCALL(rt_sigreturn,VOID,0);
+SYSCALL(ioctl,VOID,0);
+SYSCALL(pread64,VOID,0);
+SYSCALL(pwrite64,VOID,0);
+SYSCALL(readv,VOID,0);
+SYSCALL(writev,VOID,0);
+SYSCALL(access,VOID,0);
+SYSCALL(pipe,VOID,0);
+SYSCALL(select,VOID,0);
+SYSCALL(sched_yield,VOID,0);
+SYSCALL(mremap,VOID,0);
+SYSCALL(msync,VOID,0);
+SYSCALL(mincore,VOID,0);
+SYSCALL(madvise,VOID,0);
+SYSCALL(shmget,VOID,0);
+SYSCALL(shmat,VOID,0);
+SYSCALL(shmctl,VOID,0);
+SYSCALL(dup,VOID,0);
+SYSCALL(dup2,VOID,0);
+SYSCALL(pause,VOID,0);
+SYSCALL(nanosleep,VOID,0);
+SYSCALL(getitimer,VOID,0);
+SYSCALL(alarm,VOID,0);
+SYSCALL(setitimer,VOID,0);
+SYSCALL(getpid,VOID,0);
+SYSCALL(sendfile64,VOID,0);
+SYSCALL(socket,VOID,0);
+SYSCALL(connect,VOID,0);
+SYSCALL(accept,VOID,0);
+SYSCALL(sendto,VOID,0);
+SYSCALL(recvfrom,VOID,0);
+SYSCALL(sendmsg,VOID,0);
+SYSCALL(recvmsg,VOID,0);
+SYSCALL(shutdown,VOID,0);
+SYSCALL(bind,VOID,0);
+SYSCALL(listen,VOID,0);
+SYSCALL(getsockname,VOID,0);
+SYSCALL(getpeername,VOID,0);
+SYSCALL(socketpair,VOID,0);
+SYSCALL(setsockopt,VOID,0);
+SYSCALL(getsockopt,VOID,0);
+SYSCALL(clone,VOID,0);
+SYSCALL(fork,VOID,0);
+SYSCALL(vfork,VOID,0);
+SYSCALL(execve,VOID,0);
+SYSCALL(exit,VOID,0);
+SYSCALL(wait4,VOID,0);
+SYSCALL(kill,VOID,0);
+SYSCALL(uname,VOID,0);
+SYSCALL(semget,VOID,0);
+SYSCALL(semop,VOID,0);
+SYSCALL(semctl,VOID,0);
+SYSCALL(shmdt,VOID,0);
+SYSCALL(msgget,VOID,0);
+SYSCALL(msgsnd,VOID,0);
+SYSCALL(msgrcv,VOID,0);
+SYSCALL(msgctl,VOID,0);
+SYSCALL(fcntl,VOID,0);
+SYSCALL(flock,VOID,0);
+SYSCALL(fsync,VOID,0);
+SYSCALL(fdatasync,VOID,0);
+SYSCALL(truncate,VOID,0);
+SYSCALL(ftruncate,VOID,0);
+SYSCALL(getdents,VOID,0);
+SYSCALL(getcwd,VOID,0);
+SYSCALL(chdir,VOID,0);
+SYSCALL(fchdir,VOID,0);
+SYSCALL(rename,VOID,0);
+SYSCALL(mkdir,VOID,0);
+SYSCALL(rmdir,VOID,0);
+SYSCALL(creat,VOID,0);
+SYSCALL(link,VOID,0);
+SYSCALL(unlink,VOID,0);
+SYSCALL(symlink,VOID,0);
+SYSCALL(readlink,VOID,0);
+SYSCALL(chmod,VOID,0);
+SYSCALL(fchmod,VOID,0);
+SYSCALL(chown,VOID,0);
+SYSCALL(fchown,VOID,0);
+SYSCALL(lchown,VOID,0);
+SYSCALL(umask,VOID,0);
+SYSCALL(gettimeofday,VOID,0);
+SYSCALL(getrlimit,VOID,0);
+SYSCALL(getrusage,VOID,0);
+SYSCALL(sysinfo,VOID,0);
+SYSCALL(times,VOID,0);
+SYSCALL(ptrace,VOID,0);
+SYSCALL(getuid,VOID,0);
+SYSCALL(syslog,VOID,0);
+SYSCALL(getgid,VOID,0);
+SYSCALL(setuid,VOID,0);
+SYSCALL(setgid,VOID,0);
+SYSCALL(geteuid,VOID,0);
+SYSCALL(getegid,VOID,0);
+SYSCALL(setpgid,VOID,0);
+SYSCALL(getppid,VOID,0);
+SYSCALL(getpgrp,VOID,0);
+SYSCALL(setsid,VOID,0);
+SYSCALL(setreuid,VOID,0);
+SYSCALL(setregid,VOID,0);
+SYSCALL(getgroups,VOID,0);
+SYSCALL(setgroups,VOID,0);
+SYSCALL(setresuid,VOID,0);
+SYSCALL(getresuid,VOID,0);
+SYSCALL(setresgid,VOID,0);
+SYSCALL(getresgid,VOID,0);
+SYSCALL(getpgid,VOID,0);
+SYSCALL(setfsuid,VOID,0);
+SYSCALL(setfsgid,VOID,0);
+SYSCALL(getsid,VOID,0);
+SYSCALL(capget,VOID,0);
+SYSCALL(capset,VOID,0);
+SYSCALL(rt_sigpending,VOID,0);
+SYSCALL(rt_sigtimedwait,VOID,0);
+SYSCALL(rt_sigqueueinfo,VOID,0);
+SYSCALL(rt_sigsuspend,VOID,0);
+SYSCALL(sigaltstack,VOID,0);
+SYSCALL(utime,VOID,0);
+SYSCALL(mknod,VOID,0);
+SYSCALL(uselib,VOID,0);
+SYSCALL(personality,VOID,0);
+SYSCALL(ustat,VOID,0);
+SYSCALL(statfs,VOID,0);
+SYSCALL(fstatfs,VOID,0);
+SYSCALL(sysfs,VOID,0);
+SYSCALL(getpriority,VOID,0);
+SYSCALL(setpriority,VOID,0);
+SYSCALL(sched_setparam,VOID,0);
+SYSCALL(sched_getparam,VOID,0);
+SYSCALL(sched_setscheduler,VOID,0);
+SYSCALL(sched_getscheduler,VOID,0);
+SYSCALL(sched_get_priority_max,VOID,0);
+SYSCALL(sched_get_priority_min,VOID,0);
+SYSCALL(sched_rr_get_interval,VOID,0);
+SYSCALL(mlock,VOID,0);
+SYSCALL(munlock,VOID,0);
+SYSCALL(mlockall,VOID,0);
+SYSCALL(munlockall,VOID,0);
+SYSCALL(vhangup,VOID,0);
+SYSCALL(modify_ldt,VOID,0);
+SYSCALL(pivot_root,VOID,0);
+SYSCALL(_sysctl,VOID,0);
+SYSCALL(prctl,VOID,0);
+SYSCALL(arch_prctl,VOID,0);
+SYSCALL(adjtimex,VOID,0);
+SYSCALL(setrlimit,VOID,0);
+SYSCALL(chroot,VOID,0);
+SYSCALL(sync,VOID,0);
+SYSCALL(acct,VOID,0);
+SYSCALL(settimeofday,VOID,0);
+SYSCALL(mount,VOID,0);
+SYSCALL(umount2,VOID,0);
+SYSCALL(swapon,VOID,0);
+SYSCALL(swapoff,VOID,0);
+SYSCALL(reboot,VOID,0);
+SYSCALL(sethostname,VOID,0);
+SYSCALL(setdomainname,VOID,0);
+SYSCALL(iopl,VOID,0);
+SYSCALL(ioperm,VOID,0);
+SYSCALL(create_module,VOID,0);
+SYSCALL(init_module,VOID,0);
+SYSCALL(delete_module,VOID,0);
+SYSCALL(get_kernel_syms,VOID,0);
+SYSCALL(query_module,VOID,0);
+SYSCALL(quotactl,VOID,0);
+SYSCALL(nfsservctl,VOID,0);
+SYSCALL(getpmsg,VOID,0);
+SYSCALL(putpmsg,VOID,0);
+SYSCALL(afs_syscall,VOID,0);
+SYSCALL(tuxcall,VOID,0);
+SYSCALL(security,VOID,0);
+SYSCALL(gettid,VOID,0);
+SYSCALL(readahead,VOID,0);
+SYSCALL(setxattr,VOID,0);
+SYSCALL(lsetxattr,VOID,0);
+SYSCALL(fsetxattr,VOID,0);
+SYSCALL(getxattr,VOID,0);
+SYSCALL(lgetxattr,VOID,0);
+SYSCALL(fgetxattr,VOID,0);
+SYSCALL(listxattr,VOID,0);
+SYSCALL(llistxattr,VOID,0);
+SYSCALL(flistxattr,VOID,0);
+SYSCALL(removexattr,VOID,0);
+SYSCALL(lremovexattr,VOID,0);
+SYSCALL(fremovexattr,VOID,0);
+SYSCALL(tkill,VOID,0);
+SYSCALL(time,VOID,0);
+SYSCALL(futex,VOID,0);
+SYSCALL(sched_setaffinity,VOID,0);
+SYSCALL(sched_getaffinity,VOID,0);
+SYSCALL(set_thread_area,VOID,0);
+SYSCALL(io_setup,VOID,0);
+SYSCALL(io_destroy,VOID,0);
+SYSCALL(io_getevents,VOID,0);
+SYSCALL(io_submit,VOID,0);
+SYSCALL(io_cancel,VOID,0);
+SYSCALL(get_thread_area,VOID,0);
+SYSCALL(lookup_dcookie,VOID,0);
+SYSCALL(epoll_create,VOID,0);
+SYSCALL(epoll_ctl_old,VOID,0);
+SYSCALL(epoll_wait_old,VOID,0);
+SYSCALL(remap_file_pages,VOID,0);
+SYSCALL(getdents64,VOID,0);
+SYSCALL(set_tid_address,VOID,0);
+SYSCALL(restart_syscall,VOID,0);
+SYSCALL(semtimedop,VOID,0);
+SYSCALL(fadvise64,VOID,0);
+SYSCALL(timer_create,VOID,0);
+SYSCALL(timer_settime,VOID,0);
+SYSCALL(timer_gettime,VOID,0);
+SYSCALL(timer_getoverrun,VOID,0);
+SYSCALL(timer_delete,VOID,0);
+SYSCALL(clock_settime,VOID,0);
+SYSCALL(clock_gettime,VOID,0);
+SYSCALL(clock_getres,VOID,0);
+SYSCALL(clock_nanosleep,VOID,0);
+SYSCALL(exit_group,VOID,0);
+SYSCALL(epoll_wait,VOID,0);
+SYSCALL(epoll_ctl,VOID,0);
+SYSCALL(tgkill,VOID,0);
+SYSCALL(utimes,VOID,0);
+SYSCALL(vserver,VOID,0);
+SYSCALL(mbind,VOID,0);
+SYSCALL(set_mempolicy,VOID,0);
+SYSCALL(get_mempolicy,VOID,0);
+SYSCALL(mq_open,VOID,0);
+SYSCALL(mq_unlink,VOID,0);
+SYSCALL(mq_timedsend,VOID,0);
+SYSCALL(mq_timedreceive,VOID,0);
+SYSCALL(mq_notify,VOID,0);
+SYSCALL(mq_getsetattr,VOID,0);
+SYSCALL(kexec_load,VOID,0);
+SYSCALL(waitid,VOID,0);
+SYSCALL(add_key,VOID,0);
+SYSCALL(request_key,VOID,0);
+SYSCALL(keyctl,VOID,0);
+SYSCALL(ioprio_set,VOID,0);
+SYSCALL(ioprio_get,VOID,0);
+SYSCALL(inotify_init,VOID,0);
+SYSCALL(inotify_add_watch,VOID,0);
+SYSCALL(inotify_rm_watch,VOID,0);
+SYSCALL(migrate_pages,VOID,0);
+SYSCALL(mkdirat,VOID,0);
+SYSCALL(mknodat,VOID,0);
+SYSCALL(fchownat,VOID,0);
+SYSCALL(futimesat,VOID,0);
+SYSCALL(newfstatat,VOID,0);
+SYSCALL(unlinkat,VOID,0);
+SYSCALL(renameat,VOID,0);
+SYSCALL(linkat,VOID,0);
+SYSCALL(symlinkat,VOID,0);
+SYSCALL(readlinkat,VOID,0);
+SYSCALL(fchmodat,VOID,0);
+SYSCALL(faccessat,VOID,0);
+SYSCALL(pselect6,VOID,0);
+SYSCALL(ppoll,VOID,0);
+SYSCALL(unshare,VOID,0);
+SYSCALL(set_robust_list,VOID,0);
+SYSCALL(get_robust_list,VOID,0);
+SYSCALL(splice,VOID,0);
+SYSCALL(tee,VOID,0);
+SYSCALL(sync_file_range,VOID,0);
+SYSCALL(vmsplice,VOID,0);
+SYSCALL(move_pages,VOID,0);
+SYSCALL(utimensat,VOID,0);
+SYSCALL(epoll_pwait,VOID,0);
+SYSCALL(signalfd,VOID,0);
+SYSCALL(timerfd_create,VOID,0);
+SYSCALL(eventfd,VOID,0);
+SYSCALL(fallocate,VOID,0);
+SYSCALL(timerfd_settime,VOID,0);
+SYSCALL(timerfd_gettime,VOID,0);
+SYSCALL(accept4,VOID,0);
+SYSCALL(signalfd4,VOID,0);
+SYSCALL(eventfd2,VOID,0);
+SYSCALL(epoll_create1,VOID,0);
+SYSCALL(dup3,VOID,0);
+SYSCALL(pipe2,VOID,0);
+SYSCALL(inotify_init1,VOID,0);
+SYSCALL(preadv,VOID,0);
+SYSCALL(pwritev,VOID,0);
+SYSCALL(rt_tgsigqueueinfo,VOID,0);
+SYSCALL(perf_event_open,VOID,0);
+SYSCALL(recvmmsg,VOID,0);
+SYSCALL(fanotify_init,VOID,0);
+SYSCALL(fanotify_mark,VOID,0);
+SYSCALL(prlimit64,VOID,0);
+SYSCALL(name_to_handle_at,VOID,0);
+SYSCALL(open_by_handle_at,VOID,0);
+SYSCALL(clock_adjtime,VOID,0);
+SYSCALL(syncfs,VOID,0);
+SYSCALL(sendmmsg,VOID,0);
+SYSCALL(setns,VOID,0);
+SYSCALL(getcpu,VOID,0);
+SYSCALL(process_vm_readv,VOID,0);
+SYSCALL(process_vm_writev,VOID,0);
+SYSCALL(kcmp,VOID,0);
+SYSCALL(finit_module,VOID,0);
 
-    [2] =
-    {
-        .name = "open",  .ret = LONG,   .num_args = 3, .args =
-        {
-            {.name = "pathname", .dir = DIR_IN, .type = PCHAR },
-            {.name = "flags",    .dir = DIR_IN, .type = ULONG },
-            {.name = "mode",     .dir = DIR_IN, .type = ULONG },
+#pragma clang diagnostic pop
 
-        },
-    },
-
-    [3] =
-    {
-        .name = "close", .ret = LONG,   .num_args = 1, .args =
-        {
-            {.name = "fd",       .dir = DIR_IN, .type = LONG },
-        },
-    },
-
-    [257] =
-    {
-        .name = "openat",  .ret = LONG,   .num_args = 4, .args =
-        {
-            {.name = "dirfd",    .dir = DIR_IN, .type = LONG },
-            {.name = "pathname", .dir = DIR_IN, .type = PCHAR },
-            {.name = "flags",    .dir = DIR_IN, .type = ULONG },
-            {.name = "mode",     .dir = DIR_IN, .type = ULONG },
-
-        },
-    },
-
-    // TODO: define the full function prototype for the rest
-    [4] = { .name = "stat" },
-    [5] = { .name = "fstat" },
-    [6] = { .name = "lstat" },
-    [7] = { .name = "poll" },
-    [8] = { .name = "lseek" },
-    [9] = { .name = "mmap" },
-    [10] = { .name = "mprotect" },
-    [11] = { .name = "munmap" },
-    [12] = { .name = "brk" },
-    [13] = { .name = "rt_sigaction" },
-    [14] = { .name = "rt_sigprocmask" },
-    [15] = { .name = "rt_sigreturn" },
-    [16] = { .name = "ioctl" },
-    [17] = { .name = "pread64" },
-    [18] = { .name = "pwrite64" },
-    [19] = { .name = "readv" },
-    [20] = { .name = "writev" },
-    [21] = { .name = "access" },
-    [22] = { .name = "pipe" },
-    [23] = { .name = "select" },
-    [24] = { .name = "sched_yield" },
-    [25] = { .name = "mremap" },
-    [26] = { .name = "msync" },
-    [27] = { .name = "mincore" },
-    [28] = { .name = "madvise" },
-    [29] = { .name = "shmget" },
-    [30] = { .name = "shmat" },
-    [31] = { .name = "shmctl" },
-    [32] = { .name = "dup" },
-    [33] = { .name = "dup2" },
-    [34] = { .name = "pause" },
-    [35] = { .name = "nanosleep" },
-    [36] = { .name = "getitimer" },
-    [37] = { .name = "alarm" },
-    [38] = { .name = "setitimer" },
-    [39] = { .name = "getpid" },
-    [40] = { .name = "sendfile64" },
-    [41] = { .name = "socket" },
-    [42] = { .name = "connect" },
-    [43] = { .name = "accept" },
-    [44] = { .name = "sendto" },
-    [45] = { .name = "recvfrom" },
-    [46] = { .name = "sendmsg" },
-    [47] = { .name = "recvmsg" },
-    [48] = { .name = "shutdown" },
-    [49] = { .name = "bind" },
-    [50] = { .name = "listen" },
-    [51] = { .name = "getsockname" },
-    [52] = { .name = "getpeername" },
-    [53] = { .name = "socketpair" },
-    [54] = { .name = "setsockopt" },
-    [55] = { .name = "getsockopt" },
-    [56] = { .name = "clone" },
-    [57] = { .name = "fork" },
-    [58] = { .name = "vfork" },
-    [59] = { .name = "execve" },
-    [60] = { .name = "exit" },
-    [61] = { .name = "wait4" },
-    [62] = { .name = "kill" },
-    [63] = { .name = "uname" },
-    [64] = { .name = "semget" },
-    [65] = { .name = "semop" },
-    [66] = { .name = "semctl" },
-    [67] = { .name = "shmdt" },
-    [68] = { .name = "msgget" },
-    [69] = { .name = "msgsnd" },
-    [70] = { .name = "msgrcv" },
-    [71] = { .name = "msgctl" },
-    [72] = { .name = "fcntl" },
-    [73] = { .name = "flock" },
-    [74] = { .name = "fsync" },
-    [75] = { .name = "fdatasync" },
-    [76] = { .name = "truncate" },
-    [77] = { .name = "ftruncate" },
-    [78] = { .name = "getdents" },
-    [79] = { .name = "getcwd" },
-    [80] = { .name = "chdir" },
-    [81] = { .name = "fchdir" },
-    [82] = { .name = "rename" },
-    [83] = { .name = "mkdir" },
-    [84] = { .name = "rmdir" },
-    [85] = { .name = "creat" },
-    [86] = { .name = "link" },
-    [87] = { .name = "unlink" },
-    [88] = { .name = "symlink" },
-    [89] = { .name = "readlink" },
-    [90] = { .name = "chmod" },
-    [91] = { .name = "fchmod" },
-    [92] = { .name = "chown" },
-    [93] = { .name = "fchown" },
-    [94] = { .name = "lchown" },
-    [95] = { .name = "umask" },
-    [96] = { .name = "gettimeofday" },
-    [97] = { .name = "getrlimit" },
-    [98] = { .name = "getrusage" },
-    [99] = { .name = "sysinfo" },
-    [100] = { .name = "times" },
-    [101] = { .name = "ptrace" },
-    [102] = { .name = "getuid" },
-    [103] = { .name = "syslog" },
-    [104] = { .name = "getgid" },
-    [105] = { .name = "setuid" },
-    [106] = { .name = "setgid" },
-    [107] = { .name = "geteuid" },
-    [108] = { .name = "getegid" },
-    [109] = { .name = "setpgid" },
-    [110] = { .name = "getppid" },
-    [111] = { .name = "getpgrp" },
-    [112] = { .name = "setsid" },
-    [113] = { .name = "setreuid" },
-    [114] = { .name = "setregid" },
-    [115] = { .name = "getgroups" },
-    [116] = { .name = "setgroups" },
-    [117] = { .name = "setresuid" },
-    [118] = { .name = "getresuid" },
-    [119] = { .name = "setresgid" },
-    [120] = { .name = "getresgid" },
-    [121] = { .name = "getpgid" },
-    [122] = { .name = "setfsuid" },
-    [123] = { .name = "setfsgid" },
-    [124] = { .name = "getsid" },
-    [125] = { .name = "capget" },
-    [126] = { .name = "capset" },
-    [127] = { .name = "rt_sigpending" },
-    [128] = { .name = "rt_sigtimedwait" },
-    [129] = { .name = "rt_sigqueueinfo" },
-    [130] = { .name = "rt_sigsuspend" },
-    [131] = { .name = "sigaltstack" },
-    [132] = { .name = "utime" },
-    [133] = { .name = "mknod" },
-    [134] = { .name = "uselib" },
-    [135] = { .name = "personality" },
-    [136] = { .name = "ustat" },
-    [137] = { .name = "statfs" },
-    [138] = { .name = "fstatfs" },
-    [139] = { .name = "sysfs" },
-    [140] = { .name = "getpriority" },
-    [141] = { .name = "setpriority" },
-    [142] = { .name = "sched_setparam" },
-    [143] = { .name = "sched_getparam" },
-    [144] = { .name = "sched_setscheduler" },
-    [145] = { .name = "sched_getscheduler" },
-    [146] = { .name = "sched_get_priority_max" },
-    [147] = { .name = "sched_get_priority_min" },
-    [148] = { .name = "sched_rr_get_interval" },
-    [149] = { .name = "mlock" },
-    [150] = { .name = "munlock" },
-    [151] = { .name = "mlockall" },
-    [152] = { .name = "munlockall" },
-    [153] = { .name = "vhangup" },
-    [154] = { .name = "modify_ldt" },
-    [155] = { .name = "pivot_root" },
-    [156] = { .name = "_sysctl" },
-    [157] = { .name = "prctl" },
-    [158] = { .name = "arch_prctl" },
-    [159] = { .name = "adjtimex" },
-    [160] = { .name = "setrlimit" },
-    [161] = { .name = "chroot" },
-    [162] = { .name = "sync" },
-    [163] = { .name = "acct" },
-    [164] = { .name = "settimeofday" },
-    [165] = { .name = "mount" },
-    [166] = { .name = "umount2" },
-    [167] = { .name = "swapon" },
-    [168] = { .name = "swapoff" },
-    [169] = { .name = "reboot" },
-    [170] = { .name = "sethostname" },
-    [171] = { .name = "setdomainname" },
-    [172] = { .name = "iopl" },
-    [173] = { .name = "ioperm" },
-    [174] = { .name = "create_module" },
-    [175] = { .name = "init_module" },
-    [176] = { .name = "delete_module" },
-    [177] = { .name = "get_kernel_syms" },
-    [178] = { .name = "query_module" },
-    [179] = { .name = "quotactl" },
-    [180] = { .name = "nfsservctl" },
-    [181] = { .name = "getpmsg" },
-    [182] = { .name = "putpmsg" },
-    [183] = { .name = "afs_syscall" },
-    [184] = { .name = "tuxcall" },
-    [185] = { .name = "security" },
-    [186] = { .name = "gettid" },
-    [187] = { .name = "readahead" },
-    [188] = { .name = "setxattr" },
-    [189] = { .name = "lsetxattr" },
-    [190] = { .name = "fsetxattr" },
-    [191] = { .name = "getxattr" },
-    [192] = { .name = "lgetxattr" },
-    [193] = { .name = "fgetxattr" },
-    [194] = { .name = "listxattr" },
-    [195] = { .name = "llistxattr" },
-    [196] = { .name = "flistxattr" },
-    [197] = { .name = "removexattr" },
-    [198] = { .name = "lremovexattr" },
-    [199] = { .name = "fremovexattr" },
-    [200] = { .name = "tkill" },
-    [201] = { .name = "time" },
-    [202] = { .name = "futex" },
-    [203] = { .name = "sched_setaffinity" },
-    [204] = { .name = "sched_getaffinity" },
-    [205] = { .name = "set_thread_area" },
-    [206] = { .name = "io_setup" },
-    [207] = { .name = "io_destroy" },
-    [208] = { .name = "io_getevents" },
-    [209] = { .name = "io_submit" },
-    [210] = { .name = "io_cancel" },
-    [211] = { .name = "get_thread_area" },
-    [212] = { .name = "lookup_dcookie" },
-    [213] = { .name = "epoll_create" },
-    [214] = { .name = "epoll_ctl_old" },
-    [215] = { .name = "epoll_wait_old" },
-    [216] = { .name = "remap_file_pages" },
-    [217] = { .name = "getdents64" },
-    [218] = { .name = "set_tid_address" },
-    [219] = { .name = "restart_syscall" },
-    [220] = { .name = "semtimedop" },
-    [221] = { .name = "fadvise64" },
-    [222] = { .name = "timer_create" },
-    [223] = { .name = "timer_settime" },
-    [224] = { .name = "timer_gettime" },
-    [225] = { .name = "timer_getoverrun" },
-    [226] = { .name = "timer_delete" },
-    [227] = { .name = "clock_settime" },
-    [228] = { .name = "clock_gettime" },
-    [229] = { .name = "clock_getres" },
-    [230] = { .name = "clock_nanosleep" },
-    [231] = { .name = "exit_group" },
-    [232] = { .name = "epoll_wait" },
-    [233] = { .name = "epoll_ctl" },
-    [234] = { .name = "tgkill" },
-    [235] = { .name = "utimes" },
-    [236] = { .name = "vserver" },
-    [237] = { .name = "mbind" },
-    [238] = { .name = "set_mempolicy" },
-    [239] = { .name = "get_mempolicy" },
-    [240] = { .name = "mq_open" },
-    [241] = { .name = "mq_unlink" },
-    [242] = { .name = "mq_timedsend" },
-    [243] = { .name = "mq_timedreceive" },
-    [244] = { .name = "mq_notify" },
-    [245] = { .name = "mq_getsetattr" },
-    [246] = { .name = "kexec_load" },
-    [247] = { .name = "waitid" },
-    [248] = { .name = "add_key" },
-    [249] = { .name = "request_key" },
-    [250] = { .name = "keyctl" },
-    [251] = { .name = "ioprio_set" },
-    [252] = { .name = "ioprio_get" },
-    [253] = { .name = "inotify_init" },
-    [254] = { .name = "inotify_add_watch" },
-    [255] = { .name = "inotify_rm_watch" },
-    [256] = { .name = "migrate_pages" },
-    [258] = { .name = "mkdirat" },
-    [259] = { .name = "mknodat" },
-    [260] = { .name = "fchownat" },
-    [261] = { .name = "futimesat" },
-    [262] = { .name = "newfstatat" },
-    [263] = { .name = "unlinkat" },
-    [264] = { .name = "renameat" },
-    [265] = { .name = "linkat" },
-    [266] = { .name = "symlinkat" },
-    [267] = { .name = "readlinkat" },
-    [268] = { .name = "fchmodat" },
-    [269] = { .name = "faccessat" },
-    [270] = { .name = "pselect6" },
-    [271] = { .name = "ppoll" },
-    [272] = { .name = "unshare" },
-    [273] = { .name = "set_robust_list" },
-    [274] = { .name = "get_robust_list" },
-    [275] = { .name = "splice" },
-    [276] = { .name = "tee" },
-    [277] = { .name = "sync_file_range" },
-    [278] = { .name = "vmsplice" },
-    [279] = { .name = "move_pages" },
-    [280] = { .name = "utimensat" },
-    [281] = { .name = "epoll_pwait" },
-    [282] = { .name = "signalfd" },
-    [283] = { .name = "timerfd_create" },
-    [284] = { .name = "eventfd" },
-    [285] = { .name = "fallocate" },
-    [286] = { .name = "timerfd_settime" },
-    [287] = { .name = "timerfd_gettime" },
-    [288] = { .name = "accept4" },
-    [289] = { .name = "signalfd4" },
-    [290] = { .name = "eventfd2" },
-    [291] = { .name = "epoll_create1" },
-    [292] = { .name = "dup3" },
-    [293] = { .name = "pipe2" },
-    [294] = { .name = "inotify_init1" },
-    [295] = { .name = "preadv" },
-    [296] = { .name = "pwritev" },
-    [297] = { .name = "rt_tgsigqueueinfo" },
-    [298] = { .name = "perf_event_open" },
-    [299] = { .name = "recvmmsg" },
-    [300] = { .name = "fanotify_init" },
-    [301] = { .name = "fanotify_mark" },
-    [302] = { .name = "prlimit64" },
-    [303] = { .name = "name_to_handle_at" },
-    [304] = { .name = "open_by_handle_at" },
-    [305] = { .name = "clock_adjtime" },
-    [306] = { .name = "syncfs" },
-    [307] = { .name = "sendmmsg" },
-    [308] = { .name = "setns" },
-    [309] = { .name = "getcpu" },
-    [310] = { .name = "process_vm_readv" },
-    [311] = { .name = "process_vm_writev" },
-    [312] = { .name = "kcmp" },
-    [313] = { .name = "finit_module" },
+static const syscall_t* linux_syscalls[] = {
+    [0] = &read,
+    [1] = &write,
+    [2] = &open,
+    [3] = &close,
+    [4] = &stat,
+    [5] = &fstat,
+    [6] = &lstat,
+    [7] = &poll,
+    [8] = &lseek,
+    [9] = &mmap,
+    [10] = &mprotect,
+    [11] = &munmap,
+    [12] = &brk,
+    [13] = &rt_sigaction,
+    [14] = &rt_sigprocmask,
+    [15] = &rt_sigreturn,
+    [16] = &ioctl,
+    [17] = &pread64,
+    [18] = &pwrite64,
+    [19] = &readv,
+    [20] = &writev,
+    [21] = &access,
+    [22] = &pipe,
+    [23] = &select,
+    [24] = &sched_yield,
+    [25] = &mremap,
+    [26] = &msync,
+    [27] = &mincore,
+    [28] = &madvise,
+    [29] = &shmget,
+    [30] = &shmat,
+    [31] = &shmctl,
+    [32] = &dup,
+    [33] = &dup2,
+    [34] = &pause,
+    [35] = &nanosleep,
+    [36] = &getitimer,
+    [37] = &alarm,
+    [38] = &setitimer,
+    [39] = &getpid,
+    [40] = &sendfile64,
+    [41] = &socket,
+    [42] = &connect,
+    [43] = &accept,
+    [44] = &sendto,
+    [45] = &recvfrom,
+    [46] = &sendmsg,
+    [47] = &recvmsg,
+    [48] = &shutdown,
+    [49] = &bind,
+    [50] = &listen,
+    [51] = &getsockname,
+    [52] = &getpeername,
+    [53] = &socketpair,
+    [54] = &setsockopt,
+    [55] = &getsockopt,
+    [56] = &clone,
+    [57] = &fork,
+    [58] = &vfork,
+    [59] = &execve,
+    [60] = &exit,
+    [61] = &wait4,
+    [62] = &kill,
+    [63] = &uname,
+    [64] = &semget,
+    [65] = &semop,
+    [66] = &semctl,
+    [67] = &shmdt,
+    [68] = &msgget,
+    [69] = &msgsnd,
+    [70] = &msgrcv,
+    [71] = &msgctl,
+    [72] = &fcntl,
+    [73] = &flock,
+    [74] = &fsync,
+    [75] = &fdatasync,
+    [76] = &truncate,
+    [77] = &ftruncate,
+    [78] = &getdents,
+    [79] = &getcwd,
+    [80] = &chdir,
+    [81] = &fchdir,
+    [82] = &rename,
+    [83] = &mkdir,
+    [84] = &rmdir,
+    [85] = &creat,
+    [86] = &link,
+    [87] = &unlink,
+    [88] = &symlink,
+    [89] = &readlink,
+    [90] = &chmod,
+    [91] = &fchmod,
+    [92] = &chown,
+    [93] = &fchown,
+    [94] = &lchown,
+    [95] = &umask,
+    [96] = &gettimeofday,
+    [97] = &getrlimit,
+    [98] = &getrusage,
+    [99] = &sysinfo,
+    [100] = &times,
+    [101] = &ptrace,
+    [102] = &getuid,
+    [103] = &syslog,
+    [104] = &getgid,
+    [105] = &setuid,
+    [106] = &setgid,
+    [107] = &geteuid,
+    [108] = &getegid,
+    [109] = &setpgid,
+    [110] = &getppid,
+    [111] = &getpgrp,
+    [112] = &setsid,
+    [113] = &setreuid,
+    [114] = &setregid,
+    [115] = &getgroups,
+    [116] = &setgroups,
+    [117] = &setresuid,
+    [118] = &getresuid,
+    [119] = &setresgid,
+    [120] = &getresgid,
+    [121] = &getpgid,
+    [122] = &setfsuid,
+    [123] = &setfsgid,
+    [124] = &getsid,
+    [125] = &capget,
+    [126] = &capset,
+    [127] = &rt_sigpending,
+    [128] = &rt_sigtimedwait,
+    [129] = &rt_sigqueueinfo,
+    [130] = &rt_sigsuspend,
+    [131] = &sigaltstack,
+    [132] = &utime,
+    [133] = &mknod,
+    [134] = &uselib,
+    [135] = &personality,
+    [136] = &ustat,
+    [137] = &statfs,
+    [138] = &fstatfs,
+    [139] = &sysfs,
+    [140] = &getpriority,
+    [141] = &setpriority,
+    [142] = &sched_setparam,
+    [143] = &sched_getparam,
+    [144] = &sched_setscheduler,
+    [145] = &sched_getscheduler,
+    [146] = &sched_get_priority_max,
+    [147] = &sched_get_priority_min,
+    [148] = &sched_rr_get_interval,
+    [149] = &mlock,
+    [150] = &munlock,
+    [151] = &mlockall,
+    [152] = &munlockall,
+    [153] = &vhangup,
+    [154] = &modify_ldt,
+    [155] = &pivot_root,
+    [156] = &_sysctl,
+    [157] = &prctl,
+    [158] = &arch_prctl,
+    [159] = &adjtimex,
+    [160] = &setrlimit,
+    [161] = &chroot,
+    [162] = &sync,
+    [163] = &acct,
+    [164] = &settimeofday,
+    [165] = &mount,
+    [166] = &umount2,
+    [167] = &swapon,
+    [168] = &swapoff,
+    [169] = &reboot,
+    [170] = &sethostname,
+    [171] = &setdomainname,
+    [172] = &iopl,
+    [173] = &ioperm,
+    [174] = &create_module,
+    [175] = &init_module,
+    [176] = &delete_module,
+    [177] = &get_kernel_syms,
+    [178] = &query_module,
+    [179] = &quotactl,
+    [180] = &nfsservctl,
+    [181] = &getpmsg,
+    [182] = &putpmsg,
+    [183] = &afs_syscall,
+    [184] = &tuxcall,
+    [185] = &security,
+    [186] = &gettid,
+    [187] = &readahead,
+    [188] = &setxattr,
+    [189] = &lsetxattr,
+    [190] = &fsetxattr,
+    [191] = &getxattr,
+    [192] = &lgetxattr,
+    [193] = &fgetxattr,
+    [194] = &listxattr,
+    [195] = &llistxattr,
+    [196] = &flistxattr,
+    [197] = &removexattr,
+    [198] = &lremovexattr,
+    [199] = &fremovexattr,
+    [200] = &tkill,
+    [201] = &time,
+    [202] = &futex,
+    [203] = &sched_setaffinity,
+    [204] = &sched_getaffinity,
+    [205] = &set_thread_area,
+    [206] = &io_setup,
+    [207] = &io_destroy,
+    [208] = &io_getevents,
+    [209] = &io_submit,
+    [210] = &io_cancel,
+    [211] = &get_thread_area,
+    [212] = &lookup_dcookie,
+    [213] = &epoll_create,
+    [214] = &epoll_ctl_old,
+    [215] = &epoll_wait_old,
+    [216] = &remap_file_pages,
+    [217] = &getdents64,
+    [218] = &set_tid_address,
+    [219] = &restart_syscall,
+    [220] = &semtimedop,
+    [221] = &fadvise64,
+    [222] = &timer_create,
+    [223] = &timer_settime,
+    [224] = &timer_gettime,
+    [225] = &timer_getoverrun,
+    [226] = &timer_delete,
+    [227] = &clock_settime,
+    [228] = &clock_gettime,
+    [229] = &clock_getres,
+    [230] = &clock_nanosleep,
+    [231] = &exit_group,
+    [232] = &epoll_wait,
+    [233] = &epoll_ctl,
+    [234] = &tgkill,
+    [235] = &utimes,
+    [236] = &vserver,
+    [237] = &mbind,
+    [238] = &set_mempolicy,
+    [239] = &get_mempolicy,
+    [240] = &mq_open,
+    [241] = &mq_unlink,
+    [242] = &mq_timedsend,
+    [243] = &mq_timedreceive,
+    [244] = &mq_notify,
+    [245] = &mq_getsetattr,
+    [246] = &kexec_load,
+    [247] = &waitid,
+    [248] = &add_key,
+    [249] = &request_key,
+    [250] = &keyctl,
+    [251] = &ioprio_set,
+    [252] = &ioprio_get,
+    [253] = &inotify_init,
+    [254] = &inotify_add_watch,
+    [255] = &inotify_rm_watch,
+    [256] = &migrate_pages,
+    [257] = &openat,
+    [258] = &mkdirat,
+    [259] = &mknodat,
+    [260] = &fchownat,
+    [261] = &futimesat,
+    [262] = &newfstatat,
+    [263] = &unlinkat,
+    [264] = &renameat,
+    [265] = &linkat,
+    [266] = &symlinkat,
+    [267] = &readlinkat,
+    [268] = &fchmodat,
+    [269] = &faccessat,
+    [270] = &pselect6,
+    [271] = &ppoll,
+    [272] = &unshare,
+    [273] = &set_robust_list,
+    [274] = &get_robust_list,
+    [275] = &splice,
+    [276] = &tee,
+    [277] = &sync_file_range,
+    [278] = &vmsplice,
+    [279] = &move_pages,
+    [280] = &utimensat,
+    [281] = &epoll_pwait,
+    [282] = &signalfd,
+    [283] = &timerfd_create,
+    [284] = &eventfd,
+    [285] = &fallocate,
+    [286] = &timerfd_settime,
+    [287] = &timerfd_gettime,
+    [288] = &accept4,
+    [289] = &signalfd4,
+    [290] = &eventfd2,
+    [291] = &epoll_create1,
+    [292] = &dup3,
+    [293] = &pipe2,
+    [294] = &inotify_init1,
+    [295] = &preadv,
+    [296] = &pwritev,
+    [297] = &rt_tgsigqueueinfo,
+    [298] = &perf_event_open,
+    [299] = &recvmmsg,
+    [300] = &fanotify_init,
+    [301] = &fanotify_mark,
+    [302] = &prlimit64,
+    [303] = &name_to_handle_at,
+    [304] = &open_by_handle_at,
+    [305] = &clock_adjtime,
+    [306] = &syncfs,
+    [307] = &sendmmsg,
+    [308] = &setns,
+    [309] = &getcpu,
+    [310] = &process_vm_readv,
+    [311] = &process_vm_writev,
+    [312] = &kcmp,
+    [313] = &finit_module,
 };
 
+// The actual max depends on the arch and actual kernel version
+#define NUM_SYSCALLS_LINUX sizeof(linuxsc::linux_syscalls)/sizeof(syscall_t*)
+
+}
 #endif // SYSCALLS_LINUX_H

--- a/src/plugins/syscalls/private.h
+++ b/src/plugins/syscalls/private.h
@@ -424,63 +424,38 @@ typedef struct
 } arg_t;
 
 typedef struct {
-    const char*  name;
-    type_t       ret;
+    const char *name;
+    type_t ret;
     unsigned int num_args;
-    arg_t        args[17];
-} syscall_definition_t;
+    const arg_t *args;
+} syscall_t;
 
 struct wrapper;
 struct wrapper
 {
     syscalls *s;
-    const syscall_definition_t *sc;
+    const syscall_t *sc;
     const char *type;
     struct wrapper *w;
     uint16_t num;
     addr_t tid;
 };
 
-/*
- * TODO: Use the following macro to declare syscalls instead of
- *  doing this giant array approach we currently have.
- *
- *
- * typedef struct {
- *   const char *name;
- *   int ret;
- *   int num_args;
- *   const arg_t *args;
- * } syscall_t;
- *
- * #define SYSCALL(_name, _ret, _num_args, ...)                    \
- *   static const arg_t _name ## _arg[] = { __VA_ARGS__ };         \
- *   static const syscall_t _name = {                              \
- *     .name = #_name,                                             \
- *     .ret = _ret,                                                \
- *     .num_args = _num_args,                                      \
- *     .args = (const struct arg*)&_name ## _arg                   \
- *   }
- *
- *
- * Example:
- * #pragma clang diagnostic push
- * #pragma clang diagnostic ignored "-Wmissing-braces"
- * SYSCALL(syscall_name, HANDLE, 3,
- *               "arg_name1", DIR_IN, "", PVOID,
- *               "arg_name2", DIR_IN, "opt", PVOID,
- *               "arg_name3", DIR_OUT, "", PULONG
- *        );
- * #pragma clang diagnostic pop
- *
- */
+#define SYSCALL(_name, _ret, _num_args, ...)                     \
+   static const arg_t _name ## _arg[] = { __VA_ARGS__ };         \
+   static const syscall_t _name = {                              \
+     .name = #_name,                                             \
+     .ret = _ret,                                                \
+     .num_args = _num_args,                                      \
+     .args = (const arg_t*)&_name ## _arg                        \
+   }
 
 void print_header(output_format_t format, drakvuf_t drakvuf,
                   bool syscall, const drakvuf_trap_info_t* info,
-                  int nr, const char *module, const syscall_definition_t *sc,
+                  int nr, const char *module, const syscall_t *sc,
                   uint64_t ret, const char *extra_info);
 void print_nargs(output_format_t format, uint32_t nargs);
-void print_args(syscalls* s, drakvuf_t drakvuf, drakvuf_trap_info_t* info, const syscall_definition_t* sc, void* args_data);
+void print_args(syscalls* s, drakvuf_t drakvuf, drakvuf_trap_info_t* info, const syscall_t* sc, void* args_data);
 void print_footer(output_format_t format, uint32_t nargs);
 void free_trap(gpointer p);
 

--- a/src/plugins/syscalls/syscalls.cpp
+++ b/src/plugins/syscalls/syscalls.cpp
@@ -147,7 +147,7 @@ static char* extract_string(drakvuf_t drakvuf, drakvuf_trap_info_t* info, const 
 
 void print_header(output_format_t format, drakvuf_t drakvuf,
                   bool syscall, const drakvuf_trap_info_t* info,
-                  int nr, const char *module, const syscall_definition_t *sc,
+                  int nr, const char *module, const syscall_t *sc,
                   uint64_t ret, const char *extra_info)
 {
     gchar* escaped_pname = NULL;
@@ -282,7 +282,7 @@ static void print_kv_arg(syscalls* s, drakvuf_t drakvuf, drakvuf_trap_info_t* in
 }
 
 
-static void print_json_arg(syscalls* s, drakvuf_t drakvuf, drakvuf_trap_info_t* info, const syscall_definition_t* sc, size_t i, addr_t val, const char* str)
+static void print_json_arg(syscalls* s, drakvuf_t drakvuf, drakvuf_trap_info_t* info, const syscall_t* sc, size_t i, addr_t val, const char* str)
 {
     const arg_t& arg = sc->args[i];
 
@@ -321,7 +321,7 @@ static void print_default_arg(syscalls* s, drakvuf_t drakvuf, drakvuf_trap_info_
     printf("\n");
 }
 
-void print_args(syscalls* s, drakvuf_t drakvuf, drakvuf_trap_info_t* info, const syscall_definition_t* sc, void* args_data)
+void print_args(syscalls* s, drakvuf_t drakvuf, drakvuf_trap_info_t* info, const syscall_t* sc, void* args_data)
 {
     if ( !args_data )
         return;
@@ -395,21 +395,21 @@ static GHashTable* read_syscalls_filter(const char* filter_file)
         g_hash_table_destroy(table);
         return NULL;
     }
-    ssize_t read;
+    ssize_t bytes_read;
     do
     {
         char* line = NULL;
         size_t len = 0;
-        read = getline(&line, &len, f);
-        while (read > 0 && (line[read - 1] == '\n' || line[read - 1] == '\r')) read--;
-        if (read > 0)
+        bytes_read = getline(&line, &len, f);
+        while (bytes_read > 0 && (line[bytes_read - 1] == '\n' || line[bytes_read - 1] == '\r')) bytes_read--;
+        if (bytes_read > 0)
         {
-            line[read] = '\0';
+            line[bytes_read] = '\0';
             g_hash_table_insert(table, line, NULL);
         }
         else
             free(line);
-    } while (read != -1);
+    } while (bytes_read != -1);
 
     fclose(f);
     return table;

--- a/src/plugins/syscalls/win.cpp
+++ b/src/plugins/syscalls/win.cpp
@@ -126,7 +126,7 @@ static event_response_t ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
         return 0;
 
     struct wrapper *w = (struct wrapper *)wr->w;
-    const syscall_definition_t *sc = w->sc;
+    const syscall_t *sc = w->sc;
     syscalls *s = w->s;
 
     char exit_status_buf[NTSTATUS_MAX_FORMAT_STR_SIZE] = {0};
@@ -147,7 +147,7 @@ static event_response_t syscall_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 {
     vmi_lock_guard lg(drakvuf);
     struct wrapper *w = (struct wrapper*)info->trap->data;
-    const syscall_definition_t *sc = w->sc;
+    const syscall_t *sc = w->sc;
     syscalls *s = w->s;
 
     unsigned int nargs = 0;
@@ -248,7 +248,7 @@ static bool trap_syscall_table_entries(drakvuf_t drakvuf, vmi_instance_t vmi, sy
 {
     bool ret = false;
     unsigned int syscall_count = ntos ? NUM_SYSCALLS_NT : NUM_SYSCALLS_WIN32K;
-    const syscall_definition_t *definitions = ntos ? nt : win32k;
+    const syscall_t **definitions = ntos ? nt : win32k;
     int error = -1;
 
     json_object *json = ntos ? vmi_get_kernel_json(vmi) : s->win32k_json;
@@ -313,9 +313,9 @@ static bool trap_syscall_table_entries(drakvuf_t drakvuf, vmi_instance_t vmi, sy
 
                     for (unsigned int d=0; d < syscall_count; d++)
                     {
-                        if ( !strcmp(definitions[d].name, symbol->name) )
+                        if ( !strcmp(definitions[d]->name, symbol->name) )
                         {
-                            w->sc = &definitions[d];
+                            w->sc = definitions[d];
                             break;
                         }
                     }

--- a/src/plugins/syscalls/win.h
+++ b/src/plugins/syscalls/win.h
@@ -134,5072 +134,5810 @@ typedef struct sst_x86 {
     uint32_t ArgumentTable;
 } __attribute__((packed)) system_service_table_x86;
 
-static const syscall_definition_t nt[] =
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmissing-braces"
+
+SYSCALL(NtAcceptConnectPort, NTSTATUS, 6,
+		"PortHandle", "", DIR_OUT, PHANDLE,
+		"PortContext", "opt", DIR_IN, PVOID,
+		"ConnectionRequest", "", DIR_IN, PPORT_MESSAGE,
+		"AcceptConnection", "", DIR_IN, BOOLEAN,
+		"ServerView", "opt", DIR_INOUT, PPORT_VIEW,
+		"ClientView", "opt", DIR_OUT, PREMOTE_PORT_VIEW,
+);
+SYSCALL(NtAccessCheckAndAuditAlarm, NTSTATUS, 11,
+		"SubsystemName", "", DIR_IN, PUNICODE_STRING,
+		"HandleId", "opt", DIR_IN, PVOID,
+		"ObjectTypeName", "", DIR_IN, PUNICODE_STRING,
+		"ObjectName", "", DIR_IN, PUNICODE_STRING,
+		"SecurityDescriptor", "", DIR_IN, PSECURITY_DESCRIPTOR,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"GenericMapping", "", DIR_IN, PGENERIC_MAPPING,
+		"ObjectCreation", "", DIR_IN, BOOLEAN,
+		"GrantedAccess", "", DIR_OUT, PACCESS_MASK,
+		"AccessStatus", "", DIR_OUT, PNTSTATUS,
+		"GenerateOnClose", "", DIR_OUT, PBOOLEAN,
+);
+SYSCALL(NtAccessCheckByTypeAndAuditAlarm, NTSTATUS, 16,
+		"SubsystemName", "", DIR_IN, PUNICODE_STRING,
+		"HandleId", "opt", DIR_IN, PVOID,
+		"ObjectTypeName", "", DIR_IN, PUNICODE_STRING,
+		"ObjectName", "", DIR_IN, PUNICODE_STRING,
+		"SecurityDescriptor", "", DIR_IN, PSECURITY_DESCRIPTOR,
+		"PrincipalSelfSid", "opt", DIR_IN, PSID,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"AuditType", "", DIR_IN, AUDIT_EVENT_TYPE,
+		"Flags", "", DIR_IN, ULONG,
+		"ObjectTypeList", "ecount_opt(ObjectTypeListLength)", DIR_IN, POBJECT_TYPE_LIST,
+		"ObjectTypeListLength", "", DIR_IN, ULONG,
+		"GenericMapping", "", DIR_IN, PGENERIC_MAPPING,
+		"ObjectCreation", "", DIR_IN, BOOLEAN,
+		"GrantedAccess", "", DIR_OUT, PACCESS_MASK,
+		"AccessStatus", "", DIR_OUT, PNTSTATUS,
+		"GenerateOnClose", "", DIR_OUT, PBOOLEAN,
+);
+SYSCALL(NtAccessCheckByType, NTSTATUS, 11,
+		"SecurityDescriptor", "", DIR_IN, PSECURITY_DESCRIPTOR,
+		"PrincipalSelfSid", "opt", DIR_IN, PSID,
+		"ClientToken", "", DIR_IN, HANDLE,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"ObjectTypeList", "ecount(ObjectTypeListLength)", DIR_IN, POBJECT_TYPE_LIST,
+		"ObjectTypeListLength", "", DIR_IN, ULONG,
+		"GenericMapping", "", DIR_IN, PGENERIC_MAPPING,
+		"PrivilegeSet", "bcount(*PrivilegeSetLength)", DIR_OUT, PPRIVILEGE_SET,
+		"PrivilegeSetLength", "", DIR_INOUT, PULONG,
+		"GrantedAccess", "", DIR_OUT, PACCESS_MASK,
+		"AccessStatus", "", DIR_OUT, PNTSTATUS,
+);
+SYSCALL(NtAccessCheckByTypeResultListAndAuditAlarmByHandle, NTSTATUS, 17,
+		"SubsystemName", "", DIR_IN, PUNICODE_STRING,
+		"HandleId", "opt", DIR_IN, PVOID,
+		"ClientToken", "", DIR_IN, HANDLE,
+		"ObjectTypeName", "", DIR_IN, PUNICODE_STRING,
+		"ObjectName", "", DIR_IN, PUNICODE_STRING,
+		"SecurityDescriptor", "", DIR_IN, PSECURITY_DESCRIPTOR,
+		"PrincipalSelfSid", "opt", DIR_IN, PSID,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"AuditType", "", DIR_IN, AUDIT_EVENT_TYPE,
+		"Flags", "", DIR_IN, ULONG,
+		"ObjectTypeList", "ecount_opt(ObjectTypeListLength)", DIR_IN, POBJECT_TYPE_LIST,
+		"ObjectTypeListLength", "", DIR_IN, ULONG,
+		"GenericMapping", "", DIR_IN, PGENERIC_MAPPING,
+		"ObjectCreation", "", DIR_IN, BOOLEAN,
+		"GrantedAccess", "ecount(ObjectTypeListLength)", DIR_OUT, PACCESS_MASK,
+		"AccessStatus", "ecount(ObjectTypeListLength)", DIR_OUT, PNTSTATUS,
+		"GenerateOnClose", "", DIR_OUT, PBOOLEAN,
+);
+SYSCALL(NtAccessCheckByTypeResultListAndAuditAlarm, NTSTATUS, 16,
+		"SubsystemName", "", DIR_IN, PUNICODE_STRING,
+		"HandleId", "opt", DIR_IN, PVOID,
+		"ObjectTypeName", "", DIR_IN, PUNICODE_STRING,
+		"ObjectName", "", DIR_IN, PUNICODE_STRING,
+		"SecurityDescriptor", "", DIR_IN, PSECURITY_DESCRIPTOR,
+		"PrincipalSelfSid", "opt", DIR_IN, PSID,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"AuditType", "", DIR_IN, AUDIT_EVENT_TYPE,
+		"Flags", "", DIR_IN, ULONG,
+		"ObjectTypeList", "ecount_opt(ObjectTypeListLength)", DIR_IN, POBJECT_TYPE_LIST,
+		"ObjectTypeListLength", "", DIR_IN, ULONG,
+		"GenericMapping", "", DIR_IN, PGENERIC_MAPPING,
+		"ObjectCreation", "", DIR_IN, BOOLEAN,
+		"GrantedAccess", "ecount(ObjectTypeListLength)", DIR_OUT, PACCESS_MASK,
+		"AccessStatus", "ecount(ObjectTypeListLength)", DIR_OUT, PNTSTATUS,
+		"GenerateOnClose", "", DIR_OUT, PBOOLEAN,
+);
+SYSCALL(NtAccessCheckByTypeResultList, NTSTATUS, 11,
+		"SecurityDescriptor", "", DIR_IN, PSECURITY_DESCRIPTOR,
+		"PrincipalSelfSid", "opt", DIR_IN, PSID,
+		"ClientToken", "", DIR_IN, HANDLE,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"ObjectTypeList", "ecount(ObjectTypeListLength)", DIR_IN, POBJECT_TYPE_LIST,
+		"ObjectTypeListLength", "", DIR_IN, ULONG,
+		"GenericMapping", "", DIR_IN, PGENERIC_MAPPING,
+		"PrivilegeSet", "bcount(*PrivilegeSetLength)", DIR_OUT, PPRIVILEGE_SET,
+		"PrivilegeSetLength", "", DIR_INOUT, PULONG,
+		"GrantedAccess", "ecount(ObjectTypeListLength)", DIR_OUT, PACCESS_MASK,
+		"AccessStatus", "ecount(ObjectTypeListLength)", DIR_OUT, PNTSTATUS,
+);
+SYSCALL(NtAccessCheck, NTSTATUS, 8,
+		"SecurityDescriptor", "", DIR_IN, PSECURITY_DESCRIPTOR,
+		"ClientToken", "", DIR_IN, HANDLE,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"GenericMapping", "", DIR_IN, PGENERIC_MAPPING,
+		"PrivilegeSet", "bcount(*PrivilegeSetLength)", DIR_OUT, PPRIVILEGE_SET,
+		"PrivilegeSetLength", "", DIR_INOUT, PULONG,
+		"GrantedAccess", "", DIR_OUT, PACCESS_MASK,
+		"AccessStatus", "", DIR_OUT, PNTSTATUS,
+);
+SYSCALL(NtAddAtom, NTSTATUS, 3,
+		"AtomName", "bcount_opt(Length)", DIR_IN, PWSTR,
+		"Length", "", DIR_IN, ULONG,
+		"Atom", "opt", DIR_OUT, PRTL_ATOM,
+);
+SYSCALL(NtAddBootEntry, NTSTATUS, 2,
+		"BootEntry", "", DIR_IN, PBOOT_ENTRY,
+		"Id", "opt", DIR_OUT, PULONG,
+);
+SYSCALL(NtAddDriverEntry, NTSTATUS, 2,
+		"DriverEntry", "", DIR_IN, PEFI_DRIVER_ENTRY,
+		"Id", "opt", DIR_OUT, PULONG,
+);
+SYSCALL(NtAdjustGroupsToken, NTSTATUS, 6,
+		"TokenHandle", "", DIR_IN, HANDLE,
+		"ResetToDefault", "", DIR_IN, BOOLEAN,
+		"NewState", "", DIR_IN, PTOKEN_GROUPS,
+		"BufferLength", "", DIR_IN, ULONG,
+		"PreviousState", "bcount_part_opt(BufferLength,*ReturnLength)", DIR_OUT, PTOKEN_GROUPS,
+		"ReturnLength", "", DIR_OUT, PULONG,
+);
+SYSCALL(NtAdjustPrivilegesToken, NTSTATUS, 6,
+		"TokenHandle", "", DIR_IN, HANDLE,
+		"DisableAllPrivileges", "", DIR_IN, BOOLEAN,
+		"NewState", "opt", DIR_IN, PTOKEN_PRIVILEGES,
+		"BufferLength", "", DIR_IN, ULONG,
+		"PreviousState", "bcount_part_opt(BufferLength,*ReturnLength)", DIR_OUT, PTOKEN_PRIVILEGES,
+		"ReturnLength", "opt", DIR_OUT, PULONG,
+);
+SYSCALL(NtAlertResumeThread, NTSTATUS, 2,
+		"ThreadHandle", "", DIR_IN, HANDLE,
+		"PreviousSuspendCount", "opt", DIR_OUT, PULONG,
+);
+SYSCALL(NtAlertThread, NTSTATUS, 1,
+		"ThreadHandle", "", DIR_IN, HANDLE,
+);
+SYSCALL(NtAllocateLocallyUniqueId, NTSTATUS, 1,
+		"Luid", "", DIR_OUT, PLUID,
+);
+SYSCALL(NtAllocateReserveObject, NTSTATUS, 3,
+		"MemoryReserveHandle", "", DIR_OUT, PHANDLE,
+		"ObjectAttributes", "opt", DIR_IN, POBJECT_ATTRIBUTES,
+		"Type", "", DIR_IN, MEMORY_RESERVE_TYPE,
+);
+SYSCALL(NtAllocateUserPhysicalPages, NTSTATUS, 3,
+		"ProcessHandle", "", DIR_IN, HANDLE,
+		"NumberOfPages", "", DIR_INOUT, PULONG_PTR,
+		"UserPfnArra;", "ecount(*NumberOfPages)", DIR_OUT, PULONG_PTR,
+);
+SYSCALL(NtAllocateUuids, NTSTATUS, 4,
+		"Time", "", DIR_OUT, PULARGE_INTEGER,
+		"Range", "", DIR_OUT, PULONG,
+		"Sequence", "", DIR_OUT, PULONG,
+		"Seed", "", DIR_OUT, PCHAR,
+);
+SYSCALL(NtAllocateVirtualMemory, NTSTATUS, 6,
+		"ProcessHandle", "", DIR_IN, HANDLE,
+		"*BaseAddress", "", DIR_INOUT, PVOID,
+		"ZeroBits", "", DIR_IN, ULONG_PTR,
+		"RegionSize", "", DIR_INOUT, PSIZE_T,
+		"AllocationType", "", DIR_IN, ULONG,
+		"Protect", "", DIR_IN, ULONG,
+);
+SYSCALL(NtAlpcAcceptConnectPort, NTSTATUS, 9,
+		"PortHandle", "", DIR_OUT, PHANDLE,
+		"ConnectionPortHandle", "", DIR_IN, HANDLE,
+		"Flags", "", DIR_IN, ULONG,
+		"ObjectAttributes", "", DIR_IN, POBJECT_ATTRIBUTES,
+		"PortAttributes", "", DIR_IN, PALPC_PORT_ATTRIBUTES,
+		"PortContext", "opt", DIR_IN, PVOID,
+		"ConnectionRequest", "", DIR_IN, PPORT_MESSAGE,
+		"ConnectionMessageAttributes", "opt", DIR_INOUT, PALPC_MESSAGE_ATTRIBUTES,
+		"AcceptConnection", "", DIR_IN, BOOLEAN,
+);
+SYSCALL(NtAlpcCancelMessage, NTSTATUS, 3,
+		"PortHandle", "", DIR_IN, HANDLE,
+		"Flags", "", DIR_IN, ULONG,
+		"MessageContext", "", DIR_IN, PALPC_CONTEXT_ATTR,
+);
+SYSCALL(NtAlpcConnectPort, NTSTATUS, 11,
+		"PortHandle", "", DIR_OUT, PHANDLE,
+		"PortName", "", DIR_IN, PUNICODE_STRING,
+		"ObjectAttributes", "", DIR_IN, POBJECT_ATTRIBUTES,
+		"PortAttributes", "opt", DIR_IN, PALPC_PORT_ATTRIBUTES,
+		"Flags", "", DIR_IN, ULONG,
+		"RequiredServerSid", "opt", DIR_IN, PSID,
+		"ConnectionMessage", "", DIR_INOUT, PPORT_MESSAGE,
+		"BufferLength", "opt", DIR_INOUT, PULONG,
+		"OutMessageAttributes", "opt", DIR_INOUT, PALPC_MESSAGE_ATTRIBUTES,
+		"InMessageAttributes", "opt", DIR_INOUT, PALPC_MESSAGE_ATTRIBUTES,
+		"Timeout", "opt", DIR_IN, PLARGE_INTEGER,
+);
+SYSCALL(NtAlpcCreatePort, NTSTATUS, 3,
+		"PortHandle", "", DIR_OUT, PHANDLE,
+		"ObjectAttributes", "", DIR_IN, POBJECT_ATTRIBUTES,
+		"PortAttributes", "opt", DIR_IN, PALPC_PORT_ATTRIBUTES,
+);
+SYSCALL(NtAlpcCreatePortSection, NTSTATUS, 6,
+		"PortHandle", "", DIR_IN, HANDLE,
+		"Flags", "", DIR_IN, ULONG,
+		"SectionHandle", "opt", DIR_IN, HANDLE,
+		"SectionSize", "", DIR_IN, SIZE_T,
+		"AlpcSectionHandle", "", DIR_OUT, PALPC_HANDLE,
+		"ActualSectionSize", "", DIR_OUT, PSIZE_T,
+);
+SYSCALL(NtAlpcCreateResourceReserve, NTSTATUS, 4,
+		"PortHandle", "", DIR_IN, HANDLE,
+		"Flags", "", DIR_RESERVED, ULONG,
+		"MessageSize", "", DIR_IN, SIZE_T,
+		"ResourceId", "", DIR_OUT, PALPC_HANDLE,
+);
+SYSCALL(NtAlpcCreateSectionView, NTSTATUS, 3,
+		"PortHandle", "", DIR_IN, HANDLE,
+		"Flags", "", DIR_RESERVED, ULONG,
+		"ViewAttributes", "", DIR_INOUT, PALPC_DATA_VIEW_ATTR,
+);
+SYSCALL(NtAlpcCreateSecurityContext, NTSTATUS, 3,
+		"PortHandle", "", DIR_IN, HANDLE,
+		"Flags", "", DIR_RESERVED, ULONG,
+		"SecurityAttribute", "", DIR_INOUT, PALPC_SECURITY_ATTR,
+);
+SYSCALL(NtAlpcDeletePortSection, NTSTATUS, 3,
+		"PortHandle", "", DIR_IN, HANDLE,
+		"Flags", "", DIR_RESERVED, ULONG,
+		"SectionHandle", "", DIR_IN, ALPC_HANDLE,
+);
+SYSCALL(NtAlpcDeleteResourceReserve, NTSTATUS, 3,
+		"PortHandle", "", DIR_IN, HANDLE,
+		"Flags", "", DIR_RESERVED, ULONG,
+		"ResourceId", "", DIR_IN, ALPC_HANDLE,
+);
+SYSCALL(NtAlpcDeleteSectionView, NTSTATUS, 3,
+		"PortHandle", "", DIR_IN, HANDLE,
+		"Flags", "", DIR_RESERVED, ULONG,
+		"ViewBase", "", DIR_IN, PVOID,
+);
+SYSCALL(NtAlpcDeleteSecurityContext, NTSTATUS, 3,
+		"PortHandle", "", DIR_IN, HANDLE,
+		"Flags", "", DIR_RESERVED, ULONG,
+		"ContextHandle", "", DIR_IN, ALPC_HANDLE,
+);
+SYSCALL(NtAlpcDisconnectPort, NTSTATUS, 2,
+		"PortHandle", "", DIR_IN, HANDLE,
+		"Flags", "", DIR_IN, ULONG,
+);
+SYSCALL(NtAlpcImpersonateClientOfPort, NTSTATUS, 3,
+		"PortHandle", "", DIR_IN, HANDLE,
+		"PortMessage", "", DIR_IN, PPORT_MESSAGE,
+		"Reserved", "", DIR_RESERVED, PVOID,
+);
+SYSCALL(NtAlpcOpenSenderProcess, NTSTATUS, 6,
+		"ProcessHandle", "", DIR_OUT, PHANDLE,
+		"PortHandle", "", DIR_IN, HANDLE,
+		"PortMessage", "", DIR_IN, PPORT_MESSAGE,
+		"Flags", "", DIR_RESERVED, ULONG,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"ObjectAttributes", "", DIR_IN, POBJECT_ATTRIBUTES,
+);
+SYSCALL(NtAlpcOpenSenderThread, NTSTATUS, 6,
+		"ThreadHandle", "", DIR_OUT, PHANDLE,
+		"PortHandle", "", DIR_IN, HANDLE,
+		"PortMessage", "", DIR_IN, PPORT_MESSAGE,
+		"Flags", "", DIR_RESERVED, ULONG,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"ObjectAttributes", "", DIR_IN, POBJECT_ATTRIBUTES,
+);
+SYSCALL(NtAlpcQueryInformation, NTSTATUS, 5,
+		"PortHandle", "", DIR_IN, HANDLE,
+		"PortInformationClass", "", DIR_IN, ALPC_PORT_INFORMATION_CLASS,
+		"PortInformation", "bcount(Length)", DIR_OUT, PVOID,
+		"Length", "", DIR_IN, ULONG,
+		"ReturnLength", "opt", DIR_OUT, PULONG,
+);
+SYSCALL(NtAlpcQueryInformationMessage, NTSTATUS, 6,
+		"PortHandle", "", DIR_IN, HANDLE,
+		"PortMessage", "", DIR_IN, PPORT_MESSAGE,
+		"MessageInformationClass", "", DIR_IN, ALPC_MESSAGE_INFORMATION_CLASS,
+		"MessageInformation", "bcount(Length)", DIR_OUT, PVOID,
+		"Length", "", DIR_IN, ULONG,
+		"ReturnLength", "opt", DIR_OUT, PULONG,
+);
+SYSCALL(NtAlpcRevokeSecurityContext, NTSTATUS, 3,
+		"PortHandle", "", DIR_IN, HANDLE,
+		"Flags", "", DIR_RESERVED, ULONG,
+		"ContextHandle", "", DIR_IN, ALPC_HANDLE,
+);
+SYSCALL(NtAlpcSendWaitReceivePort, NTSTATUS, 8,
+		"PortHandle", "", DIR_IN, HANDLE,
+		"Flags", "", DIR_IN, ULONG,
+		"SendMessage", "opt", DIR_IN, PPORT_MESSAGE,
+		"SendMessageAttributes", "opt", DIR_IN, PALPC_MESSAGE_ATTRIBUTES,
+		"ReceiveMessage", "opt", DIR_INOUT, PPORT_MESSAGE,
+		"BufferLength", "opt", DIR_INOUT, PULONG,
+		"ReceiveMessageAttributes", "opt", DIR_INOUT, PALPC_MESSAGE_ATTRIBUTES,
+		"Timeout", "opt", DIR_IN, PLARGE_INTEGER,
+);
+SYSCALL(NtAlpcSetInformation, NTSTATUS, 4,
+		"PortHandle", "", DIR_IN, HANDLE,
+		"PortInformationClass", "", DIR_IN, ALPC_PORT_INFORMATION_CLASS,
+		"PortInformation", "bcount(Length)", DIR_IN, PVOID,
+		"Length", "", DIR_IN, ULONG,
+);
+SYSCALL(NtApphelpCacheControl, NTSTATUS, 2,
+		"type", "", DIR_IN, APPHELPCOMMAND,
+		"buf", "", DIR_IN, PVOID,
+);
+SYSCALL(NtAreMappedFilesTheSame, NTSTATUS, 2,
+		"File1MappedAsAnImage", "", DIR_IN, PVOID,
+		"File2MappedAsFile", "", DIR_IN, PVOID,
+);
+SYSCALL(NtAssignProcessToJobObject, NTSTATUS, 2,
+		"JobHandle", "", DIR_IN, HANDLE,
+		"ProcessHandle", "", DIR_IN, HANDLE,
+);
+SYSCALL(NtCallbackReturn, NTSTATUS, 3,
+		"OutputBuffer", "opt", DIR_IN, PVOID,
+		"OutputLength", "", DIR_IN, ULONG,
+		"Status", "", DIR_IN, NTSTATUS,
+);
+SYSCALL(NtCancelIoFileEx, NTSTATUS, 3,
+		"FileHandle", "", DIR_IN, HANDLE,
+		"IoRequestToCancel", "opt", DIR_IN, PIO_STATUS_BLOCK,
+		"IoStatusBlock", "", DIR_OUT, PIO_STATUS_BLOCK,
+);
+SYSCALL(NtCancelIoFile, NTSTATUS, 2,
+		"FileHandle", "", DIR_IN, HANDLE,
+		"IoStatusBlock", "", DIR_OUT, PIO_STATUS_BLOCK,
+);
+SYSCALL(NtCancelSynchronousIoFile, NTSTATUS, 3,
+		"ThreadHandle", "", DIR_IN, HANDLE,
+		"IoRequestToCancel", "opt", DIR_IN, PIO_STATUS_BLOCK,
+		"IoStatusBlock", "", DIR_OUT, PIO_STATUS_BLOCK,
+);
+SYSCALL(NtCancelTimer, NTSTATUS, 2,
+		"TimerHandle", "", DIR_IN, HANDLE,
+		"CurrentState", "opt", DIR_OUT, PBOOLEAN,
+);
+SYSCALL(NtClearEvent, NTSTATUS, 1,
+		"EventHandle", "", DIR_IN, HANDLE,
+);
+SYSCALL(NtClose, NTSTATUS, 1,
+		"Handle", "", DIR_IN, HANDLE,
+);
+SYSCALL(NtCloseObjectAuditAlarm, NTSTATUS, 3,
+		"SubsystemName", "", DIR_IN, PUNICODE_STRING,
+		"HandleId", "opt", DIR_IN, PVOID,
+		"GenerateOnClose", "", DIR_IN, BOOLEAN,
+);
+SYSCALL(NtCommitComplete, NTSTATUS, 2,
+		"EnlistmentHandle", "", DIR_IN, HANDLE,
+		"TmVirtualClock", "opt", DIR_IN, PLARGE_INTEGER,
+);
+SYSCALL(NtCommitEnlistment, NTSTATUS, 2,
+		"EnlistmentHandle", "", DIR_IN, HANDLE,
+		"TmVirtualClock", "opt", DIR_IN, PLARGE_INTEGER,
+);
+SYSCALL(NtCommitTransaction, NTSTATUS, 2,
+		"TransactionHandle", "", DIR_IN, HANDLE,
+		"Wait", "", DIR_IN, BOOLEAN,
+);
+SYSCALL(NtCompactKeys, NTSTATUS, 2,
+		"Count", "", DIR_IN, ULONG,
+		"KeyArray[;", "ecount(Count)", DIR_IN, HANDLE,
+);
+SYSCALL(NtCompareTokens, NTSTATUS, 3,
+		"FirstTokenHandle", "", DIR_IN, HANDLE,
+		"SecondTokenHandle", "", DIR_IN, HANDLE,
+		"Equal", "", DIR_OUT, PBOOLEAN,
+);
+SYSCALL(NtCompleteConnectPort, NTSTATUS, 1,
+		"PortHandle", "", DIR_IN, HANDLE,
+);
+SYSCALL(NtCompressKey, NTSTATUS, 1,
+		"Key", "", DIR_IN, HANDLE,
+);
+SYSCALL(NtConnectPort, NTSTATUS, 8,
+		"PortHandle", "", DIR_OUT, PHANDLE,
+		"PortName", "", DIR_IN, PUNICODE_STRING,
+		"SecurityQos", "", DIR_IN, PSECURITY_QUALITY_OF_SERVICE,
+		"ClientView", "opt", DIR_INOUT, PPORT_VIEW,
+		"ServerView", "opt", DIR_INOUT, PREMOTE_PORT_VIEW,
+		"MaxMessageLength", "opt", DIR_OUT, PULONG,
+		"ConnectionInformation", "opt", DIR_INOUT, PVOID,
+		"ConnectionInformationLength", "opt", DIR_INOUT, PULONG,
+);
+SYSCALL(NtContinue, NTSTATUS, 2,
+		"ContextRecord", "", DIR_IN, PCONTEXT,
+		"TestAlert", "", DIR_IN, BOOLEAN,
+);
+SYSCALL(NtCreateDebugObject, NTSTATUS, 4,
+		"DebugObjectHandle", "", DIR_OUT, PHANDLE,
+		"DesiredAccess", "", DIR_OUT, ACCESS_MASK,
+		"ObjectAttributes", "", DIR_OUT, POBJECT_ATTRIBUTES,
+		"Flags", "", DIR_OUT, ULONG,
+);
+SYSCALL(NtCreateDirectoryObject, NTSTATUS, 3,
+		"DirectoryHandle", "", DIR_OUT, PHANDLE,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"ObjectAttributes", "", DIR_IN, POBJECT_ATTRIBUTES,
+);
+SYSCALL(NtCreateEnlistment, NTSTATUS, 8,
+		"EnlistmentHandle", "", DIR_OUT, PHANDLE,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"ResourceManagerHandle", "", DIR_IN, HANDLE,
+		"TransactionHandle", "", DIR_IN, HANDLE,
+		"ObjectAttributes", "opt", DIR_IN, POBJECT_ATTRIBUTES,
+		"CreateOptions", "opt", DIR_IN, ULONG,
+		"NotificationMask", "", DIR_IN, NOTIFICATION_MASK,
+		"EnlistmentKey", "opt", DIR_IN, PVOID,
+);
+SYSCALL(NtCreateEvent, NTSTATUS, 5,
+		"EventHandle", "", DIR_OUT, PHANDLE,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"ObjectAttributes", "opt", DIR_IN, POBJECT_ATTRIBUTES,
+		"EventType", "", DIR_IN, EVENT_TYPE,
+		"InitialState", "", DIR_IN, BOOLEAN,
+);
+SYSCALL(NtCreateEventPair, NTSTATUS, 3,
+		"EventPairHandle", "", DIR_OUT, PHANDLE,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"ObjectAttributes", "opt", DIR_IN, POBJECT_ATTRIBUTES,
+);
+SYSCALL(NtCreateFile, NTSTATUS, 11,
+		"FileHandle", "", DIR_OUT, PHANDLE,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"ObjectAttributes", "", DIR_IN, POBJECT_ATTRIBUTES,
+		"IoStatusBlock", "", DIR_OUT, PIO_STATUS_BLOCK,
+		"AllocationSize", "opt", DIR_IN, PLARGE_INTEGER,
+		"FileAttributes", "", DIR_IN, ULONG,
+		"ShareAccess", "", DIR_IN, ULONG,
+		"CreateDisposition", "", DIR_IN, ULONG,
+		"CreateOptions", "", DIR_IN, ULONG,
+		"EaBuffer", "bcount_opt(EaLength)", DIR_IN, PVOID,
+		"EaLength", "", DIR_IN, ULONG,
+);
+SYSCALL(NtCreateIoCompletion, NTSTATUS, 4,
+		"IoCompletionHandle", "", DIR_OUT, PHANDLE,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"ObjectAttributes", "opt", DIR_IN, POBJECT_ATTRIBUTES,
+		"Count", "", DIR_IN, ULONG,
+);
+SYSCALL(NtCreateJobObject, NTSTATUS, 3,
+		"JobHandle", "", DIR_OUT, PHANDLE,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"ObjectAttributes", "opt", DIR_IN, POBJECT_ATTRIBUTES,
+);
+SYSCALL(NtCreateJobSet, NTSTATUS, 3,
+		"NumJob", "", DIR_IN, ULONG,
+		"UserJobSet", "ecount(NumJob)", DIR_IN, PJOB_SET_ARRAY,
+		"Flags", "", DIR_IN, ULONG,
+);
+SYSCALL(NtCreateKeyedEvent, NTSTATUS, 4,
+		"KeyedEventHandle", "", DIR_OUT, PHANDLE,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"ObjectAttributes", "opt", DIR_IN, POBJECT_ATTRIBUTES,
+		"Flags", "", DIR_IN, ULONG,
+);
+SYSCALL(NtCreateKey, NTSTATUS, 7,
+		"KeyHandle", "", DIR_OUT, PHANDLE,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"ObjectAttributes", "", DIR_IN, POBJECT_ATTRIBUTES,
+		"TitleIndex", "", DIR_RESERVED, ULONG,
+		"Class", "opt", DIR_IN, PUNICODE_STRING,
+		"CreateOptions", "", DIR_IN, ULONG,
+		"Disposition", "opt", DIR_OUT, PULONG,
+);
+SYSCALL(NtCreateKeyTransacted, NTSTATUS, 8,
+		"KeyHandle", "", DIR_OUT, PHANDLE,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"ObjectAttributes", "", DIR_IN, POBJECT_ATTRIBUTES,
+		"TitleIndex", "", DIR_RESERVED, ULONG,
+		"Class", "opt", DIR_IN, PUNICODE_STRING,
+		"CreateOptions", "", DIR_IN, ULONG,
+		"TransactionHandle", "", DIR_IN, HANDLE,
+		"Disposition", "opt", DIR_OUT, PULONG,
+);
+SYSCALL(NtCreateMailslotFile, NTSTATUS, 8,
+		"FileHandle", "", DIR_OUT, PHANDLE,
+		"DesiredAccess", "", DIR_IN, ULONG,
+		"ObjectAttributes", "", DIR_IN, POBJECT_ATTRIBUTES,
+		"IoStatusBlock", "", DIR_OUT, PIO_STATUS_BLOCK,
+		"CreateOptions", "", DIR_IN, ULONG,
+		"MailslotQuota", "", DIR_IN, ULONG,
+		"MaximumMessageSize", "", DIR_IN, ULONG,
+		"ReadTimeout", "", DIR_IN, PLARGE_INTEGER,
+);
+SYSCALL(NtCreateMutant, NTSTATUS, 4,
+		"MutantHandle", "", DIR_OUT, PHANDLE,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"ObjectAttributes", "opt", DIR_IN, POBJECT_ATTRIBUTES,
+		"InitialOwner", "", DIR_IN, BOOLEAN,
+);
+SYSCALL(NtCreateNamedPipeFile, NTSTATUS, 14,
+		"FileHandle", "", DIR_OUT, PHANDLE,
+		"DesiredAccess", "", DIR_IN, ULONG,
+		"ObjectAttributes", "", DIR_IN, POBJECT_ATTRIBUTES,
+		"IoStatusBlock", "", DIR_OUT, PIO_STATUS_BLOCK,
+		"ShareAccess", "", DIR_IN, ULONG,
+		"CreateDisposition", "", DIR_IN, ULONG,
+		"CreateOptions", "", DIR_IN, ULONG,
+		"NamedPipeType", "", DIR_IN, ULONG,
+		"ReadMode", "", DIR_IN, ULONG,
+		"CompletionMode", "", DIR_IN, ULONG,
+		"MaximumInstances", "", DIR_IN, ULONG,
+		"InboundQuota", "", DIR_IN, ULONG,
+		"OutboundQuota", "", DIR_IN, ULONG,
+		"DefaultTimeout", "opt", DIR_IN, PLARGE_INTEGER,
+);
+SYSCALL(NtCreatePagingFile, NTSTATUS, 4,
+		"PageFileName", "", DIR_IN, PUNICODE_STRING,
+		"MinimumSize", "", DIR_IN, PLARGE_INTEGER,
+		"MaximumSize", "", DIR_IN, PLARGE_INTEGER,
+		"Priority", "", DIR_IN, ULONG,
+);
+SYSCALL(NtCreatePort, NTSTATUS, 5,
+		"PortHandle", "", DIR_OUT, PHANDLE,
+		"ObjectAttributes", "", DIR_IN, POBJECT_ATTRIBUTES,
+		"MaxConnectionInfoLength", "", DIR_IN, ULONG,
+		"MaxMessageLength", "", DIR_IN, ULONG,
+		"MaxPoolUsage", "opt", DIR_IN, ULONG,
+);
+SYSCALL(NtCreatePrivateNamespace, NTSTATUS, 4,
+		"NamespaceHandle", "", DIR_OUT, PHANDLE,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"ObjectAttributes", "opt", DIR_IN, POBJECT_ATTRIBUTES,
+		"BoundaryDescriptor", "", DIR_IN, PVOID,
+);
+SYSCALL(NtCreateProcessEx, NTSTATUS, 9,
+		"ProcessHandle", "", DIR_OUT, PHANDLE,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"ObjectAttributes", "opt", DIR_IN, POBJECT_ATTRIBUTES,
+		"ParentProcess", "", DIR_IN, HANDLE,
+		"Flags", "", DIR_IN, ULONG,
+		"SectionHandle", "opt", DIR_IN, HANDLE,
+		"DebugPort", "opt", DIR_IN, HANDLE,
+		"ExceptionPort", "opt", DIR_IN, HANDLE,
+		"JobMemberLevel", "", DIR_IN, ULONG,
+);
+SYSCALL(NtCreateProcess, NTSTATUS, 8,
+		"ProcessHandle", "", DIR_OUT, PHANDLE,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"ObjectAttributes", "opt", DIR_IN, POBJECT_ATTRIBUTES,
+		"ParentProcess", "", DIR_IN, HANDLE,
+		"InheritObjectTable", "", DIR_IN, BOOLEAN,
+		"SectionHandle", "opt", DIR_IN, HANDLE,
+		"DebugPort", "opt", DIR_IN, HANDLE,
+		"ExceptionPort", "opt", DIR_IN, HANDLE,
+);
+SYSCALL(NtCreateProfileEx, NTSTATUS, 10,
+		"ProfileHandle", "", DIR_OUT, PHANDLE,
+		"Process", "opt", DIR_IN, HANDLE,
+		"ProfileBase", "", DIR_IN, PVOID,
+		"ProfileSize", "", DIR_IN, SIZE_T,
+		"BucketSize", "", DIR_IN, ULONG,
+		"Buffer", "", DIR_IN, PULONG,
+		"BufferSize", "", DIR_IN, ULONG,
+		"ProfileSource", "", DIR_IN, KPROFILE_SOURCE,
+		"GroupAffinityCount", "", DIR_IN, ULONG,
+		"GroupAffinity", "opt", DIR_IN, PGROUP_AFFINITY,
+);
+SYSCALL(NtCreateProfile, NTSTATUS, 9,
+		"ProfileHandle", "", DIR_OUT, PHANDLE,
+		"Process", "", DIR_IN, HANDLE,
+		"RangeBase", "", DIR_IN, PVOID,
+		"RangeSize", "", DIR_IN, SIZE_T,
+		"BucketSize", "", DIR_IN, ULONG,
+		"Buffer", "", DIR_IN, PULONG,
+		"BufferSize", "", DIR_IN, ULONG,
+		"ProfileSource", "", DIR_IN, KPROFILE_SOURCE,
+		"Affinity", "", DIR_IN, KAFFINITY,
+);
+SYSCALL(NtCreateResourceManager, NTSTATUS, 7,
+		"ResourceManagerHandle", "", DIR_OUT, PHANDLE,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"TmHandle", "", DIR_IN, HANDLE,
+		"RmGuid", "", DIR_IN, LPGUID,
+		"ObjectAttributes", "opt", DIR_IN, POBJECT_ATTRIBUTES,
+		"CreateOptions", "opt", DIR_IN, ULONG,
+		"Description", "opt", DIR_IN, PUNICODE_STRING,
+);
+SYSCALL(NtCreateSection, NTSTATUS, 7,
+		"SectionHandle", "", DIR_OUT, PHANDLE,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"ObjectAttributes", "opt", DIR_IN, POBJECT_ATTRIBUTES,
+		"MaximumSize", "opt", DIR_IN, PLARGE_INTEGER,
+		"SectionPageProtection", "", DIR_IN, ULONG,
+		"AllocationAttributes", "", DIR_IN, ULONG,
+		"FileHandle", "opt", DIR_IN, HANDLE,
+);
+SYSCALL(NtCreateSemaphore, NTSTATUS, 5,
+		"SemaphoreHandle", "", DIR_OUT, PHANDLE,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"ObjectAttributes", "opt", DIR_IN, POBJECT_ATTRIBUTES,
+		"InitialCount", "", DIR_IN, LONG,
+		"MaximumCount", "", DIR_IN, LONG,
+);
+SYSCALL(NtCreateSymbolicLinkObject, NTSTATUS, 4,
+		"LinkHandle", "", DIR_OUT, PHANDLE,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"ObjectAttributes", "", DIR_IN, POBJECT_ATTRIBUTES,
+		"LinkTarget", "", DIR_IN, PUNICODE_STRING,
+);
+SYSCALL(NtCreateThreadEx, NTSTATUS, 11,
+		"ThreadHandle", "", DIR_OUT, PHANDLE,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"ObjectAttributes", "opt", DIR_IN, POBJECT_ATTRIBUTES,
+		"ProcessHandle", "", DIR_IN, HANDLE,
+		"StartRoutine", "", DIR_IN, PVOID,
+		"Argument", "opt", DIR_IN, PVOID,
+		"CreateFlags", "", DIR_IN, ULONG,
+		"ZeroBits", "opt", DIR_IN, ULONG_PTR,
+		"StackSize", "opt", DIR_IN, SIZE_T,
+		"MaximumStackSize", "opt", DIR_IN, SIZE_T,
+		"AttributeList", "opt", DIR_IN, PPS_ATTRIBUTE_LIST,
+);
+SYSCALL(NtCreateThread, NTSTATUS, 8,
+		"ThreadHandle", "", DIR_OUT, PHANDLE,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"ObjectAttributes", "opt", DIR_IN, POBJECT_ATTRIBUTES,
+		"ProcessHandle", "", DIR_IN, HANDLE,
+		"ClientId", "", DIR_OUT, PCLIENT_ID,
+		"ThreadContext", "", DIR_IN, PCONTEXT,
+		"InitialTeb", "", DIR_IN, PINITIAL_TEB,
+		"CreateSuspended", "", DIR_IN, BOOLEAN,
+);
+SYSCALL(NtCreateTimer, NTSTATUS, 4,
+		"TimerHandle", "", DIR_OUT, PHANDLE,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"ObjectAttributes", "opt", DIR_IN, POBJECT_ATTRIBUTES,
+		"TimerType", "", DIR_IN, TIMER_TYPE,
+);
+SYSCALL(NtCreateToken, NTSTATUS, 13,
+		"TokenHandle", "", DIR_OUT, PHANDLE,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"ObjectAttributes", "opt", DIR_IN, POBJECT_ATTRIBUTES,
+		"TokenType", "", DIR_IN, TOKEN_TYPE,
+		"AuthenticationId", "", DIR_IN, PLUID,
+		"ExpirationTime", "", DIR_IN, PLARGE_INTEGER,
+		"User", "", DIR_IN, PTOKEN_USER,
+		"Groups", "", DIR_IN, PTOKEN_GROUPS,
+		"Privileges", "", DIR_IN, PTOKEN_PRIVILEGES,
+		"Owner", "opt", DIR_IN, PTOKEN_OWNER,
+		"PrimaryGroup", "", DIR_IN, PTOKEN_PRIMARY_GROUP,
+		"DefaultDacl", "opt", DIR_IN, PTOKEN_DEFAULT_DACL,
+		"TokenSource", "", DIR_IN, PTOKEN_SOURCE,
+);
+SYSCALL(NtCreateTransactionManager, NTSTATUS, 6,
+		"TmHandle", "", DIR_OUT, PHANDLE,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"ObjectAttributes", "opt", DIR_IN, POBJECT_ATTRIBUTES,
+		"LogFileName", "opt", DIR_IN, PUNICODE_STRING,
+		"CreateOptions", "opt", DIR_IN, ULONG,
+		"CommitStrength", "opt", DIR_IN, ULONG,
+);
+SYSCALL(NtCreateTransaction, NTSTATUS, 10,
+		"TransactionHandle", "", DIR_OUT, PHANDLE,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"ObjectAttributes", "opt", DIR_IN, POBJECT_ATTRIBUTES,
+		"Uow", "opt", DIR_IN, LPGUID,
+		"TmHandle", "opt", DIR_IN, HANDLE,
+		"CreateOptions", "opt", DIR_IN, ULONG,
+		"IsolationLevel", "opt", DIR_IN, ULONG,
+		"IsolationFlags", "opt", DIR_IN, ULONG,
+		"Timeout", "opt", DIR_IN, PLARGE_INTEGER,
+		"Description", "opt", DIR_IN, PUNICODE_STRING,
+);
+SYSCALL(NtCreateUserProcess, NTSTATUS, 11,
+		"ProcessHandle", "", DIR_OUT, PHANDLE,
+		"ThreadHandle", "", DIR_OUT, PHANDLE,
+		"ProcessDesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"ThreadDesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"ProcessObjectAttributes", "opt", DIR_IN, POBJECT_ATTRIBUTES,
+		"ThreadObjectAttributes", "opt", DIR_IN, POBJECT_ATTRIBUTES,
+		"ProcessFlags", "", DIR_IN, ULONG,
+		"ThreadFlags", "", DIR_IN, ULONG,
+		"ProcessParameters", "opt", DIR_IN, PRTL_USER_PROCESS_PARAMETERS,
+		"CreateInfo", "opt", DIR_IN, PPROCESS_CREATE_INFO,
+		"AttributeList", "opt", DIR_IN, PPROCESS_ATTRIBUTE_LIST,
+);
+SYSCALL(NtCreateWaitablePort, NTSTATUS, 5,
+		"PortHandle", "", DIR_OUT, PHANDLE,
+		"ObjectAttributes", "", DIR_IN, POBJECT_ATTRIBUTES,
+		"MaxConnectionInfoLength", "", DIR_IN, ULONG,
+		"MaxMessageLength", "", DIR_IN, ULONG,
+		"MaxPoolUsage", "opt", DIR_IN, ULONG,
+);
+SYSCALL(NtCreateWorkerFactory, NTSTATUS, 10,
+		"WorkerFactoryHandleReturn", "", DIR_OUT, PHANDLE,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"ObjectAttributes", "opt", DIR_IN, POBJECT_ATTRIBUTES,
+		"CompletionPortHandle", "", DIR_IN, HANDLE,
+		"WorkerProcessHandle", "", DIR_IN, HANDLE,
+		"StartRoutine", "", DIR_IN, PVOID,
+		"StartParameter", "opt", DIR_IN, PVOID,
+		"MaxThreadCount", "opt", DIR_IN, ULONG,
+		"StackReserve", "opt", DIR_IN, SIZE_T,
+		"StackCommit", "opt", DIR_IN, SIZE_T,
+);
+SYSCALL(NtDebugActiveProcess, NTSTATUS, 2,
+		"ProcessHandle", "", DIR_OUT, HANDLE,
+		"DebugObjectHandle", "", DIR_OUT, HANDLE,
+);
+SYSCALL(NtDebugContinue, NTSTATUS, 3,
+		"DebugObjectHandle", "", DIR_OUT, HANDLE,
+		"ClientId", "", DIR_OUT, PCLIENT_ID,
+		"ContinueStatus", "", DIR_OUT, NTSTATUS,
+);
+SYSCALL(NtDelayExecution, NTSTATUS, 2,
+		"Alertable", "", DIR_IN, BOOLEAN,
+		"DelayInterval", "", DIR_IN, PLARGE_INTEGER,
+);
+SYSCALL(NtDeleteAtom, NTSTATUS, 1,
+		"Atom", "", DIR_IN, RTL_ATOM,
+);
+SYSCALL(NtDeleteBootEntry, NTSTATUS, 1,
+		"Id", "", DIR_IN, ULONG,
+);
+SYSCALL(NtDeleteDriverEntry, NTSTATUS, 1,
+		"Id", "", DIR_IN, ULONG,
+);
+SYSCALL(NtDeleteFile, NTSTATUS, 1,
+		"ObjectAttributes", "", DIR_IN, POBJECT_ATTRIBUTES,
+);
+SYSCALL(NtDeleteKey, NTSTATUS, 1,
+		"KeyHandle", "", DIR_IN, HANDLE,
+);
+SYSCALL(NtDeleteObjectAuditAlarm, NTSTATUS, 3,
+		"SubsystemName", "", DIR_IN, PUNICODE_STRING,
+		"HandleId", "opt", DIR_IN, PVOID,
+		"GenerateOnClose", "", DIR_IN, BOOLEAN,
+);
+SYSCALL(NtDeletePrivateNamespace, NTSTATUS, 1,
+		"NamespaceHandle", "", DIR_IN, HANDLE,
+);
+SYSCALL(NtDeleteValueKey, NTSTATUS, 2,
+		"KeyHandle", "", DIR_IN, HANDLE,
+		"ValueName", "", DIR_IN, PUNICODE_STRING,
+);
+SYSCALL(NtDeviceIoControlFile, NTSTATUS, 10,
+		"FileHandle", "", DIR_IN, HANDLE,
+		"Event", "opt", DIR_IN, HANDLE,
+		"ApcRoutine", "opt", DIR_IN, PIO_APC_ROUTINE,
+		"ApcContext", "opt", DIR_IN, PVOID,
+		"IoStatusBlock", "", DIR_OUT, PIO_STATUS_BLOCK,
+		"IoControlCode", "", DIR_IN, ULONG,
+		"InputBuffer", "bcount_opt(InputBufferLength)", DIR_IN, PVOID,
+		"InputBufferLength", "", DIR_IN, ULONG,
+		"OutputBuffer", "bcount_opt(OutputBufferLength)", DIR_OUT, PVOID,
+		"OutputBufferLength", "", DIR_IN, ULONG,
+);
+SYSCALL(NtDisplayString, NTSTATUS, 1,
+		"String", "", DIR_IN, PUNICODE_STRING,
+);
+SYSCALL(NtDrawText, NTSTATUS, 1,
+		"Text", "", DIR_IN, PUNICODE_STRING,
+);
+SYSCALL(NtDuplicateObject, NTSTATUS, 7,
+		"SourceProcessHandle", "", DIR_IN, HANDLE,
+		"SourceHandle", "", DIR_IN, HANDLE,
+		"TargetProcessHandle", "opt", DIR_IN, HANDLE,
+		"TargetHandle", "opt", DIR_OUT, PHANDLE,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"HandleAttributes", "", DIR_IN, ULONG,
+		"Options", "", DIR_IN, ULONG,
+);
+SYSCALL(NtDuplicateToken, NTSTATUS, 6,
+		"ExistingTokenHandle", "", DIR_IN, HANDLE,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"ObjectAttributes", "", DIR_IN, POBJECT_ATTRIBUTES,
+		"EffectiveOnly", "", DIR_IN, BOOLEAN,
+		"TokenType", "", DIR_IN, TOKEN_TYPE,
+		"NewTokenHandle", "", DIR_OUT, PHANDLE,
+);
+SYSCALL(NtEnumerateBootEntries, NTSTATUS, 2,
+		"Buffer", "bcount_opt(*BufferLength)", DIR_OUT, PVOID,
+		"BufferLength", "", DIR_INOUT, PULONG,
+);
+SYSCALL(NtEnumerateDriverEntries, NTSTATUS, 2,
+		"Buffer", "bcount(*BufferLength)", DIR_OUT, PVOID,
+		"BufferLength", "", DIR_INOUT, PULONG,
+);
+SYSCALL(NtEnumerateKey, NTSTATUS, 6,
+		"KeyHandle", "", DIR_IN, HANDLE,
+		"Index", "", DIR_IN, ULONG,
+		"KeyInformationClass", "", DIR_IN, KEY_INFORMATION_CLASS,
+		"KeyInformation", "bcount_opt(Length)", DIR_OUT, PVOID,
+		"Length", "", DIR_IN, ULONG,
+		"ResultLength", "", DIR_OUT, PULONG,
+);
+SYSCALL(NtEnumerateSystemEnvironmentValuesEx, NTSTATUS, 3,
+		"InformationClass", "", DIR_IN, ULONG,
+		"Buffer", "", DIR_OUT, PVOID,
+		"BufferLength", "", DIR_INOUT, PULONG,
+);
+SYSCALL(NtEnumerateTransactionObject, NTSTATUS, 5,
+		"RootObjectHandle", "opt", DIR_IN, HANDLE,
+		"QueryType", "", DIR_IN, KTMOBJECT_TYPE,
+		"ObjectCursor", "bcount(ObjectCursorLength)", DIR_INOUT, PKTMOBJECT_CURSOR,
+		"ObjectCursorLength", "", DIR_IN, ULONG,
+		"ReturnLength", "", DIR_OUT, PULONG,
+);
+SYSCALL(NtEnumerateValueKey, NTSTATUS, 6,
+		"KeyHandle", "", DIR_IN, HANDLE,
+		"Index", "", DIR_IN, ULONG,
+		"KeyValueInformationClass", "", DIR_IN, KEY_VALUE_INFORMATION_CLASS,
+		"KeyValueInformation", "bcount_opt(Length)", DIR_OUT, PVOID,
+		"Length", "", DIR_IN, ULONG,
+		"ResultLength", "", DIR_OUT, PULONG,
+);
+SYSCALL(NtExtendSection, NTSTATUS, 2,
+		"SectionHandle", "", DIR_IN, HANDLE,
+		"NewSectionSize", "", DIR_INOUT, PLARGE_INTEGER,
+);
+SYSCALL(NtFilterToken, NTSTATUS, 6,
+		"ExistingTokenHandle", "", DIR_IN, HANDLE,
+		"Flags", "", DIR_IN, ULONG,
+		"SidsToDisable", "opt", DIR_IN, PTOKEN_GROUPS,
+		"PrivilegesToDelete", "opt", DIR_IN, PTOKEN_PRIVILEGES,
+		"RestrictedSids", "opt", DIR_IN, PTOKEN_GROUPS,
+		"NewTokenHandle", "", DIR_OUT, PHANDLE,
+);
+SYSCALL(NtFindAtom, NTSTATUS, 3,
+		"AtomName", "bcount_opt(Length)", DIR_IN, PWSTR,
+		"Length", "", DIR_IN, ULONG,
+		"Atom", "opt", DIR_OUT, PRTL_ATOM,
+);
+SYSCALL(NtFlushBuffersFile, NTSTATUS, 2,
+		"FileHandle", "", DIR_IN, HANDLE,
+		"IoStatusBlock", "", DIR_OUT, PIO_STATUS_BLOCK,
+);
+SYSCALL(NtFlushInstallUILanguage, NTSTATUS, 2,
+		"InstallUILanguage", "", DIR_IN, LANGID,
+		"SetComittedFlag", "", DIR_IN, ULONG,
+);
+SYSCALL(NtFlushInstructionCache, NTSTATUS, 3,
+		"ProcessHandle", "", DIR_IN, HANDLE,
+		"BaseAddress", "opt", DIR_IN, PVOID,
+		"Length", "", DIR_IN, SIZE_T,
+);
+SYSCALL(NtFlushKey, NTSTATUS, 1,
+		"KeyHandle", "", DIR_IN, HANDLE,
+);
+SYSCALL(NtFlushVirtualMemory, NTSTATUS, 4,
+		"ProcessHandle", "", DIR_IN, HANDLE,
+		"*BaseAddress", "", DIR_INOUT, PVOID,
+		"RegionSize", "", DIR_INOUT, PSIZE_T,
+		"IoStatus", "", DIR_OUT, PIO_STATUS_BLOCK,
+);
+SYSCALL(NtFreeUserPhysicalPages, NTSTATUS, 3,
+		"ProcessHandle", "", DIR_IN, HANDLE,
+		"NumberOfPages", "", DIR_INOUT, PULONG_PTR,
+		"UserPfnArra;", "ecount(*NumberOfPages)", DIR_IN, PULONG_PTR,
+);
+SYSCALL(NtFreeVirtualMemory, NTSTATUS, 4,
+		"ProcessHandle", "", DIR_IN, HANDLE,
+		"*BaseAddress", "", DIR_INOUT, PVOID,
+		"RegionSize", "", DIR_INOUT, PSIZE_T,
+		"FreeType", "", DIR_IN, ULONG,
+);
+SYSCALL(NtFreezeRegistry, NTSTATUS, 1,
+		"TimeOutInSeconds", "", DIR_IN, ULONG,
+);
+SYSCALL(NtFreezeTransactions, NTSTATUS, 2,
+		"FreezeTimeout", "", DIR_IN, PLARGE_INTEGER,
+		"ThawTimeout", "", DIR_IN, PLARGE_INTEGER,
+);
+SYSCALL(NtFsControlFile, NTSTATUS, 10,
+		"FileHandle", "", DIR_IN, HANDLE,
+		"Event", "opt", DIR_IN, HANDLE,
+		"ApcRoutine", "opt", DIR_IN, PIO_APC_ROUTINE,
+		"ApcContext", "opt", DIR_IN, PVOID,
+		"IoStatusBlock", "", DIR_OUT, PIO_STATUS_BLOCK,
+		"IoControlCode", "", DIR_IN, ULONG,
+		"InputBuffer", "bcount_opt(InputBufferLength)", DIR_IN, PVOID,
+		"InputBufferLength", "", DIR_IN, ULONG,
+		"OutputBuffer", "bcount_opt(OutputBufferLength)", DIR_OUT, PVOID,
+		"OutputBufferLength", "", DIR_IN, ULONG,
+);
+SYSCALL(NtGetContextThread, NTSTATUS, 2,
+		"ThreadHandle", "", DIR_IN, HANDLE,
+		"ThreadContext", "", DIR_INOUT, PCONTEXT,
+);
+SYSCALL(NtGetDevicePowerState, NTSTATUS, 2,
+		"Device", "", DIR_IN, HANDLE,
+		"*State", "", DIR_OUT, DEVICE_POWER_STATE,
+);
+SYSCALL(NtGetMUIRegistryInfo, NTSTATUS, 3,
+		"Flags", "", DIR_IN, ULONG,
+		"DataSize", "", DIR_INOUT, PULONG,
+		"Data", "", DIR_OUT, PVOID,
+);
+SYSCALL(NtGetNextProcess, NTSTATUS, 5,
+		"ProcessHandle", "", DIR_IN, HANDLE,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"HandleAttributes", "", DIR_IN, ULONG,
+		"Flags", "", DIR_IN, ULONG,
+		"NewProcessHandle", "", DIR_OUT, PHANDLE,
+);
+SYSCALL(NtGetNextThread, NTSTATUS, 6,
+		"ProcessHandle", "", DIR_IN, HANDLE,
+		"ThreadHandle", "", DIR_IN, HANDLE,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"HandleAttributes", "", DIR_IN, ULONG,
+		"Flags", "", DIR_IN, ULONG,
+		"NewThreadHandle", "", DIR_OUT, PHANDLE,
+);
+SYSCALL(NtGetNlsSectionPtr, NTSTATUS, 5,
+		"SectionType", "", DIR_IN, ULONG,
+		"SectionData", "", DIR_IN, ULONG,
+		"ContextData", "", DIR_IN, PVOID,
+		"*SectionPointer", "", DIR_OUT, PVOID,
+		"SectionSize", "", DIR_OUT, PULONG,
+);
+SYSCALL(NtGetNotificationResourceManager, NTSTATUS, 7,
+		"ResourceManagerHandle", "", DIR_IN, HANDLE,
+		"TransactionNotification", "", DIR_OUT, PTRANSACTION_NOTIFICATION,
+		"NotificationLength", "", DIR_IN, ULONG,
+		"Timeout", "opt", DIR_IN, PLARGE_INTEGER,
+		"ReturnLength", "opt", DIR_OUT, PULONG,
+		"Asynchronous", "", DIR_IN, ULONG,
+		"AsynchronousContext", "opt", DIR_IN, ULONG_PTR,
+);
+SYSCALL(NtGetPlugPlayEvent, NTSTATUS, 4,
+		"EventHandle", "", DIR_IN, HANDLE,
+		"Context", "opt", DIR_IN, PVOID,
+		"EventBlock", "bcount(EventBufferSize)", DIR_OUT, PPLUGPLAY_EVENT_BLOCK,
+		"EventBufferSize", "", DIR_IN, ULONG,
+);
+SYSCALL(NtGetWriteWatch, NTSTATUS, 7,
+		"ProcessHandle", "", DIR_IN, HANDLE,
+		"Flags", "", DIR_IN, ULONG,
+		"BaseAddress", "", DIR_IN, PVOID,
+		"RegionSize", "", DIR_IN, SIZE_T,
+		"*UserAddressArray", "ecount(*EntriesInUserAddressArray)", DIR_OUT, PVOID,
+		"EntriesInUserAddressArray", "", DIR_INOUT, PULONG_PTR,
+		"Granularity", "", DIR_OUT, PULONG,
+);
+SYSCALL(NtImpersonateAnonymousToken, NTSTATUS, 1,
+		"ThreadHandle", "", DIR_IN, HANDLE,
+);
+SYSCALL(NtImpersonateClientOfPort, NTSTATUS, 2,
+		"PortHandle", "", DIR_IN, HANDLE,
+		"Message", "", DIR_IN, PPORT_MESSAGE,
+);
+SYSCALL(NtImpersonateThread, NTSTATUS, 3,
+		"ServerThreadHandle", "", DIR_IN, HANDLE,
+		"ClientThreadHandle", "", DIR_IN, HANDLE,
+		"SecurityQos", "", DIR_IN, PSECURITY_QUALITY_OF_SERVICE,
+);
+SYSCALL(NtInitializeNlsFiles, NTSTATUS, 3,
+		"*BaseAddress", "", DIR_OUT, PVOID,
+		"DefaultLocaleId", "", DIR_OUT, PLCID,
+		"DefaultCasingTableSize", "", DIR_OUT, PLARGE_INTEGER,
+);
+SYSCALL(NtInitializeRegistry, NTSTATUS, 1,
+		"BootCondition", "", DIR_IN, USHORT,
+);
+SYSCALL(NtInitiatePowerAction, NTSTATUS, 4,
+		"SystemAction", "", DIR_IN, POWER_ACTION,
+		"MinSystemState", "", DIR_IN, SYSTEM_POWER_STATE,
+		"Flags", "", DIR_IN, ULONG,
+		"Asynchronous", "", DIR_IN, BOOLEAN,
+);
+SYSCALL(NtIsProcessInJob, NTSTATUS, 2,
+		"ProcessHandle", "", DIR_IN, HANDLE,
+		"JobHandle", "opt", DIR_IN, HANDLE,
+);
+SYSCALL(NtListenPort, NTSTATUS, 2,
+		"PortHandle", "", DIR_IN, HANDLE,
+		"ConnectionRequest", "", DIR_OUT, PPORT_MESSAGE,
+);
+SYSCALL(NtLoadDriver, NTSTATUS, 1,
+		"DriverServiceName", "", DIR_IN, PUNICODE_STRING,
+);
+SYSCALL(NtLoadKey2, NTSTATUS, 3,
+		"TargetKey", "", DIR_IN, POBJECT_ATTRIBUTES,
+		"SourceFile", "", DIR_IN, POBJECT_ATTRIBUTES,
+		"Flags", "", DIR_IN, ULONG,
+);
+SYSCALL(NtLoadKeyEx, NTSTATUS, 4,
+		"TargetKey", "", DIR_IN, POBJECT_ATTRIBUTES,
+		"SourceFile", "", DIR_IN, POBJECT_ATTRIBUTES,
+		"Flags", "", DIR_IN, ULONG,
+		"TrustClassKey", "opt", DIR_IN, HANDLE,
+);
+SYSCALL(NtLoadKey, NTSTATUS, 2,
+		"TargetKey", "", DIR_IN, POBJECT_ATTRIBUTES,
+		"SourceFile", "", DIR_IN, POBJECT_ATTRIBUTES,
+);
+SYSCALL(NtLockFile, NTSTATUS, 10,
+		"FileHandle", "", DIR_IN, HANDLE,
+		"Event", "opt", DIR_IN, HANDLE,
+		"ApcRoutine", "opt", DIR_IN, PIO_APC_ROUTINE,
+		"ApcContext", "opt", DIR_IN, PVOID,
+		"IoStatusBlock", "", DIR_OUT, PIO_STATUS_BLOCK,
+		"ByteOffset", "", DIR_IN, PLARGE_INTEGER,
+		"Length", "", DIR_IN, PLARGE_INTEGER,
+		"Key", "", DIR_IN, ULONG,
+		"FailImmediately", "", DIR_IN, BOOLEAN,
+		"ExclusiveLock", "", DIR_IN, BOOLEAN,
+);
+SYSCALL(NtLockProductActivationKeys, NTSTATUS, 2,
+		"*pPrivateVer", "opt", DIR_INOUT, ULONG,
+		"*pSafeMode", "opt", DIR_OUT, ULONG,
+);
+SYSCALL(NtLockRegistryKey, NTSTATUS, 1,
+		"KeyHandle", "", DIR_IN, HANDLE,
+);
+SYSCALL(NtLockVirtualMemory, NTSTATUS, 4,
+		"ProcessHandle", "", DIR_IN, HANDLE,
+		"*BaseAddress", "", DIR_INOUT, PVOID,
+		"RegionSize", "", DIR_INOUT, PSIZE_T,
+		"MapType", "", DIR_IN, ULONG,
+);
+SYSCALL(NtMakePermanentObject, NTSTATUS, 1,
+		"Handle", "", DIR_IN, HANDLE,
+);
+SYSCALL(NtMakeTemporaryObject, NTSTATUS, 1,
+		"Handle", "", DIR_IN, HANDLE,
+);
+SYSCALL(NtMapCMFModule, NTSTATUS, 6,
+		"What", "", DIR_IN, ULONG,
+		"Index", "", DIR_IN, ULONG,
+		"CacheIndexOut", "opt", DIR_OUT, PULONG,
+		"CacheFlagsOut", "opt", DIR_OUT, PULONG,
+		"ViewSizeOut", "opt", DIR_OUT, PULONG,
+		"*BaseAddress", "opt", DIR_OUT, PVOID,
+);
+SYSCALL(NtMapUserPhysicalPages, NTSTATUS, 3,
+		"VirtualAddress", "", DIR_IN, PVOID,
+		"NumberOfPages", "", DIR_IN, ULONG_PTR,
+		"UserPfnArra;", "ecount_opt(NumberOfPages)", DIR_IN, PULONG_PTR,
+);
+SYSCALL(NtMapUserPhysicalPagesScatter, NTSTATUS, 3,
+		"*VirtualAddresses", "ecount(NumberOfPages)", DIR_IN, PVOID,
+		"NumberOfPages", "", DIR_IN, ULONG_PTR,
+		"UserPfnArray", "ecount_opt(NumberOfPages)", DIR_IN, PULONG_PTR,
+);
+SYSCALL(NtMapViewOfSection, NTSTATUS, 10,
+		"SectionHandle", "", DIR_IN, HANDLE,
+		"ProcessHandle", "", DIR_IN, HANDLE,
+		"*BaseAddress", "", DIR_INOUT, PVOID,
+		"ZeroBits", "", DIR_IN, ULONG_PTR,
+		"CommitSize", "", DIR_IN, SIZE_T,
+		"SectionOffset", "opt", DIR_INOUT, PLARGE_INTEGER,
+		"ViewSize", "", DIR_INOUT, PSIZE_T,
+		"InheritDisposition", "", DIR_IN, SECTION_INHERIT,
+		"AllocationType", "", DIR_IN, ULONG,
+		"Win32Protect", "", DIR_IN, WIN32_PROTECTION_MASK,
+);
+SYSCALL(NtModifyBootEntry, NTSTATUS, 1,
+		"BootEntry", "", DIR_IN, PBOOT_ENTRY,
+);
+SYSCALL(NtModifyDriverEntry, NTSTATUS, 1,
+		"DriverEntry", "", DIR_IN, PEFI_DRIVER_ENTRY,
+);
+SYSCALL(NtNotifyChangeDirectoryFile, NTSTATUS, 9,
+		"FileHandle", "", DIR_IN, HANDLE,
+		"Event", "opt", DIR_IN, HANDLE,
+		"ApcRoutine", "opt", DIR_IN, PIO_APC_ROUTINE,
+		"ApcContext", "opt", DIR_IN, PVOID,
+		"IoStatusBlock", "", DIR_OUT, PIO_STATUS_BLOCK,
+		"Buffer", "bcount(Length)", DIR_OUT, PVOID,
+		"Length", "", DIR_IN, ULONG,
+		"CompletionFilter", "", DIR_IN, ULONG,
+		"WatchTree", "", DIR_IN, BOOLEAN,
+);
+SYSCALL(NtNotifyChangeKey, NTSTATUS, 10,
+		"KeyHandle", "", DIR_IN, HANDLE,
+		"Event", "opt", DIR_IN, HANDLE,
+		"ApcRoutine", "opt", DIR_IN, PIO_APC_ROUTINE,
+		"ApcContext", "opt", DIR_IN, PVOID,
+		"IoStatusBlock", "", DIR_OUT, PIO_STATUS_BLOCK,
+		"CompletionFilter", "", DIR_IN, ULONG,
+		"WatchTree", "", DIR_IN, BOOLEAN,
+		"Buffer", "bcount_opt(BufferSize)", DIR_OUT, PVOID,
+		"BufferSize", "", DIR_IN, ULONG,
+		"Asynchronous", "", DIR_IN, BOOLEAN,
+);
+SYSCALL(NtNotifyChangeMultipleKeys, NTSTATUS, 12,
+		"MasterKeyHandle", "", DIR_IN, HANDLE,
+		"Count", "opt", DIR_IN, ULONG,
+		"SlaveObjects[]", "ecount_opt(Count)", DIR_IN, OBJECT_ATTRIBUTES,
+		"Event", "opt", DIR_IN, HANDLE,
+		"ApcRoutine", "opt", DIR_IN, PIO_APC_ROUTINE,
+		"ApcContext", "opt", DIR_IN, PVOID,
+		"IoStatusBlock", "", DIR_OUT, PIO_STATUS_BLOCK,
+		"CompletionFilter", "", DIR_IN, ULONG,
+		"WatchTree", "", DIR_IN, BOOLEAN,
+		"Buffer", "bcount_opt(BufferSize)", DIR_OUT, PVOID,
+		"BufferSize", "", DIR_IN, ULONG,
+		"Asynchronous", "", DIR_IN, BOOLEAN,
+);
+SYSCALL(NtNotifyChangeSession, NTSTATUS, 8,
+		"Session", "", DIR_IN, HANDLE,
+		"IoStateSequence", "", DIR_IN, ULONG,
+		"Reserved", "", DIR_IN, PVOID,
+		"Action", "", DIR_IN, ULONG,
+		"IoState", "", DIR_IN,  IO_SESSION_STATE,
+		"IoState2", "", DIR_IN,  IO_SESSION_STATE,
+		"Buffer", "", DIR_IN, PVOID,
+		"BufferSize", "", DIR_IN, ULONG,
+);
+SYSCALL(NtOpenDirectoryObject, NTSTATUS, 3,
+		"DirectoryHandle", "", DIR_OUT, PHANDLE,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"ObjectAttributes", "", DIR_IN, POBJECT_ATTRIBUTES,
+);
+SYSCALL(NtOpenEnlistment, NTSTATUS, 5,
+		"EnlistmentHandle", "", DIR_OUT, PHANDLE,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"ResourceManagerHandle", "", DIR_IN, HANDLE,
+		"EnlistmentGuid", "", DIR_IN, LPGUID,
+		"ObjectAttributes", "opt", DIR_IN, POBJECT_ATTRIBUTES,
+);
+SYSCALL(NtOpenEvent, NTSTATUS, 3,
+		"EventHandle", "", DIR_OUT, PHANDLE,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"ObjectAttributes", "", DIR_IN, POBJECT_ATTRIBUTES,
+);
+SYSCALL(NtOpenEventPair, NTSTATUS, 3,
+		"EventPairHandle", "", DIR_OUT, PHANDLE,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"ObjectAttributes", "", DIR_IN, POBJECT_ATTRIBUTES,
+);
+SYSCALL(NtOpenFile, NTSTATUS, 6,
+		"FileHandle", "", DIR_OUT, PHANDLE,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"ObjectAttributes", "", DIR_IN, POBJECT_ATTRIBUTES,
+		"IoStatusBlock", "", DIR_OUT, PIO_STATUS_BLOCK,
+		"ShareAccess", "", DIR_IN, ULONG,
+		"OpenOptions", "", DIR_IN, ULONG,
+);
+SYSCALL(NtOpenIoCompletion, NTSTATUS, 3,
+		"IoCompletionHandle", "", DIR_OUT, PHANDLE,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"ObjectAttributes", "", DIR_IN, POBJECT_ATTRIBUTES,
+);
+SYSCALL(NtOpenJobObject, NTSTATUS, 3,
+		"JobHandle", "", DIR_OUT, PHANDLE,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"ObjectAttributes", "", DIR_IN, POBJECT_ATTRIBUTES,
+);
+SYSCALL(NtOpenKeyedEvent, NTSTATUS, 3,
+		"KeyedEventHandle", "", DIR_OUT, PHANDLE,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"ObjectAttributes", "", DIR_IN, POBJECT_ATTRIBUTES,
+);
+SYSCALL(NtOpenKeyEx, NTSTATUS, 4,
+		"KeyHandle", "", DIR_OUT, PHANDLE,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"ObjectAttributes", "", DIR_IN, POBJECT_ATTRIBUTES,
+		"OpenOptions", "", DIR_IN, ULONG,
+);
+SYSCALL(NtOpenKey, NTSTATUS, 3,
+		"KeyHandle", "", DIR_OUT, PHANDLE,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"ObjectAttributes", "", DIR_IN, POBJECT_ATTRIBUTES,
+);
+SYSCALL(NtOpenKeyTransactedEx, NTSTATUS, 5,
+		"KeyHandle", "", DIR_OUT, PHANDLE,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"ObjectAttributes", "", DIR_IN, POBJECT_ATTRIBUTES,
+		"OpenOptions", "", DIR_IN, ULONG,
+		"TransactionHandle", "", DIR_IN, HANDLE,
+);
+SYSCALL(NtOpenKeyTransacted, NTSTATUS, 4,
+		"KeyHandle", "", DIR_OUT, PHANDLE,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"ObjectAttributes", "", DIR_IN, POBJECT_ATTRIBUTES,
+		"TransactionHandle", "", DIR_IN, HANDLE,
+);
+SYSCALL(NtOpenMutant, NTSTATUS, 3,
+		"MutantHandle", "", DIR_OUT, PHANDLE,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"ObjectAttributes", "", DIR_IN, POBJECT_ATTRIBUTES,
+);
+SYSCALL(NtOpenObjectAuditAlarm, NTSTATUS, 12,
+		"SubsystemName", "", DIR_IN, PUNICODE_STRING,
+		"HandleId", "opt", DIR_IN, PVOID,
+		"ObjectTypeName", "", DIR_IN, PUNICODE_STRING,
+		"ObjectName", "", DIR_IN, PUNICODE_STRING,
+		"SecurityDescriptor", "opt", DIR_IN, PSECURITY_DESCRIPTOR,
+		"ClientToken", "", DIR_IN, HANDLE,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"GrantedAccess", "", DIR_IN, ACCESS_MASK,
+		"Privileges", "opt", DIR_IN, PPRIVILEGE_SET,
+		"ObjectCreation", "", DIR_IN, BOOLEAN,
+		"AccessGranted", "", DIR_IN, BOOLEAN,
+		"GenerateOnClose", "", DIR_OUT, PBOOLEAN,
+);
+SYSCALL(NtOpenPrivateNamespace, NTSTATUS, 4,
+		"NamespaceHandle", "", DIR_OUT, PHANDLE,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"ObjectAttributes", "opt", DIR_IN, POBJECT_ATTRIBUTES,
+		"BoundaryDescriptor", "", DIR_IN, PVOID,
+);
+SYSCALL(NtOpenProcess, NTSTATUS, 4,
+		"ProcessHandle", "", DIR_OUT, PHANDLE,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"ObjectAttributes", "", DIR_IN, POBJECT_ATTRIBUTES,
+		"ClientId", "opt", DIR_IN, PCLIENT_ID,
+);
+SYSCALL(NtOpenProcessTokenEx, NTSTATUS, 4,
+		"ProcessHandle", "", DIR_IN, HANDLE,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"HandleAttributes", "", DIR_IN, ULONG,
+		"TokenHandle", "", DIR_OUT, PHANDLE,
+);
+SYSCALL(NtOpenProcessToken, NTSTATUS, 3,
+		"ProcessHandle", "", DIR_IN, HANDLE,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"TokenHandle", "", DIR_OUT, PHANDLE,
+);
+SYSCALL(NtOpenResourceManager, NTSTATUS, 5,
+		"ResourceManagerHandle", "", DIR_OUT, PHANDLE,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"TmHandle", "", DIR_IN, HANDLE,
+		"ResourceManagerGuid", "opt", DIR_IN, LPGUID,
+		"ObjectAttributes", "opt", DIR_IN, POBJECT_ATTRIBUTES,
+);
+SYSCALL(NtOpenSection, NTSTATUS, 3,
+		"SectionHandle", "", DIR_OUT, PHANDLE,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"ObjectAttributes", "", DIR_IN, POBJECT_ATTRIBUTES,
+);
+SYSCALL(NtOpenSemaphore, NTSTATUS, 3,
+		"SemaphoreHandle", "", DIR_OUT, PHANDLE,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"ObjectAttributes", "", DIR_IN, POBJECT_ATTRIBUTES,
+);
+SYSCALL(NtOpenSession, NTSTATUS, 3,
+		"SessionHandle", "", DIR_OUT, PHANDLE,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"ObjectAttributes", "", DIR_IN, POBJECT_ATTRIBUTES,
+);
+SYSCALL(NtOpenSymbolicLinkObject, NTSTATUS, 3,
+		"LinkHandle", "", DIR_OUT, PHANDLE,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"ObjectAttributes", "", DIR_IN, POBJECT_ATTRIBUTES,
+);
+SYSCALL(NtOpenThread, NTSTATUS, 4,
+		"ThreadHandle", "", DIR_OUT, PHANDLE,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"ObjectAttributes", "", DIR_IN, POBJECT_ATTRIBUTES,
+		"ClientId", "opt", DIR_IN, PCLIENT_ID,
+);
+SYSCALL(NtOpenThreadTokenEx, NTSTATUS, 5,
+		"ThreadHandle", "", DIR_IN, HANDLE,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"OpenAsSelf", "", DIR_IN, BOOLEAN,
+		"HandleAttributes", "", DIR_IN, ULONG,
+		"TokenHandle", "", DIR_OUT, PHANDLE,
+);
+SYSCALL(NtOpenThreadToken, NTSTATUS, 4,
+		"ThreadHandle", "", DIR_IN, HANDLE,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"OpenAsSelf", "", DIR_IN, BOOLEAN,
+		"TokenHandle", "", DIR_OUT, PHANDLE,
+);
+SYSCALL(NtOpenTimer, NTSTATUS, 3,
+		"TimerHandle", "", DIR_OUT, PHANDLE,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"ObjectAttributes", "", DIR_IN, POBJECT_ATTRIBUTES,
+);
+SYSCALL(NtOpenTransactionManager, NTSTATUS, 6,
+		"TmHandle", "", DIR_OUT, PHANDLE,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"ObjectAttributes", "opt", DIR_IN, POBJECT_ATTRIBUTES,
+		"LogFileName", "opt", DIR_IN, PUNICODE_STRING,
+		"TmIdentity", "opt", DIR_IN, LPGUID,
+		"OpenOptions", "opt", DIR_IN, ULONG,
+);
+SYSCALL(NtOpenTransaction, NTSTATUS, 5,
+		"TransactionHandle", "", DIR_OUT, PHANDLE,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"ObjectAttributes", "", DIR_IN, POBJECT_ATTRIBUTES,
+		"Uow", "", DIR_IN, LPGUID,
+		"TmHandle", "opt", DIR_IN, HANDLE,
+);
+SYSCALL(NtPlugPlayControl, NTSTATUS, 3,
+		"PnPControlClass", "", DIR_IN, PLUGPLAY_CONTROL_CLASS,
+		"PnPControlData", "bcount(PnPControlDataLength)", DIR_INOUT, PVOID,
+		"PnPControlDataLength", "", DIR_IN, ULONG,
+);
+SYSCALL(NtPowerInformation, NTSTATUS, 5,
+		"InformationLevel", "", DIR_IN, POWER_INFORMATION_LEVEL,
+		"InputBuffer", "bcount_opt(InputBufferLength)", DIR_IN, PVOID,
+		"InputBufferLength", "", DIR_IN, ULONG,
+		"OutputBuffer", "bcount_opt(OutputBufferLength)", DIR_OUT, PVOID,
+		"OutputBufferLength", "", DIR_IN, ULONG,
+);
+SYSCALL(NtPrepareComplete, NTSTATUS, 2,
+		"EnlistmentHandle", "", DIR_IN, HANDLE,
+		"TmVirtualClock", "opt", DIR_IN, PLARGE_INTEGER,
+);
+SYSCALL(NtPrepareEnlistment, NTSTATUS, 2,
+		"EnlistmentHandle", "", DIR_IN, HANDLE,
+		"TmVirtualClock", "opt", DIR_IN, PLARGE_INTEGER,
+);
+SYSCALL(NtPrePrepareComplete, NTSTATUS, 2,
+		"EnlistmentHandle", "", DIR_IN, HANDLE,
+		"TmVirtualClock", "opt", DIR_IN, PLARGE_INTEGER,
+);
+SYSCALL(NtPrePrepareEnlistment, NTSTATUS, 2,
+		"EnlistmentHandle", "", DIR_IN, HANDLE,
+		"TmVirtualClock", "opt", DIR_IN, PLARGE_INTEGER,
+);
+SYSCALL(NtPrivilegeCheck, NTSTATUS, 3,
+		"ClientToken", "", DIR_IN, HANDLE,
+		"RequiredPrivileges", "", DIR_INOUT, PPRIVILEGE_SET,
+		"Result", "", DIR_OUT, PBOOLEAN,
+);
+SYSCALL(NtPrivilegedServiceAuditAlarm, NTSTATUS, 5,
+		"SubsystemName", "", DIR_IN, PUNICODE_STRING,
+		"ServiceName", "", DIR_IN, PUNICODE_STRING,
+		"ClientToken", "", DIR_IN, HANDLE,
+		"Privileges", "", DIR_IN, PPRIVILEGE_SET,
+		"AccessGranted", "", DIR_IN, BOOLEAN,
+);
+SYSCALL(NtPrivilegeObjectAuditAlarm, NTSTATUS, 6,
+		"SubsystemName", "", DIR_IN, PUNICODE_STRING,
+		"HandleId", "opt", DIR_IN, PVOID,
+		"ClientToken", "", DIR_IN, HANDLE,
+		"DesiredAccess", "", DIR_IN, ACCESS_MASK,
+		"Privileges", "", DIR_IN, PPRIVILEGE_SET,
+		"AccessGranted", "", DIR_IN, BOOLEAN,
+);
+SYSCALL(NtPropagationComplete, NTSTATUS, 4,
+		"ResourceManagerHandle", "", DIR_IN, HANDLE,
+		"RequestCookie", "", DIR_IN, ULONG,
+		"BufferLength", "", DIR_IN, ULONG,
+		"Buffer", "", DIR_IN, PVOID,
+);
+SYSCALL(NtPropagationFailed, NTSTATUS, 3,
+		"ResourceManagerHandle", "", DIR_IN, HANDLE,
+		"RequestCookie", "", DIR_IN, ULONG,
+		"PropStatus", "", DIR_IN, NTSTATUS,
+);
+SYSCALL(NtProtectVirtualMemory, NTSTATUS, 5,
+		"ProcessHandle", "", DIR_IN, HANDLE,
+		"*BaseAddress", "", DIR_INOUT, PVOID,
+		"RegionSize", "", DIR_INOUT, PSIZE_T,
+		"NewProtectWin32", "", DIR_IN, WIN32_PROTECTION_MASK,
+		"OldProtect", "", DIR_OUT, PULONG,
+);
+SYSCALL(NtPulseEvent, NTSTATUS, 2,
+		"EventHandle", "", DIR_IN, HANDLE,
+		"PreviousState", "opt", DIR_OUT, PLONG,
+);
+SYSCALL(NtQueryAttributesFile, NTSTATUS, 2,
+		"ObjectAttributes", "", DIR_IN, POBJECT_ATTRIBUTES,
+		"FileInformation", "", DIR_OUT, PFILE_BASIC_INFORMATION,
+);
+SYSCALL(NtQueryBootEntryOrder, NTSTATUS, 2,
+		"Ids", "ecount_opt(*Count)", DIR_OUT, PULONG,
+		"Count", "", DIR_INOUT, PULONG,
+);
+SYSCALL(NtQueryBootOptions, NTSTATUS, 2,
+		"BootOptions", "bcount_opt(*BootOptionsLength)", DIR_OUT, PBOOT_OPTIONS,
+		"BootOptionsLength", "", DIR_INOUT, PULONG,
+);
+SYSCALL(NtQueryDebugFilterState, NTSTATUS, 2,
+		"ComponentId", "", DIR_IN, ULONG,
+		"Level", "", DIR_IN, ULONG,
+);
+SYSCALL(NtQueryDefaultLocale, NTSTATUS, 2,
+		"UserProfile", "", DIR_IN, BOOLEAN,
+		"DefaultLocaleId", "", DIR_OUT, PLCID,
+);
+SYSCALL(NtQueryDefaultUILanguage, NTSTATUS, 1,
+		"*DefaultUILanguageId", "", DIR_OUT, LANGID,
+);
+SYSCALL(NtQueryDirectoryFile, NTSTATUS, 11,
+		"FileHandle", "", DIR_IN, HANDLE,
+		"Event", "opt", DIR_IN, HANDLE,
+		"ApcRoutine", "opt", DIR_IN, PIO_APC_ROUTINE,
+		"ApcContext", "opt", DIR_IN, PVOID,
+		"IoStatusBlock", "", DIR_OUT, PIO_STATUS_BLOCK,
+		"FileInformation", "bcount(Length)", DIR_OUT, PVOID,
+		"Length", "", DIR_IN, ULONG,
+		"FileInformationClass", "", DIR_IN, FILE_INFORMATION_CLASS,
+		"ReturnSingleEntry", "", DIR_IN, BOOLEAN,
+		"FileName", "", DIR_IN, PUNICODE_STRING,
+		"RestartScan", "", DIR_IN, BOOLEAN,
+);
+SYSCALL(NtQueryDirectoryObject, NTSTATUS, 7,
+		"DirectoryHandle", "", DIR_IN, HANDLE,
+		"Buffer", "bcount_opt(Length)", DIR_OUT, PVOID,
+		"Length", "", DIR_IN, ULONG,
+		"ReturnSingleEntry", "", DIR_IN, BOOLEAN,
+		"RestartScan", "", DIR_IN, BOOLEAN,
+		"Context", "", DIR_INOUT, PULONG,
+		"ReturnLength", "opt", DIR_OUT, PULONG,
+);
+SYSCALL(NtQueryDriverEntryOrder, NTSTATUS, 2,
+		"Ids", "ecount(*Count)", DIR_OUT, PULONG,
+		"Count", "", DIR_INOUT, PULONG,
+);
+SYSCALL(NtQueryEaFile, NTSTATUS, 9,
+		"FileHandle", "", DIR_IN, HANDLE,
+		"IoStatusBlock", "", DIR_OUT, PIO_STATUS_BLOCK,
+		"Buffer", "bcount(Length)", DIR_OUT, PVOID,
+		"Length", "", DIR_IN, ULONG,
+		"ReturnSingleEntry", "", DIR_IN, BOOLEAN,
+		"EaList", "bcount_opt(EaListLength)", DIR_IN, PVOID,
+		"EaListLength", "", DIR_IN, ULONG,
+		"EaIndex", "opt", DIR_IN, PULONG,
+		"RestartScan", "", DIR_IN, BOOLEAN,
+);
+SYSCALL(NtQueryEvent, NTSTATUS, 5,
+		"EventHandle", "", DIR_IN, HANDLE,
+		"EventInformationClass", "", DIR_IN, EVENT_INFORMATION_CLASS,
+		"EventInformation", "bcount(EventInformationLength)", DIR_OUT, PVOID,
+		"EventInformationLength", "", DIR_IN, ULONG,
+		"ReturnLength", "opt", DIR_OUT, PULONG,
+);
+SYSCALL(NtQueryFullAttributesFile, NTSTATUS, 2,
+		"ObjectAttributes", "", DIR_IN, POBJECT_ATTRIBUTES,
+		"FileInformation", "", DIR_OUT, PFILE_NETWORK_OPEN_INFORMATION,
+);
+SYSCALL(NtQueryInformationAtom, NTSTATUS, 5,
+		"Atom", "", DIR_IN, RTL_ATOM,
+		"InformationClass", "", DIR_IN, ATOM_INFORMATION_CLASS,
+		"AtomInformation", "bcount(AtomInformationLength)", DIR_OUT, PVOID,
+		"AtomInformationLength", "", DIR_IN, ULONG,
+		"ReturnLength", "opt", DIR_OUT, PULONG,
+);
+SYSCALL(NtQueryInformationEnlistment, NTSTATUS, 5,
+		"EnlistmentHandle", "", DIR_IN, HANDLE,
+		"EnlistmentInformationClass", "", DIR_IN, ENLISTMENT_INFORMATION_CLASS,
+		"EnlistmentInformation", "bcount(EnlistmentInformationLength)", DIR_OUT, PVOID,
+		"EnlistmentInformationLength", "", DIR_IN, ULONG,
+		"ReturnLength", "opt", DIR_OUT, PULONG,
+);
+SYSCALL(NtQueryInformationFile, NTSTATUS, 5,
+		"FileHandle", "", DIR_IN, HANDLE,
+		"IoStatusBlock", "", DIR_OUT, PIO_STATUS_BLOCK,
+		"FileInformation", "bcount(Length)", DIR_OUT, PVOID,
+		"Length", "", DIR_IN, ULONG,
+		"FileInformationClass", "", DIR_IN, FILE_INFORMATION_CLASS,
+);
+SYSCALL(NtQueryInformationJobObject, NTSTATUS, 5,
+		"JobHandle", "opt", DIR_IN, HANDLE,
+		"JobObjectInformationClass", "", DIR_IN, JOBOBJECTINFOCLASS,
+		"JobObjectInformation", "bcount(JobObjectInformationLength)", DIR_OUT, PVOID,
+		"JobObjectInformationLength", "", DIR_IN, ULONG,
+		"ReturnLength", "opt", DIR_OUT, PULONG,
+);
+SYSCALL(NtQueryInformationPort, NTSTATUS, 5,
+		"PortHandle", "", DIR_IN, HANDLE,
+		"PortInformationClass", "", DIR_IN, PORT_INFORMATION_CLASS,
+		"PortInformation", "bcount(Length)", DIR_OUT, PVOID,
+		"Length", "", DIR_IN, ULONG,
+		"ReturnLength", "opt", DIR_OUT, PULONG,
+);
+SYSCALL(NtQueryInformationProcess, NTSTATUS, 5,
+		"ProcessHandle", "", DIR_IN, HANDLE,
+		"ProcessInformationClass", "", DIR_IN, PROCESSINFOCLASS,
+		"ProcessInformation", "bcount(ProcessInformationLength)", DIR_OUT, PVOID,
+		"ProcessInformationLength", "", DIR_IN, ULONG,
+		"ReturnLength", "opt", DIR_OUT, PULONG,
+);
+SYSCALL(NtQueryInformationResourceManager, NTSTATUS, 5,
+		"ResourceManagerHandle", "", DIR_IN, HANDLE,
+		"ResourceManagerInformationClass", "", DIR_IN, RESOURCEMANAGER_INFORMATION_CLASS,
+		"ResourceManagerInformation", "bcount(ResourceManagerInformationLength)", DIR_OUT, PVOID,
+		"ResourceManagerInformationLength", "", DIR_IN, ULONG,
+		"ReturnLength", "opt", DIR_OUT, PULONG,
+);
+SYSCALL(NtQueryInformationThread, NTSTATUS, 5,
+		"ThreadHandle", "", DIR_IN, HANDLE,
+		"ThreadInformationClass", "", DIR_IN, THREADINFOCLASS,
+		"ThreadInformation", "bcount(ThreadInformationLength)", DIR_OUT, PVOID,
+		"ThreadInformationLength", "", DIR_IN, ULONG,
+		"ReturnLength", "opt", DIR_OUT, PULONG,
+);
+SYSCALL(NtQueryInformationToken, NTSTATUS, 5,
+		"TokenHandle", "", DIR_IN, HANDLE,
+		"TokenInformationClass", "", DIR_IN, TOKEN_INFORMATION_CLASS,
+		"TokenInformation", "bcount_part_opt(TokenInformationLength,*ReturnLength)", DIR_OUT, PVOID,
+		"TokenInformationLength", "", DIR_IN, ULONG,
+		"ReturnLength", "", DIR_OUT, PULONG,
+);
+SYSCALL(NtQueryInformationTransaction, NTSTATUS, 5,
+		"TransactionHandle", "", DIR_IN, HANDLE,
+		"TransactionInformationClass", "", DIR_IN, TRANSACTION_INFORMATION_CLASS,
+		"TransactionInformation", "bcount(TransactionInformationLength)", DIR_OUT, PVOID,
+		"TransactionInformationLength", "", DIR_IN, ULONG,
+		"ReturnLength", "opt", DIR_OUT, PULONG,
+);
+SYSCALL(NtQueryInformationTransactionManager, NTSTATUS, 5,
+		"TransactionManagerHandle", "", DIR_IN, HANDLE,
+		"TransactionManagerInformationClass", "", DIR_IN, TRANSACTIONMANAGER_INFORMATION_CLASS,
+		"TransactionManagerInformation", "bcount(TransactionManagerInformationLength)", DIR_OUT, PVOID,
+		"TransactionManagerInformationLength", "", DIR_IN, ULONG,
+		"ReturnLength", "opt", DIR_OUT, PULONG,
+);
+SYSCALL(NtQueryInformationWorkerFactory, NTSTATUS, 5,
+		"WorkerFactoryHandle", "", DIR_IN, HANDLE,
+		"WorkerFactoryInformationClass", "", DIR_IN, WORKERFACTORYINFOCLASS,
+		"WorkerFactoryInformation", "bcount(WorkerFactoryInformationLength)", DIR_OUT, PVOID,
+		"WorkerFactoryInformationLength", "", DIR_IN, ULONG,
+		"ReturnLength", "opt", DIR_OUT, PULONG,
+);
+SYSCALL(NtQueryInstallUILanguage, NTSTATUS, 1,
+		"*InstallUILanguageId", "", DIR_OUT, LANGID,
+);
+SYSCALL(NtQueryIntervalProfile, NTSTATUS, 2,
+		"ProfileSource", "", DIR_IN, KPROFILE_SOURCE,
+		"Interval", "", DIR_OUT, PULONG,
+);
+SYSCALL(NtQueryIoCompletion, NTSTATUS, 5,
+		"IoCompletionHandle", "", DIR_IN, HANDLE,
+		"IoCompletionInformationClass", "", DIR_IN, IO_COMPLETION_INFORMATION_CLASS,
+		"IoCompletionInformation", "bcount(IoCompletionInformationLength)", DIR_OUT, PVOID,
+		"IoCompletionInformationLength", "", DIR_IN, ULONG,
+		"ReturnLength", "opt", DIR_OUT, PULONG,
+);
+SYSCALL(NtQueryKey, NTSTATUS, 5,
+		"KeyHandle", "", DIR_IN, HANDLE,
+		"KeyInformationClass", "", DIR_IN, KEY_INFORMATION_CLASS,
+		"KeyInformation", "bcount_opt(Length)", DIR_OUT, PVOID,
+		"Length", "", DIR_IN, ULONG,
+		"ResultLength", "", DIR_OUT, PULONG,
+);
+SYSCALL(NtQueryLicenseValue, NTSTATUS, 5,
+		"Name", "", DIR_IN, PUNICODE_STRING,
+		"Type", "opt", DIR_OUT, PULONG,
+		"Buffer", "bcount(ReturnedLength)", DIR_OUT, PVOID,
+		"Length", "", DIR_IN, ULONG,
+		"ReturnedLength", "", DIR_OUT, PULONG,
+);
+SYSCALL(NtQueryMultipleValueKey, NTSTATUS, 6,
+		"KeyHandle", "", DIR_IN, HANDLE,
+		"ValueEntries", "ecount(EntryCount)", DIR_INOUT, PKEY_VALUE_ENTRY,
+		"EntryCount", "", DIR_IN, ULONG,
+		"ValueBuffer", "bcount(*BufferLength)", DIR_OUT, PVOID,
+		"BufferLength", "", DIR_INOUT, PULONG,
+		"RequiredBufferLength", "opt", DIR_OUT, PULONG,
+);
+SYSCALL(NtQueryMutant, NTSTATUS, 5,
+		"MutantHandle", "", DIR_IN, HANDLE,
+		"MutantInformationClass", "", DIR_IN, MUTANT_INFORMATION_CLASS,
+		"MutantInformation", "bcount(MutantInformationLength)", DIR_OUT, PVOID,
+		"MutantInformationLength", "", DIR_IN, ULONG,
+		"ReturnLength", "opt", DIR_OUT, PULONG,
+);
+SYSCALL(NtQueryObject, NTSTATUS, 5,
+		"Handle", "", DIR_IN, HANDLE,
+		"ObjectInformationClass", "", DIR_IN, OBJECT_INFORMATION_CLASS,
+		"ObjectInformation", "bcount_opt(ObjectInformationLength)", DIR_OUT, PVOID,
+		"ObjectInformationLength", "", DIR_IN, ULONG,
+		"ReturnLength", "opt", DIR_OUT, PULONG,
+);
+SYSCALL(NtQueryOpenSubKeysEx, NTSTATUS, 4,
+		"TargetKey", "", DIR_IN, POBJECT_ATTRIBUTES,
+		"BufferLength", "", DIR_IN, ULONG,
+		"Buffer", "bcount(BufferLength)", DIR_OUT, PVOID,
+		"RequiredSize", "", DIR_OUT, PULONG,
+);
+SYSCALL(NtQueryOpenSubKeys, NTSTATUS, 2,
+		"TargetKey", "", DIR_IN, POBJECT_ATTRIBUTES,
+		"HandleCount", "", DIR_OUT, PULONG,
+);
+SYSCALL(NtQueryPerformanceCounter, NTSTATUS, 2,
+		"PerformanceCounter", "", DIR_OUT, PLARGE_INTEGER,
+		"PerformanceFrequency", "opt", DIR_OUT, PLARGE_INTEGER,
+);
+SYSCALL(NtQueryQuotaInformationFile, NTSTATUS, 9,
+		"FileHandle", "", DIR_IN, HANDLE,
+		"IoStatusBlock", "", DIR_OUT, PIO_STATUS_BLOCK,
+		"Buffer", "bcount(Length)", DIR_OUT, PVOID,
+		"Length", "", DIR_IN, ULONG,
+		"ReturnSingleEntry", "", DIR_IN, BOOLEAN,
+		"SidList", "bcount_opt(SidListLength)", DIR_IN, PVOID,
+		"SidListLength", "", DIR_IN, ULONG,
+		"StartSid", "opt", DIR_IN, PULONG,
+		"RestartScan", "", DIR_IN, BOOLEAN,
+);
+SYSCALL(NtQuerySection, NTSTATUS, 5,
+		"SectionHandle", "", DIR_IN, HANDLE,
+		"SectionInformationClass", "", DIR_IN, SECTION_INFORMATION_CLASS,
+		"SectionInformation", "bcount(SectionInformationLength)", DIR_OUT, PVOID,
+		"SectionInformationLength", "", DIR_IN, SIZE_T,
+		"ReturnLength", "opt", DIR_OUT, PSIZE_T,
+);
+SYSCALL(NtQuerySecurityAttributesToken, NTSTATUS, 6,
+		"TokenHandle", "", DIR_IN, HANDLE,
+		"Attributes", "ecount_opt(NumberOfAttributes)", DIR_IN, PUNICODE_STRING,
+		"NumberOfAttributes", "", DIR_IN, ULONG,
+		"Buffer", "bcount(Length)", DIR_OUT, PVOID,
+		"Length", "", DIR_IN, ULONG,
+		"ReturnLength", "", DIR_OUT, PULONG,
+);
+SYSCALL(NtQuerySecurityObject, NTSTATUS, 5,
+		"Handle", "", DIR_IN, HANDLE,
+		"SecurityInformation", "", DIR_IN, SECURITY_INFORMATION,
+		"SecurityDescriptor", "bcount_opt(Length)", DIR_OUT, PSECURITY_DESCRIPTOR,
+		"Length", "", DIR_IN, ULONG,
+		"LengthNeeded", "", DIR_OUT, PULONG,
+);
+SYSCALL(NtQuerySemaphore, NTSTATUS, 5,
+		"SemaphoreHandle", "", DIR_IN, HANDLE,
+		"SemaphoreInformationClass", "", DIR_IN, SEMAPHORE_INFORMATION_CLASS,
+		"SemaphoreInformation", "bcount(SemaphoreInformationLength)", DIR_OUT, PVOID,
+		"SemaphoreInformationLength", "", DIR_IN, ULONG,
+		"ReturnLength", "opt", DIR_OUT, PULONG,
+);
+SYSCALL(NtQuerySymbolicLinkObject, NTSTATUS, 3,
+		"LinkHandle", "", DIR_IN, HANDLE,
+		"LinkTarget", "", DIR_INOUT, PUNICODE_STRING,
+		"ReturnedLength", "opt", DIR_OUT, PULONG,
+);
+SYSCALL(NtQuerySystemEnvironmentValueEx, NTSTATUS, 5,
+		"VariableName", "", DIR_IN, PUNICODE_STRING,
+		"VendorGuid", "", DIR_IN, LPGUID,
+		"Value", "bcount_opt(*ValueLength)", DIR_OUT, PVOID,
+		"ValueLength", "", DIR_INOUT, PULONG,
+		"Attributes", "opt", DIR_OUT, PULONG,
+);
+SYSCALL(NtQuerySystemEnvironmentValue, NTSTATUS, 4,
+		"VariableName", "", DIR_IN, PUNICODE_STRING,
+		"VariableValue", "bcount(ValueLength)", DIR_OUT, PWSTR,
+		"ValueLength", "", DIR_IN, USHORT,
+		"ReturnLength", "opt", DIR_OUT, PUSHORT,
+);
+SYSCALL(NtQuerySystemInformationEx, NTSTATUS, 6,
+		"SystemInformationClass", "", DIR_IN, SYSTEM_INFORMATION_CLASS,
+		"QueryInformation", "bcount(QueryInformationLength)", DIR_IN, PVOID,
+		"QueryInformationLength", "", DIR_IN, ULONG,
+		"SystemInformation", "bcount_opt(SystemInformationLength)", DIR_OUT, PVOID,
+		"SystemInformationLength", "", DIR_IN, ULONG,
+		"ReturnLength", "opt", DIR_OUT, PULONG,
+);
+SYSCALL(NtQuerySystemInformation, NTSTATUS, 4,
+		"SystemInformationClass", "", DIR_IN, SYSTEM_INFORMATION_CLASS,
+		"SystemInformation", "bcount_opt(SystemInformationLength)", DIR_OUT, PVOID,
+		"SystemInformationLength", "", DIR_IN, ULONG,
+		"ReturnLength", "opt", DIR_OUT, PULONG,
+);
+SYSCALL(NtQuerySystemTime, NTSTATUS, 1,
+		"SystemTime", "", DIR_OUT, PLARGE_INTEGER,
+);
+SYSCALL(NtQueryTimer, NTSTATUS, 5,
+		"TimerHandle", "", DIR_IN, HANDLE,
+		"TimerInformationClass", "", DIR_IN, TIMER_INFORMATION_CLASS,
+		"TimerInformation", "bcount(TimerInformationLength)", DIR_OUT, PVOID,
+		"TimerInformationLength", "", DIR_IN, ULONG,
+		"ReturnLength", "opt", DIR_OUT, PULONG,
+);
+SYSCALL(NtQueryTimerResolution, NTSTATUS, 3,
+		"MaximumTime", "", DIR_OUT, PULONG,
+		"MinimumTime", "", DIR_OUT, PULONG,
+		"CurrentTime", "", DIR_OUT, PULONG,
+);
+SYSCALL(NtQueryValueKey, NTSTATUS, 6,
+		"KeyHandle", "", DIR_IN, HANDLE,
+		"ValueName", "", DIR_IN, PUNICODE_STRING,
+		"KeyValueInformationClass", "", DIR_IN, KEY_VALUE_INFORMATION_CLASS,
+		"KeyValueInformation", "bcount_opt(Length)", DIR_OUT, PVOID,
+		"Length", "", DIR_IN, ULONG,
+		"ResultLength", "", DIR_OUT, PULONG,
+);
+SYSCALL(NtQueryVirtualMemory, NTSTATUS, 6,
+		"ProcessHandle", "", DIR_IN, HANDLE,
+		"BaseAddress", "", DIR_IN, PVOID,
+		"MemoryInformationClass", "", DIR_IN, MEMORY_INFORMATION_CLASS,
+		"MemoryInformation", "bcount(MemoryInformationLength)", DIR_OUT, PVOID,
+		"MemoryInformationLength", "", DIR_IN, SIZE_T,
+		"ReturnLength", "opt", DIR_OUT, PSIZE_T,
+);
+SYSCALL(NtQueryVolumeInformationFile, NTSTATUS, 5,
+		"FileHandle", "", DIR_IN, HANDLE,
+		"IoStatusBlock", "", DIR_OUT, PIO_STATUS_BLOCK,
+		"FsInformation", "bcount(Length)", DIR_OUT, PVOID,
+		"Length", "", DIR_IN, ULONG,
+		"FsInformationClass", "", DIR_IN, FS_INFORMATION_CLASS,
+);
+SYSCALL(NtQueueApcThreadEx, NTSTATUS, 6,
+		"ThreadHandle", "", DIR_IN, HANDLE,
+		"UserApcReserveHandle", "opt", DIR_IN, HANDLE,
+		"ApcRoutine", "", DIR_IN, PPS_APC_ROUTINE,
+		"ApcArgument1", "opt", DIR_IN, PVOID,
+		"ApcArgument2", "opt", DIR_IN, PVOID,
+		"ApcArgument3", "opt", DIR_IN, PVOID,
+);
+SYSCALL(NtQueueApcThread, NTSTATUS, 5,
+		"ThreadHandle", "", DIR_IN, HANDLE,
+		"ApcRoutine", "", DIR_IN, PPS_APC_ROUTINE,
+		"ApcArgument1", "opt", DIR_IN, PVOID,
+		"ApcArgument2", "opt", DIR_IN, PVOID,
+		"ApcArgument3", "opt", DIR_IN, PVOID,
+);
+SYSCALL(NtRaiseException, NTSTATUS, 3,
+		"ExceptionRecord", "", DIR_OUT, PEXCEPTION_RECORD,
+		"ContextRecord", "", DIR_OUT, PCONTEXT,
+		"FirstChance", "", DIR_OUT, BOOLEAN,
+);
+SYSCALL(NtRaiseHardError, NTSTATUS, 6,
+		"ErrorStatus", "", DIR_IN, NTSTATUS,
+		"NumberOfParameters", "", DIR_IN, ULONG,
+		"UnicodeStringParameterMask", "", DIR_IN, ULONG,
+		"Parameters", "ecount(NumberOfParameters)", DIR_IN, PULONG_PTR,
+		"ValidResponseOptions", "", DIR_IN, ULONG,
+		"Response", "", DIR_OUT, PULONG,
+);
+SYSCALL(NtReadFile, NTSTATUS, 9,
+		"FileHandle", "", DIR_IN, HANDLE,
+		"Event", "opt", DIR_IN, HANDLE,
+		"ApcRoutine", "opt", DIR_IN, PIO_APC_ROUTINE,
+		"ApcContext", "opt", DIR_IN, PVOID,
+		"IoStatusBlock", "", DIR_OUT, PIO_STATUS_BLOCK,
+		"Buffer", "bcount(Length)", DIR_OUT, PVOID,
+		"Length", "", DIR_IN, ULONG,
+		"ByteOffset", "opt", DIR_IN, PLARGE_INTEGER,
+		"Key", "opt", DIR_IN, PULONG,
+);
+SYSCALL(NtReadFileScatter, NTSTATUS, 9,
+		"FileHandle", "", DIR_IN, HANDLE,
+		"Event", "opt", DIR_IN, HANDLE,
+		"ApcRoutine", "opt", DIR_IN, PIO_APC_ROUTINE,
+		"ApcContext", "opt", DIR_IN, PVOID,
+		"IoStatusBlock", "", DIR_OUT, PIO_STATUS_BLOCK,
+		"SegmentArray", "", DIR_IN, PFILE_SEGMENT_ELEMENT,
+		"Length", "", DIR_IN, ULONG,
+		"ByteOffset", "opt", DIR_IN, PLARGE_INTEGER,
+		"Key", "opt", DIR_IN, PULONG,
+);
+SYSCALL(NtReadOnlyEnlistment, NTSTATUS, 2,
+		"EnlistmentHandle", "", DIR_IN, HANDLE,
+		"TmVirtualClock", "opt", DIR_IN, PLARGE_INTEGER,
+);
+SYSCALL(NtReadRequestData, NTSTATUS, 6,
+		"PortHandle", "", DIR_IN, HANDLE,
+		"Message", "", DIR_IN, PPORT_MESSAGE,
+		"DataEntryIndex", "", DIR_IN, ULONG,
+		"Buffer", "bcount(BufferSize)", DIR_OUT, PVOID,
+		"BufferSize", "", DIR_IN, SIZE_T,
+		"NumberOfBytesRead", "opt", DIR_OUT, PSIZE_T,
+);
+SYSCALL(NtReadVirtualMemory, NTSTATUS, 5,
+		"ProcessHandle", "", DIR_IN, HANDLE,
+		"BaseAddress", "opt", DIR_IN, PVOID,
+		"Buffer", "bcount(BufferSize)", DIR_OUT, PVOID,
+		"BufferSize", "", DIR_IN, SIZE_T,
+		"NumberOfBytesRead", "opt", DIR_OUT, PSIZE_T,
+);
+SYSCALL(NtRecoverEnlistment, NTSTATUS, 2,
+		"EnlistmentHandle", "", DIR_IN, HANDLE,
+		"EnlistmentKey", "opt", DIR_IN, PVOID,
+);
+SYSCALL(NtRecoverResourceManager, NTSTATUS, 1,
+		"ResourceManagerHandle", "", DIR_IN, HANDLE,
+);
+SYSCALL(NtRecoverTransactionManager, NTSTATUS, 1,
+		"TransactionManagerHandle", "", DIR_IN, HANDLE,
+);
+SYSCALL(NtRegisterProtocolAddressInformation, NTSTATUS, 5,
+		"ResourceManager", "", DIR_IN, HANDLE,
+		"ProtocolId", "", DIR_IN, PCRM_PROTOCOL_ID,
+		"ProtocolInformationSize", "", DIR_IN, ULONG,
+		"ProtocolInformation", "", DIR_IN, PVOID,
+		"CreateOptions", "opt", DIR_IN, ULONG,
+);
+SYSCALL(NtRegisterThreadTerminatePort, NTSTATUS, 1,
+		"PortHandle", "", DIR_IN, HANDLE,
+);
+SYSCALL(NtReleaseKeyedEvent, NTSTATUS, 4,
+		"KeyedEventHandle", "", DIR_IN, HANDLE,
+		"KeyValue", "", DIR_IN, PVOID,
+		"Alertable", "", DIR_IN, BOOLEAN,
+		"Timeout", "opt", DIR_IN, PLARGE_INTEGER,
+);
+SYSCALL(NtReleaseMutant, NTSTATUS, 2,
+		"MutantHandle", "", DIR_IN, HANDLE,
+		"PreviousCount", "opt", DIR_OUT, PLONG,
+);
+SYSCALL(NtReleaseSemaphore, NTSTATUS, 3,
+		"SemaphoreHandle", "", DIR_IN, HANDLE,
+		"ReleaseCount", "", DIR_IN, LONG,
+		"PreviousCount", "opt", DIR_OUT, PLONG,
+);
+SYSCALL(NtReleaseWorkerFactoryWorker, NTSTATUS, 1,
+		"WorkerFactoryHandle", "", DIR_IN, HANDLE,
+);
+SYSCALL(NtRemoveIoCompletionEx, NTSTATUS, 6,
+		"IoCompletionHandle", "", DIR_IN, HANDLE,
+		"IoCompletionInformation", "ecount(Count)", DIR_OUT, PFILE_IO_COMPLETION_INFORMATION,
+		"Count", "", DIR_IN, ULONG,
+		"NumEntriesRemoved", "", DIR_OUT, PULONG,
+		"Timeout", "opt", DIR_IN, PLARGE_INTEGER,
+		"Alertable", "", DIR_IN, BOOLEAN,
+);
+SYSCALL(NtRemoveIoCompletion, NTSTATUS, 5,
+		"IoCompletionHandle", "", DIR_IN, HANDLE,
+		"*KeyContext", "", DIR_OUT, PVOID,
+		"*ApcContext", "", DIR_OUT, PVOID,
+		"IoStatusBlock", "", DIR_OUT, PIO_STATUS_BLOCK,
+		"Timeout", "opt", DIR_IN, PLARGE_INTEGER,
+);
+SYSCALL(NtRemoveProcessDebug, NTSTATUS, 2,
+		"ProcessHandle", "", DIR_OUT, HANDLE,
+		"DebugObjectHandle", "", DIR_OUT, HANDLE,
+);
+SYSCALL(NtRenameKey, NTSTATUS, 2,
+		"KeyHandle", "", DIR_IN, HANDLE,
+		"NewName", "", DIR_IN, PUNICODE_STRING,
+);
+SYSCALL(NtRenameTransactionManager, NTSTATUS, 2,
+		"LogFileName", "", DIR_IN, PUNICODE_STRING,
+		"ExistingTransactionManagerGuid", "", DIR_IN, LPGUID,
+);
+SYSCALL(NtReplaceKey, NTSTATUS, 3,
+		"NewFile", "", DIR_IN, POBJECT_ATTRIBUTES,
+		"TargetHandle", "", DIR_IN, HANDLE,
+		"OldFile", "", DIR_IN, POBJECT_ATTRIBUTES,
+);
+SYSCALL(NtReplacePartitionUnit, NTSTATUS, 3,
+		"TargetInstancePath", "", DIR_IN, PUNICODE_STRING,
+		"SpareInstancePath", "", DIR_IN, PUNICODE_STRING,
+		"Flags", "", DIR_IN, ULONG,
+);
+SYSCALL(NtReplyPort, NTSTATUS, 2,
+		"PortHandle", "", DIR_IN, HANDLE,
+		"ReplyMessage", "", DIR_IN, PPORT_MESSAGE,
+);
+SYSCALL(NtReplyWaitReceivePortEx, NTSTATUS, 5,
+		"PortHandle", "", DIR_IN, HANDLE,
+		"*PortContext", "opt", DIR_OUT, PVOID,
+		"ReplyMessage", "opt", DIR_IN, PPORT_MESSAGE,
+		"ReceiveMessage", "", DIR_OUT, PPORT_MESSAGE,
+		"Timeout", "opt", DIR_IN, PLARGE_INTEGER,
+);
+SYSCALL(NtReplyWaitReceivePort, NTSTATUS, 4,
+		"PortHandle", "", DIR_IN, HANDLE,
+		"*PortContext", "opt", DIR_OUT, PVOID,
+		"ReplyMessage", "opt", DIR_IN, PPORT_MESSAGE,
+		"ReceiveMessage", "", DIR_OUT, PPORT_MESSAGE,
+);
+SYSCALL(NtReplyWaitReplyPort, NTSTATUS, 2,
+		"PortHandle", "", DIR_IN, HANDLE,
+		"ReplyMessage", "", DIR_INOUT, PPORT_MESSAGE,
+);
+SYSCALL(NtRequestPort, NTSTATUS, 2,
+		"PortHandle", "", DIR_IN, HANDLE,
+		"RequestMessage", "", DIR_IN, PPORT_MESSAGE,
+);
+SYSCALL(NtRequestWaitReplyPort, NTSTATUS, 3,
+		"PortHandle", "", DIR_IN, HANDLE,
+		"RequestMessage", "", DIR_IN, PPORT_MESSAGE,
+		"ReplyMessage", "", DIR_OUT, PPORT_MESSAGE,
+);
+SYSCALL(NtResetEvent, NTSTATUS, 2,
+		"EventHandle", "", DIR_IN, HANDLE,
+		"PreviousState", "opt", DIR_OUT, PLONG,
+);
+SYSCALL(NtResetWriteWatch, NTSTATUS, 3,
+		"ProcessHandle", "", DIR_IN, HANDLE,
+		"BaseAddress", "", DIR_IN, PVOID,
+		"RegionSize", "", DIR_IN, SIZE_T,
+);
+SYSCALL(NtRestoreKey, NTSTATUS, 3,
+		"KeyHandle", "", DIR_IN, HANDLE,
+		"FileHandle", "", DIR_IN, HANDLE,
+		"Flags", "", DIR_IN, ULONG,
+);
+SYSCALL(NtResumeProcess, NTSTATUS, 1,
+		"ProcessHandle", "", DIR_IN, HANDLE,
+);
+SYSCALL(NtResumeThread, NTSTATUS, 2,
+		"ThreadHandle", "", DIR_IN, HANDLE,
+		"PreviousSuspendCount", "opt", DIR_OUT, PULONG,
+);
+SYSCALL(NtRollbackComplete, NTSTATUS, 2,
+		"EnlistmentHandle", "", DIR_IN, HANDLE,
+		"TmVirtualClock", "opt", DIR_IN, PLARGE_INTEGER,
+);
+SYSCALL(NtRollbackEnlistment, NTSTATUS, 2,
+		"EnlistmentHandle", "", DIR_IN, HANDLE,
+		"TmVirtualClock", "opt", DIR_IN, PLARGE_INTEGER,
+);
+SYSCALL(NtRollbackTransaction, NTSTATUS, 2,
+		"TransactionHandle", "", DIR_IN, HANDLE,
+		"Wait", "", DIR_IN, BOOLEAN,
+);
+SYSCALL(NtRollforwardTransactionManager, NTSTATUS, 2,
+		"TransactionManagerHandle", "", DIR_IN, HANDLE,
+		"TmVirtualClock", "opt", DIR_IN, PLARGE_INTEGER,
+);
+SYSCALL(NtSaveKeyEx, NTSTATUS, 3,
+		"KeyHandle", "", DIR_IN, HANDLE,
+		"FileHandle", "", DIR_IN, HANDLE,
+		"Format", "", DIR_IN, ULONG,
+);
+SYSCALL(NtSaveKey, NTSTATUS, 2,
+		"KeyHandle", "", DIR_IN, HANDLE,
+		"FileHandle", "", DIR_IN, HANDLE,
+);
+SYSCALL(NtSaveMergedKeys, NTSTATUS, 3,
+		"HighPrecedenceKeyHandle", "", DIR_IN, HANDLE,
+		"LowPrecedenceKeyHandle", "", DIR_IN, HANDLE,
+		"FileHandle", "", DIR_IN, HANDLE,
+);
+SYSCALL(NtSecureConnectPort, NTSTATUS, 9,
+		"PortHandle", "", DIR_OUT, PHANDLE,
+		"PortName", "", DIR_IN, PUNICODE_STRING,
+		"SecurityQos", "", DIR_IN, PSECURITY_QUALITY_OF_SERVICE,
+		"ClientView", "opt", DIR_INOUT, PPORT_VIEW,
+		"RequiredServerSid", "opt", DIR_IN, PSID,
+		"ServerView", "opt", DIR_INOUT, PREMOTE_PORT_VIEW,
+		"MaxMessageLength", "opt", DIR_OUT, PULONG,
+		"ConnectionInformation", "opt", DIR_INOUT, PVOID,
+		"ConnectionInformationLength", "opt", DIR_INOUT, PULONG,
+);
+SYSCALL(NtSetBootEntryOrder, NTSTATUS, 2,
+		"Ids", "ecount(Count)", DIR_IN, PULONG,
+		"Count", "", DIR_IN, ULONG,
+);
+SYSCALL(NtSetBootOptions, NTSTATUS, 2,
+		"BootOptions", "", DIR_IN, PBOOT_OPTIONS,
+		"FieldsToChange", "", DIR_IN, ULONG,
+);
+SYSCALL(NtSetContextThread, NTSTATUS, 2,
+		"ThreadHandle", "", DIR_IN, HANDLE,
+		"ThreadContext", "", DIR_IN, PCONTEXT,
+);
+SYSCALL(NtSetDebugFilterState, NTSTATUS, 3,
+		"ComponentId", "", DIR_IN, ULONG,
+		"Level", "", DIR_IN, ULONG,
+		"State", "", DIR_IN, BOOLEAN,
+);
+SYSCALL(NtSetDefaultHardErrorPort, NTSTATUS, 1,
+		"DefaultHardErrorPort", "", DIR_IN, HANDLE,
+);
+SYSCALL(NtSetDefaultLocale, NTSTATUS, 2,
+		"UserProfile", "", DIR_IN, BOOLEAN,
+		"DefaultLocaleId", "", DIR_IN, LCID,
+);
+SYSCALL(NtSetDefaultUILanguage, NTSTATUS, 1,
+		"DefaultUILanguageId", "", DIR_IN, LANGID,
+);
+SYSCALL(NtSetDriverEntryOrder, NTSTATUS, 2,
+		"Ids", "ecount(Count)", DIR_IN, PULONG,
+		"Count", "", DIR_IN, ULONG,
+);
+SYSCALL(NtSetEaFile, NTSTATUS, 4,
+		"FileHandle", "", DIR_IN, HANDLE,
+		"IoStatusBlock", "", DIR_OUT, PIO_STATUS_BLOCK,
+		"Buffer", "bcount(Length)", DIR_IN, PVOID,
+		"Length", "", DIR_IN, ULONG,
+);
+SYSCALL(NtSetEventBoostPriority, NTSTATUS, 1,
+		"EventHandle", "", DIR_IN, HANDLE,
+);
+SYSCALL(NtSetEvent, NTSTATUS, 2,
+		"EventHandle", "", DIR_IN, HANDLE,
+		"PreviousState", "opt", DIR_OUT, PLONG,
+);
+SYSCALL(NtSetHighEventPair, NTSTATUS, 1,
+		"EventPairHandle", "", DIR_IN, HANDLE,
+);
+SYSCALL(NtSetHighWaitLowEventPair, NTSTATUS, 1,
+		"EventPairHandle", "", DIR_IN, HANDLE,
+);
+SYSCALL(NtSetInformationDebugObject, NTSTATUS, 5,
+		"DebugObjectHandle", "", DIR_OUT, HANDLE,
+		"DebugObjectInformationClass", "", DIR_OUT, DEBUGOBJECTINFOCLASS,
+		"DebugInformation", "", DIR_OUT, PVOID,
+		"DebugInformationLength", "", DIR_OUT, ULONG,
+		"ReturnLength", "", DIR_OUT, PULONG,
+);
+SYSCALL(NtSetInformationEnlistment, NTSTATUS, 4,
+		"EnlistmentHandle", "opt", DIR_IN, HANDLE,
+		"EnlistmentInformationClass", "", DIR_IN, ENLISTMENT_INFORMATION_CLASS,
+		"EnlistmentInformation", "bcount(EnlistmentInformationLength)", DIR_IN, PVOID,
+		"EnlistmentInformationLength", "", DIR_IN, ULONG,
+);
+SYSCALL(NtSetInformationFile, NTSTATUS, 5,
+		"FileHandle", "", DIR_IN, HANDLE,
+		"IoStatusBlock", "", DIR_OUT, PIO_STATUS_BLOCK,
+		"FileInformation", "bcount(Length)", DIR_IN, PVOID,
+		"Length", "", DIR_IN, ULONG,
+		"FileInformationClass", "", DIR_IN, FILE_INFORMATION_CLASS,
+);
+SYSCALL(NtSetInformationJobObject, NTSTATUS, 4,
+		"JobHandle", "", DIR_IN, HANDLE,
+		"JobObjectInformationClass", "", DIR_IN, JOBOBJECTINFOCLASS,
+		"JobObjectInformation", "bcount(JobObjectInformationLength)", DIR_IN, PVOID,
+		"JobObjectInformationLength", "", DIR_IN, ULONG,
+);
+SYSCALL(NtSetInformationKey, NTSTATUS, 4,
+		"KeyHandle", "", DIR_IN, HANDLE,
+		"KeySetInformationClass", "", DIR_IN, KEY_SET_INFORMATION_CLASS,
+		"KeySetInformation", "bcount(KeySetInformationLength)", DIR_IN, PVOID,
+		"KeySetInformationLength", "", DIR_IN, ULONG,
+);
+SYSCALL(NtSetInformationObject, NTSTATUS, 4,
+		"Handle", "", DIR_IN, HANDLE,
+		"ObjectInformationClass", "", DIR_IN, OBJECT_INFORMATION_CLASS,
+		"ObjectInformation", "bcount(ObjectInformationLength)", DIR_IN, PVOID,
+		"ObjectInformationLength", "", DIR_IN, ULONG,
+);
+SYSCALL(NtSetInformationProcess, NTSTATUS, 4,
+		"ProcessHandle", "", DIR_IN, HANDLE,
+		"ProcessInformationClass", "", DIR_IN, PROCESSINFOCLASS,
+		"ProcessInformation", "bcount(ProcessInformationLength)", DIR_IN, PVOID,
+		"ProcessInformationLength", "", DIR_IN, ULONG,
+);
+SYSCALL(NtSetInformationResourceManager, NTSTATUS, 4,
+		"ResourceManagerHandle", "", DIR_IN, HANDLE,
+		"ResourceManagerInformationClass", "", DIR_IN, RESOURCEMANAGER_INFORMATION_CLASS,
+		"ResourceManagerInformation", "bcount(ResourceManagerInformationLength)", DIR_IN, PVOID,
+		"ResourceManagerInformationLength", "", DIR_IN, ULONG,
+);
+SYSCALL(NtSetInformationThread, NTSTATUS, 4,
+		"ThreadHandle", "", DIR_IN, HANDLE,
+		"ThreadInformationClass", "", DIR_IN, THREADINFOCLASS,
+		"ThreadInformation", "bcount(ThreadInformationLength)", DIR_IN, PVOID,
+		"ThreadInformationLength", "", DIR_IN, ULONG,
+);
+SYSCALL(NtSetInformationToken, NTSTATUS, 4,
+		"TokenHandle", "", DIR_IN, HANDLE,
+		"TokenInformationClass", "", DIR_IN, TOKEN_INFORMATION_CLASS,
+		"TokenInformation", "bcount(TokenInformationLength)", DIR_IN, PVOID,
+		"TokenInformationLength", "", DIR_IN, ULONG,
+);
+SYSCALL(NtSetInformationTransaction, NTSTATUS, 4,
+		"TransactionHandle", "", DIR_IN, HANDLE,
+		"TransactionInformationClass", "", DIR_IN, TRANSACTION_INFORMATION_CLASS,
+		"TransactionInformation", "bcount(TransactionInformationLength)", DIR_IN, PVOID,
+		"TransactionInformationLength", "", DIR_IN, ULONG,
+);
+SYSCALL(NtSetInformationTransactionManager, NTSTATUS, 4,
+		"TmHandle", "opt", DIR_IN, HANDLE,
+		"TransactionManagerInformationClass", "", DIR_IN, TRANSACTIONMANAGER_INFORMATION_CLASS,
+		"TransactionManagerInformation", "bcount(TransactionManagerInformationLength)", DIR_IN, PVOID,
+		"TransactionManagerInformationLength", "", DIR_IN, ULONG,
+);
+SYSCALL(NtSetInformationWorkerFactory, NTSTATUS, 4,
+		"WorkerFactoryHandle", "", DIR_IN, HANDLE,
+		"WorkerFactoryInformationClass", "", DIR_IN, WORKERFACTORYINFOCLASS,
+		"WorkerFactoryInformation", "bcount(WorkerFactoryInformationLength)", DIR_IN, PVOID,
+		"WorkerFactoryInformationLength", "", DIR_IN, ULONG,
+);
+SYSCALL(NtSetIntervalProfile, NTSTATUS, 2,
+		"Interval", "", DIR_IN, ULONG,
+		"Source", "", DIR_IN, KPROFILE_SOURCE,
+);
+SYSCALL(NtSetIoCompletionEx, NTSTATUS, 6,
+		"IoCompletionHandle", "", DIR_IN, HANDLE,
+		"IoCompletionReserveHandle", "", DIR_IN, HANDLE,
+		"KeyContext", "", DIR_IN, PVOID,
+		"ApcContext", "opt", DIR_IN, PVOID,
+		"IoStatus", "", DIR_IN, NTSTATUS,
+		"IoStatusInformation", "", DIR_IN, ULONG_PTR,
+);
+SYSCALL(NtSetIoCompletion, NTSTATUS, 5,
+		"IoCompletionHandle", "", DIR_IN, HANDLE,
+		"KeyContext", "", DIR_IN, PVOID,
+		"ApcContext", "opt", DIR_IN, PVOID,
+		"IoStatus", "", DIR_IN, NTSTATUS,
+		"IoStatusInformation", "", DIR_IN, ULONG_PTR,
+);
+SYSCALL(NtSetLdtEntries, NTSTATUS, 6,
+		"Selector0", "", DIR_IN, ULONG,
+		"Entry0Low", "", DIR_IN, ULONG,
+		"Entry0Hi", "", DIR_IN, ULONG,
+		"Selector1", "", DIR_IN, ULONG,
+		"Entry1Low", "", DIR_IN, ULONG,
+		"Entry1Hi", "", DIR_IN, ULONG,
+);
+SYSCALL(NtSetLowEventPair, NTSTATUS, 1,
+		"EventPairHandle", "", DIR_IN, HANDLE,
+);
+SYSCALL(NtSetLowWaitHighEventPair, NTSTATUS, 1,
+		"EventPairHandle", "", DIR_IN, HANDLE,
+);
+SYSCALL(NtSetQuotaInformationFile, NTSTATUS, 4,
+		"FileHandle", "", DIR_IN, HANDLE,
+		"IoStatusBlock", "", DIR_OUT, PIO_STATUS_BLOCK,
+		"Buffer", "bcount(Length)", DIR_IN, PVOID,
+		"Length", "", DIR_IN, ULONG,
+);
+SYSCALL(NtSetSecurityObject, NTSTATUS, 3,
+		"Handle", "", DIR_IN, HANDLE,
+		"SecurityInformation", "", DIR_IN, SECURITY_INFORMATION,
+		"SecurityDescriptor", "", DIR_IN, PSECURITY_DESCRIPTOR,
+);
+SYSCALL(NtSetSystemEnvironmentValueEx, NTSTATUS, 5,
+		"VariableName", "", DIR_IN, PUNICODE_STRING,
+		"VendorGuid", "", DIR_IN, LPGUID,
+		"Value", "bcount_opt(ValueLength)", DIR_IN, PVOID,
+		"ValueLength", "", DIR_IN, ULONG,
+		"Attributes", "", DIR_IN, ULONG,
+);
+SYSCALL(NtSetSystemEnvironmentValue, NTSTATUS, 2,
+		"VariableName", "", DIR_IN, PUNICODE_STRING,
+		"VariableValue", "", DIR_IN, PUNICODE_STRING,
+);
+SYSCALL(NtSetSystemInformation, NTSTATUS, 3,
+		"SystemInformationClass", "", DIR_IN, SYSTEM_INFORMATION_CLASS,
+		"SystemInformation", "bcount_opt(SystemInformationLength)", DIR_IN, PVOID,
+		"SystemInformationLength", "", DIR_IN, ULONG,
+);
+SYSCALL(NtSetSystemPowerState, NTSTATUS, 3,
+		"SystemAction", "", DIR_IN, POWER_ACTION,
+		"MinSystemState", "", DIR_IN, SYSTEM_POWER_STATE,
+		"Flags", "", DIR_IN, ULONG,
+);
+SYSCALL(NtSetSystemTime, NTSTATUS, 2,
+		"SystemTime", "opt", DIR_IN, PLARGE_INTEGER,
+		"PreviousTime", "opt", DIR_OUT, PLARGE_INTEGER,
+);
+SYSCALL(NtSetThreadExecutionState, NTSTATUS, 2,
+		"esFlags", "", DIR_IN, EXECUTION_STATE,
+		"*PreviousFlags", "", DIR_OUT, EXECUTION_STATE,
+);
+SYSCALL(NtSetTimerEx, NTSTATUS, 4,
+		"TimerHandle", "", DIR_IN, HANDLE,
+		"TimerSetInformationClass", "", DIR_IN, TIMER_SET_INFORMATION_CLASS,
+		"TimerSetInformation", "bcount(TimerSetInformationLength)", DIR_INOUT, PVOID,
+		"TimerSetInformationLength", "", DIR_IN, ULONG,
+);
+SYSCALL(NtSetTimer, NTSTATUS, 7,
+		"TimerHandle", "", DIR_IN, HANDLE,
+		"DueTime", "", DIR_IN, PLARGE_INTEGER,
+		"TimerApcRoutine", "opt", DIR_IN, PTIMER_APC_ROUTINE,
+		"TimerContext", "opt", DIR_IN, PVOID,
+		"WakeTimer", "", DIR_IN, BOOLEAN,
+		"Period", "opt", DIR_IN, LONG,
+		"PreviousState", "opt", DIR_OUT, PBOOLEAN,
+);
+SYSCALL(NtSetTimerResolution, NTSTATUS, 3,
+		"DesiredTime", "", DIR_IN, ULONG,
+		"SetResolution", "", DIR_IN, BOOLEAN,
+		"ActualTime", "", DIR_OUT, PULONG,
+);
+SYSCALL(NtSetUuidSeed, NTSTATUS, 1,
+		"Seed", "", DIR_IN, PCHAR,
+);
+SYSCALL(NtSetValueKey, NTSTATUS, 6,
+		"KeyHandle", "", DIR_IN, HANDLE,
+		"ValueName", "", DIR_IN, PUNICODE_STRING,
+		"TitleIndex", "opt", DIR_IN, ULONG,
+		"Type", "", DIR_IN, ULONG,
+		"Data", "bcount_opt(DataSize)", DIR_IN, PVOID,
+		"DataSize", "", DIR_IN, ULONG,
+);
+SYSCALL(NtSetVolumeInformationFile, NTSTATUS, 5,
+		"FileHandle", "", DIR_IN, HANDLE,
+		"IoStatusBlock", "", DIR_OUT, PIO_STATUS_BLOCK,
+		"FsInformation", "bcount(Length)", DIR_IN, PVOID,
+		"Length", "", DIR_IN, ULONG,
+		"FsInformationClass", "", DIR_IN, FS_INFORMATION_CLASS,
+);
+SYSCALL(NtShutdownSystem, NTSTATUS, 1,
+		"Action", "", DIR_IN, SHUTDOWN_ACTION,
+);
+SYSCALL(NtShutdownWorkerFactory, NTSTATUS, 2,
+		"WorkerFactoryHandle", "", DIR_IN, HANDLE,
+		"*PendingWorkerCount", "", DIR_INOUT, LONG,
+);
+SYSCALL(NtSignalAndWaitForSingleObject, NTSTATUS, 4,
+		"SignalHandle", "", DIR_IN, HANDLE,
+		"WaitHandle", "", DIR_IN, HANDLE,
+		"Alertable", "", DIR_IN, BOOLEAN,
+		"Timeout", "opt", DIR_IN, PLARGE_INTEGER,
+);
+SYSCALL(NtSinglePhaseReject, NTSTATUS, 2,
+		"EnlistmentHandle", "", DIR_IN, HANDLE,
+		"TmVirtualClock", "opt", DIR_IN, PLARGE_INTEGER,
+);
+SYSCALL(NtStartProfile, NTSTATUS, 1,
+		"ProfileHandle", "", DIR_IN, HANDLE,
+);
+SYSCALL(NtStopProfile, NTSTATUS, 1,
+		"ProfileHandle", "", DIR_IN, HANDLE,
+);
+SYSCALL(NtSuspendProcess, NTSTATUS, 1,
+		"ProcessHandle", "", DIR_IN, HANDLE,
+);
+SYSCALL(NtSuspendThread, NTSTATUS, 2,
+		"ThreadHandle", "", DIR_IN, HANDLE,
+		"PreviousSuspendCount", "opt", DIR_OUT, PULONG,
+);
+SYSCALL(NtSystemDebugControl, NTSTATUS, 6,
+		"Command", "", DIR_IN, SYSDBG_COMMAND,
+		"InputBuffer", "bcount_opt(InputBufferLength)", DIR_INOUT, PVOID,
+		"InputBufferLength", "", DIR_IN, ULONG,
+		"OutputBuffer", "bcount_opt(OutputBufferLength)", DIR_OUT, PVOID,
+		"OutputBufferLength", "", DIR_IN, ULONG,
+		"ReturnLength", "opt", DIR_OUT, PULONG,
+);
+SYSCALL(NtTerminateJobObject, NTSTATUS, 2,
+		"JobHandle", "", DIR_IN, HANDLE,
+		"ExitStatus", "", DIR_IN, NTSTATUS,
+);
+SYSCALL(NtTerminateProcess, NTSTATUS, 2,
+		"ProcessHandle", "opt", DIR_IN, HANDLE,
+		"ExitStatus", "", DIR_IN, NTSTATUS,
+);
+SYSCALL(NtTerminateThread, NTSTATUS, 2,
+		"ThreadHandle", "opt", DIR_IN, HANDLE,
+		"ExitStatus", "", DIR_IN, NTSTATUS,
+);
+SYSCALL(NtTraceControl, NTSTATUS, 6,
+		"FunctionCode", "", DIR_IN, ULONG,
+		"InBuffer", "bcount_opt(InBufferLen)", DIR_IN, PVOID,
+		"InBufferLen", "", DIR_IN, ULONG,
+		"OutBuffer", "bcount_opt(OutBufferLen)", DIR_OUT, PVOID,
+		"OutBufferLen", "", DIR_IN, ULONG,
+		"ReturnLength", "", DIR_OUT, PULONG,
+);
+SYSCALL(NtTraceEvent, NTSTATUS, 4,
+		"TraceHandle", "", DIR_IN, HANDLE,
+		"Flags", "", DIR_IN, ULONG,
+		"FieldSize", "", DIR_IN, ULONG,
+		"Fields", "", DIR_IN, PVOID,
+);
+SYSCALL(NtTranslateFilePath, NTSTATUS, 4,
+		"InputFilePath", "", DIR_IN, PFILE_PATH,
+		"OutputType", "", DIR_IN, ULONG,
+		"OutputFilePath", "bcount_opt(*OutputFilePathLength)", DIR_OUT, PFILE_PATH,
+		"OutputFilePathLength", "opt", DIR_INOUT, PULONG,
+);
+SYSCALL(NtUnloadDriver, NTSTATUS, 1,
+		"DriverServiceName", "", DIR_IN, PUNICODE_STRING,
+);
+SYSCALL(NtUnloadKey2, NTSTATUS, 2,
+		"TargetKey", "", DIR_IN, POBJECT_ATTRIBUTES,
+		"Flags", "", DIR_IN, ULONG,
+);
+SYSCALL(NtUnloadKeyEx, NTSTATUS, 2,
+		"TargetKey", "", DIR_IN, POBJECT_ATTRIBUTES,
+		"Event", "opt", DIR_IN, HANDLE,
+);
+SYSCALL(NtUnloadKey, NTSTATUS, 1,
+		"TargetKey", "", DIR_IN, POBJECT_ATTRIBUTES,
+);
+SYSCALL(NtUnlockFile, NTSTATUS, 5,
+		"FileHandle", "", DIR_IN, HANDLE,
+		"IoStatusBlock", "", DIR_OUT, PIO_STATUS_BLOCK,
+		"ByteOffset", "", DIR_IN, PLARGE_INTEGER,
+		"Length", "", DIR_IN, PLARGE_INTEGER,
+		"Key", "", DIR_IN, ULONG,
+);
+SYSCALL(NtUnlockVirtualMemory, NTSTATUS, 4,
+		"ProcessHandle", "", DIR_IN, HANDLE,
+		"*BaseAddress", "", DIR_INOUT, PVOID,
+		"RegionSize", "", DIR_INOUT, PSIZE_T,
+		"MapType", "", DIR_IN, ULONG,
+);
+SYSCALL(NtUnmapViewOfSection, NTSTATUS, 2,
+		"ProcessHandle", "", DIR_IN, HANDLE,
+		"BaseAddress", "", DIR_IN, PVOID,
+);
+SYSCALL(NtVdmControl, NTSTATUS, 2,
+		"Service", "", DIR_IN, VDMSERVICECLASS,
+		"ServiceData", "", DIR_INOUT, PVOID,
+);
+SYSCALL(NtWaitForDebugEvent, NTSTATUS, 4,
+		"DebugObjectHandle", "", DIR_OUT, HANDLE,
+		"Alertable", "", DIR_OUT, BOOLEAN,
+		"Timeout", "", DIR_OUT, PLARGE_INTEGER,
+		"WaitStateChange", "", DIR_OUT, PDBGUI_WAIT_STATE_CHANGE,
+);
+SYSCALL(NtWaitForKeyedEvent, NTSTATUS, 4,
+		"KeyedEventHandle", "", DIR_IN, HANDLE,
+		"KeyValue", "", DIR_IN, PVOID,
+		"Alertable", "", DIR_IN, BOOLEAN,
+		"Timeout", "opt", DIR_IN, PLARGE_INTEGER,
+);
+SYSCALL(NtWaitForMultipleObjects32, NTSTATUS, 5,
+		"Count", "", DIR_IN, ULONG,
+		"Handles[]", "ecount(Count)", DIR_IN, LONG,
+		"WaitType", "", DIR_IN, WAIT_TYPE,
+		"Alertable", "", DIR_IN, BOOLEAN,
+		"Timeout", "opt", DIR_IN, PLARGE_INTEGER,
+);
+SYSCALL(NtWaitForMultipleObjects, NTSTATUS, 5,
+		"Count", "", DIR_IN, ULONG,
+		"Handles[]", "ecount(Count)", DIR_IN, HANDLE,
+		"WaitType", "", DIR_IN, WAIT_TYPE,
+		"Alertable", "", DIR_IN, BOOLEAN,
+		"Timeout", "opt", DIR_IN, PLARGE_INTEGER,
+);
+SYSCALL(NtWaitForSingleObject, NTSTATUS, 3,
+		"Handle", "", DIR_IN, HANDLE,
+		"Alertable", "", DIR_IN, BOOLEAN,
+		"Timeout", "opt", DIR_IN, PLARGE_INTEGER,
+);
+SYSCALL(NtWaitForWorkViaWorkerFactory, NTSTATUS, 2,
+		"WorkerFactoryHandle", "", DIR_IN, HANDLE,
+		"MiniPacket", "", DIR_OUT, PFILE_IO_COMPLETION_INFORMATION,
+);
+SYSCALL(NtWaitHighEventPair, NTSTATUS, 1,
+		"EventPairHandle", "", DIR_IN, HANDLE,
+);
+SYSCALL(NtWaitLowEventPair, NTSTATUS, 1,
+		"EventPairHandle", "", DIR_IN, HANDLE,
+);
+SYSCALL(NtWorkerFactoryWorkerReady, NTSTATUS, 1,
+		"WorkerFactoryHandle", "", DIR_IN, HANDLE,
+);
+SYSCALL(NtWriteFileGather, NTSTATUS, 9,
+		"FileHandle", "", DIR_IN, HANDLE,
+		"Event", "opt", DIR_IN, HANDLE,
+		"ApcRoutine", "opt", DIR_IN, PIO_APC_ROUTINE,
+		"ApcContext", "opt", DIR_IN, PVOID,
+		"IoStatusBlock", "", DIR_OUT, PIO_STATUS_BLOCK,
+		"SegmentArray", "", DIR_IN, PFILE_SEGMENT_ELEMENT,
+		"Length", "", DIR_IN, ULONG,
+		"ByteOffset", "opt", DIR_IN, PLARGE_INTEGER,
+		"Key", "opt", DIR_IN, PULONG,
+);
+SYSCALL(NtWriteFile, NTSTATUS, 9,
+		"FileHandle", "", DIR_IN, HANDLE,
+		"Event", "opt", DIR_IN, HANDLE,
+		"ApcRoutine", "opt", DIR_IN, PIO_APC_ROUTINE,
+		"ApcContext", "opt", DIR_IN, PVOID,
+		"IoStatusBlock", "", DIR_OUT, PIO_STATUS_BLOCK,
+		"Buffer", "bcount(Length)", DIR_IN, PVOID,
+		"Length", "", DIR_IN, ULONG,
+		"ByteOffset", "opt", DIR_IN, PLARGE_INTEGER,
+		"Key", "opt", DIR_IN, PULONG,
+);
+SYSCALL(NtWriteRequestData, NTSTATUS, 6,
+		"PortHandle", "", DIR_IN, HANDLE,
+		"Message", "", DIR_IN, PPORT_MESSAGE,
+		"DataEntryIndex", "", DIR_IN, ULONG,
+		"Buffer", "bcount(BufferSize)", DIR_IN, PVOID,
+		"BufferSize", "", DIR_IN, SIZE_T,
+		"NumberOfBytesWritten", "opt", DIR_OUT, PSIZE_T,
+);
+SYSCALL(NtWriteVirtualMemory, NTSTATUS, 5,
+		"ProcessHandle", "", DIR_IN, HANDLE,
+		"BaseAddress", "opt", DIR_IN, PVOID,
+		"Buffer", "bcount(BufferSize)", DIR_IN, PVOID,
+		"BufferSize", "", DIR_IN, SIZE_T,
+		"NumberOfBytesWritten", "opt", DIR_OUT, PSIZE_T,
+);
+
+// TODO: fill in argument information
+SYSCALL(NtUmsThreadYield, NTSTATUS, 0);
+SYSCALL(NtThawTransactions, NTSTATUS, 0);
+SYSCALL(NtThawRegistry, NTSTATUS, 0);
+SYSCALL(NtTestAlert, NTSTATUS, 0);
+SYSCALL(NtSerializeBoot, NTSTATUS, 0);
+SYSCALL(NtQueryPortInformationProcess, NTSTATUS, 0);
+SYSCALL(NtFlushWriteBuffer, NTSTATUS, 0);
+SYSCALL(NtEnableLastKnownGood, NTSTATUS, 0);
+SYSCALL(NtDisableLastKnownGood, NTSTATUS, 0);
+SYSCALL(NtFlushProcessWriteBuffers, VOID, 0);
+SYSCALL(NtGetCurrentProcessorNumber, ULONG, 0);
+SYSCALL(NtGetEnvironmentVariableEx, MISSING, 0);
+SYSCALL(NtIsSystemResumeAutomatic, BOOLEAN, 0);
+SYSCALL(NtIsUILanguageComitted, NTSTATUS, 0);
+SYSCALL(NtQueryEnvironmentVariableInfoEx, MISSING, 0);
+SYSCALL(NtYieldExecution, NTSTATUS, 0);
+SYSCALL(NtAcquireProcessActivityReference, NTSTATUS, 0);
+SYSCALL(NtAddAtomEx, NTSTATUS, 0);
+SYSCALL(NtAlertThreadByThreadId, NTSTATUS, 0);
+SYSCALL(NtAllocateVirtualMemoryEx, NTSTATUS, 0);
+SYSCALL(NtAlpcConnectPortEx, NTSTATUS, 0);
+SYSCALL(NtAlpcImpersonateClientContainerOfPort, NTSTATUS, 0);
+SYSCALL(NtAssociateWaitCompletionPacket, NTSTATUS, 0);
+SYSCALL(NtCallEnclave, NTSTATUS, 0);
+SYSCALL(NtCancelTimer2, NTSTATUS, 0);
+SYSCALL(NtCancelWaitCompletionPacket, NTSTATUS, 0);
+SYSCALL(NtCommitRegistryTransaction, NTSTATUS, 0);
+SYSCALL(NtCompareObjects, NTSTATUS, 0);
+SYSCALL(NtCompareSigningLevels, NTSTATUS, 0);
+SYSCALL(NtConvertBetweenAuxiliaryCounterAndPerformanceCounter, NTSTATUS, 0);
+SYSCALL(NtCreateDirectoryObjectEx, NTSTATUS, 0);
+SYSCALL(NtCreateEnclave, NTSTATUS, 0);
+SYSCALL(NtCreateIRTimer, NTSTATUS, 0);
+SYSCALL(NtCreateLowBoxToken, NTSTATUS, 0);
+SYSCALL(NtCreatePartition, NTSTATUS, 0);
+SYSCALL(NtCreateRegistryTransaction, NTSTATUS, 0);
+SYSCALL(NtCreateTimer2, NTSTATUS, 0);
+SYSCALL(NtCreateTokenEx, NTSTATUS, 0);
+SYSCALL(NtCreateWaitCompletionPacket, NTSTATUS, 0);
+SYSCALL(NtCreateWnfStateName, NTSTATUS, 0);
+SYSCALL(NtDeleteWnfStateData, NTSTATUS, 0);
+SYSCALL(NtDeleteWnfStateName, NTSTATUS, 0);
+SYSCALL(NtFilterBootOption, NTSTATUS, 0);
+SYSCALL(NtFlushBuffersFileEx, NTSTATUS, 0);
+SYSCALL(NtGetCachedSigningLevel, NTSTATUS, 0);
+SYSCALL(NtGetCompleteWnfStateSubscription, NTSTATUS, 0);
+SYSCALL(NtGetCurrentProcessorNumberEx, NTSTATUS, 0);
+SYSCALL(NtInitializeEnclave, NTSTATUS, 0);
+SYSCALL(NtLoadEnclaveData, NTSTATUS, 0);
+SYSCALL(NtLoadHotPatch, NTSTATUS, 0);
+SYSCALL(NtManagePartition, NTSTATUS, 0);
+SYSCALL(NtMapViewOfSectionEx, NTSTATUS, 0);
+SYSCALL(NtNotifyChangeDirectoryFileEx, NTSTATUS, 0);
+SYSCALL(NtOpenPartition, NTSTATUS, 0);
+SYSCALL(NtOpenRegistryTransaction, NTSTATUS, 0);
+SYSCALL(NtQueryAuxiliaryCounterFrequency, NTSTATUS, 0);
+SYSCALL(NtQueryDirectoryFileEx, NTSTATUS, 0);
+SYSCALL(NtQueryInformationByName, NTSTATUS, 0);
+SYSCALL(NtQuerySecurityPolicy, NTSTATUS, 0);
+SYSCALL(NtQueryWnfStateData, NTSTATUS, 0);
+SYSCALL(NtQueryWnfStateNameInformation, NTSTATUS, 0);
+SYSCALL(NtRevertContainerImpersonation, NTSTATUS, 0);
+SYSCALL(NtRollbackRegistryTransaction, NTSTATUS, 0);
+SYSCALL(NtSetCachedSigningLevel, NTSTATUS, 0);
+SYSCALL(NtSetCachedSigningLevel2, NTSTATUS, 0);
+SYSCALL(NtSetIRTimer, NTSTATUS, 0);
+SYSCALL(NtSetInformationSymbolicLink, NTSTATUS, 0);
+SYSCALL(NtSetInformationVirtualMemory, NTSTATUS, 0);
+SYSCALL(NtSetTimer2, NTSTATUS, 0);
+SYSCALL(NtSetWnfProcessNotificationEvent, NTSTATUS, 0);
+SYSCALL(NtSubscribeWnfStateChange, NTSTATUS, 0);
+SYSCALL(NtTerminateEnclave, NTSTATUS, 0);
+SYSCALL(NtUnmapViewOfSectionEx, NTSTATUS, 0);
+SYSCALL(NtUnsubscribeWnfStateChange, NTSTATUS, 0);
+SYSCALL(NtUpdateWnfStateData, NTSTATUS, 0);
+SYSCALL(NtWaitForAlertByThreadId, NTSTATUS, 0);
+SYSCALL(NtCreateSectionEx, NTSTATUS, 0);
+SYSCALL(NtManageHotPatch, NTSTATUS, 0);
+SYSCALL(BvgaSetVirtualFrameBuffer, NTSTATUS, 0);
+SYSCALL(CmpCleanUpHigherLayerKcbCachesPreCallback, NTSTATUS, 0);
+SYSCALL(GetPnpProperty, NTSTATUS, 0);
+SYSCALL(ArbPreprocessEntry, NTSTATUS, 0);
+SYSCALL(ArbAddReserved, NTSTATUS, 0);
+
+// WIN32K
+
+SYSCALL(NtBindCompositionSurface, NTSTATUS, 0);
+SYSCALL(NtCloseCompositionInputSink, NTSTATUS, 0);
+SYSCALL(NtCompositionInputThread, NTSTATUS, 0);
+SYSCALL(NtCompositionSetDropTarget, NTSTATUS, 0);
+SYSCALL(NtConfigureInputSpace, NTSTATUS, 0);
+SYSCALL(NtCreateCompositionInputSink, NTSTATUS, 0);
+SYSCALL(NtCreateCompositionSurfaceHandle, NTSTATUS, 0);
+SYSCALL(NtCreateImplicitCompositionInputSink, NTSTATUS, 0);
+SYSCALL(NtDCompositionAddCrossDeviceVisualChild, NTSTATUS, 0);
+SYSCALL(NtDCompositionAddVisualChild, NTSTATUS, 0);
+SYSCALL(NtDCompositionAttachMouseWheelToHwnd, NTSTATUS, 0);
+SYSCALL(NtDCompositionBeginFrame, NTSTATUS, 0);
+SYSCALL(NtDCompositionCapturePointer, NTSTATUS, 0);
+SYSCALL(NtDCompositionCommitChannel, NTSTATUS, 0);
+SYSCALL(NtDCompositionCommitSynchronizationObject, NTSTATUS, 0);
+SYSCALL(NtDCompositionConfirmFrame, NTSTATUS, 0);
+SYSCALL(NtDCompositionConnectPipe, NTSTATUS, 0);
+SYSCALL(NtDCompositionCreateAndBindSharedSection, NTSTATUS, 0);
+SYSCALL(NtDCompositionCreateChannel, NTSTATUS, 0);
+SYSCALL(NtDCompositionCreateConnection, NTSTATUS, 0);
+SYSCALL(NtDCompositionCreateConnectionContext, NTSTATUS, 0);
+SYSCALL(NtDCompositionCreateDwmChannel, NTSTATUS, 0);
+SYSCALL(NtDCompositionCreateResource, NTSTATUS, 0);
+SYSCALL(NtDCompositionCreateSharedResourceHandle, NTSTATUS, 0);
+SYSCALL(NtDCompositionCreateSharedVisualHandle, NTSTATUS, 0);
+SYSCALL(NtDCompositionCreateSynchronizationObject, NTSTATUS, 0);
+SYSCALL(NtDCompositionCurrentBatchId, NTSTATUS, 0);
+SYSCALL(NtDCompositionDestroyChannel, NTSTATUS, 0);
+SYSCALL(NtDCompositionDestroyConnection, NTSTATUS, 0);
+SYSCALL(NtDCompositionDestroyConnectionContext, NTSTATUS, 0);
+SYSCALL(NtDCompositionDiscardFrame, NTSTATUS, 0);
+SYSCALL(NtDCompositionDuplicateHandleToProcess, NTSTATUS, 0);
+SYSCALL(NtDCompositionDuplicateSwapchainHandleToDwm, NTSTATUS, 0);
+SYSCALL(NtDCompositionDwmSyncFlush, NTSTATUS, 0);
+SYSCALL(NtDCompositionEnableDDASupport, NTSTATUS, 0);
+SYSCALL(NtDCompositionEnableMMCSS, NTSTATUS, 0);
+SYSCALL(NtDCompositionGetAnimationTime, NTSTATUS, 0);
+SYSCALL(NtDCompositionGetBatchId, NTSTATUS, 0);
+SYSCALL(NtDCompositionGetChannels, NTSTATUS, 0);
+SYSCALL(NtDCompositionGetConnectionBatch, NTSTATUS, 0);
+SYSCALL(NtDCompositionGetConnectionContextBatch, NTSTATUS, 0);
+SYSCALL(NtDCompositionGetDeletedResources, NTSTATUS, 0);
+SYSCALL(NtDCompositionGetFrameLegacyTokens, NTSTATUS, 0);
+SYSCALL(NtDCompositionGetFrameStatistics, NTSTATUS, 0);
+SYSCALL(NtDCompositionGetFrameSurfaceUpdates, NTSTATUS, 0);
+SYSCALL(NtDCompositionGetMaterialProperty, NTSTATUS, 0);
+SYSCALL(NtDCompositionOpenSharedResource, NTSTATUS, 0);
+SYSCALL(NtDCompositionOpenSharedResourceHandle, NTSTATUS, 0);
+SYSCALL(NtDCompositionProcessChannelBatchBuffer, NTSTATUS, 0);
+SYSCALL(NtDCompositionReferenceSharedResourceOnDwmChannel, NTSTATUS, 0);
+SYSCALL(NtDCompositionRegisterThumbnailVisual, NTSTATUS, 0);
+SYSCALL(NtDCompositionRegisterVirtualDesktopVisual, NTSTATUS, 0);
+SYSCALL(NtDCompositionReleaseAllResources, NTSTATUS, 0);
+SYSCALL(NtDCompositionReleaseResource, NTSTATUS, 0);
+SYSCALL(NtDCompositionRemoveCrossDeviceVisualChild, NTSTATUS, 0);
+SYSCALL(NtDCompositionRemoveVisualChild, NTSTATUS, 0);
+SYSCALL(NtDCompositionReplaceVisualChildren, NTSTATUS, 0);
+SYSCALL(NtDCompositionRetireFrame, NTSTATUS, 0);
+SYSCALL(NtDCompositionSetChannelCallbackId, NTSTATUS, 0);
+SYSCALL(NtDCompositionSetChannelCommitCompletionEvent, NTSTATUS, 0);
+SYSCALL(NtDCompositionSetChannelConnectionId, NTSTATUS, 0);
+SYSCALL(NtDCompositionSetChildRootVisual, NTSTATUS, 0);
+SYSCALL(NtDCompositionSetDebugCounter, NTSTATUS, 0);
+SYSCALL(NtDCompositionSetMaterialProperty, NTSTATUS, 0);
+SYSCALL(NtDCompositionSetResourceAnimationProperty, NTSTATUS, 0);
+SYSCALL(NtDCompositionSetResourceBufferProperty, NTSTATUS, 0);
+SYSCALL(NtDCompositionSetResourceCallbackId, NTSTATUS, 0);
+SYSCALL(NtDCompositionSetResourceDeletedNotificationTag, NTSTATUS, 0);
+SYSCALL(NtDCompositionSetResourceFloatProperty, NTSTATUS, 0);
+SYSCALL(NtDCompositionSetResourceHandleProperty, NTSTATUS, 0);
+SYSCALL(NtDCompositionSetResourceIntegerProperty, NTSTATUS, 0);
+SYSCALL(NtDCompositionSetResourceReferenceArrayProperty, NTSTATUS, 0);
+SYSCALL(NtDCompositionSetResourceReferenceProperty, NTSTATUS, 0);
+SYSCALL(NtDCompositionSetVisualInputSink, NTSTATUS, 0);
+SYSCALL(NtDCompositionSignalGpuFence, NTSTATUS, 0);
+SYSCALL(NtDCompositionSubmitDWMBatch, NTSTATUS, 0);
+SYSCALL(NtDCompositionSuspendAnimations, NTSTATUS, 0);
+SYSCALL(NtDCompositionSynchronize, NTSTATUS, 0);
+SYSCALL(NtDCompositionTelemetryAnimationScenarioBegin, NTSTATUS, 0);
+SYSCALL(NtDCompositionTelemetryAnimationScenarioReference, NTSTATUS, 0);
+SYSCALL(NtDCompositionTelemetryAnimationScenarioUnreference, NTSTATUS, 0);
+SYSCALL(NtDCompositionTelemetrySetApplicationId, NTSTATUS, 0);
+SYSCALL(NtDCompositionTelemetryTouchInteractionBegin, NTSTATUS, 0);
+SYSCALL(NtDCompositionTelemetryTouchInteractionEnd, NTSTATUS, 0);
+SYSCALL(NtDCompositionTelemetryTouchInteractionUpdate, NTSTATUS, 0);
+SYSCALL(NtDCompositionUpdatePointerCapture, NTSTATUS, 0);
+SYSCALL(NtDCompositionValidateAndReferenceSystemVisualForHwndTarget, NTSTATUS, 0);
+SYSCALL(NtDCompositionWaitForChannel, NTSTATUS, 0);
+SYSCALL(NtDWMBindCursorToOutputConfig, NTSTATUS, 0);
+SYSCALL(NtDWMCommitInputSystemOutputConfig, NTSTATUS, 0);
+SYSCALL(NtDWMSetCursorOrientation, NTSTATUS, 0);
+SYSCALL(NtDWMSetInputSystemOutputConfig, NTSTATUS, 0);
+SYSCALL(NtDesktopCaptureBits, NTSTATUS, 0);
+SYSCALL(NtDuplicateCompositionInputSink, NTSTATUS, 0);
+SYSCALL(NtDxgkCreateTrackedWorkload, NTSTATUS, 0);
+SYSCALL(NtDxgkDestroyTrackedWorkload, NTSTATUS, 0);
+SYSCALL(NtDxgkDispMgrOperation, NTSTATUS, 0);
+SYSCALL(NtDxgkEndTrackedWorkload, NTSTATUS, 0);
+SYSCALL(NtDxgkGetAvailableTrackedWorkloadIndex, NTSTATUS, 0);
+SYSCALL(NtDxgkGetProcessList, NTSTATUS, 0);
+SYSCALL(NtDxgkGetTrackedWorkloadStatistics, NTSTATUS, 0);
+SYSCALL(NtDxgkOutputDuplPresentToHwQueue, NTSTATUS, 0);
+SYSCALL(NtDxgkRegisterVailProcess, NTSTATUS, 0);
+SYSCALL(NtDxgkResetTrackedWorkload, NTSTATUS, 0);
+SYSCALL(NtDxgkSubmitPresentBltToHwQueue, NTSTATUS, 0);
+SYSCALL(NtDxgkSubmitPresentToHwQueue, NTSTATUS, 0);
+SYSCALL(NtDxgkUpdateTrackedWorkload, NTSTATUS, 0);
+SYSCALL(NtDxgkVailConnect, NTSTATUS, 0);
+SYSCALL(NtDxgkVailDisconnect, NTSTATUS, 0);
+SYSCALL(NtDxgkVailPromoteCompositionSurface, NTSTATUS, 0);
+SYSCALL(NtEnableOneCoreTransformMode, NTSTATUS, 0);
+SYSCALL(NtFlipObjectAddContent, NTSTATUS, 0);
+SYSCALL(NtFlipObjectAddPoolBuffer, NTSTATUS, 0);
+SYSCALL(NtFlipObjectConsumerAcquirePresent, NTSTATUS, 0);
+SYSCALL(NtFlipObjectConsumerAdjustUsageReference, NTSTATUS, 0);
+SYSCALL(NtFlipObjectConsumerBeginProcessPresent, NTSTATUS, 0);
+SYSCALL(NtFlipObjectConsumerEndProcessPresent, NTSTATUS, 0);
+SYSCALL(NtFlipObjectConsumerPostMessage, NTSTATUS, 0);
+SYSCALL(NtFlipObjectConsumerQueryBufferInfo, NTSTATUS, 0);
+SYSCALL(NtFlipObjectCreate, NTSTATUS, 0);
+SYSCALL(NtFlipObjectDisconnectEndpoint, NTSTATUS, 0);
+SYSCALL(NtFlipObjectOpen, NTSTATUS, 0);
+SYSCALL(NtFlipObjectPresentCancel, NTSTATUS, 0);
+SYSCALL(NtFlipObjectQueryBufferAvailableEvent, NTSTATUS, 0);
+SYSCALL(NtFlipObjectQueryEndpointConnected, NTSTATUS, 0);
+SYSCALL(NtFlipObjectQueryNextMessageToProducer, NTSTATUS, 0);
+SYSCALL(NtFlipObjectReadNextMessageToProducer, NTSTATUS, 0);
+SYSCALL(NtFlipObjectRemoveContent, NTSTATUS, 0);
+SYSCALL(NtFlipObjectRemovePoolBuffer, NTSTATUS, 0);
+SYSCALL(NtFlipObjectSetContent, NTSTATUS, 0);
+SYSCALL(NtGdiAbortDoc, NTSTATUS, 0);
+SYSCALL(NtGdiAbortPath, NTSTATUS, 0);
+SYSCALL(NtGdiAddEmbFontToDC, NTSTATUS, 0);
+SYSCALL(NtGdiAddFontMemResourceEx, NTSTATUS, 0);
+SYSCALL(NtGdiAddFontResourceW, NTSTATUS, 0);
+SYSCALL(NtGdiAddInitialFonts, NTSTATUS, 0);
+SYSCALL(NtGdiAddRemoteFontToDC, NTSTATUS, 0);
+SYSCALL(NtGdiAddRemoteMMInstanceToDC, NTSTATUS, 0);
+SYSCALL(NtGdiAlphaBlend, NTSTATUS, 0);
+SYSCALL(NtGdiAngleArc, NTSTATUS, 0);
+SYSCALL(NtGdiAnyLinkedFonts, NTSTATUS, 0);
+SYSCALL(NtGdiArcInternal, NTSTATUS, 0);
+SYSCALL(NtGdiBRUSHOBJ_DeleteRbrush, NTSTATUS, 0);
+SYSCALL(NtGdiBRUSHOBJ_hGetColorTransform, NTSTATUS, 0);
+SYSCALL(NtGdiBRUSHOBJ_pvAllocRbrush, NTSTATUS, 0);
+SYSCALL(NtGdiBRUSHOBJ_pvGetRbrush, NTSTATUS, 0);
+SYSCALL(NtGdiBRUSHOBJ_ulGetBrushColor, NTSTATUS, 0);
+SYSCALL(NtGdiBeginGdiRendering, NTSTATUS, 0);
+SYSCALL(NtGdiBeginPath, NTSTATUS, 0);
+SYSCALL(NtGdiBitBlt, NTSTATUS, 0);
+SYSCALL(NtGdiCLIPOBJ_bEnum, NTSTATUS, 0);
+SYSCALL(NtGdiCLIPOBJ_cEnumStart, NTSTATUS, 0);
+SYSCALL(NtGdiCLIPOBJ_ppoGetPath, NTSTATUS, 0);
+SYSCALL(NtGdiCancelDC, NTSTATUS, 0);
+SYSCALL(NtGdiChangeGhostFont, NTSTATUS, 0);
+SYSCALL(NtGdiCheckBitmapBits, NTSTATUS, 0);
+SYSCALL(NtGdiClearBitmapAttributes, NTSTATUS, 0);
+SYSCALL(NtGdiClearBrushAttributes, NTSTATUS, 0);
+SYSCALL(NtGdiCloseFigure, NTSTATUS, 0);
+SYSCALL(NtGdiColorCorrectPalette, NTSTATUS, 0);
+SYSCALL(NtGdiCombineRgn, NTSTATUS, 0);
+SYSCALL(NtGdiCombineTransform, NTSTATUS, 0);
+SYSCALL(NtGdiComputeXformCoefficients, NTSTATUS, 0);
+SYSCALL(NtGdiConfigureOPMProtectedOutput, NTSTATUS, 0);
+SYSCALL(NtGdiConsoleTextOut, NTSTATUS, 0);
+SYSCALL(NtGdiConvertMetafileRect, NTSTATUS, 0);
+SYSCALL(NtGdiCreateBitmap, NTSTATUS, 0);
+SYSCALL(NtGdiCreateBitmapFromDxSurface, NTSTATUS, 0);
+SYSCALL(NtGdiCreateBitmapFromDxSurface2, NTSTATUS, 0);
+SYSCALL(NtGdiCreateClientObj, NTSTATUS, 0);
+SYSCALL(NtGdiCreateColorSpace, NTSTATUS, 0);
+SYSCALL(NtGdiCreateColorTransform, NTSTATUS, 0);
+SYSCALL(NtGdiCreateCompatibleBitmap, NTSTATUS, 0);
+SYSCALL(NtGdiCreateCompatibleDC, NTSTATUS, 0);
+SYSCALL(NtGdiCreateDIBBrush, NTSTATUS, 0);
+SYSCALL(NtGdiCreateDIBSection, NTSTATUS, 0);
+SYSCALL(NtGdiCreateDIBitmapInternal, NTSTATUS, 0);
+SYSCALL(NtGdiCreateEllipticRgn, NTSTATUS, 0);
+SYSCALL(NtGdiCreateHalftonePalette, NTSTATUS, 0);
+SYSCALL(NtGdiCreateHatchBrushInternal, NTSTATUS, 0);
+SYSCALL(NtGdiCreateMetafileDC, NTSTATUS, 0);
+SYSCALL(NtGdiCreateOPMProtectedOutput, NTSTATUS, 0);
+SYSCALL(NtGdiCreateOPMProtectedOutputs, NTSTATUS, 0);
+SYSCALL(NtGdiCreatePaletteInternal, NTSTATUS, 0);
+SYSCALL(NtGdiCreatePatternBrushInternal, NTSTATUS, 0);
+SYSCALL(NtGdiCreatePen, NTSTATUS, 0);
+SYSCALL(NtGdiCreateRectRgn, NTSTATUS, 0);
+SYSCALL(NtGdiCreateRoundRectRgn, NTSTATUS, 0);
+SYSCALL(NtGdiCreateServerMetaFile, NTSTATUS, 0);
+SYSCALL(NtGdiCreateSessionMappedDIBSection, NTSTATUS, 0);
+SYSCALL(NtGdiCreateSolidBrush, NTSTATUS, 0);
+SYSCALL(NtGdiD3dContextCreate, NTSTATUS, 0);
+SYSCALL(NtGdiD3dContextDestroy, NTSTATUS, 0);
+SYSCALL(NtGdiD3dContextDestroyAll, NTSTATUS, 0);
+SYSCALL(NtGdiD3dDrawPrimitives2, NTSTATUS, 0);
+SYSCALL(NtGdiD3dValidateTextureStageState, NTSTATUS, 0);
+SYSCALL(NtGdiDDCCIGetCapabilitiesString, NTSTATUS, 0);
+SYSCALL(NtGdiDDCCIGetCapabilitiesStringLength, NTSTATUS, 0);
+SYSCALL(NtGdiDDCCIGetTimingReport, NTSTATUS, 0);
+SYSCALL(NtGdiDDCCIGetVCPFeature, NTSTATUS, 0);
+SYSCALL(NtGdiDDCCISaveCurrentSettings, NTSTATUS, 0);
+SYSCALL(NtGdiDDCCISetVCPFeature, NTSTATUS, 0);
+SYSCALL(NtGdiDdAddAttachedSurface, NTSTATUS, 0);
+SYSCALL(NtGdiDdAlphaBlt, NTSTATUS, 0);
+SYSCALL(NtGdiDdAttachSurface, NTSTATUS, 0);
+SYSCALL(NtGdiDdBeginMoCompFrame, NTSTATUS, 0);
+SYSCALL(NtGdiDdBlt, NTSTATUS, 0);
+SYSCALL(NtGdiDdCanCreateD3DBuffer, NTSTATUS, 0);
+SYSCALL(NtGdiDdCanCreateSurface, NTSTATUS, 0);
+SYSCALL(NtGdiDdColorControl, NTSTATUS, 0);
+SYSCALL(NtGdiDdCreateD3DBuffer, NTSTATUS, 0);
+SYSCALL(NtGdiDdCreateDirectDrawObject, NTSTATUS, 0);
+SYSCALL(NtGdiDdCreateFullscreenSprite, NTSTATUS, 0);
+SYSCALL(NtGdiDdCreateMoComp, NTSTATUS, 0);
+SYSCALL(NtGdiDdCreateSurface, NTSTATUS, 0);
+SYSCALL(NtGdiDdCreateSurfaceEx, NTSTATUS, 0);
+SYSCALL(NtGdiDdCreateSurfaceObject, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIAbandonSwapChain, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIAcquireKeyedMutex, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIAcquireKeyedMutex2, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIAcquireSwapChain, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIAddSurfaceToSwapChain, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIAdjustFullscreenGamma, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDICacheHybridQueryValue, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIChangeVideoMemoryReservation, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDICheckExclusiveOwnership, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDICheckMonitorPowerState, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDICheckMultiPlaneOverlaySupport, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDICheckMultiPlaneOverlaySupport2, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDICheckMultiPlaneOverlaySupport3, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDICheckOcclusion, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDICheckSharedResourceAccess, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDICheckVidPnExclusiveOwnership, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDICloseAdapter, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIConfigureSharedResource, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDICreateAllocation, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDICreateBundleObject, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDICreateContext, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDICreateContextVirtual, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDICreateDCFromMemory, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDICreateDevice, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDICreateHwContext, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDICreateHwQueue, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDICreateKeyedMutex, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDICreateKeyedMutex2, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDICreateOutputDupl, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDICreateOverlay, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDICreatePagingQueue, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDICreateProtectedSession, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDICreateSwapChain, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDICreateSynchronizationObject, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIDDisplayEnum, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIDestroyAllocation, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIDestroyAllocation2, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIDestroyContext, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIDestroyDCFromMemory, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIDestroyDevice, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIDestroyHwContext, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIDestroyHwQueue, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIDestroyKeyedMutex, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIDestroyOutputDupl, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIDestroyOverlay, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIDestroyPagingQueue, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIDestroyProtectedSession, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIDestroySynchronizationObject, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIDispMgrCreate, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIDispMgrSourceOperation, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIDispMgrTargetOperation, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIEnumAdapters, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIEnumAdapters2, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIEscape, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIEvict, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIExtractBundleObject, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIFlipOverlay, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIFlushHeapTransitions, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIFreeGpuVirtualAddress, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIGetAllocationPriority, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIGetCachedHybridQueryValue, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIGetContextInProcessSchedulingPriority, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIGetContextSchedulingPriority, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIGetDWMVerticalBlankEvent, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIGetDeviceState, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIGetDisplayModeList, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIGetMemoryBudgetTarget, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIGetMultiPlaneOverlayCaps, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIGetMultisampleMethodList, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIGetOverlayState, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIGetPostCompositionCaps, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIGetPresentHistory, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIGetPresentQueueEvent, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIGetProcessDeviceLostSupport, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIGetProcessDeviceRemovalSupport, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIGetProcessSchedulingPriorityBand, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIGetProcessSchedulingPriorityClass, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIGetResourcePresentPrivateDriverData, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIGetRuntimeData, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIGetScanLine, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIGetSetSwapChainMetadata, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIGetSharedPrimaryHandle, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIGetSharedResourceAdapterLuid, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIGetSharedResourceAdapterLuidFlipManager, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIGetYieldPercentage, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIInvalidateActiveVidPn, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIInvalidateCache, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDILock, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDILock2, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIMakeResident, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIMapGpuVirtualAddress, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIMarkDeviceAsError, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDINetDispGetNextChunkInfo, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDINetDispQueryMiracastDisplayDeviceStatus, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDINetDispQueryMiracastDisplayDeviceSupport, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDINetDispStartMiracastDisplayDevice, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDINetDispStartMiracastDisplayDeviceEx, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDINetDispStopMiracastDisplayDevice, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDINetDispStopSessions, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIOfferAllocations, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIOpenAdapterFromDeviceName, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIOpenAdapterFromHdc, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIOpenAdapterFromLuid, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIOpenBundleObjectNtHandleFromName, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIOpenKeyedMutex, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIOpenKeyedMutex2, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIOpenKeyedMutexFromNtHandle, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIOpenNtHandleFromName, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIOpenProtectedSessionFromNtHandle, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIOpenResource, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIOpenResourceFromNtHandle, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIOpenSwapChain, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIOpenSyncObjectFromNtHandle, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIOpenSyncObjectFromNtHandle2, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIOpenSyncObjectNtHandleFromName, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIOpenSynchronizationObject, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIOutputDuplGetFrameInfo, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIOutputDuplGetMetaData, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIOutputDuplGetPointerShapeData, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIOutputDuplPresent, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIOutputDuplReleaseFrame, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIPinDirectFlipResources, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIPollDisplayChildren, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIPresent, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIPresentMultiPlaneOverlay, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIPresentMultiPlaneOverlay2, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIPresentMultiPlaneOverlay3, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIPresentRedirected, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIQueryAdapterInfo, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIQueryAllocationResidency, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIQueryClockCalibration, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIQueryFSEBlock, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIQueryProcessOfferInfo, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIQueryProtectedSessionInfoFromNtHandle, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIQueryProtectedSessionStatus, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIQueryRemoteVidPnSourceFromGdiDisplayName, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIQueryResourceInfo, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIQueryResourceInfoFromNtHandle, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIQueryStatistics, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIQueryVidPnExclusiveOwnership, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIQueryVideoMemoryInfo, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIReclaimAllocations, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIReclaimAllocations2, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIReleaseKeyedMutex, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIReleaseKeyedMutex2, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIReleaseProcessVidPnSourceOwners, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIReleaseSwapChain, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIRemoveSurfaceFromSwapChain, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIRender, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIReserveGpuVirtualAddress, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDISetAllocationPriority, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDISetContextInProcessSchedulingPriority, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDISetContextSchedulingPriority, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDISetDeviceLostSupport, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDISetDisplayMode, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDISetDisplayPrivateDriverFormat, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDISetDodIndirectSwapchain, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDISetFSEBlock, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDISetGammaRamp, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDISetHwProtectionTeardownRecovery, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDISetMemoryBudgetTarget, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDISetMonitorColorSpaceTransform, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDISetProcessDeviceRemovalSupport, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDISetProcessSchedulingPriorityBand, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDISetProcessSchedulingPriorityClass, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDISetQueuedLimit, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDISetStablePowerState, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDISetStereoEnabled, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDISetSyncRefreshCountWaitTarget, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDISetVidPnSourceHwProtection, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDISetVidPnSourceOwner, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDISetVidPnSourceOwner1, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDISetYieldPercentage, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIShareObjects, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDISharedPrimaryLockNotification, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDISharedPrimaryUnLockNotification, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDISignalSynchronizationObject, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDISignalSynchronizationObjectFromCpu, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDISignalSynchronizationObjectFromGpu, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDISignalSynchronizationObjectFromGpu2, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDISubmitCommand, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDISubmitCommandToHwQueue, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDISubmitSignalSyncObjectsToHwQueue, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDISubmitWaitForSyncObjectsToHwQueue, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDITrimProcessCommitment, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIUnOrderedPresentSwapChain, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIUnlock, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIUnlock2, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIUnpinDirectFlipResources, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIUpdateAllocationProperty, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIUpdateGpuVirtualAddress, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIUpdateOverlay, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIWaitForIdle, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIWaitForSynchronizationObject, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIWaitForSynchronizationObjectFromCpu, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIWaitForSynchronizationObjectFromGpu, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIWaitForVerticalBlankEvent, NTSTATUS, 0);
+SYSCALL(NtGdiDdDDIWaitForVerticalBlankEvent2, NTSTATUS, 0);
+SYSCALL(NtGdiDdDeleteDirectDrawObject, NTSTATUS, 0);
+SYSCALL(NtGdiDdDeleteSurfaceObject, NTSTATUS, 0);
+SYSCALL(NtGdiDdDestroyD3DBuffer, NTSTATUS, 0);
+SYSCALL(NtGdiDdDestroyFullscreenSprite, NTSTATUS, 0);
+SYSCALL(NtGdiDdDestroyMoComp, NTSTATUS, 0);
+SYSCALL(NtGdiDdDestroySurface, NTSTATUS, 0);
+SYSCALL(NtGdiDdEndMoCompFrame, NTSTATUS, 0);
+SYSCALL(NtGdiDdFlip, NTSTATUS, 0);
+SYSCALL(NtGdiDdFlipToGDISurface, NTSTATUS, 0);
+SYSCALL(NtGdiDdGetAvailDriverMemory, NTSTATUS, 0);
+SYSCALL(NtGdiDdGetBltStatus, NTSTATUS, 0);
+SYSCALL(NtGdiDdGetDC, NTSTATUS, 0);
+SYSCALL(NtGdiDdGetDriverInfo, NTSTATUS, 0);
+SYSCALL(NtGdiDdGetDriverState, NTSTATUS, 0);
+SYSCALL(NtGdiDdGetDxHandle, NTSTATUS, 0);
+SYSCALL(NtGdiDdGetFlipStatus, NTSTATUS, 0);
+SYSCALL(NtGdiDdGetInternalMoCompInfo, NTSTATUS, 0);
+SYSCALL(NtGdiDdGetMoCompBuffInfo, NTSTATUS, 0);
+SYSCALL(NtGdiDdGetMoCompFormats, NTSTATUS, 0);
+SYSCALL(NtGdiDdGetMoCompGuids, NTSTATUS, 0);
+SYSCALL(NtGdiDdGetScanLine, NTSTATUS, 0);
+SYSCALL(NtGdiDdLock, NTSTATUS, 0);
+SYSCALL(NtGdiDdLockD3D, NTSTATUS, 0);
+SYSCALL(NtGdiDdNotifyFullscreenSpriteUpdate, NTSTATUS, 0);
+SYSCALL(NtGdiDdQueryDirectDrawObject, NTSTATUS, 0);
+SYSCALL(NtGdiDdQueryMoCompStatus, NTSTATUS, 0);
+SYSCALL(NtGdiDdQueryVisRgnUniqueness, NTSTATUS, 0);
+SYSCALL(NtGdiDdReenableDirectDrawObject, NTSTATUS, 0);
+SYSCALL(NtGdiDdReleaseDC, NTSTATUS, 0);
+SYSCALL(NtGdiDdRenderMoComp, NTSTATUS, 0);
+SYSCALL(NtGdiDdResetVisrgn, NTSTATUS, 0);
+SYSCALL(NtGdiDdSetColorKey, NTSTATUS, 0);
+SYSCALL(NtGdiDdSetExclusiveMode, NTSTATUS, 0);
+SYSCALL(NtGdiDdSetGammaRamp, NTSTATUS, 0);
+SYSCALL(NtGdiDdSetOverlayPosition, NTSTATUS, 0);
+SYSCALL(NtGdiDdUnattachSurface, NTSTATUS, 0);
+SYSCALL(NtGdiDdUnlock, NTSTATUS, 0);
+SYSCALL(NtGdiDdUnlockD3D, NTSTATUS, 0);
+SYSCALL(NtGdiDdUpdateOverlay, NTSTATUS, 0);
+SYSCALL(NtGdiDdWaitForVerticalBlank, NTSTATUS, 0);
+SYSCALL(NtGdiDeleteClientObj, NTSTATUS, 0);
+SYSCALL(NtGdiDeleteColorSpace, NTSTATUS, 0);
+SYSCALL(NtGdiDeleteColorTransform, NTSTATUS, 0);
+SYSCALL(NtGdiDeleteObjectApp, NTSTATUS, 0);
+SYSCALL(NtGdiDescribePixelFormat, NTSTATUS, 0);
+SYSCALL(NtGdiDestroyOPMProtectedOutput, NTSTATUS, 0);
+SYSCALL(NtGdiDestroyPhysicalMonitor, NTSTATUS, 0);
+SYSCALL(NtGdiDoBanding, NTSTATUS, 0);
+SYSCALL(NtGdiDoPalette, NTSTATUS, 0);
+SYSCALL(NtGdiDrawEscape, NTSTATUS, 0);
+SYSCALL(NtGdiDrawStream, NTSTATUS, 0);
+SYSCALL(NtGdiDvpAcquireNotification, NTSTATUS, 0);
+SYSCALL(NtGdiDvpCanCreateVideoPort, NTSTATUS, 0);
+SYSCALL(NtGdiDvpColorControl, NTSTATUS, 0);
+SYSCALL(NtGdiDvpCreateVideoPort, NTSTATUS, 0);
+SYSCALL(NtGdiDvpDestroyVideoPort, NTSTATUS, 0);
+SYSCALL(NtGdiDvpFlipVideoPort, NTSTATUS, 0);
+SYSCALL(NtGdiDvpGetVideoPortBandwidth, NTSTATUS, 0);
+SYSCALL(NtGdiDvpGetVideoPortConnectInfo, NTSTATUS, 0);
+SYSCALL(NtGdiDvpGetVideoPortField, NTSTATUS, 0);
+SYSCALL(NtGdiDvpGetVideoPortFlipStatus, NTSTATUS, 0);
+SYSCALL(NtGdiDvpGetVideoPortInputFormats, NTSTATUS, 0);
+SYSCALL(NtGdiDvpGetVideoPortLine, NTSTATUS, 0);
+SYSCALL(NtGdiDvpGetVideoPortOutputFormats, NTSTATUS, 0);
+SYSCALL(NtGdiDvpGetVideoSignalStatus, NTSTATUS, 0);
+SYSCALL(NtGdiDvpReleaseNotification, NTSTATUS, 0);
+SYSCALL(NtGdiDvpUpdateVideoPort, NTSTATUS, 0);
+SYSCALL(NtGdiDvpWaitForVideoPortSync, NTSTATUS, 0);
+SYSCALL(NtGdiDwmCreatedBitmapRemotingOutput, NTSTATUS, 0);
+SYSCALL(NtGdiDwmGetDirtyRgn, NTSTATUS, 0);
+SYSCALL(NtGdiDwmGetSurfaceData, NTSTATUS, 0);
+SYSCALL(NtGdiDxgGenericThunk, NTSTATUS, 0);
+SYSCALL(NtGdiEllipse, NTSTATUS, 0);
+SYSCALL(NtGdiEnableEudc, NTSTATUS, 0);
+SYSCALL(NtGdiEndDoc, NTSTATUS, 0);
+SYSCALL(NtGdiEndGdiRendering, NTSTATUS, 0);
+SYSCALL(NtGdiEndPage, NTSTATUS, 0);
+SYSCALL(NtGdiEndPath, NTSTATUS, 0);
+SYSCALL(NtGdiEngAlphaBlend, NTSTATUS, 0);
+SYSCALL(NtGdiEngAssociateSurface, NTSTATUS, 0);
+SYSCALL(NtGdiEngBitBlt, NTSTATUS, 0);
+SYSCALL(NtGdiEngCheckAbort, NTSTATUS, 0);
+SYSCALL(NtGdiEngComputeGlyphSet, NTSTATUS, 0);
+SYSCALL(NtGdiEngCopyBits, NTSTATUS, 0);
+SYSCALL(NtGdiEngCreateBitmap, NTSTATUS, 0);
+SYSCALL(NtGdiEngCreateClip, NTSTATUS, 0);
+SYSCALL(NtGdiEngCreateDeviceBitmap, NTSTATUS, 0);
+SYSCALL(NtGdiEngCreateDeviceSurface, NTSTATUS, 0);
+SYSCALL(NtGdiEngCreatePalette, NTSTATUS, 0);
+SYSCALL(NtGdiEngDeleteClip, NTSTATUS, 0);
+SYSCALL(NtGdiEngDeletePalette, NTSTATUS, 0);
+SYSCALL(NtGdiEngDeletePath, NTSTATUS, 0);
+SYSCALL(NtGdiEngDeleteSurface, NTSTATUS, 0);
+SYSCALL(NtGdiEngEraseSurface, NTSTATUS, 0);
+SYSCALL(NtGdiEngFillPath, NTSTATUS, 0);
+SYSCALL(NtGdiEngGradientFill, NTSTATUS, 0);
+SYSCALL(NtGdiEngLineTo, NTSTATUS, 0);
+SYSCALL(NtGdiEngLockSurface, NTSTATUS, 0);
+SYSCALL(NtGdiEngMarkBandingSurface, NTSTATUS, 0);
+SYSCALL(NtGdiEngPaint, NTSTATUS, 0);
+SYSCALL(NtGdiEngPlgBlt, NTSTATUS, 0);
+SYSCALL(NtGdiEngStretchBlt, NTSTATUS, 0);
+SYSCALL(NtGdiEngStretchBltROP, NTSTATUS, 0);
+SYSCALL(NtGdiEngStrokeAndFillPath, NTSTATUS, 0);
+SYSCALL(NtGdiEngStrokePath, NTSTATUS, 0);
+SYSCALL(NtGdiEngTextOut, NTSTATUS, 0);
+SYSCALL(NtGdiEngTransparentBlt, NTSTATUS, 0);
+SYSCALL(NtGdiEngUnlockSurface, NTSTATUS, 0);
+SYSCALL(NtGdiEnsureDpiDepDefaultGuiFontForPlateau, NTSTATUS, 0);
+SYSCALL(NtGdiEnumFontChunk, NTSTATUS, 0);
+SYSCALL(NtGdiEnumFontClose, NTSTATUS, 0);
+SYSCALL(NtGdiEnumFontOpen, NTSTATUS, 0);
+SYSCALL(NtGdiEnumFonts, NTSTATUS, 0);
+SYSCALL(NtGdiEnumObjects, NTSTATUS, 0);
+SYSCALL(NtGdiEqualRgn, NTSTATUS, 0);
+SYSCALL(NtGdiEudcLoadUnloadLink, NTSTATUS, 0);
+SYSCALL(NtGdiExcludeClipRect, NTSTATUS, 0);
+SYSCALL(NtGdiExtCreatePen, NTSTATUS, 0);
+SYSCALL(NtGdiExtCreateRegion, NTSTATUS, 0);
+SYSCALL(NtGdiExtEscape, NTSTATUS, 0);
+SYSCALL(NtGdiExtFloodFill, NTSTATUS, 0);
+SYSCALL(NtGdiExtGetObjectW, NTSTATUS, 0);
+SYSCALL(NtGdiExtSelectClipRgn, NTSTATUS, 0);
+SYSCALL(NtGdiExtTextOutW, NTSTATUS, 0);
+SYSCALL(NtGdiFONTOBJ_cGetAllGlyphHandles, NTSTATUS, 0);
+SYSCALL(NtGdiFONTOBJ_cGetGlyphs, NTSTATUS, 0);
+SYSCALL(NtGdiFONTOBJ_pQueryGlyphAttrs, NTSTATUS, 0);
+SYSCALL(NtGdiFONTOBJ_pfdg, NTSTATUS, 0);
+SYSCALL(NtGdiFONTOBJ_pifi, NTSTATUS, 0);
+SYSCALL(NtGdiFONTOBJ_pvTrueTypeFontFile, NTSTATUS, 0);
+SYSCALL(NtGdiFONTOBJ_pxoGetXform, NTSTATUS, 0);
+SYSCALL(NtGdiFONTOBJ_vGetInfo, NTSTATUS, 0);
+SYSCALL(NtGdiFillPath, NTSTATUS, 0);
+SYSCALL(NtGdiFillRgn, NTSTATUS, 0);
+SYSCALL(NtGdiFlattenPath, NTSTATUS, 0);
+SYSCALL(NtGdiFlush, NTSTATUS, 0);
+SYSCALL(NtGdiFontIsLinked, NTSTATUS, 0);
+SYSCALL(NtGdiForceUFIMapping, NTSTATUS, 0);
+SYSCALL(NtGdiFrameRgn, NTSTATUS, 0);
+SYSCALL(NtGdiFullscreenControl, NTSTATUS, 0);
+SYSCALL(NtGdiGetAndSetDCDword, NTSTATUS, 0);
+SYSCALL(NtGdiGetAppClipBox, NTSTATUS, 0);
+SYSCALL(NtGdiGetAppliedDeviceGammaRamp, NTSTATUS, 0);
+SYSCALL(NtGdiGetBitmapBits, NTSTATUS, 0);
+SYSCALL(NtGdiGetBitmapDimension, NTSTATUS, 0);
+SYSCALL(NtGdiGetBitmapDpiScaleValue, NTSTATUS, 0);
+SYSCALL(NtGdiGetBoundsRect, NTSTATUS, 0);
+SYSCALL(NtGdiGetCOPPCompatibleOPMInformation, NTSTATUS, 0);
+SYSCALL(NtGdiGetCertificate, NTSTATUS, 0);
+SYSCALL(NtGdiGetCertificateByHandle, NTSTATUS, 0);
+SYSCALL(NtGdiGetCertificateSize, NTSTATUS, 0);
+SYSCALL(NtGdiGetCertificateSizeByHandle, NTSTATUS, 0);
+SYSCALL(NtGdiGetCharABCWidthsW, NTSTATUS, 0);
+SYSCALL(NtGdiGetCharSet, NTSTATUS, 0);
+SYSCALL(NtGdiGetCharWidthInfo, NTSTATUS, 0);
+SYSCALL(NtGdiGetCharWidthW, NTSTATUS, 0);
+SYSCALL(NtGdiGetCharacterPlacementW, NTSTATUS, 0);
+SYSCALL(NtGdiGetColorAdjustment, NTSTATUS, 0);
+SYSCALL(NtGdiGetColorSpaceforBitmap, NTSTATUS, 0);
+SYSCALL(NtGdiGetCurrentDpiInfo, NTSTATUS, 0);
+SYSCALL(NtGdiGetDCDpiScaleValue, NTSTATUS, 0);
+SYSCALL(NtGdiGetDCDword, NTSTATUS, 0);
+SYSCALL(NtGdiGetDCObject, NTSTATUS, 0);
+SYSCALL(NtGdiGetDCPoint, NTSTATUS, 0);
+SYSCALL(NtGdiGetDCforBitmap, NTSTATUS, 0);
+SYSCALL(NtGdiGetDIBitsInternal, NTSTATUS, 0);
+SYSCALL(NtGdiGetDeviceCaps, NTSTATUS, 0);
+SYSCALL(NtGdiGetDeviceCapsAll, NTSTATUS, 0);
+SYSCALL(NtGdiGetDeviceGammaRamp, NTSTATUS, 0);
+SYSCALL(NtGdiGetDeviceWidth, NTSTATUS, 0);
+SYSCALL(NtGdiGetDhpdev, NTSTATUS, 0);
+SYSCALL(NtGdiGetETM, NTSTATUS, 0);
+SYSCALL(NtGdiGetEmbUFI, NTSTATUS, 0);
+SYSCALL(NtGdiGetEmbedFonts, NTSTATUS, 0);
+SYSCALL(NtGdiGetEntry, NTSTATUS, 0);
+SYSCALL(NtGdiGetEudcTimeStampEx, NTSTATUS, 0);
+SYSCALL(NtGdiGetFontData, NTSTATUS, 0);
+SYSCALL(NtGdiGetFontFileData, NTSTATUS, 0);
+SYSCALL(NtGdiGetFontFileInfo, NTSTATUS, 0);
+SYSCALL(NtGdiGetFontResourceInfoInternalW, NTSTATUS, 0);
+SYSCALL(NtGdiGetFontUnicodeRanges, NTSTATUS, 0);
+SYSCALL(NtGdiGetGammaRampCapability, NTSTATUS, 0);
+SYSCALL(NtGdiGetGlyphIndicesW, NTSTATUS, 0);
+SYSCALL(NtGdiGetGlyphIndicesWInternal, NTSTATUS, 0);
+SYSCALL(NtGdiGetGlyphOutline, NTSTATUS, 0);
+SYSCALL(NtGdiGetKerningPairs, NTSTATUS, 0);
+SYSCALL(NtGdiGetLinkedUFIs, NTSTATUS, 0);
+SYSCALL(NtGdiGetMiterLimit, NTSTATUS, 0);
+SYSCALL(NtGdiGetMonitorID, NTSTATUS, 0);
+SYSCALL(NtGdiGetNearestColor, NTSTATUS, 0);
+SYSCALL(NtGdiGetNearestPaletteIndex, NTSTATUS, 0);
+SYSCALL(NtGdiGetNumberOfPhysicalMonitors, NTSTATUS, 0);
+SYSCALL(NtGdiGetOPMInformation, NTSTATUS, 0);
+SYSCALL(NtGdiGetOPMRandomNumber, NTSTATUS, 0);
+SYSCALL(NtGdiGetObjectBitmapHandle, NTSTATUS, 0);
+SYSCALL(NtGdiGetOutlineTextMetricsInternalW, NTSTATUS, 0);
+SYSCALL(NtGdiGetPath, NTSTATUS, 0);
+SYSCALL(NtGdiGetPerBandInfo, NTSTATUS, 0);
+SYSCALL(NtGdiGetPhysicalMonitorDescription, NTSTATUS, 0);
+SYSCALL(NtGdiGetPhysicalMonitors, NTSTATUS, 0);
+SYSCALL(NtGdiGetPixel, NTSTATUS, 0);
+SYSCALL(NtGdiGetProcessSessionFonts, NTSTATUS, 0);
+SYSCALL(NtGdiGetPublicFontTableChangeCookie, NTSTATUS, 0);
+SYSCALL(NtGdiGetRandomRgn, NTSTATUS, 0);
+SYSCALL(NtGdiGetRasterizerCaps, NTSTATUS, 0);
+SYSCALL(NtGdiGetRealizationInfo, NTSTATUS, 0);
+SYSCALL(NtGdiGetRegionData, NTSTATUS, 0);
+SYSCALL(NtGdiGetRgnBox, NTSTATUS, 0);
+SYSCALL(NtGdiGetServerMetaFileBits, NTSTATUS, 0);
+SYSCALL(NtGdiGetSpoolMessage, NTSTATUS, 0);
+SYSCALL(NtGdiGetStats, NTSTATUS, 0);
+SYSCALL(NtGdiGetStockObject, NTSTATUS, 0);
+SYSCALL(NtGdiGetStringBitmapW, NTSTATUS, 0);
+SYSCALL(NtGdiGetSuggestedOPMProtectedOutputArraySize, NTSTATUS, 0);
+SYSCALL(NtGdiGetSystemPaletteUse, NTSTATUS, 0);
+SYSCALL(NtGdiGetTextCharsetInfo, NTSTATUS, 0);
+SYSCALL(NtGdiGetTextExtent, NTSTATUS, 0);
+SYSCALL(NtGdiGetTextExtentExW, NTSTATUS, 0);
+SYSCALL(NtGdiGetTextFaceW, NTSTATUS, 0);
+SYSCALL(NtGdiGetTextMetricsW, NTSTATUS, 0);
+SYSCALL(NtGdiGetTransform, NTSTATUS, 0);
+SYSCALL(NtGdiGetUFI, NTSTATUS, 0);
+SYSCALL(NtGdiGetUFIPathname, NTSTATUS, 0);
+SYSCALL(NtGdiGetWidthTable, NTSTATUS, 0);
+SYSCALL(NtGdiGradientFill, NTSTATUS, 0);
+SYSCALL(NtGdiHLSurfGetInformation, NTSTATUS, 0);
+SYSCALL(NtGdiHLSurfSetInformation, NTSTATUS, 0);
+SYSCALL(NtGdiHT_Get8BPPFormatPalette, NTSTATUS, 0);
+SYSCALL(NtGdiHT_Get8BPPMaskPalette, NTSTATUS, 0);
+SYSCALL(NtGdiHfontCreate, NTSTATUS, 0);
+SYSCALL(NtGdiIcmBrushInfo, NTSTATUS, 0);
+SYSCALL(NtGdiInit, NTSTATUS, 0);
+SYSCALL(NtGdiInitSpool, NTSTATUS, 0);
+SYSCALL(NtGdiIntersectClipRect, NTSTATUS, 0);
+SYSCALL(NtGdiInvertRgn, NTSTATUS, 0);
+SYSCALL(NtGdiLineTo, NTSTATUS, 0);
+SYSCALL(NtGdiMakeFontDir, NTSTATUS, 0);
+SYSCALL(NtGdiMakeInfoDC, NTSTATUS, 0);
+SYSCALL(NtGdiMakeObjectUnXferable, NTSTATUS, 0);
+SYSCALL(NtGdiMakeObjectXferable, NTSTATUS, 0);
+SYSCALL(NtGdiMaskBlt, NTSTATUS, 0);
+SYSCALL(NtGdiMirrorWindowOrg, NTSTATUS, 0);
+SYSCALL(NtGdiModifyWorldTransform, NTSTATUS, 0);
+SYSCALL(NtGdiMonoBitmap, NTSTATUS, 0);
+SYSCALL(NtGdiMoveTo, NTSTATUS, 0);
+SYSCALL(NtGdiOffsetClipRgn, NTSTATUS, 0);
+SYSCALL(NtGdiOffsetRgn, NTSTATUS, 0);
+SYSCALL(NtGdiOpenDCW, NTSTATUS, 0);
+SYSCALL(NtGdiPATHOBJ_bEnum, NTSTATUS, 0);
+SYSCALL(NtGdiPATHOBJ_bEnumClipLines, NTSTATUS, 0);
+SYSCALL(NtGdiPATHOBJ_vEnumStart, NTSTATUS, 0);
+SYSCALL(NtGdiPATHOBJ_vEnumStartClipLines, NTSTATUS, 0);
+SYSCALL(NtGdiPATHOBJ_vGetBounds, NTSTATUS, 0);
+SYSCALL(NtGdiPatBlt, NTSTATUS, 0);
+SYSCALL(NtGdiPathToRegion, NTSTATUS, 0);
+SYSCALL(NtGdiPlgBlt, NTSTATUS, 0);
+SYSCALL(NtGdiPolyDraw, NTSTATUS, 0);
+SYSCALL(NtGdiPolyPatBlt, NTSTATUS, 0);
+SYSCALL(NtGdiPolyPolyDraw, NTSTATUS, 0);
+SYSCALL(NtGdiPolyTextOutW, NTSTATUS, 0);
+SYSCALL(NtGdiPtInRegion, NTSTATUS, 0);
+SYSCALL(NtGdiPtVisible, NTSTATUS, 0);
+SYSCALL(NtGdiQueryFontAssocInfo, NTSTATUS, 0);
+SYSCALL(NtGdiQueryFonts, NTSTATUS, 0);
+SYSCALL(NtGdiRectInRegion, NTSTATUS, 0);
+SYSCALL(NtGdiRectVisible, NTSTATUS, 0);
+SYSCALL(NtGdiRectangle, NTSTATUS, 0);
+SYSCALL(NtGdiRemoveFontMemResourceEx, NTSTATUS, 0);
+SYSCALL(NtGdiRemoveFontResourceW, NTSTATUS, 0);
+SYSCALL(NtGdiRemoveMergeFont, NTSTATUS, 0);
+SYSCALL(NtGdiResetDC, NTSTATUS, 0);
+SYSCALL(NtGdiResizePalette, NTSTATUS, 0);
+SYSCALL(NtGdiRestoreDC, NTSTATUS, 0);
+SYSCALL(NtGdiRoundRect, NTSTATUS, 0);
+SYSCALL(NtGdiSTROBJ_bEnum, NTSTATUS, 0);
+SYSCALL(NtGdiSTROBJ_bEnumPositionsOnly, NTSTATUS, 0);
+SYSCALL(NtGdiSTROBJ_bGetAdvanceWidths, NTSTATUS, 0);
+SYSCALL(NtGdiSTROBJ_dwGetCodePage, NTSTATUS, 0);
+SYSCALL(NtGdiSTROBJ_vEnumStart, NTSTATUS, 0);
+SYSCALL(NtGdiSaveDC, NTSTATUS, 0);
+SYSCALL(NtGdiScaleRgn, NTSTATUS, 0);
+SYSCALL(NtGdiScaleValues, NTSTATUS, 0);
+SYSCALL(NtGdiScaleViewportExtEx, NTSTATUS, 0);
+SYSCALL(NtGdiScaleWindowExtEx, NTSTATUS, 0);
+SYSCALL(NtGdiSelectBitmap, NTSTATUS, 0);
+SYSCALL(NtGdiSelectBrush, NTSTATUS, 0);
+SYSCALL(NtGdiSelectClipPath, NTSTATUS, 0);
+SYSCALL(NtGdiSelectFont, NTSTATUS, 0);
+SYSCALL(NtGdiSelectPen, NTSTATUS, 0);
+SYSCALL(NtGdiSetBitmapAttributes, NTSTATUS, 0);
+SYSCALL(NtGdiSetBitmapBits, NTSTATUS, 0);
+SYSCALL(NtGdiSetBitmapDimension, NTSTATUS, 0);
+SYSCALL(NtGdiSetBoundsRect, NTSTATUS, 0);
+SYSCALL(NtGdiSetBrushAttributes, NTSTATUS, 0);
+SYSCALL(NtGdiSetBrushOrg, NTSTATUS, 0);
+SYSCALL(NtGdiSetColorAdjustment, NTSTATUS, 0);
+SYSCALL(NtGdiSetColorSpace, NTSTATUS, 0);
+SYSCALL(NtGdiSetDIBitsToDeviceInternal, NTSTATUS, 0);
+SYSCALL(NtGdiSetDeviceGammaRamp, NTSTATUS, 0);
+SYSCALL(NtGdiSetFontEnumeration, NTSTATUS, 0);
+SYSCALL(NtGdiSetFontXform, NTSTATUS, 0);
+SYSCALL(NtGdiSetIcmMode, NTSTATUS, 0);
+SYSCALL(NtGdiSetLayout, NTSTATUS, 0);
+SYSCALL(NtGdiSetLinkedUFIs, NTSTATUS, 0);
+SYSCALL(NtGdiSetMagicColors, NTSTATUS, 0);
+SYSCALL(NtGdiSetMetaRgn, NTSTATUS, 0);
+SYSCALL(NtGdiSetMiterLimit, NTSTATUS, 0);
+SYSCALL(NtGdiSetOPMSigningKeyAndSequenceNumbers, NTSTATUS, 0);
+SYSCALL(NtGdiSetPUMPDOBJ, NTSTATUS, 0);
+SYSCALL(NtGdiSetPixel, NTSTATUS, 0);
+SYSCALL(NtGdiSetPixelFormat, NTSTATUS, 0);
+SYSCALL(NtGdiSetPrivateDeviceGammaRamp, NTSTATUS, 0);
+SYSCALL(NtGdiSetRectRgn, NTSTATUS, 0);
+SYSCALL(NtGdiSetSizeDevice, NTSTATUS, 0);
+SYSCALL(NtGdiSetSystemPaletteUse, NTSTATUS, 0);
+SYSCALL(NtGdiSetTextJustification, NTSTATUS, 0);
+SYSCALL(NtGdiSetUMPDSandboxState, NTSTATUS, 0);
+SYSCALL(NtGdiSetVirtualResolution, NTSTATUS, 0);
+SYSCALL(NtGdiSetupPublicCFONT, NTSTATUS, 0);
+SYSCALL(NtGdiSfmGetNotificationTokens, NTSTATUS, 0);
+SYSCALL(NtGdiStartDoc, NTSTATUS, 0);
+SYSCALL(NtGdiStartPage, NTSTATUS, 0);
+SYSCALL(NtGdiStretchBlt, NTSTATUS, 0);
+SYSCALL(NtGdiStretchDIBitsInternal, NTSTATUS, 0);
+SYSCALL(NtGdiStrokeAndFillPath, NTSTATUS, 0);
+SYSCALL(NtGdiStrokePath, NTSTATUS, 0);
+SYSCALL(NtGdiSwapBuffers, NTSTATUS, 0);
+SYSCALL(NtGdiTransformPoints, NTSTATUS, 0);
+SYSCALL(NtGdiTransparentBlt, NTSTATUS, 0);
+SYSCALL(NtGdiUMPDEngFreeUserMem, NTSTATUS, 0);
+SYSCALL(NtGdiUnloadPrinterDriver, NTSTATUS, 0);
+SYSCALL(NtGdiUnmapMemFont, NTSTATUS, 0);
+SYSCALL(NtGdiUnrealizeObject, NTSTATUS, 0);
+SYSCALL(NtGdiUpdateColors, NTSTATUS, 0);
+SYSCALL(NtGdiUpdateTransform, NTSTATUS, 0);
+SYSCALL(NtGdiWidenPath, NTSTATUS, 0);
+SYSCALL(NtGdiXFORMOBJ_bApplyXform, NTSTATUS, 0);
+SYSCALL(NtGdiXFORMOBJ_iGetXform, NTSTATUS, 0);
+SYSCALL(NtGdiXLATEOBJ_cGetPalette, NTSTATUS, 0);
+SYSCALL(NtGdiXLATEOBJ_hGetColorTransform, NTSTATUS, 0);
+SYSCALL(NtGdiXLATEOBJ_iXlate, NTSTATUS, 0);
+SYSCALL(NtHWCursorUpdatePointer, NTSTATUS, 0);
+SYSCALL(NtIsOneCoreTransformMode, NTSTATUS, 0);
+SYSCALL(NtMITActivateInputProcessing, NTSTATUS, 0);
+SYSCALL(NtMITBindInputTypeToMonitors, NTSTATUS, 0);
+SYSCALL(NtMITCoreMsgKGetConnectionHandle, NTSTATUS, 0);
+SYSCALL(NtMITCoreMsgKOpenConnectionTo, NTSTATUS, 0);
+SYSCALL(NtMITCoreMsgKSend, NTSTATUS, 0);
+SYSCALL(NtMITDeactivateInputProcessing, NTSTATUS, 0);
+SYSCALL(NtMITDisableMouseIntercept, NTSTATUS, 0);
+SYSCALL(NtMITDispatchCompletion, NTSTATUS, 0);
+SYSCALL(NtMITEnableMouseIntercept, NTSTATUS, 0);
+SYSCALL(NtMITGetCursorUpdateHandle, NTSTATUS, 0);
+SYSCALL(NtMITSetInputCallbacks, NTSTATUS, 0);
+SYSCALL(NtMITSetInputDelegationMode, NTSTATUS, 0);
+SYSCALL(NtMITSetInputSuppressionState, NTSTATUS, 0);
+SYSCALL(NtMITSetKeyboardInputRoutingPolicy, NTSTATUS, 0);
+SYSCALL(NtMITSetKeyboardOverriderState, NTSTATUS, 0);
+SYSCALL(NtMITSetLastInputRecipient, NTSTATUS, 0);
+SYSCALL(NtMITSynthesizeKeyboardInput, NTSTATUS, 0);
+SYSCALL(NtMITSynthesizeMouseInput, NTSTATUS, 0);
+SYSCALL(NtMITSynthesizeMouseWheel, NTSTATUS, 0);
+SYSCALL(NtMITSynthesizeTouchInput, NTSTATUS, 0);
+SYSCALL(NtMITUpdateInputGlobals, NTSTATUS, 0);
+SYSCALL(NtMITWaitForMultipleObjectsEx, NTSTATUS, 0);
+SYSCALL(NtMapVisualRelativePoints, NTSTATUS, 0);
+SYSCALL(NtNotifyPresentToCompositionSurface, NTSTATUS, 0);
+SYSCALL(NtOpenCompositionSurfaceDirtyRegion, NTSTATUS, 0);
+SYSCALL(NtOpenCompositionSurfaceSectionInfo, NTSTATUS, 0);
+SYSCALL(NtOpenCompositionSurfaceSwapChainHandleInfo, NTSTATUS, 0);
+SYSCALL(NtQueryCompositionInputIsImplicit, NTSTATUS, 0);
+SYSCALL(NtQueryCompositionInputQueueAndTransform, NTSTATUS, 0);
+SYSCALL(NtQueryCompositionInputSink, NTSTATUS, 0);
+SYSCALL(NtQueryCompositionInputSinkLuid, NTSTATUS, 0);
+SYSCALL(NtQueryCompositionInputSinkViewId, NTSTATUS, 0);
+SYSCALL(NtQueryCompositionSurfaceBinding, NTSTATUS, 0);
+SYSCALL(NtQueryCompositionSurfaceHDRMetaData, NTSTATUS, 0);
+SYSCALL(NtQueryCompositionSurfaceRenderingRealization, NTSTATUS, 0);
+SYSCALL(NtQueryCompositionSurfaceStatistics, NTSTATUS, 0);
+SYSCALL(NtRIMAddInputObserver, NTSTATUS, 0);
+SYSCALL(NtRIMAreSiblingDevices, NTSTATUS, 0);
+SYSCALL(NtRIMDeviceIoControl, NTSTATUS, 0);
+SYSCALL(NtRIMEnableMonitorMappingForDevice, NTSTATUS, 0);
+SYSCALL(NtRIMFreeInputBuffer, NTSTATUS, 0);
+SYSCALL(NtRIMGetDevicePreparsedData, NTSTATUS, 0);
+SYSCALL(NtRIMGetDevicePreparsedDataLockfree, NTSTATUS, 0);
+SYSCALL(NtRIMGetDeviceProperties, NTSTATUS, 0);
+SYSCALL(NtRIMGetDevicePropertiesLockfree, NTSTATUS, 0);
+SYSCALL(NtRIMGetPhysicalDeviceRect, NTSTATUS, 0);
+SYSCALL(NtRIMGetSourceProcessId, NTSTATUS, 0);
+SYSCALL(NtRIMObserveNextInput, NTSTATUS, 0);
+SYSCALL(NtRIMOnPnpNotification, NTSTATUS, 0);
+SYSCALL(NtRIMOnTimerNotification, NTSTATUS, 0);
+SYSCALL(NtRIMReadInput, NTSTATUS, 0);
+SYSCALL(NtRIMRegisterForInput, NTSTATUS, 0);
+SYSCALL(NtRIMRemoveInputObserver, NTSTATUS, 0);
+SYSCALL(NtRIMSetExtendedDeviceProperty, NTSTATUS, 0);
+SYSCALL(NtRIMSetTestModeStatus, NTSTATUS, 0);
+SYSCALL(NtRIMUnregisterForInput, NTSTATUS, 0);
+SYSCALL(NtRIMUpdateInputObserverRegistration, NTSTATUS, 0);
+SYSCALL(NtSetCompositionSurfaceAnalogExclusive, NTSTATUS, 0);
+SYSCALL(NtSetCompositionSurfaceBufferCompositionMode, NTSTATUS, 0);
+SYSCALL(NtSetCompositionSurfaceBufferCompositionModeAndOrientation, NTSTATUS, 0);
+SYSCALL(NtSetCompositionSurfaceBufferUsage, NTSTATUS, 0);
+SYSCALL(NtSetCompositionSurfaceDirectFlipState, NTSTATUS, 0);
+SYSCALL(NtSetCompositionSurfaceHDRMetaData, NTSTATUS, 0);
+SYSCALL(NtSetCompositionSurfaceIndependentFlipInfo, NTSTATUS, 0);
+SYSCALL(NtSetCompositionSurfaceOutOfFrameDirectFlipNotification, NTSTATUS, 0);
+SYSCALL(NtSetCompositionSurfaceStatistics, NTSTATUS, 0);
+SYSCALL(NtSetCursorInputSpace, NTSTATUS, 0);
+SYSCALL(NtSetPointerDeviceInputSpace, NTSTATUS, 0);
+SYSCALL(NtSetShellCursorState, NTSTATUS, 0);
+SYSCALL(NtTokenManagerConfirmOutstandingAnalogToken, NTSTATUS, 0);
+SYSCALL(NtTokenManagerCreateCompositionTokenHandle, NTSTATUS, 0);
+SYSCALL(NtTokenManagerCreateFlipObjectReturnTokenHandle, NTSTATUS, 0);
+SYSCALL(NtTokenManagerCreateFlipObjectTokenHandle, NTSTATUS, 0);
+SYSCALL(NtTokenManagerDeleteOutstandingDirectFlipTokens, NTSTATUS, 0);
+SYSCALL(NtTokenManagerGetAnalogExclusiveSurfaceUpdates, NTSTATUS, 0);
+SYSCALL(NtTokenManagerGetAnalogExclusiveTokenEvent, NTSTATUS, 0);
+SYSCALL(NtTokenManagerGetOutOfFrameDirectFlipSurfaceUpdates, NTSTATUS, 0);
+SYSCALL(NtTokenManagerOpenEvent, NTSTATUS, 0);
+SYSCALL(NtTokenManagerOpenSection, NTSTATUS, 0);
+SYSCALL(NtTokenManagerOpenSectionAndEvents, NTSTATUS, 0);
+SYSCALL(NtTokenManagerThread, NTSTATUS, 0);
+SYSCALL(NtUnBindCompositionSurface, NTSTATUS, 0);
+SYSCALL(NtUpdateInputSinkTransforms, NTSTATUS, 0);
+SYSCALL(NtUserAcquireIAMKey, NTSTATUS, 0);
+SYSCALL(NtUserAcquireInteractiveControlBackgroundAccess, NTSTATUS, 0);
+SYSCALL(NtUserActivateKeyboardLayout, NTSTATUS, 0);
+SYSCALL(NtUserAddClipboardFormatListener, NTSTATUS, 0);
+SYSCALL(NtUserAddVisualIdentifier, NTSTATUS, 0);
+SYSCALL(NtUserAlterWindowStyle, NTSTATUS, 0);
+SYSCALL(NtUserAssociateInputContext, NTSTATUS, 0);
+SYSCALL(NtUserAttachThreadInput, NTSTATUS, 0);
+SYSCALL(NtUserAutoPromoteMouseInPointer, NTSTATUS, 0);
+SYSCALL(NtUserAutoRotateScreen, NTSTATUS, 0);
+SYSCALL(NtUserBeginLayoutUpdate, NTSTATUS, 0);
+SYSCALL(NtUserBeginPaint, NTSTATUS, 0);
+SYSCALL(NtUserBitBltSysBmp, NTSTATUS, 0);
+SYSCALL(NtUserBlockInput, NTSTATUS, 0);
+SYSCALL(NtUserBroadcastThemeChangeEvent, NTSTATUS, 0);
+SYSCALL(NtUserBuildHimcList, NTSTATUS, 0);
+SYSCALL(NtUserBuildHwndList, NTSTATUS, 0);
+SYSCALL(NtUserBuildNameList, NTSTATUS, 0);
+SYSCALL(NtUserBuildPropList, NTSTATUS, 0);
+SYSCALL(NtUserCalcMenuBar, NTSTATUS, 0);
+SYSCALL(NtUserCalculatePopupWindowPosition, NTSTATUS, 0);
+SYSCALL(NtUserCallHwnd, NTSTATUS, 0);
+SYSCALL(NtUserCallHwndLock, NTSTATUS, 0);
+SYSCALL(NtUserCallHwndLockSafe, NTSTATUS, 0);
+SYSCALL(NtUserCallHwndOpt, NTSTATUS, 0);
+SYSCALL(NtUserCallHwndParam, NTSTATUS, 0);
+SYSCALL(NtUserCallHwndParamLock, NTSTATUS, 0);
+SYSCALL(NtUserCallHwndParamLockSafe, NTSTATUS, 0);
+SYSCALL(NtUserCallHwndSafe, NTSTATUS, 0);
+SYSCALL(NtUserCallMsgFilter, NTSTATUS, 0);
+SYSCALL(NtUserCallNextHookEx, NTSTATUS, 0);
+SYSCALL(NtUserCallNoParam, NTSTATUS, 0);
+SYSCALL(NtUserCallOneParam, NTSTATUS, 0);
+SYSCALL(NtUserCallTwoParam, NTSTATUS, 0);
+SYSCALL(NtUserCanBrokerForceForeground, NTSTATUS, 0);
+SYSCALL(NtUserChangeClipboardChain, NTSTATUS, 0);
+SYSCALL(NtUserChangeDisplaySettings, NTSTATUS, 0);
+SYSCALL(NtUserChangeWindowMessageFilterEx, NTSTATUS, 0);
+SYSCALL(NtUserCheckAccessForIntegrityLevel, NTSTATUS, 0);
+SYSCALL(NtUserCheckDesktopByThreadId, NTSTATUS, 0);
+SYSCALL(NtUserCheckImeHotKey, NTSTATUS, 0);
+SYSCALL(NtUserCheckMenuItem, NTSTATUS, 0);
+SYSCALL(NtUserCheckProcessForClipboardAccess, NTSTATUS, 0);
+SYSCALL(NtUserCheckProcessSession, NTSTATUS, 0);
+SYSCALL(NtUserCheckWindowThreadDesktop, NTSTATUS, 0);
+SYSCALL(NtUserChildWindowFromPointEx, NTSTATUS, 0);
+SYSCALL(NtUserClearForeground, NTSTATUS, 0);
+SYSCALL(NtUserClipCursor, NTSTATUS, 0);
+SYSCALL(NtUserCloseClipboard, NTSTATUS, 0);
+SYSCALL(NtUserCloseDesktop, NTSTATUS, 0);
+SYSCALL(NtUserCloseWindowStation, NTSTATUS, 0);
+SYSCALL(NtUserCompositionInputSinkLuidFromPoint, NTSTATUS, 0);
+SYSCALL(NtUserCompositionInputSinkViewInstanceIdFromPoint, NTSTATUS, 0);
+SYSCALL(NtUserConfigureActivationObject, NTSTATUS, 0);
+SYSCALL(NtUserConfirmResizeCommit, NTSTATUS, 0);
+SYSCALL(NtUserConsoleControl, NTSTATUS, 0);
+SYSCALL(NtUserConvertMemHandle, NTSTATUS, 0);
+SYSCALL(NtUserCopyAcceleratorTable, NTSTATUS, 0);
+SYSCALL(NtUserCountClipboardFormats, NTSTATUS, 0);
+SYSCALL(NtUserCreateAcceleratorTable, NTSTATUS, 0);
+SYSCALL(NtUserCreateActivationObject, NTSTATUS, 0);
+SYSCALL(NtUserCreateCaret, NTSTATUS, 0);
+SYSCALL(NtUserCreateDCompositionHwndTarget, NTSTATUS, 0);
+SYSCALL(NtUserCreateDesktop, NTSTATUS, 0);
+SYSCALL(NtUserCreateDesktopEx, NTSTATUS, 0);
+SYSCALL(NtUserCreateEmptyCursorObject, NTSTATUS, 0);
+SYSCALL(NtUserCreateInputContext, NTSTATUS, 0);
+SYSCALL(NtUserCreateLocalMemHandle, NTSTATUS, 0);
+SYSCALL(NtUserCreatePalmRejectionDelayZone, NTSTATUS, 0);
+SYSCALL(NtUserCreateWindowEx, NTSTATUS, 0);
+SYSCALL(NtUserCreateWindowGroup, NTSTATUS, 0);
+SYSCALL(NtUserCreateWindowStation, NTSTATUS, 0);
+SYSCALL(NtUserCtxDisplayIOCtl, NTSTATUS, 0);
+SYSCALL(NtUserDdeGetQualityOfService, NTSTATUS, 0);
+SYSCALL(NtUserDdeInitialize, NTSTATUS, 0);
+SYSCALL(NtUserDdeSetQualityOfService, NTSTATUS, 0);
+SYSCALL(NtUserDefSetText, NTSTATUS, 0);
+SYSCALL(NtUserDeferWindowDpiChanges, NTSTATUS, 0);
+SYSCALL(NtUserDeferWindowPos, NTSTATUS, 0);
+SYSCALL(NtUserDeferWindowPosAndBand, NTSTATUS, 0);
+SYSCALL(NtUserDelegateCapturePointers, NTSTATUS, 0);
+SYSCALL(NtUserDelegateInput, NTSTATUS, 0);
+SYSCALL(NtUserDeleteMenu, NTSTATUS, 0);
+SYSCALL(NtUserDeleteWindowGroup, NTSTATUS, 0);
+SYSCALL(NtUserDestroyAcceleratorTable, NTSTATUS, 0);
+SYSCALL(NtUserDestroyActivationObject, NTSTATUS, 0);
+SYSCALL(NtUserDestroyCursor, NTSTATUS, 0);
+SYSCALL(NtUserDestroyDCompositionHwndTarget, NTSTATUS, 0);
+SYSCALL(NtUserDestroyInputContext, NTSTATUS, 0);
+SYSCALL(NtUserDestroyMenu, NTSTATUS, 0);
+SYSCALL(NtUserDestroyPalmRejectionDelayZone, NTSTATUS, 0);
+SYSCALL(NtUserDestroyWindow, NTSTATUS, 0);
+SYSCALL(NtUserDisableImmersiveOwner, NTSTATUS, 0);
+SYSCALL(NtUserDisableProcessWindowFiltering, NTSTATUS, 0);
+SYSCALL(NtUserDisableThreadIme, NTSTATUS, 0);
+SYSCALL(NtUserDiscardPointerFrameMessages, NTSTATUS, 0);
+SYSCALL(NtUserDispatchMessage, NTSTATUS, 0);
+SYSCALL(NtUserDisplayConfigGetDeviceInfo, NTSTATUS, 0);
+SYSCALL(NtUserDisplayConfigSetDeviceInfo, NTSTATUS, 0);
+SYSCALL(NtUserDoSoundConnect, NTSTATUS, 0);
+SYSCALL(NtUserDoSoundDisconnect, NTSTATUS, 0);
+SYSCALL(NtUserDownlevelTouchpad, NTSTATUS, 0);
+SYSCALL(NtUserDragDetect, NTSTATUS, 0);
+SYSCALL(NtUserDragObject, NTSTATUS, 0);
+SYSCALL(NtUserDrawAnimatedRects, NTSTATUS, 0);
+SYSCALL(NtUserDrawCaption, NTSTATUS, 0);
+SYSCALL(NtUserDrawCaptionTemp, NTSTATUS, 0);
+SYSCALL(NtUserDrawIconEx, NTSTATUS, 0);
+SYSCALL(NtUserDrawMenuBarTemp, NTSTATUS, 0);
+SYSCALL(NtUserDwmGetDxRgn, NTSTATUS, 0);
+SYSCALL(NtUserDwmGetRemoteSessionOcclusionEvent, NTSTATUS, 0);
+SYSCALL(NtUserDwmGetRemoteSessionOcclusionState, NTSTATUS, 0);
+SYSCALL(NtUserDwmHintDxUpdate, NTSTATUS, 0);
+SYSCALL(NtUserDwmKernelShutdown, NTSTATUS, 0);
+SYSCALL(NtUserDwmKernelStartup, NTSTATUS, 0);
+SYSCALL(NtUserDwmStartRedirection, NTSTATUS, 0);
+SYSCALL(NtUserDwmStopRedirection, NTSTATUS, 0);
+SYSCALL(NtUserDwmValidateWindow, NTSTATUS, 0);
+SYSCALL(NtUserEmptyClipboard, NTSTATUS, 0);
+SYSCALL(NtUserEnableChildWindowDpiMessage, NTSTATUS, 0);
+SYSCALL(NtUserEnableIAMAccess, NTSTATUS, 0);
+SYSCALL(NtUserEnableMenuItem, NTSTATUS, 0);
+SYSCALL(NtUserEnableMouseInPointer, NTSTATUS, 0);
+SYSCALL(NtUserEnableMouseInputForCursorSuppression, NTSTATUS, 0);
+SYSCALL(NtUserEnableNonClientDpiScaling, NTSTATUS, 0);
+SYSCALL(NtUserEnableResizeLayoutSynchronization, NTSTATUS, 0);
+SYSCALL(NtUserEnableScrollBar, NTSTATUS, 0);
+SYSCALL(NtUserEnableSoftwareCursorForScreenCapture, NTSTATUS, 0);
+SYSCALL(NtUserEnableTouchPad, NTSTATUS, 0);
+SYSCALL(NtUserEnableWindowGDIScaledDpiMessage, NTSTATUS, 0);
+SYSCALL(NtUserEnableWindowGroupPolicy, NTSTATUS, 0);
+SYSCALL(NtUserEnableWindowResizeOptimization, NTSTATUS, 0);
+SYSCALL(NtUserEndDeferWindowPosEx, NTSTATUS, 0);
+SYSCALL(NtUserEndMenu, NTSTATUS, 0);
+SYSCALL(NtUserEndPaint, NTSTATUS, 0);
+SYSCALL(NtUserEndTouchOperation, NTSTATUS, 0);
+SYSCALL(NtUserEnumDisplayDevices, NTSTATUS, 0);
+SYSCALL(NtUserEnumDisplayMonitors, NTSTATUS, 0);
+SYSCALL(NtUserEnumDisplaySettings, NTSTATUS, 0);
+SYSCALL(NtUserEvent, NTSTATUS, 0);
+SYSCALL(NtUserExcludeUpdateRgn, NTSTATUS, 0);
+SYSCALL(NtUserFillWindow, NTSTATUS, 0);
+SYSCALL(NtUserFindExistingCursorIcon, NTSTATUS, 0);
+SYSCALL(NtUserFindWindowEx, NTSTATUS, 0);
+SYSCALL(NtUserFlashWindowEx, NTSTATUS, 0);
+SYSCALL(NtUserForceWindowToDpiForTest, NTSTATUS, 0);
+SYSCALL(NtUserFrostCrashedWindow, NTSTATUS, 0);
+SYSCALL(NtUserFunctionalizeDisplayConfig, NTSTATUS, 0);
+SYSCALL(NtUserGetActiveProcessesDpis, NTSTATUS, 0);
+SYSCALL(NtUserGetAltTabInfo, NTSTATUS, 0);
+SYSCALL(NtUserGetAncestor, NTSTATUS, 0);
+SYSCALL(NtUserGetAppImeLevel, NTSTATUS, 0);
+SYSCALL(NtUserGetAsyncKeyState, NTSTATUS, 0);
+SYSCALL(NtUserGetAtomName, NTSTATUS, 0);
+SYSCALL(NtUserGetAutoRotationState, NTSTATUS, 0);
+SYSCALL(NtUserGetCIMSSM, NTSTATUS, 0);
+SYSCALL(NtUserGetCPD, NTSTATUS, 0);
+SYSCALL(NtUserGetCaretBlinkTime, NTSTATUS, 0);
+SYSCALL(NtUserGetCaretPos, NTSTATUS, 0);
+SYSCALL(NtUserGetClassInfoEx, NTSTATUS, 0);
+SYSCALL(NtUserGetClassName, NTSTATUS, 0);
+SYSCALL(NtUserGetClipCursor, NTSTATUS, 0);
+SYSCALL(NtUserGetClipboardAccessToken, NTSTATUS, 0);
+SYSCALL(NtUserGetClipboardData, NTSTATUS, 0);
+SYSCALL(NtUserGetClipboardFormatName, NTSTATUS, 0);
+SYSCALL(NtUserGetClipboardOwner, NTSTATUS, 0);
+SYSCALL(NtUserGetClipboardSequenceNumber, NTSTATUS, 0);
+SYSCALL(NtUserGetClipboardViewer, NTSTATUS, 0);
+SYSCALL(NtUserGetComboBoxInfo, NTSTATUS, 0);
+SYSCALL(NtUserGetControlBrush, NTSTATUS, 0);
+SYSCALL(NtUserGetControlColor, NTSTATUS, 0);
+SYSCALL(NtUserGetCurrentDpiInfoForWindow, NTSTATUS, 0);
+SYSCALL(NtUserGetCurrentInputMessageSource, NTSTATUS, 0);
+SYSCALL(NtUserGetCursor, NTSTATUS, 0);
+SYSCALL(NtUserGetCursorDims, NTSTATUS, 0);
+SYSCALL(NtUserGetCursorFrameInfo, NTSTATUS, 0);
+SYSCALL(NtUserGetCursorInfo, NTSTATUS, 0);
+SYSCALL(NtUserGetDC, NTSTATUS, 0);
+SYSCALL(NtUserGetDCEx, NTSTATUS, 0);
+SYSCALL(NtUserGetDManipHookInitFunction, NTSTATUS, 0);
+SYSCALL(NtUserGetDesktopID, NTSTATUS, 0);
+SYSCALL(NtUserGetDisplayAutoRotationPreferences, NTSTATUS, 0);
+SYSCALL(NtUserGetDisplayAutoRotationPreferencesByProcessId, NTSTATUS, 0);
+SYSCALL(NtUserGetDisplayConfigBufferSizes, NTSTATUS, 0);
+SYSCALL(NtUserGetDoubleClickTime, NTSTATUS, 0);
+SYSCALL(NtUserGetDpiForCurrentProcess, NTSTATUS, 0);
+SYSCALL(NtUserGetDpiForMonitor, NTSTATUS, 0);
+SYSCALL(NtUserGetDpiSystemMetrics, NTSTATUS, 0);
+SYSCALL(NtUserGetExtendedPointerDeviceProperty, NTSTATUS, 0);
+SYSCALL(NtUserGetForegroundWindow, NTSTATUS, 0);
+SYSCALL(NtUserGetGUIThreadInfo, NTSTATUS, 0);
+SYSCALL(NtUserGetGestureConfig, NTSTATUS, 0);
+SYSCALL(NtUserGetGestureExtArgs, NTSTATUS, 0);
+SYSCALL(NtUserGetGestureInfo, NTSTATUS, 0);
+SYSCALL(NtUserGetGlobalIMEStatus, NTSTATUS, 0);
+SYSCALL(NtUserGetGuiResources, NTSTATUS, 0);
+SYSCALL(NtUserGetHDevName, NTSTATUS, 0);
+SYSCALL(NtUserGetHimetricScaleFactorFromPixelLocation, NTSTATUS, 0);
+SYSCALL(NtUserGetIconInfo, NTSTATUS, 0);
+SYSCALL(NtUserGetIconSize, NTSTATUS, 0);
+SYSCALL(NtUserGetImeHotKey, NTSTATUS, 0);
+SYSCALL(NtUserGetImeInfoEx, NTSTATUS, 0);
+SYSCALL(NtUserGetInputContainerId, NTSTATUS, 0);
+SYSCALL(NtUserGetInputLocaleInfo, NTSTATUS, 0);
+SYSCALL(NtUserGetInteractiveControlDeviceInfo, NTSTATUS, 0);
+SYSCALL(NtUserGetInteractiveControlInfo, NTSTATUS, 0);
+SYSCALL(NtUserGetInteractiveCtrlSupportedWaveforms, NTSTATUS, 0);
+SYSCALL(NtUserGetInternalWindowPos, NTSTATUS, 0);
+SYSCALL(NtUserGetKeyNameText, NTSTATUS, 0);
+SYSCALL(NtUserGetKeyState, NTSTATUS, 0);
+SYSCALL(NtUserGetKeyboardLayout, NTSTATUS, 0);
+SYSCALL(NtUserGetKeyboardLayoutList, NTSTATUS, 0);
+SYSCALL(NtUserGetKeyboardLayoutName, NTSTATUS, 0);
+SYSCALL(NtUserGetKeyboardState, NTSTATUS, 0);
+SYSCALL(NtUserGetLayeredWindowAttributes, NTSTATUS, 0);
+SYSCALL(NtUserGetListBoxInfo, NTSTATUS, 0);
+SYSCALL(NtUserGetMenuBarInfo, NTSTATUS, 0);
+SYSCALL(NtUserGetMenuIndex, NTSTATUS, 0);
+SYSCALL(NtUserGetMenuItemRect, NTSTATUS, 0);
+SYSCALL(NtUserGetMessage, NTSTATUS, 0);
+SYSCALL(NtUserGetMonitorBrightness, NTSTATUS, 0);
+SYSCALL(NtUserGetMouseMovePointsEx, NTSTATUS, 0);
+SYSCALL(NtUserGetObjectInformation, NTSTATUS, 0);
+SYSCALL(NtUserGetOemBitmapSize, NTSTATUS, 0);
+SYSCALL(NtUserGetOpenClipboardWindow, NTSTATUS, 0);
+SYSCALL(NtUserGetOwnerTransformedMonitorRect, NTSTATUS, 0);
+SYSCALL(NtUserGetPhysicalDeviceRect, NTSTATUS, 0);
+SYSCALL(NtUserGetPointerCursorId, NTSTATUS, 0);
+SYSCALL(NtUserGetPointerDevice, NTSTATUS, 0);
+SYSCALL(NtUserGetPointerDeviceCursors, NTSTATUS, 0);
+SYSCALL(NtUserGetPointerDeviceOrientation, NTSTATUS, 0);
+SYSCALL(NtUserGetPointerDeviceProperties, NTSTATUS, 0);
+SYSCALL(NtUserGetPointerDeviceRects, NTSTATUS, 0);
+SYSCALL(NtUserGetPointerDevices, NTSTATUS, 0);
+SYSCALL(NtUserGetPointerFrameArrivalTimes, NTSTATUS, 0);
+SYSCALL(NtUserGetPointerFrameTimes, NTSTATUS, 0);
+SYSCALL(NtUserGetPointerInfoList, NTSTATUS, 0);
+SYSCALL(NtUserGetPointerInputTransform, NTSTATUS, 0);
+SYSCALL(NtUserGetPointerProprietaryId, NTSTATUS, 0);
+SYSCALL(NtUserGetPointerType, NTSTATUS, 0);
+SYSCALL(NtUserGetPrecisionTouchPadConfiguration, NTSTATUS, 0);
+SYSCALL(NtUserGetPriorityClipboardFormat, NTSTATUS, 0);
+SYSCALL(NtUserGetProcessDpiAwareness, NTSTATUS, 0);
+SYSCALL(NtUserGetProcessDpiAwarenessContext, NTSTATUS, 0);
+SYSCALL(NtUserGetProcessUIContextInformation, NTSTATUS, 0);
+SYSCALL(NtUserGetProcessWindowStation, NTSTATUS, 0);
+SYSCALL(NtUserGetProp, NTSTATUS, 0);
+SYSCALL(NtUserGetQueueEventStatus, NTSTATUS, 0);
+SYSCALL(NtUserGetQueueStatusReadonly, NTSTATUS, 0);
+SYSCALL(NtUserGetRawInputBuffer, NTSTATUS, 0);
+SYSCALL(NtUserGetRawInputData, NTSTATUS, 0);
+SYSCALL(NtUserGetRawInputDeviceInfo, NTSTATUS, 0);
+SYSCALL(NtUserGetRawInputDeviceList, NTSTATUS, 0);
+SYSCALL(NtUserGetRawPointerDeviceData, NTSTATUS, 0);
+SYSCALL(NtUserGetRegisteredRawInputDevices, NTSTATUS, 0);
+SYSCALL(NtUserGetRequiredCursorSizes, NTSTATUS, 0);
+SYSCALL(NtUserGetResizeDCompositionSynchronizationObject, NTSTATUS, 0);
+SYSCALL(NtUserGetScrollBarInfo, NTSTATUS, 0);
+SYSCALL(NtUserGetSystemDpiForProcess, NTSTATUS, 0);
+SYSCALL(NtUserGetSystemMenu, NTSTATUS, 0);
+SYSCALL(NtUserGetThreadDesktop, NTSTATUS, 0);
+SYSCALL(NtUserGetThreadState, NTSTATUS, 0);
+SYSCALL(NtUserGetTitleBarInfo, NTSTATUS, 0);
+SYSCALL(NtUserGetTopLevelWindow, NTSTATUS, 0);
+SYSCALL(NtUserGetTouchInputInfo, NTSTATUS, 0);
+SYSCALL(NtUserGetTouchValidationStatus, NTSTATUS, 0);
+SYSCALL(NtUserGetUniformSpaceMapping, NTSTATUS, 0);
+SYSCALL(NtUserGetUpdateRect, NTSTATUS, 0);
+SYSCALL(NtUserGetUpdateRgn, NTSTATUS, 0);
+SYSCALL(NtUserGetUpdatedClipboardFormats, NTSTATUS, 0);
+SYSCALL(NtUserGetWOWClass, NTSTATUS, 0);
+SYSCALL(NtUserGetWindowBand, NTSTATUS, 0);
+SYSCALL(NtUserGetWindowCompositionAttribute, NTSTATUS, 0);
+SYSCALL(NtUserGetWindowCompositionInfo, NTSTATUS, 0);
+SYSCALL(NtUserGetWindowDC, NTSTATUS, 0);
+SYSCALL(NtUserGetWindowDisplayAffinity, NTSTATUS, 0);
+SYSCALL(NtUserGetWindowFeedbackSetting, NTSTATUS, 0);
+SYSCALL(NtUserGetWindowGroupId, NTSTATUS, 0);
+SYSCALL(NtUserGetWindowMinimizeRect, NTSTATUS, 0);
+SYSCALL(NtUserGetWindowPlacement, NTSTATUS, 0);
+SYSCALL(NtUserGetWindowProcessHandle, NTSTATUS, 0);
+SYSCALL(NtUserGetWindowRgnEx, NTSTATUS, 0);
+SYSCALL(NtUserGhostWindowFromHungWindow, NTSTATUS, 0);
+SYSCALL(NtUserHandleDelegatedInput, NTSTATUS, 0);
+SYSCALL(NtUserHardErrorControl, NTSTATUS, 0);
+SYSCALL(NtUserHideCaret, NTSTATUS, 0);
+SYSCALL(NtUserHidePointerContactVisualization, NTSTATUS, 0);
+SYSCALL(NtUserHiliteMenuItem, NTSTATUS, 0);
+SYSCALL(NtUserHungWindowFromGhostWindow, NTSTATUS, 0);
+SYSCALL(NtUserHwndQueryRedirectionInfo, NTSTATUS, 0);
+SYSCALL(NtUserHwndSetRedirectionInfo, NTSTATUS, 0);
+SYSCALL(NtUserImpersonateDdeClientWindow, NTSTATUS, 0);
+SYSCALL(NtUserInheritWindowMonitor, NTSTATUS, 0);
+SYSCALL(NtUserInitTask, NTSTATUS, 0);
+SYSCALL(NtUserInitialize, NTSTATUS, 0);
+SYSCALL(NtUserInitializeClientPfnArrays, NTSTATUS, 0);
+SYSCALL(NtUserInitializeGenericHidInjection, NTSTATUS, 0);
+SYSCALL(NtUserInitializeInputDeviceInjection, NTSTATUS, 0);
+SYSCALL(NtUserInitializePointerDeviceInjection, NTSTATUS, 0);
+SYSCALL(NtUserInitializePointerDeviceInjectionEx, NTSTATUS, 0);
+SYSCALL(NtUserInitializeTouchInjection, NTSTATUS, 0);
+SYSCALL(NtUserInjectDeviceInput, NTSTATUS, 0);
+SYSCALL(NtUserInjectGenericHidInput, NTSTATUS, 0);
+SYSCALL(NtUserInjectGesture, NTSTATUS, 0);
+SYSCALL(NtUserInjectKeyboardInput, NTSTATUS, 0);
+SYSCALL(NtUserInjectMouseInput, NTSTATUS, 0);
+SYSCALL(NtUserInjectPointerInput, NTSTATUS, 0);
+SYSCALL(NtUserInjectTouchInput, NTSTATUS, 0);
+SYSCALL(NtUserInteractiveControlQueryUsage, NTSTATUS, 0);
+SYSCALL(NtUserInternalClipCursor, NTSTATUS, 0);
+SYSCALL(NtUserInternalGetWindowIcon, NTSTATUS, 0);
+SYSCALL(NtUserInternalGetWindowText, NTSTATUS, 0);
+SYSCALL(NtUserInvalidateRect, NTSTATUS, 0);
+SYSCALL(NtUserInvalidateRgn, NTSTATUS, 0);
+SYSCALL(NtUserIsChildWindowDpiMessageEnabled, NTSTATUS, 0);
+SYSCALL(NtUserIsClipboardFormatAvailable, NTSTATUS, 0);
+SYSCALL(NtUserIsMouseInPointerEnabled, NTSTATUS, 0);
+SYSCALL(NtUserIsMouseInputEnabled, NTSTATUS, 0);
+SYSCALL(NtUserIsNonClientDpiScalingEnabled, NTSTATUS, 0);
+SYSCALL(NtUserIsResizeLayoutSynchronizationEnabled, NTSTATUS, 0);
+SYSCALL(NtUserIsTopLevelWindow, NTSTATUS, 0);
+SYSCALL(NtUserIsTouchWindow, NTSTATUS, 0);
+SYSCALL(NtUserIsWindowBroadcastingDpiToChildren, NTSTATUS, 0);
+SYSCALL(NtUserIsWindowGDIScaledDpiMessageEnabled, NTSTATUS, 0);
+SYSCALL(NtUserKillTimer, NTSTATUS, 0);
+SYSCALL(NtUserLayoutCompleted, NTSTATUS, 0);
+SYSCALL(NtUserLinkDpiCursor, NTSTATUS, 0);
+SYSCALL(NtUserLoadKeyboardLayoutEx, NTSTATUS, 0);
+SYSCALL(NtUserLockCursor, NTSTATUS, 0);
+SYSCALL(NtUserLockWindowStation, NTSTATUS, 0);
+SYSCALL(NtUserLockWindowUpdate, NTSTATUS, 0);
+SYSCALL(NtUserLockWorkStation, NTSTATUS, 0);
+SYSCALL(NtUserLogicalToPerMonitorDPIPhysicalPoint, NTSTATUS, 0);
+SYSCALL(NtUserLogicalToPhysicalDpiPointForWindow, NTSTATUS, 0);
+SYSCALL(NtUserLogicalToPhysicalPoint, NTSTATUS, 0);
+SYSCALL(NtUserMNDragLeave, NTSTATUS, 0);
+SYSCALL(NtUserMNDragOver, NTSTATUS, 0);
+SYSCALL(NtUserMagControl, NTSTATUS, 0);
+SYSCALL(NtUserMagGetContextInformation, NTSTATUS, 0);
+SYSCALL(NtUserMagSetContextInformation, NTSTATUS, 0);
+SYSCALL(NtUserManageGestureHandlerWindow, NTSTATUS, 0);
+SYSCALL(NtUserMapPointsByVisualIdentifier, NTSTATUS, 0);
+SYSCALL(NtUserMapVirtualKeyEx, NTSTATUS, 0);
+SYSCALL(NtUserMenuItemFromPoint, NTSTATUS, 0);
+SYSCALL(NtUserMessageCall, NTSTATUS, 0);
+SYSCALL(NtUserMinMaximize, NTSTATUS, 0);
+SYSCALL(NtUserModifyUserStartupInfoFlags, NTSTATUS, 0);
+SYSCALL(NtUserModifyWindowTouchCapability, NTSTATUS, 0);
+SYSCALL(NtUserMoveWindow, NTSTATUS, 0);
+SYSCALL(NtUserMsgWaitForMultipleObjectsEx, NTSTATUS, 0);
+SYSCALL(NtUserNavigateFocus, NTSTATUS, 0);
+SYSCALL(NtUserNotifyIMEStatus, NTSTATUS, 0);
+SYSCALL(NtUserNotifyProcessCreate, NTSTATUS, 0);
+SYSCALL(NtUserNotifyWinEvent, NTSTATUS, 0);
+SYSCALL(NtUserOpenClipboard, NTSTATUS, 0);
+SYSCALL(NtUserOpenDesktop, NTSTATUS, 0);
+SYSCALL(NtUserOpenInputDesktop, NTSTATUS, 0);
+SYSCALL(NtUserOpenThreadDesktop, NTSTATUS, 0);
+SYSCALL(NtUserOpenWindowStation, NTSTATUS, 0);
+SYSCALL(NtUserPaintDesktop, NTSTATUS, 0);
+SYSCALL(NtUserPaintMenuBar, NTSTATUS, 0);
+SYSCALL(NtUserPaintMonitor, NTSTATUS, 0);
+SYSCALL(NtUserPeekMessage, NTSTATUS, 0);
+SYSCALL(NtUserPerMonitorDPIPhysicalToLogicalPoint, NTSTATUS, 0);
+SYSCALL(NtUserPhysicalToLogicalDpiPointForWindow, NTSTATUS, 0);
+SYSCALL(NtUserPhysicalToLogicalPoint, NTSTATUS, 0);
+SYSCALL(NtUserPostMessage, NTSTATUS, 0);
+SYSCALL(NtUserPostThreadMessage, NTSTATUS, 0);
+SYSCALL(NtUserPrintWindow, NTSTATUS, 0);
+SYSCALL(NtUserProcessConnect, NTSTATUS, 0);
+SYSCALL(NtUserProcessInkFeedbackCommand, NTSTATUS, 0);
+SYSCALL(NtUserPromoteMouseInPointer, NTSTATUS, 0);
+SYSCALL(NtUserPromotePointer, NTSTATUS, 0);
+SYSCALL(NtUserQueryActivationObject, NTSTATUS, 0);
+SYSCALL(NtUserQueryBSDRWindow, NTSTATUS, 0);
+SYSCALL(NtUserQueryDisplayConfig, NTSTATUS, 0);
+SYSCALL(NtUserQueryInformationThread, NTSTATUS, 0);
+SYSCALL(NtUserQueryInputContext, NTSTATUS, 0);
+SYSCALL(NtUserQuerySendMessage, NTSTATUS, 0);
+SYSCALL(NtUserQueryWindow, NTSTATUS, 0);
+SYSCALL(NtUserRealChildWindowFromPoint, NTSTATUS, 0);
+SYSCALL(NtUserRealInternalGetMessage, NTSTATUS, 0);
+SYSCALL(NtUserRealWaitMessageEx, NTSTATUS, 0);
+SYSCALL(NtUserRedrawWindow, NTSTATUS, 0);
+SYSCALL(NtUserRegisterBSDRWindow, NTSTATUS, 0);
+SYSCALL(NtUserRegisterClassExWOW, NTSTATUS, 0);
+SYSCALL(NtUserRegisterDManipHook, NTSTATUS, 0);
+SYSCALL(NtUserRegisterEdgy, NTSTATUS, 0);
+SYSCALL(NtUserRegisterErrorReportingDialog, NTSTATUS, 0);
+SYSCALL(NtUserRegisterHotKey, NTSTATUS, 0);
+SYSCALL(NtUserRegisterManipulationThread, NTSTATUS, 0);
+SYSCALL(NtUserRegisterPointerDeviceNotifications, NTSTATUS, 0);
+SYSCALL(NtUserRegisterPointerInputTarget, NTSTATUS, 0);
+SYSCALL(NtUserRegisterRawInputDevices, NTSTATUS, 0);
+SYSCALL(NtUserRegisterServicesProcess, NTSTATUS, 0);
+SYSCALL(NtUserRegisterSessionPort, NTSTATUS, 0);
+SYSCALL(NtUserRegisterShellPTPListener, NTSTATUS, 0);
+SYSCALL(NtUserRegisterTasklist, NTSTATUS, 0);
+SYSCALL(NtUserRegisterTouchHitTestingWindow, NTSTATUS, 0);
+SYSCALL(NtUserRegisterTouchPadCapable, NTSTATUS, 0);
+SYSCALL(NtUserRegisterUserApiHook, NTSTATUS, 0);
+SYSCALL(NtUserRegisterWindowMessage, NTSTATUS, 0);
+SYSCALL(NtUserReleaseDC, NTSTATUS, 0);
+SYSCALL(NtUserReleaseDwmHitTestWaiters, NTSTATUS, 0);
+SYSCALL(NtUserRemoteConnect, NTSTATUS, 0);
+SYSCALL(NtUserRemoteRedrawRectangle, NTSTATUS, 0);
+SYSCALL(NtUserRemoteRedrawScreen, NTSTATUS, 0);
+SYSCALL(NtUserRemoteStopScreenUpdates, NTSTATUS, 0);
+SYSCALL(NtUserRemoveClipboardFormatListener, NTSTATUS, 0);
+SYSCALL(NtUserRemoveInjectionDevice, NTSTATUS, 0);
+SYSCALL(NtUserRemoveMenu, NTSTATUS, 0);
+SYSCALL(NtUserRemoveProp, NTSTATUS, 0);
+SYSCALL(NtUserRemoveVisualIdentifier, NTSTATUS, 0);
+SYSCALL(NtUserReportInertia, NTSTATUS, 0);
+SYSCALL(NtUserRequestMoveSizeOperation, NTSTATUS, 0);
+SYSCALL(NtUserResolveDesktop, NTSTATUS, 0);
+SYSCALL(NtUserResolveDesktopForWOW, NTSTATUS, 0);
+SYSCALL(NtUserRestoreWindowDpiChanges, NTSTATUS, 0);
+SYSCALL(NtUserSBGetParms, NTSTATUS, 0);
+SYSCALL(NtUserScrollDC, NTSTATUS, 0);
+SYSCALL(NtUserScrollWindowEx, NTSTATUS, 0);
+SYSCALL(NtUserSelectPalette, NTSTATUS, 0);
+SYSCALL(NtUserSendEventMessage, NTSTATUS, 0);
+SYSCALL(NtUserSendInput, NTSTATUS, 0);
+SYSCALL(NtUserSendInteractiveControlHapticsReport, NTSTATUS, 0);
+SYSCALL(NtUserSendTouchInput, NTSTATUS, 0);
+SYSCALL(NtUserSetActivationFilter, NTSTATUS, 0);
+SYSCALL(NtUserSetActiveProcess, NTSTATUS, 0);
+SYSCALL(NtUserSetActiveProcessForMonitor, NTSTATUS, 0);
+SYSCALL(NtUserSetActiveWindow, NTSTATUS, 0);
+SYSCALL(NtUserSetAppImeLevel, NTSTATUS, 0);
+SYSCALL(NtUserSetAutoRotation, NTSTATUS, 0);
+SYSCALL(NtUserSetBridgeWindowChild, NTSTATUS, 0);
+SYSCALL(NtUserSetBrokeredForeground, NTSTATUS, 0);
+SYSCALL(NtUserSetCalibrationData, NTSTATUS, 0);
+SYSCALL(NtUserSetCapture, NTSTATUS, 0);
+SYSCALL(NtUserSetChildWindowNoActivate, NTSTATUS, 0);
+SYSCALL(NtUserSetClassLong, NTSTATUS, 0);
+SYSCALL(NtUserSetClassLongPtr, NTSTATUS, 0);
+SYSCALL(NtUserSetClassWord, NTSTATUS, 0);
+SYSCALL(NtUserSetClipboardData, NTSTATUS, 0);
+SYSCALL(NtUserSetClipboardViewer, NTSTATUS, 0);
+SYSCALL(NtUserSetConsoleReserveKeys, NTSTATUS, 0);
+SYSCALL(NtUserSetCoreWindow, NTSTATUS, 0);
+SYSCALL(NtUserSetCoreWindowPartner, NTSTATUS, 0);
+SYSCALL(NtUserSetCursor, NTSTATUS, 0);
+SYSCALL(NtUserSetCursorContents, NTSTATUS, 0);
+SYSCALL(NtUserSetCursorIconData, NTSTATUS, 0);
+SYSCALL(NtUserSetCursorPos, NTSTATUS, 0);
+SYSCALL(NtUserSetDesktopColorTransform, NTSTATUS, 0);
+SYSCALL(NtUserSetDialogControlDpiChangeBehavior, NTSTATUS, 0);
+SYSCALL(NtUserSetDimUndimTransitionTime, NTSTATUS, 0);
+SYSCALL(NtUserSetDisplayAutoRotationPreferences, NTSTATUS, 0);
+SYSCALL(NtUserSetDisplayConfig, NTSTATUS, 0);
+SYSCALL(NtUserSetDisplayMapping, NTSTATUS, 0);
+SYSCALL(NtUserSetFallbackForeground, NTSTATUS, 0);
+SYSCALL(NtUserSetFeatureReportResponse, NTSTATUS, 0);
+SYSCALL(NtUserSetFocus, NTSTATUS, 0);
+SYSCALL(NtUserSetForegroundWindowForApplication, NTSTATUS, 0);
+SYSCALL(NtUserSetGestureConfig, NTSTATUS, 0);
+SYSCALL(NtUserSetImeHotKey, NTSTATUS, 0);
+SYSCALL(NtUserSetImeInfoEx, NTSTATUS, 0);
+SYSCALL(NtUserSetImeOwnerWindow, NTSTATUS, 0);
+SYSCALL(NtUserSetImmersiveBackgroundWindow, NTSTATUS, 0);
+SYSCALL(NtUserSetInformationProcess, NTSTATUS, 0);
+SYSCALL(NtUserSetInformationThread, NTSTATUS, 0);
+SYSCALL(NtUserSetInteractiveControlFocus, NTSTATUS, 0);
+SYSCALL(NtUserSetInteractiveCtrlRotationAngle, NTSTATUS, 0);
+SYSCALL(NtUserSetInternalWindowPos, NTSTATUS, 0);
+SYSCALL(NtUserSetKeyboardState, NTSTATUS, 0);
+SYSCALL(NtUserSetLayeredWindowAttributes, NTSTATUS, 0);
+SYSCALL(NtUserSetLogonNotifyWindow, NTSTATUS, 0);
+SYSCALL(NtUserSetMagnificationDesktopMagnifierOffsetsDWMUpdated, NTSTATUS, 0);
+SYSCALL(NtUserSetManipulationInputTarget, NTSTATUS, 0);
+SYSCALL(NtUserSetMenu, NTSTATUS, 0);
+SYSCALL(NtUserSetMenuContextHelpId, NTSTATUS, 0);
+SYSCALL(NtUserSetMenuDefaultItem, NTSTATUS, 0);
+SYSCALL(NtUserSetMenuFlagRtoL, NTSTATUS, 0);
+SYSCALL(NtUserSetMirrorRendering, NTSTATUS, 0);
+SYSCALL(NtUserSetMonitorBrightness, NTSTATUS, 0);
+SYSCALL(NtUserSetObjectInformation, NTSTATUS, 0);
+SYSCALL(NtUserSetParent, NTSTATUS, 0);
+SYSCALL(NtUserSetPrecisionTouchPadConfiguration, NTSTATUS, 0);
+SYSCALL(NtUserSetProcessDPIAware, NTSTATUS, 0);
+SYSCALL(NtUserSetProcessDpiAwareness, NTSTATUS, 0);
+SYSCALL(NtUserSetProcessDpiAwarenessContext, NTSTATUS, 0);
+SYSCALL(NtUserSetProcessInteractionFlags, NTSTATUS, 0);
+SYSCALL(NtUserSetProcessMousewheelRoutingMode, NTSTATUS, 0);
+SYSCALL(NtUserSetProcessRestrictionExemption, NTSTATUS, 0);
+SYSCALL(NtUserSetProcessUIAccessZorder, NTSTATUS, 0);
+SYSCALL(NtUserSetProcessWindowStation, NTSTATUS, 0);
+SYSCALL(NtUserSetProp, NTSTATUS, 0);
+SYSCALL(NtUserSetScrollInfo, NTSTATUS, 0);
+SYSCALL(NtUserSetSensorPresence, NTSTATUS, 0);
+SYSCALL(NtUserSetShellWindowEx, NTSTATUS, 0);
+SYSCALL(NtUserSetSysColors, NTSTATUS, 0);
+SYSCALL(NtUserSetSystemCursor, NTSTATUS, 0);
+SYSCALL(NtUserSetSystemMenu, NTSTATUS, 0);
+SYSCALL(NtUserSetSystemTimer, NTSTATUS, 0);
+SYSCALL(NtUserSetTargetForResourceBrokering, NTSTATUS, 0);
+SYSCALL(NtUserSetThreadDesktop, NTSTATUS, 0);
+SYSCALL(NtUserSetThreadInputBlocked, NTSTATUS, 0);
+SYSCALL(NtUserSetThreadLayoutHandles, NTSTATUS, 0);
+SYSCALL(NtUserSetThreadState, NTSTATUS, 0);
+SYSCALL(NtUserSetTimer, NTSTATUS, 0);
+SYSCALL(NtUserSetWinEventHook, NTSTATUS, 0);
+SYSCALL(NtUserSetWindowArrangement, NTSTATUS, 0);
+SYSCALL(NtUserSetWindowBand, NTSTATUS, 0);
+SYSCALL(NtUserSetWindowCompositionAttribute, NTSTATUS, 0);
+SYSCALL(NtUserSetWindowCompositionTransition, NTSTATUS, 0);
+SYSCALL(NtUserSetWindowDisplayAffinity, NTSTATUS, 0);
+SYSCALL(NtUserSetWindowFNID, NTSTATUS, 0);
+SYSCALL(NtUserSetWindowFeedbackSetting, NTSTATUS, 0);
+SYSCALL(NtUserSetWindowGroup, NTSTATUS, 0);
+SYSCALL(NtUserSetWindowLong, NTSTATUS, 0);
+SYSCALL(NtUserSetWindowLongPtr, NTSTATUS, 0);
+SYSCALL(NtUserSetWindowPlacement, NTSTATUS, 0);
+SYSCALL(NtUserSetWindowPos, NTSTATUS, 0);
+SYSCALL(NtUserSetWindowRgn, NTSTATUS, 0);
+SYSCALL(NtUserSetWindowRgnEx, NTSTATUS, 0);
+SYSCALL(NtUserSetWindowShowState, NTSTATUS, 0);
+SYSCALL(NtUserSetWindowStationUser, NTSTATUS, 0);
+SYSCALL(NtUserSetWindowWord, NTSTATUS, 0);
+SYSCALL(NtUserSetWindowsHookAW, NTSTATUS, 0);
+SYSCALL(NtUserSetWindowsHookEx, NTSTATUS, 0);
+SYSCALL(NtUserSfmDestroyLogicalSurfaceBinding, NTSTATUS, 0);
+SYSCALL(NtUserSfmDxBindSwapChain, NTSTATUS, 0);
+SYSCALL(NtUserSfmDxGetSwapChainStats, NTSTATUS, 0);
+SYSCALL(NtUserSfmDxOpenSwapChain, NTSTATUS, 0);
+SYSCALL(NtUserSfmDxQuerySwapChainBindingStatus, NTSTATUS, 0);
+SYSCALL(NtUserSfmDxReleaseSwapChain, NTSTATUS, 0);
+SYSCALL(NtUserSfmDxReportPendingBindingsToDwm, NTSTATUS, 0);
+SYSCALL(NtUserSfmDxSetSwapChainBindingStatus, NTSTATUS, 0);
+SYSCALL(NtUserSfmDxSetSwapChainStats, NTSTATUS, 0);
+SYSCALL(NtUserSfmGetLogicalSurfaceBinding, NTSTATUS, 0);
+SYSCALL(NtUserShowCaret, NTSTATUS, 0);
+SYSCALL(NtUserShowCursor, NTSTATUS, 0);
+SYSCALL(NtUserShowScrollBar, NTSTATUS, 0);
+SYSCALL(NtUserShowSystemCursor, NTSTATUS, 0);
+SYSCALL(NtUserShowWindow, NTSTATUS, 0);
+SYSCALL(NtUserShowWindowAsync, NTSTATUS, 0);
+SYSCALL(NtUserShutdownBlockReasonCreate, NTSTATUS, 0);
+SYSCALL(NtUserShutdownBlockReasonQuery, NTSTATUS, 0);
+SYSCALL(NtUserShutdownReasonDestroy, NTSTATUS, 0);
+SYSCALL(NtUserSignalRedirectionStartComplete, NTSTATUS, 0);
+SYSCALL(NtUserSlicerControl, NTSTATUS, 0);
+SYSCALL(NtUserSoundSentry, NTSTATUS, 0);
+SYSCALL(NtUserStopAndEndInertia, NTSTATUS, 0);
+SYSCALL(NtUserSwitchDesktop, NTSTATUS, 0);
+SYSCALL(NtUserSystemParametersInfo, NTSTATUS, 0);
+SYSCALL(NtUserSystemParametersInfoForDpi, NTSTATUS, 0);
+SYSCALL(NtUserTestForInteractiveUser, NTSTATUS, 0);
+SYSCALL(NtUserThunkedMenuInfo, NTSTATUS, 0);
+SYSCALL(NtUserThunkedMenuItemInfo, NTSTATUS, 0);
+SYSCALL(NtUserToUnicodeEx, NTSTATUS, 0);
+SYSCALL(NtUserTrackMouseEvent, NTSTATUS, 0);
+SYSCALL(NtUserTrackPopupMenuEx, NTSTATUS, 0);
+SYSCALL(NtUserTransformPoint, NTSTATUS, 0);
+SYSCALL(NtUserTransformRect, NTSTATUS, 0);
+SYSCALL(NtUserTranslateAccelerator, NTSTATUS, 0);
+SYSCALL(NtUserTranslateMessage, NTSTATUS, 0);
+SYSCALL(NtUserUndelegateInput, NTSTATUS, 0);
+SYSCALL(NtUserUnhookWinEvent, NTSTATUS, 0);
+SYSCALL(NtUserUnhookWindowsHookEx, NTSTATUS, 0);
+SYSCALL(NtUserUnloadKeyboardLayout, NTSTATUS, 0);
+SYSCALL(NtUserUnlockWindowStation, NTSTATUS, 0);
+SYSCALL(NtUserUnregisterClass, NTSTATUS, 0);
+SYSCALL(NtUserUnregisterHotKey, NTSTATUS, 0);
+SYSCALL(NtUserUnregisterSessionPort, NTSTATUS, 0);
+SYSCALL(NtUserUnregisterUserApiHook, NTSTATUS, 0);
+SYSCALL(NtUserUpdateDefaultDesktopThumbnail, NTSTATUS, 0);
+SYSCALL(NtUserUpdateInputContext, NTSTATUS, 0);
+SYSCALL(NtUserUpdateInstance, NTSTATUS, 0);
+SYSCALL(NtUserUpdateLayeredWindow, NTSTATUS, 0);
+SYSCALL(NtUserUpdatePerUserSystemParameters, NTSTATUS, 0);
+SYSCALL(NtUserUpdateWindowInputSinkHints, NTSTATUS, 0);
+SYSCALL(NtUserUpdateWindowTrackingInfo, NTSTATUS, 0);
+SYSCALL(NtUserUpdateWindowTransform, NTSTATUS, 0);
+SYSCALL(NtUserUserHandleGrantAccess, NTSTATUS, 0);
+SYSCALL(NtUserValidateHandleSecure, NTSTATUS, 0);
+SYSCALL(NtUserValidateRect, NTSTATUS, 0);
+SYSCALL(NtUserValidateTimerCallback, NTSTATUS, 0);
+SYSCALL(NtUserVkKeyScanEx, NTSTATUS, 0);
+SYSCALL(NtUserWOWCleanup, NTSTATUS, 0);
+SYSCALL(NtUserWaitAvailableMessageEx, NTSTATUS, 0);
+SYSCALL(NtUserWaitForInputIdle, NTSTATUS, 0);
+SYSCALL(NtUserWaitForMsgAndEvent, NTSTATUS, 0);
+SYSCALL(NtUserWaitForRedirectionStartComplete, NTSTATUS, 0);
+SYSCALL(NtUserWaitMessage, NTSTATUS, 0);
+SYSCALL(NtUserWin32PoolAllocationStats, NTSTATUS, 0);
+SYSCALL(NtUserWindowFromDC, NTSTATUS, 0);
+SYSCALL(NtUserWindowFromPhysicalPoint, NTSTATUS, 0);
+SYSCALL(NtUserWindowFromPoint, NTSTATUS, 0);
+SYSCALL(NtUserYieldTask, NTSTATUS, 0);
+SYSCALL(NtValidateCompositionSurfaceHandle, NTSTATUS, 0);
+SYSCALL(NtVisualCaptureBits, NTSTATUS, 0);
+
+#pragma clang diagnostic pop
+
+static const syscall_t* nt[] =
 {
-    { .name = "NtFlushProcessWriteBuffers", .ret = VOID, .num_args = 0  },
-    { .name = "NtGetCurrentProcessorNumber", .ret = ULONG, .num_args = 0  },
-    {
-        .name = "NtGetEnvironmentVariableEx", .ret = MISSING, .num_args = 1, .args =
-        {
-            {.name = "Missing", .dir = DIR_MISSING, .dir_opt = "", .type = MISSING}
-        }
-    },
-    {
-        .name = "NtIsSystemResumeAutomatic", .ret = MISSING, .num_args = 1, .args =
-        {
-            {.name = "Missing", .dir = DIR_MISSING, .dir_opt = "", .type = MISSING}
-        }
-    },
-    {
-        .name = "NtQueryEnvironmentVariableInfoEx", .ret = MISSING, .num_args = 1, .args =
-        {
-            {.name = "Missing", .dir = DIR_MISSING, .dir_opt = "", .type = MISSING}
-        }
-    },
-    {
-        .name = "NtAcceptConnectPort", .ret = NTSTATUS, .num_args = 6, .args =
-        {
-            {.name = "PortHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "PortContext", .dir = DIR_IN, .dir_opt = "opt", .type = PVOID},
-            {.name = "ConnectionRequest", .dir = DIR_IN, .dir_opt = "", .type = PPORT_MESSAGE},
-            {.name = "AcceptConnection", .dir = DIR_IN, .dir_opt = "", .type = BOOLEAN},
-            {.name = "ServerView", .dir = DIR_INOUT, .dir_opt = "opt", .type = PPORT_VIEW},
-            {.name = "ClientView", .dir = DIR_OUT, .dir_opt = "opt", .type = PREMOTE_PORT_VIEW}
-        }
-    },
-    {
-        .name = "NtAccessCheckAndAuditAlarm", .ret = NTSTATUS, .num_args = 11, .args =
-        {
-            {.name = "SubsystemName", .dir = DIR_IN, .dir_opt = "", .type = PUNICODE_STRING},
-            {.name = "HandleId", .dir = DIR_IN, .dir_opt = "opt", .type = PVOID},
-            {.name = "ObjectTypeName", .dir = DIR_IN, .dir_opt = "", .type = PUNICODE_STRING},
-            {.name = "ObjectName", .dir = DIR_IN, .dir_opt = "", .type = PUNICODE_STRING},
-            {.name = "SecurityDescriptor", .dir = DIR_IN, .dir_opt = "", .type = PSECURITY_DESCRIPTOR},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "GenericMapping", .dir = DIR_IN, .dir_opt = "", .type = PGENERIC_MAPPING},
-            {.name = "ObjectCreation", .dir = DIR_IN, .dir_opt = "", .type = BOOLEAN},
-            {.name = "GrantedAccess", .dir = DIR_OUT, .dir_opt = "", .type = PACCESS_MASK},
-            {.name = "AccessStatus", .dir = DIR_OUT, .dir_opt = "", .type = PNTSTATUS},
-            {.name = "GenerateOnClose", .dir = DIR_OUT, .dir_opt = "", .type = PBOOLEAN}
-        }
-    },
-    {
-        .name = "NtAccessCheckByTypeAndAuditAlarm", .ret = NTSTATUS, .num_args = 16, .args =
-        {
-            {.name = "SubsystemName", .dir = DIR_IN, .dir_opt = "", .type = PUNICODE_STRING},
-            {.name = "HandleId", .dir = DIR_IN, .dir_opt = "opt", .type = PVOID},
-            {.name = "ObjectTypeName", .dir = DIR_IN, .dir_opt = "", .type = PUNICODE_STRING},
-            {.name = "ObjectName", .dir = DIR_IN, .dir_opt = "", .type = PUNICODE_STRING},
-            {.name = "SecurityDescriptor", .dir = DIR_IN, .dir_opt = "", .type = PSECURITY_DESCRIPTOR},
-            {.name = "PrincipalSelfSid", .dir = DIR_IN, .dir_opt = "opt", .type = PSID},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "AuditType", .dir = DIR_IN, .dir_opt = "", .type = AUDIT_EVENT_TYPE},
-            {.name = "Flags", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "ObjectTypeList", .dir = DIR_IN, .dir_opt = "ecount_opt(ObjectTypeListLength)", .type = POBJECT_TYPE_LIST},
-            {.name = "ObjectTypeListLength", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "GenericMapping", .dir = DIR_IN, .dir_opt = "", .type = PGENERIC_MAPPING},
-            {.name = "ObjectCreation", .dir = DIR_IN, .dir_opt = "", .type = BOOLEAN},
-            {.name = "GrantedAccess", .dir = DIR_OUT, .dir_opt = "", .type = PACCESS_MASK},
-            {.name = "AccessStatus", .dir = DIR_OUT, .dir_opt = "", .type = PNTSTATUS},
-            {.name = "GenerateOnClose", .dir = DIR_OUT, .dir_opt = "", .type = PBOOLEAN}
-        }
-    },
-    {
-        .name = "NtAccessCheckByType", .ret = NTSTATUS, .num_args = 11, .args =
-        {
-            {.name = "SecurityDescriptor", .dir = DIR_IN, .dir_opt = "", .type = PSECURITY_DESCRIPTOR},
-            {.name = "PrincipalSelfSid", .dir = DIR_IN, .dir_opt = "opt", .type = PSID},
-            {.name = "ClientToken", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "ObjectTypeList", .dir = DIR_IN, .dir_opt = "ecount(ObjectTypeListLength)", .type = POBJECT_TYPE_LIST},
-            {.name = "ObjectTypeListLength", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "GenericMapping", .dir = DIR_IN, .dir_opt = "", .type = PGENERIC_MAPPING},
-            {.name = "PrivilegeSet", .dir = DIR_OUT, .dir_opt = "bcount(*PrivilegeSetLength)", .type = PPRIVILEGE_SET},
-            {.name = "PrivilegeSetLength", .dir = DIR_INOUT, .dir_opt = "", .type = PULONG},
-            {.name = "GrantedAccess", .dir = DIR_OUT, .dir_opt = "", .type = PACCESS_MASK},
-            {.name = "AccessStatus", .dir = DIR_OUT, .dir_opt = "", .type = PNTSTATUS}
-        }
-    },
-    {
-        .name = "NtAccessCheckByTypeResultListAndAuditAlarmByHandle", .ret = NTSTATUS, .num_args = 17, .args =
-        {
-            {.name = "SubsystemName", .dir = DIR_IN, .dir_opt = "", .type = PUNICODE_STRING},
-            {.name = "HandleId", .dir = DIR_IN, .dir_opt = "opt", .type = PVOID},
-            {.name = "ClientToken", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "ObjectTypeName", .dir = DIR_IN, .dir_opt = "", .type = PUNICODE_STRING},
-            {.name = "ObjectName", .dir = DIR_IN, .dir_opt = "", .type = PUNICODE_STRING},
-            {.name = "SecurityDescriptor", .dir = DIR_IN, .dir_opt = "", .type = PSECURITY_DESCRIPTOR},
-            {.name = "PrincipalSelfSid", .dir = DIR_IN, .dir_opt = "opt", .type = PSID},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "AuditType", .dir = DIR_IN, .dir_opt = "", .type = AUDIT_EVENT_TYPE},
-            {.name = "Flags", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "ObjectTypeList", .dir = DIR_IN, .dir_opt = "ecount_opt(ObjectTypeListLength)", .type = POBJECT_TYPE_LIST},
-            {.name = "ObjectTypeListLength", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "GenericMapping", .dir = DIR_IN, .dir_opt = "", .type = PGENERIC_MAPPING},
-            {.name = "ObjectCreation", .dir = DIR_IN, .dir_opt = "", .type = BOOLEAN},
-            {.name = "GrantedAccess", .dir = DIR_OUT, .dir_opt = "ecount(ObjectTypeListLength)", .type = PACCESS_MASK},
-            {.name = "AccessStatus", .dir = DIR_OUT, .dir_opt = "ecount(ObjectTypeListLength)", .type = PNTSTATUS},
-            {.name = "GenerateOnClose", .dir = DIR_OUT, .dir_opt = "", .type = PBOOLEAN}
-        }
-    },
-    {
-        .name = "NtAccessCheckByTypeResultListAndAuditAlarm", .ret = NTSTATUS, .num_args = 16, .args =
-        {
-            {.name = "SubsystemName", .dir = DIR_IN, .dir_opt = "", .type = PUNICODE_STRING},
-            {.name = "HandleId", .dir = DIR_IN, .dir_opt = "opt", .type = PVOID},
-            {.name = "ObjectTypeName", .dir = DIR_IN, .dir_opt = "", .type = PUNICODE_STRING},
-            {.name = "ObjectName", .dir = DIR_IN, .dir_opt = "", .type = PUNICODE_STRING},
-            {.name = "SecurityDescriptor", .dir = DIR_IN, .dir_opt = "", .type = PSECURITY_DESCRIPTOR},
-            {.name = "PrincipalSelfSid", .dir = DIR_IN, .dir_opt = "opt", .type = PSID},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "AuditType", .dir = DIR_IN, .dir_opt = "", .type = AUDIT_EVENT_TYPE},
-            {.name = "Flags", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "ObjectTypeList", .dir = DIR_IN, .dir_opt = "ecount_opt(ObjectTypeListLength)", .type = POBJECT_TYPE_LIST},
-            {.name = "ObjectTypeListLength", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "GenericMapping", .dir = DIR_IN, .dir_opt = "", .type = PGENERIC_MAPPING},
-            {.name = "ObjectCreation", .dir = DIR_IN, .dir_opt = "", .type = BOOLEAN},
-            {.name = "GrantedAccess", .dir = DIR_OUT, .dir_opt = "ecount(ObjectTypeListLength)", .type = PACCESS_MASK},
-            {.name = "AccessStatus", .dir = DIR_OUT, .dir_opt = "ecount(ObjectTypeListLength)", .type = PNTSTATUS},
-            {.name = "GenerateOnClose", .dir = DIR_OUT, .dir_opt = "", .type = PBOOLEAN}
-        }
-    },
-    {
-        .name = "NtAccessCheckByTypeResultList", .ret = NTSTATUS, .num_args = 11, .args =
-        {
-            {.name = "SecurityDescriptor", .dir = DIR_IN, .dir_opt = "", .type = PSECURITY_DESCRIPTOR},
-            {.name = "PrincipalSelfSid", .dir = DIR_IN, .dir_opt = "opt", .type = PSID},
-            {.name = "ClientToken", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "ObjectTypeList", .dir = DIR_IN, .dir_opt = "ecount(ObjectTypeListLength)", .type = POBJECT_TYPE_LIST},
-            {.name = "ObjectTypeListLength", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "GenericMapping", .dir = DIR_IN, .dir_opt = "", .type = PGENERIC_MAPPING},
-            {.name = "PrivilegeSet", .dir = DIR_OUT, .dir_opt = "bcount(*PrivilegeSetLength)", .type = PPRIVILEGE_SET},
-            {.name = "PrivilegeSetLength", .dir = DIR_INOUT, .dir_opt = "", .type = PULONG},
-            {.name = "GrantedAccess", .dir = DIR_OUT, .dir_opt = "ecount(ObjectTypeListLength)", .type = PACCESS_MASK},
-            {.name = "AccessStatus", .dir = DIR_OUT, .dir_opt = "ecount(ObjectTypeListLength)", .type = PNTSTATUS}
-        }
-    },
-    {
-        .name = "NtAccessCheck", .ret = NTSTATUS, .num_args = 8, .args =
-        {
-            {.name = "SecurityDescriptor", .dir = DIR_IN, .dir_opt = "", .type = PSECURITY_DESCRIPTOR},
-            {.name = "ClientToken", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "GenericMapping", .dir = DIR_IN, .dir_opt = "", .type = PGENERIC_MAPPING},
-            {.name = "PrivilegeSet", .dir = DIR_OUT, .dir_opt = "bcount(*PrivilegeSetLength)", .type = PPRIVILEGE_SET},
-            {.name = "PrivilegeSetLength", .dir = DIR_INOUT, .dir_opt = "", .type = PULONG},
-            {.name = "GrantedAccess", .dir = DIR_OUT, .dir_opt = "", .type = PACCESS_MASK},
-            {.name = "AccessStatus", .dir = DIR_OUT, .dir_opt = "", .type = PNTSTATUS}
-        }
-    },
-    {
-        .name = "NtAddAtom", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "AtomName", .dir = DIR_IN, .dir_opt = "bcount_opt(Length)", .type = PWSTR},
-            {.name = "Length", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "Atom", .dir = DIR_OUT, .dir_opt = "opt", .type = PRTL_ATOM}
-        }
-    },
-    {
-        .name = "NtAddBootEntry", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "BootEntry", .dir = DIR_IN, .dir_opt = "", .type = PBOOT_ENTRY},
-            {.name = "Id", .dir = DIR_OUT, .dir_opt = "opt", .type = PULONG}
-        }
-    },
-    {
-        .name = "NtAddDriverEntry", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "DriverEntry", .dir = DIR_IN, .dir_opt = "", .type = PEFI_DRIVER_ENTRY},
-            {.name = "Id", .dir = DIR_OUT, .dir_opt = "opt", .type = PULONG}
-        }
-    },
-    {
-        .name = "NtAdjustGroupsToken", .ret = NTSTATUS, .num_args = 6, .args =
-        {
-            {.name = "TokenHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "ResetToDefault", .dir = DIR_IN, .dir_opt = "", .type = BOOLEAN},
-            {.name = "NewState", .dir = DIR_IN, .dir_opt = "", .type = PTOKEN_GROUPS},
-            {.name = "BufferLength", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "PreviousState", .dir = DIR_OUT, .dir_opt = "bcount_part_opt(BufferLength,*ReturnLength)", .type = PTOKEN_GROUPS},
-            {.name = "ReturnLength", .dir = DIR_OUT, .dir_opt = "", .type = PULONG}
-        }
-    },
-    {
-        .name = "NtAdjustPrivilegesToken", .ret = NTSTATUS, .num_args = 6, .args =
-        {
-            {.name = "TokenHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "DisableAllPrivileges", .dir = DIR_IN, .dir_opt = "", .type = BOOLEAN},
-            {.name = "NewState", .dir = DIR_IN, .dir_opt = "opt", .type = PTOKEN_PRIVILEGES},
-            {.name = "BufferLength", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "PreviousState", .dir = DIR_OUT, .dir_opt = "bcount_part_opt(BufferLength,*ReturnLength)", .type = PTOKEN_PRIVILEGES},
-            {.name = "ReturnLength", .dir = DIR_OUT, .dir_opt = "opt", .type = PULONG}
-        }
-    },
-    {
-        .name = "NtAlertResumeThread", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "ThreadHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "PreviousSuspendCount", .dir = DIR_OUT, .dir_opt = "opt", .type = PULONG}
-        }
-    },
-    {
-        .name = "NtAlertThread", .ret = NTSTATUS, .num_args = 1, .args =
-        {
-            {.name = "ThreadHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE}
-        }
-    },
-    {
-        .name = "NtAllocateLocallyUniqueId", .ret = NTSTATUS, .num_args = 1, .args =
-        {
-            {.name = "Luid", .dir = DIR_OUT, .dir_opt = "", .type = PLUID}
-        }
-    },
-    {
-        .name = "NtAllocateReserveObject", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "MemoryReserveHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "ObjectAttributes", .dir = DIR_IN, .dir_opt = "opt", .type = POBJECT_ATTRIBUTES},
-            {.name = "Type", .dir = DIR_IN, .dir_opt = "", .type = MEMORY_RESERVE_TYPE}
-        }
-    },
-    {
-        .name = "NtAllocateUserPhysicalPages", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "ProcessHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "NumberOfPages", .dir = DIR_INOUT, .dir_opt = "", .type = PULONG_PTR},
-            {.name = "UserPfnArra;", .dir = DIR_OUT, .dir_opt = "ecount(*NumberOfPages)", .type = PULONG_PTR}
-        }
-    },
-    {
-        .name = "NtAllocateUuids", .ret = NTSTATUS, .num_args = 4, .args =
-        {
-            {.name = "Time", .dir = DIR_OUT, .dir_opt = "", .type = PULARGE_INTEGER},
-            {.name = "Range", .dir = DIR_OUT, .dir_opt = "", .type = PULONG},
-            {.name = "Sequence", .dir = DIR_OUT, .dir_opt = "", .type = PULONG},
-            {.name = "Seed", .dir = DIR_OUT, .dir_opt = "", .type = PCHAR}
-        }
-    },
-    {
-        .name = "NtAllocateVirtualMemory", .ret = NTSTATUS, .num_args = 6, .args =
-        {
-            {.name = "ProcessHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "*BaseAddress", .dir = DIR_INOUT, .dir_opt = "", .type = PVOID},
-            {.name = "ZeroBits", .dir = DIR_IN, .dir_opt = "", .type = ULONG_PTR},
-            {.name = "RegionSize", .dir = DIR_INOUT, .dir_opt = "", .type = PSIZE_T},
-            {.name = "AllocationType", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "Protect", .dir = DIR_IN, .dir_opt = "", .type = ULONG}
-        }
-    },
-    {
-        .name = "NtAlpcAcceptConnectPort", .ret = NTSTATUS, .num_args = 9, .args =
-        {
-            {.name = "PortHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "ConnectionPortHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "Flags", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "ObjectAttributes", .dir = DIR_IN, .dir_opt = "", .type = POBJECT_ATTRIBUTES},
-            {.name = "PortAttributes", .dir = DIR_IN, .dir_opt = "", .type = PALPC_PORT_ATTRIBUTES},
-            {.name = "PortContext", .dir = DIR_IN, .dir_opt = "opt", .type = PVOID},
-            {.name = "ConnectionRequest", .dir = DIR_IN, .dir_opt = "", .type = PPORT_MESSAGE},
-            {.name = "ConnectionMessageAttributes", .dir = DIR_INOUT, .dir_opt = "opt", .type = PALPC_MESSAGE_ATTRIBUTES},
-            {.name = "AcceptConnection", .dir = DIR_IN, .dir_opt = "", .type = BOOLEAN}
-        }
-    },
-    {
-        .name = "NtAlpcCancelMessage", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "PortHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "Flags", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "MessageContext", .dir = DIR_IN, .dir_opt = "", .type = PALPC_CONTEXT_ATTR}
-        }
-    },
-    {
-        .name = "NtAlpcConnectPort", .ret = NTSTATUS, .num_args = 11, .args =
-        {
-            {.name = "PortHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "PortName", .dir = DIR_IN, .dir_opt = "", .type = PUNICODE_STRING},
-            {.name = "ObjectAttributes", .dir = DIR_IN, .dir_opt = "", .type = POBJECT_ATTRIBUTES},
-            {.name = "PortAttributes", .dir = DIR_IN, .dir_opt = "opt", .type = PALPC_PORT_ATTRIBUTES},
-            {.name = "Flags", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "RequiredServerSid", .dir = DIR_IN, .dir_opt = "opt", .type = PSID},
-            {.name = "ConnectionMessage", .dir = DIR_INOUT, .dir_opt = "", .type = PPORT_MESSAGE},
-            {.name = "BufferLength", .dir = DIR_INOUT, .dir_opt = "opt", .type = PULONG},
-            {.name = "OutMessageAttributes", .dir = DIR_INOUT, .dir_opt = "opt", .type = PALPC_MESSAGE_ATTRIBUTES},
-            {.name = "InMessageAttributes", .dir = DIR_INOUT, .dir_opt = "opt", .type = PALPC_MESSAGE_ATTRIBUTES},
-            {.name = "Timeout", .dir = DIR_IN, .dir_opt = "opt", .type = PLARGE_INTEGER}
-        }
-    },
-    {
-        .name = "NtAlpcCreatePort", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "PortHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "ObjectAttributes", .dir = DIR_IN, .dir_opt = "", .type = POBJECT_ATTRIBUTES},
-            {.name = "PortAttributes", .dir = DIR_IN, .dir_opt = "opt", .type = PALPC_PORT_ATTRIBUTES}
-        }
-    },
-    {
-        .name = "NtAlpcCreatePortSection", .ret = NTSTATUS, .num_args = 6, .args =
-        {
-            {.name = "PortHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "Flags", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "SectionHandle", .dir = DIR_IN, .dir_opt = "opt", .type = HANDLE},
-            {.name = "SectionSize", .dir = DIR_IN, .dir_opt = "", .type = SIZE_T},
-            {.name = "AlpcSectionHandle", .dir = DIR_OUT, .dir_opt = "", .type = PALPC_HANDLE},
-            {.name = "ActualSectionSize", .dir = DIR_OUT, .dir_opt = "", .type = PSIZE_T}
-        }
-    },
-    {
-        .name = "NtAlpcCreateResourceReserve", .ret = NTSTATUS, .num_args = 4, .args =
-        {
-            {.name = "PortHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "Flags", .dir = DIR_RESERVED, .dir_opt = "", .type = ULONG},
-            {.name = "MessageSize", .dir = DIR_IN, .dir_opt = "", .type = SIZE_T},
-            {.name = "ResourceId", .dir = DIR_OUT, .dir_opt = "", .type = PALPC_HANDLE}
-        }
-    },
-    {
-        .name = "NtAlpcCreateSectionView", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "PortHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "Flags", .dir = DIR_RESERVED, .dir_opt = "", .type = ULONG},
-            {.name = "ViewAttributes", .dir = DIR_INOUT, .dir_opt = "", .type = PALPC_DATA_VIEW_ATTR}
-        }
-    },
-    {
-        .name = "NtAlpcCreateSecurityContext", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "PortHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "Flags", .dir = DIR_RESERVED, .dir_opt = "", .type = ULONG},
-            {.name = "SecurityAttribute", .dir = DIR_INOUT, .dir_opt = "", .type = PALPC_SECURITY_ATTR}
-        }
-    },
-    {
-        .name = "NtAlpcDeletePortSection", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "PortHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "Flags", .dir = DIR_RESERVED, .dir_opt = "", .type = ULONG},
-            {.name = "SectionHandle", .dir = DIR_IN, .dir_opt = "", .type = ALPC_HANDLE}
-        }
-    },
-    {
-        .name = "NtAlpcDeleteResourceReserve", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "PortHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "Flags", .dir = DIR_RESERVED, .dir_opt = "", .type = ULONG},
-            {.name = "ResourceId", .dir = DIR_IN, .dir_opt = "", .type = ALPC_HANDLE}
-        }
-    },
-    {
-        .name = "NtAlpcDeleteSectionView", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "PortHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "Flags", .dir = DIR_RESERVED, .dir_opt = "", .type = ULONG},
-            {.name = "ViewBase", .dir = DIR_IN, .dir_opt = "", .type = PVOID}
-        }
-    },
-    {
-        .name = "NtAlpcDeleteSecurityContext", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "PortHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "Flags", .dir = DIR_RESERVED, .dir_opt = "", .type = ULONG},
-            {.name = "ContextHandle", .dir = DIR_IN, .dir_opt = "", .type = ALPC_HANDLE}
-        }
-    },
-    {
-        .name = "NtAlpcDisconnectPort", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "PortHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "Flags", .dir = DIR_IN, .dir_opt = "", .type = ULONG}
-        }
-    },
-    {
-        .name = "NtAlpcImpersonateClientOfPort", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "PortHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "PortMessage", .dir = DIR_IN, .dir_opt = "", .type = PPORT_MESSAGE},
-            {.name = "Reserved", .dir = DIR_RESERVED, .dir_opt = "", .type = PVOID}
-        }
-    },
-    {
-        .name = "NtAlpcOpenSenderProcess", .ret = NTSTATUS, .num_args = 6, .args =
-        {
-            {.name = "ProcessHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "PortHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "PortMessage", .dir = DIR_IN, .dir_opt = "", .type = PPORT_MESSAGE},
-            {.name = "Flags", .dir = DIR_RESERVED, .dir_opt = "", .type = ULONG},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "ObjectAttributes", .dir = DIR_IN, .dir_opt = "", .type = POBJECT_ATTRIBUTES}
-        }
-    },
-    {
-        .name = "NtAlpcOpenSenderThread", .ret = NTSTATUS, .num_args = 6, .args =
-        {
-            {.name = "ThreadHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "PortHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "PortMessage", .dir = DIR_IN, .dir_opt = "", .type = PPORT_MESSAGE},
-            {.name = "Flags", .dir = DIR_RESERVED, .dir_opt = "", .type = ULONG},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "ObjectAttributes", .dir = DIR_IN, .dir_opt = "", .type = POBJECT_ATTRIBUTES}
-        }
-    },
-    {
-        .name = "NtAlpcQueryInformation", .ret = NTSTATUS, .num_args = 5, .args =
-        {
-            {.name = "PortHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "PortInformationClass", .dir = DIR_IN, .dir_opt = "", .type = ALPC_PORT_INFORMATION_CLASS},
-            {.name = "PortInformation", .dir = DIR_OUT, .dir_opt = "bcount(Length)", .type = PVOID},
-            {.name = "Length", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "ReturnLength", .dir = DIR_OUT, .dir_opt = "opt", .type = PULONG}
-        }
-    },
-    {
-        .name = "NtAlpcQueryInformationMessage", .ret = NTSTATUS, .num_args = 6, .args =
-        {
-            {.name = "PortHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "PortMessage", .dir = DIR_IN, .dir_opt = "", .type = PPORT_MESSAGE},
-            {.name = "MessageInformationClass", .dir = DIR_IN, .dir_opt = "", .type = ALPC_MESSAGE_INFORMATION_CLASS},
-            {.name = "MessageInformation", .dir = DIR_OUT, .dir_opt = "bcount(Length)", .type = PVOID},
-            {.name = "Length", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "ReturnLength", .dir = DIR_OUT, .dir_opt = "opt", .type = PULONG}
-        }
-    },
-    {
-        .name = "NtAlpcRevokeSecurityContext", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "PortHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "Flags", .dir = DIR_RESERVED, .dir_opt = "", .type = ULONG},
-            {.name = "ContextHandle", .dir = DIR_IN, .dir_opt = "", .type = ALPC_HANDLE}
-        }
-    },
-    {
-        .name = "NtAlpcSendWaitReceivePort", .ret = NTSTATUS, .num_args = 8, .args =
-        {
-            {.name = "PortHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "Flags", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "SendMessage", .dir = DIR_IN, .dir_opt = "opt", .type = PPORT_MESSAGE},
-            {.name = "SendMessageAttributes", .dir = DIR_IN, .dir_opt = "opt", .type = PALPC_MESSAGE_ATTRIBUTES},
-            {.name = "ReceiveMessage", .dir = DIR_INOUT, .dir_opt = "opt", .type = PPORT_MESSAGE},
-            {.name = "BufferLength", .dir = DIR_INOUT, .dir_opt = "opt", .type = PULONG},
-            {.name = "ReceiveMessageAttributes", .dir = DIR_INOUT, .dir_opt = "opt", .type = PALPC_MESSAGE_ATTRIBUTES},
-            {.name = "Timeout", .dir = DIR_IN, .dir_opt = "opt", .type = PLARGE_INTEGER}
-        }
-    },
-    {
-        .name = "NtAlpcSetInformation", .ret = NTSTATUS, .num_args = 4, .args =
-        {
-            {.name = "PortHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "PortInformationClass", .dir = DIR_IN, .dir_opt = "", .type = ALPC_PORT_INFORMATION_CLASS},
-            {.name = "PortInformation", .dir = DIR_IN, .dir_opt = "bcount(Length)", .type = PVOID},
-            {.name = "Length", .dir = DIR_IN, .dir_opt = "", .type = ULONG}
-        }
-    },
-    {
-        .name = "NtApphelpCacheControl", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "type", .dir = DIR_IN, .dir_opt = "", .type = APPHELPCOMMAND},
-            {.name = "buf", .dir = DIR_IN, .dir_opt = "", .type = PVOID}
-        }
-    },
-    {
-        .name = "NtAreMappedFilesTheSame", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "File1MappedAsAnImage", .dir = DIR_IN, .dir_opt = "", .type = PVOID},
-            {.name = "File2MappedAsFile", .dir = DIR_IN, .dir_opt = "", .type = PVOID}
-        }
-    },
-    {
-        .name = "NtAssignProcessToJobObject", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "JobHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "ProcessHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE}
-        }
-    },
-    {
-        .name = "NtCallbackReturn", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "OutputBuffer", .dir = DIR_IN, .dir_opt = "opt", .type = PVOID},
-            {.name = "OutputLength", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "Status", .dir = DIR_IN, .dir_opt = "", .type = NTSTATUS}
-        }
-    },
-    {
-        .name = "NtCancelIoFileEx", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "FileHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "IoRequestToCancel", .dir = DIR_IN, .dir_opt = "opt", .type = PIO_STATUS_BLOCK},
-            {.name = "IoStatusBlock", .dir = DIR_OUT, .dir_opt = "", .type = PIO_STATUS_BLOCK}
-        }
-    },
-    {
-        .name = "NtCancelIoFile", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "FileHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "IoStatusBlock", .dir = DIR_OUT, .dir_opt = "", .type = PIO_STATUS_BLOCK}
-        }
-    },
-    {
-        .name = "NtCancelSynchronousIoFile", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "ThreadHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "IoRequestToCancel", .dir = DIR_IN, .dir_opt = "opt", .type = PIO_STATUS_BLOCK},
-            {.name = "IoStatusBlock", .dir = DIR_OUT, .dir_opt = "", .type = PIO_STATUS_BLOCK}
-        }
-    },
-    {
-        .name = "NtCancelTimer", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "TimerHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "CurrentState", .dir = DIR_OUT, .dir_opt = "opt", .type = PBOOLEAN}
-        }
-    },
-    {
-        .name = "NtClearEvent", .ret = NTSTATUS, .num_args = 1, .args =
-        {
-            {.name = "EventHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE}
-        }
-    },
-    {
-        .name = "NtClose", .ret = NTSTATUS, .num_args = 1, .args =
-        {
-            {.name = "Handle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE}
-        }
-    },
-    {
-        .name = "NtCloseObjectAuditAlarm", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "SubsystemName", .dir = DIR_IN, .dir_opt = "", .type = PUNICODE_STRING},
-            {.name = "HandleId", .dir = DIR_IN, .dir_opt = "opt", .type = PVOID},
-            {.name = "GenerateOnClose", .dir = DIR_IN, .dir_opt = "", .type = BOOLEAN}
-        }
-    },
-    {
-        .name = "NtCommitComplete", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "EnlistmentHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "TmVirtualClock", .dir = DIR_IN, .dir_opt = "opt", .type = PLARGE_INTEGER}
-        }
-    },
-    {
-        .name = "NtCommitEnlistment", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "EnlistmentHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "TmVirtualClock", .dir = DIR_IN, .dir_opt = "opt", .type = PLARGE_INTEGER}
-        }
-    },
-    {
-        .name = "NtCommitTransaction", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "TransactionHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "Wait", .dir = DIR_IN, .dir_opt = "", .type = BOOLEAN}
-        }
-    },
-    {
-        .name = "NtCompactKeys", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "Count", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "KeyArray[;", .dir = DIR_IN, .dir_opt = "ecount(Count)", .type = HANDLE}
-        }
-    },
-    {
-        .name = "NtCompareTokens", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "FirstTokenHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "SecondTokenHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "Equal", .dir = DIR_OUT, .dir_opt = "", .type = PBOOLEAN}
-        }
-    },
-    {
-        .name = "NtCompleteConnectPort", .ret = NTSTATUS, .num_args = 1, .args =
-        {
-            {.name = "PortHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE}
-        }
-    },
-    {
-        .name = "NtCompressKey", .ret = NTSTATUS, .num_args = 1, .args =
-        {
-            {.name = "Key", .dir = DIR_IN, .dir_opt = "", .type = HANDLE}
-        }
-    },
-    {
-        .name = "NtConnectPort", .ret = NTSTATUS, .num_args = 8, .args =
-        {
-            {.name = "PortHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "PortName", .dir = DIR_IN, .dir_opt = "", .type = PUNICODE_STRING},
-            {.name = "SecurityQos", .dir = DIR_IN, .dir_opt = "", .type = PSECURITY_QUALITY_OF_SERVICE},
-            {.name = "ClientView", .dir = DIR_INOUT, .dir_opt = "opt", .type = PPORT_VIEW},
-            {.name = "ServerView", .dir = DIR_INOUT, .dir_opt = "opt", .type = PREMOTE_PORT_VIEW},
-            {.name = "MaxMessageLength", .dir = DIR_OUT, .dir_opt = "opt", .type = PULONG},
-            {.name = "ConnectionInformation", .dir = DIR_INOUT, .dir_opt = "opt", .type = PVOID},
-            {.name = "ConnectionInformationLength", .dir = DIR_INOUT, .dir_opt = "opt", .type = PULONG}
-        }
-    },
-    {
-        .name = "NtContinue", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "ContextRecord", .dir = DIR_IN, .dir_opt = "", .type = PCONTEXT},
-            {.name = "TestAlert", .dir = DIR_IN, .dir_opt = "", .type = BOOLEAN}
-        }
-    },
-    {
-        .name = "NtCreateDebugObject", .ret = NTSTATUS, .num_args = 4, .args =
-        {
-            {.name = "DebugObjectHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "DesiredAccess", .dir = DIR_OUT, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "ObjectAttributes", .dir = DIR_OUT, .dir_opt = "", .type = POBJECT_ATTRIBUTES},
-            {.name = "Flags", .dir = DIR_OUT, .dir_opt = "", .type = ULONG}
-        }
-    },
-    {
-        .name = "NtCreateDirectoryObject", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "DirectoryHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "ObjectAttributes", .dir = DIR_IN, .dir_opt = "", .type = POBJECT_ATTRIBUTES}
-        }
-    },
-    {
-        .name = "NtCreateEnlistment", .ret = NTSTATUS, .num_args = 8, .args =
-        {
-            {.name = "EnlistmentHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "ResourceManagerHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "TransactionHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "ObjectAttributes", .dir = DIR_IN, .dir_opt = "opt", .type = POBJECT_ATTRIBUTES},
-            {.name = "CreateOptions", .dir = DIR_IN, .dir_opt = "opt", .type = ULONG},
-            {.name = "NotificationMask", .dir = DIR_IN, .dir_opt = "", .type = NOTIFICATION_MASK},
-            {.name = "EnlistmentKey", .dir = DIR_IN, .dir_opt = "opt", .type = PVOID}
-        }
-    },
-    {
-        .name = "NtCreateEvent", .ret = NTSTATUS, .num_args = 5, .args =
-        {
-            {.name = "EventHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "ObjectAttributes", .dir = DIR_IN, .dir_opt = "opt", .type = POBJECT_ATTRIBUTES},
-            {.name = "EventType", .dir = DIR_IN, .dir_opt = "", .type = EVENT_TYPE},
-            {.name = "InitialState", .dir = DIR_IN, .dir_opt = "", .type = BOOLEAN}
-        }
-    },
-    {
-        .name = "NtCreateEventPair", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "EventPairHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "ObjectAttributes", .dir = DIR_IN, .dir_opt = "opt", .type = POBJECT_ATTRIBUTES}
-        }
-    },
-    {
-        .name = "NtCreateFile", .ret = NTSTATUS, .num_args = 11, .args =
-        {
-            {.name = "FileHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "ObjectAttributes", .dir = DIR_IN, .dir_opt = "", .type = POBJECT_ATTRIBUTES},
-            {.name = "IoStatusBlock", .dir = DIR_OUT, .dir_opt = "", .type = PIO_STATUS_BLOCK},
-            {.name = "AllocationSize", .dir = DIR_IN, .dir_opt = "opt", .type = PLARGE_INTEGER},
-            {.name = "FileAttributes", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "ShareAccess", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "CreateDisposition", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "CreateOptions", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "EaBuffer", .dir = DIR_IN, .dir_opt = "bcount_opt(EaLength)", .type = PVOID},
-            {.name = "EaLength", .dir = DIR_IN, .dir_opt = "", .type = ULONG}
-        }
-    },
-    {
-        .name = "NtCreateIoCompletion", .ret = NTSTATUS, .num_args = 4, .args =
-        {
-            {.name = "IoCompletionHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "ObjectAttributes", .dir = DIR_IN, .dir_opt = "opt", .type = POBJECT_ATTRIBUTES},
-            {.name = "Count", .dir = DIR_IN, .dir_opt = "", .type = ULONG}
-        }
-    },
-    {
-        .name = "NtCreateJobObject", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "JobHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "ObjectAttributes", .dir = DIR_IN, .dir_opt = "opt", .type = POBJECT_ATTRIBUTES}
-        }
-    },
-    {
-        .name = "NtCreateJobSet", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "NumJob", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "UserJobSet", .dir = DIR_IN, .dir_opt = "ecount(NumJob)", .type = PJOB_SET_ARRAY},
-            {.name = "Flags", .dir = DIR_IN, .dir_opt = "", .type = ULONG}
-        }
-    },
-    {
-        .name = "NtCreateKeyedEvent", .ret = NTSTATUS, .num_args = 4, .args =
-        {
-            {.name = "KeyedEventHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "ObjectAttributes", .dir = DIR_IN, .dir_opt = "opt", .type = POBJECT_ATTRIBUTES},
-            {.name = "Flags", .dir = DIR_IN, .dir_opt = "", .type = ULONG}
-        }
-    },
-    {
-        .name = "NtCreateKey", .ret = NTSTATUS, .num_args = 7, .args =
-        {
-            {.name = "KeyHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "ObjectAttributes", .dir = DIR_IN, .dir_opt = "", .type = POBJECT_ATTRIBUTES},
-            {.name = "TitleIndex", .dir = DIR_RESERVED, .dir_opt = "", .type = ULONG},
-            {.name = "Class", .dir = DIR_IN, .dir_opt = "opt", .type = PUNICODE_STRING},
-            {.name = "CreateOptions", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "Disposition", .dir = DIR_OUT, .dir_opt = "opt", .type = PULONG}
-        }
-    },
-    {
-        .name = "NtCreateKeyTransacted", .ret = NTSTATUS, .num_args = 8, .args =
-        {
-            {.name = "KeyHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "ObjectAttributes", .dir = DIR_IN, .dir_opt = "", .type = POBJECT_ATTRIBUTES},
-            {.name = "TitleIndex", .dir = DIR_RESERVED, .dir_opt = "", .type = ULONG},
-            {.name = "Class", .dir = DIR_IN, .dir_opt = "opt", .type = PUNICODE_STRING},
-            {.name = "CreateOptions", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "TransactionHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "Disposition", .dir = DIR_OUT, .dir_opt = "opt", .type = PULONG}
-        }
-    },
-    {
-        .name = "NtCreateMailslotFile", .ret = NTSTATUS, .num_args = 8, .args =
-        {
-            {.name = "FileHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "ObjectAttributes", .dir = DIR_IN, .dir_opt = "", .type = POBJECT_ATTRIBUTES},
-            {.name = "IoStatusBlock", .dir = DIR_OUT, .dir_opt = "", .type = PIO_STATUS_BLOCK},
-            {.name = "CreateOptions", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "MailslotQuota", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "MaximumMessageSize", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "ReadTimeout", .dir = DIR_IN, .dir_opt = "", .type = PLARGE_INTEGER}
-        }
-    },
-    {
-        .name = "NtCreateMutant", .ret = NTSTATUS, .num_args = 4, .args =
-        {
-            {.name = "MutantHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "ObjectAttributes", .dir = DIR_IN, .dir_opt = "opt", .type = POBJECT_ATTRIBUTES},
-            {.name = "InitialOwner", .dir = DIR_IN, .dir_opt = "", .type = BOOLEAN}
-        }
-    },
-    {
-        .name = "NtCreateNamedPipeFile", .ret = NTSTATUS, .num_args = 14, .args =
-        {
-            {.name = "FileHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "ObjectAttributes", .dir = DIR_IN, .dir_opt = "", .type = POBJECT_ATTRIBUTES},
-            {.name = "IoStatusBlock", .dir = DIR_OUT, .dir_opt = "", .type = PIO_STATUS_BLOCK},
-            {.name = "ShareAccess", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "CreateDisposition", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "CreateOptions", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "NamedPipeType", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "ReadMode", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "CompletionMode", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "MaximumInstances", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "InboundQuota", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "OutboundQuota", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "DefaultTimeout", .dir = DIR_IN, .dir_opt = "opt", .type = PLARGE_INTEGER}
-        }
-    },
-    {
-        .name = "NtCreatePagingFile", .ret = NTSTATUS, .num_args = 4, .args =
-        {
-            {.name = "PageFileName", .dir = DIR_IN, .dir_opt = "", .type = PUNICODE_STRING},
-            {.name = "MinimumSize", .dir = DIR_IN, .dir_opt = "", .type = PLARGE_INTEGER},
-            {.name = "MaximumSize", .dir = DIR_IN, .dir_opt = "", .type = PLARGE_INTEGER},
-            {.name = "Priority", .dir = DIR_IN, .dir_opt = "", .type = ULONG}
-        }
-    },
-    {
-        .name = "NtCreatePort", .ret = NTSTATUS, .num_args = 5, .args =
-        {
-            {.name = "PortHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "ObjectAttributes", .dir = DIR_IN, .dir_opt = "", .type = POBJECT_ATTRIBUTES},
-            {.name = "MaxConnectionInfoLength", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "MaxMessageLength", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "MaxPoolUsage", .dir = DIR_IN, .dir_opt = "opt", .type = ULONG}
-        }
-    },
-    {
-        .name = "NtCreatePrivateNamespace", .ret = NTSTATUS, .num_args = 4, .args =
-        {
-            {.name = "NamespaceHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "ObjectAttributes", .dir = DIR_IN, .dir_opt = "opt", .type = POBJECT_ATTRIBUTES},
-            {.name = "BoundaryDescriptor", .dir = DIR_IN, .dir_opt = "", .type = PVOID}
-        }
-    },
-    {
-        .name = "NtCreateProcessEx", .ret = NTSTATUS, .num_args = 9, .args =
-        {
-            {.name = "ProcessHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "ObjectAttributes", .dir = DIR_IN, .dir_opt = "opt", .type = POBJECT_ATTRIBUTES},
-            {.name = "ParentProcess", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "Flags", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "SectionHandle", .dir = DIR_IN, .dir_opt = "opt", .type = HANDLE},
-            {.name = "DebugPort", .dir = DIR_IN, .dir_opt = "opt", .type = HANDLE},
-            {.name = "ExceptionPort", .dir = DIR_IN, .dir_opt = "opt", .type = HANDLE},
-            {.name = "JobMemberLevel", .dir = DIR_IN, .dir_opt = "", .type = ULONG}
-        }
-    },
-    {
-        .name = "NtCreateProcess", .ret = NTSTATUS, .num_args = 8, .args =
-        {
-            {.name = "ProcessHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "ObjectAttributes", .dir = DIR_IN, .dir_opt = "opt", .type = POBJECT_ATTRIBUTES},
-            {.name = "ParentProcess", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "InheritObjectTable", .dir = DIR_IN, .dir_opt = "", .type = BOOLEAN},
-            {.name = "SectionHandle", .dir = DIR_IN, .dir_opt = "opt", .type = HANDLE},
-            {.name = "DebugPort", .dir = DIR_IN, .dir_opt = "opt", .type = HANDLE},
-            {.name = "ExceptionPort", .dir = DIR_IN, .dir_opt = "opt", .type = HANDLE}
-        }
-    },
-    {
-        .name = "NtCreateProfileEx", .ret = NTSTATUS, .num_args = 10, .args =
-        {
-            {.name = "ProfileHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "Process", .dir = DIR_IN, .dir_opt = "opt", .type = HANDLE},
-            {.name = "ProfileBase", .dir = DIR_IN, .dir_opt = "", .type = PVOID},
-            {.name = "ProfileSize", .dir = DIR_IN, .dir_opt = "", .type = SIZE_T},
-            {.name = "BucketSize", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "Buffer", .dir = DIR_IN, .dir_opt = "", .type = PULONG},
-            {.name = "BufferSize", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "ProfileSource", .dir = DIR_IN, .dir_opt = "", .type = KPROFILE_SOURCE},
-            {.name = "GroupAffinityCount", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "GroupAffinity", .dir = DIR_IN, .dir_opt = "opt", .type = PGROUP_AFFINITY}
-        }
-    },
-    {
-        .name = "NtCreateProfile", .ret = NTSTATUS, .num_args = 9, .args =
-        {
-            {.name = "ProfileHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "Process", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "RangeBase", .dir = DIR_IN, .dir_opt = "", .type = PVOID},
-            {.name = "RangeSize", .dir = DIR_IN, .dir_opt = "", .type = SIZE_T},
-            {.name = "BucketSize", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "Buffer", .dir = DIR_IN, .dir_opt = "", .type = PULONG},
-            {.name = "BufferSize", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "ProfileSource", .dir = DIR_IN, .dir_opt = "", .type = KPROFILE_SOURCE},
-            {.name = "Affinity", .dir = DIR_IN, .dir_opt = "", .type = KAFFINITY}
-        }
-    },
-    {
-        .name = "NtCreateResourceManager", .ret = NTSTATUS, .num_args = 7, .args =
-        {
-            {.name = "ResourceManagerHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "TmHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "RmGuid", .dir = DIR_IN, .dir_opt = "", .type = LPGUID},
-            {.name = "ObjectAttributes", .dir = DIR_IN, .dir_opt = "opt", .type = POBJECT_ATTRIBUTES},
-            {.name = "CreateOptions", .dir = DIR_IN, .dir_opt = "opt", .type = ULONG},
-            {.name = "Description", .dir = DIR_IN, .dir_opt = "opt", .type = PUNICODE_STRING}
-        }
-    },
-    {
-        .name = "NtCreateSection", .ret = NTSTATUS, .num_args = 7, .args =
-        {
-            {.name = "SectionHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "ObjectAttributes", .dir = DIR_IN, .dir_opt = "opt", .type = POBJECT_ATTRIBUTES},
-            {.name = "MaximumSize", .dir = DIR_IN, .dir_opt = "opt", .type = PLARGE_INTEGER},
-            {.name = "SectionPageProtection", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "AllocationAttributes", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "FileHandle", .dir = DIR_IN, .dir_opt = "opt", .type = HANDLE}
-        }
-    },
-    {
-        .name = "NtCreateSemaphore", .ret = NTSTATUS, .num_args = 5, .args =
-        {
-            {.name = "SemaphoreHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "ObjectAttributes", .dir = DIR_IN, .dir_opt = "opt", .type = POBJECT_ATTRIBUTES},
-            {.name = "InitialCount", .dir = DIR_IN, .dir_opt = "", .type = LONG},
-            {.name = "MaximumCount", .dir = DIR_IN, .dir_opt = "", .type = LONG}
-        }
-    },
-    {
-        .name = "NtCreateSymbolicLinkObject", .ret = NTSTATUS, .num_args = 4, .args =
-        {
-            {.name = "LinkHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "ObjectAttributes", .dir = DIR_IN, .dir_opt = "", .type = POBJECT_ATTRIBUTES},
-            {.name = "LinkTarget", .dir = DIR_IN, .dir_opt = "", .type = PUNICODE_STRING}
-        }
-    },
-    {
-        .name = "NtCreateThreadEx", .ret = NTSTATUS, .num_args = 11, .args =
-        {
-            {.name = "ThreadHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "ObjectAttributes", .dir = DIR_IN, .dir_opt = "opt", .type = POBJECT_ATTRIBUTES},
-            {.name = "ProcessHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "StartRoutine", .dir = DIR_IN, .dir_opt = "", .type = PVOID},
-            {.name = "Argument", .dir = DIR_IN, .dir_opt = "opt", .type = PVOID},
-            {.name = "CreateFlags", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "ZeroBits", .dir = DIR_IN, .dir_opt = "opt", .type = ULONG_PTR},
-            {.name = "StackSize", .dir = DIR_IN, .dir_opt = "opt", .type = SIZE_T},
-            {.name = "MaximumStackSize", .dir = DIR_IN, .dir_opt = "opt", .type = SIZE_T},
-            {.name = "AttributeList", .dir = DIR_IN, .dir_opt = "opt", .type = PPS_ATTRIBUTE_LIST}
-        }
-    },
-    {
-        .name = "NtCreateThread", .ret = NTSTATUS, .num_args = 8, .args =
-        {
-            {.name = "ThreadHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "ObjectAttributes", .dir = DIR_IN, .dir_opt = "opt", .type = POBJECT_ATTRIBUTES},
-            {.name = "ProcessHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "ClientId", .dir = DIR_OUT, .dir_opt = "", .type = PCLIENT_ID},
-            {.name = "ThreadContext", .dir = DIR_IN, .dir_opt = "", .type = PCONTEXT},
-            {.name = "InitialTeb", .dir = DIR_IN, .dir_opt = "", .type = PINITIAL_TEB},
-            {.name = "CreateSuspended", .dir = DIR_IN, .dir_opt = "", .type = BOOLEAN}
-        }
-    },
-    {
-        .name = "NtCreateTimer", .ret = NTSTATUS, .num_args = 4, .args =
-        {
-            {.name = "TimerHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "ObjectAttributes", .dir = DIR_IN, .dir_opt = "opt", .type = POBJECT_ATTRIBUTES},
-            {.name = "TimerType", .dir = DIR_IN, .dir_opt = "", .type = TIMER_TYPE}
-        }
-    },
-    {
-        .name = "NtCreateToken", .ret = NTSTATUS, .num_args = 13, .args =
-        {
-            {.name = "TokenHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "ObjectAttributes", .dir = DIR_IN, .dir_opt = "opt", .type = POBJECT_ATTRIBUTES},
-            {.name = "TokenType", .dir = DIR_IN, .dir_opt = "", .type = TOKEN_TYPE},
-            {.name = "AuthenticationId", .dir = DIR_IN, .dir_opt = "", .type = PLUID},
-            {.name = "ExpirationTime", .dir = DIR_IN, .dir_opt = "", .type = PLARGE_INTEGER},
-            {.name = "User", .dir = DIR_IN, .dir_opt = "", .type = PTOKEN_USER},
-            {.name = "Groups", .dir = DIR_IN, .dir_opt = "", .type = PTOKEN_GROUPS},
-            {.name = "Privileges", .dir = DIR_IN, .dir_opt = "", .type = PTOKEN_PRIVILEGES},
-            {.name = "Owner", .dir = DIR_IN, .dir_opt = "opt", .type = PTOKEN_OWNER},
-            {.name = "PrimaryGroup", .dir = DIR_IN, .dir_opt = "", .type = PTOKEN_PRIMARY_GROUP},
-            {.name = "DefaultDacl", .dir = DIR_IN, .dir_opt = "opt", .type = PTOKEN_DEFAULT_DACL},
-            {.name = "TokenSource", .dir = DIR_IN, .dir_opt = "", .type = PTOKEN_SOURCE}
-        }
-    },
-    {
-        .name = "NtCreateTransactionManager", .ret = NTSTATUS, .num_args = 6, .args =
-        {
-            {.name = "TmHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "ObjectAttributes", .dir = DIR_IN, .dir_opt = "opt", .type = POBJECT_ATTRIBUTES},
-            {.name = "LogFileName", .dir = DIR_IN, .dir_opt = "opt", .type = PUNICODE_STRING},
-            {.name = "CreateOptions", .dir = DIR_IN, .dir_opt = "opt", .type = ULONG},
-            {.name = "CommitStrength", .dir = DIR_IN, .dir_opt = "opt", .type = ULONG}
-        }
-    },
-    {
-        .name = "NtCreateTransaction", .ret = NTSTATUS, .num_args = 10, .args =
-        {
-            {.name = "TransactionHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "ObjectAttributes", .dir = DIR_IN, .dir_opt = "opt", .type = POBJECT_ATTRIBUTES},
-            {.name = "Uow", .dir = DIR_IN, .dir_opt = "opt", .type = LPGUID},
-            {.name = "TmHandle", .dir = DIR_IN, .dir_opt = "opt", .type = HANDLE},
-            {.name = "CreateOptions", .dir = DIR_IN, .dir_opt = "opt", .type = ULONG},
-            {.name = "IsolationLevel", .dir = DIR_IN, .dir_opt = "opt", .type = ULONG},
-            {.name = "IsolationFlags", .dir = DIR_IN, .dir_opt = "opt", .type = ULONG},
-            {.name = "Timeout", .dir = DIR_IN, .dir_opt = "opt", .type = PLARGE_INTEGER},
-            {.name = "Description", .dir = DIR_IN, .dir_opt = "opt", .type = PUNICODE_STRING}
-        }
-    },
-    {
-        .name = "NtCreateUserProcess", .ret = NTSTATUS, .num_args = 11, .args =
-        {
-            {.name = "ProcessHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "ThreadHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "ProcessDesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "ThreadDesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "ProcessObjectAttributes", .dir = DIR_IN, .dir_opt = "opt", .type = POBJECT_ATTRIBUTES},
-            {.name = "ThreadObjectAttributes", .dir = DIR_IN, .dir_opt = "opt", .type = POBJECT_ATTRIBUTES},
-            {.name = "ProcessFlags", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "ThreadFlags", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "ProcessParameters", .dir = DIR_IN, .dir_opt = "opt", .type = PRTL_USER_PROCESS_PARAMETERS},
-            {.name = "CreateInfo", .dir = DIR_IN, .dir_opt = "opt", .type = PPROCESS_CREATE_INFO},
-            {.name = "AttributeList", .dir = DIR_IN, .dir_opt = "opt", .type = PPROCESS_ATTRIBUTE_LIST}
-        }
-    },
-    {
-        .name = "NtCreateWaitablePort", .ret = NTSTATUS, .num_args = 5, .args =
-        {
-            {.name = "PortHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "ObjectAttributes", .dir = DIR_IN, .dir_opt = "", .type = POBJECT_ATTRIBUTES},
-            {.name = "MaxConnectionInfoLength", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "MaxMessageLength", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "MaxPoolUsage", .dir = DIR_IN, .dir_opt = "opt", .type = ULONG}
-        }
-    },
-    {
-        .name = "NtCreateWorkerFactory", .ret = NTSTATUS, .num_args = 10, .args =
-        {
-            {.name = "WorkerFactoryHandleReturn", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "ObjectAttributes", .dir = DIR_IN, .dir_opt = "opt", .type = POBJECT_ATTRIBUTES},
-            {.name = "CompletionPortHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "WorkerProcessHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "StartRoutine", .dir = DIR_IN, .dir_opt = "", .type = PVOID},
-            {.name = "StartParameter", .dir = DIR_IN, .dir_opt = "opt", .type = PVOID},
-            {.name = "MaxThreadCount", .dir = DIR_IN, .dir_opt = "opt", .type = ULONG},
-            {.name = "StackReserve", .dir = DIR_IN, .dir_opt = "opt", .type = SIZE_T},
-            {.name = "StackCommit", .dir = DIR_IN, .dir_opt = "opt", .type = SIZE_T}
-        }
-    },
-    {
-        .name = "NtDebugActiveProcess", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "ProcessHandle", .dir = DIR_OUT, .dir_opt = "", .type = HANDLE},
-            {.name = "DebugObjectHandle", .dir = DIR_OUT, .dir_opt = "", .type = HANDLE}
-        }
-    },
-    {
-        .name = "NtDebugContinue", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "DebugObjectHandle", .dir = DIR_OUT, .dir_opt = "", .type = HANDLE},
-            {.name = "ClientId", .dir = DIR_OUT, .dir_opt = "", .type = PCLIENT_ID},
-            {.name = "ContinueStatus", .dir = DIR_OUT, .dir_opt = "", .type = NTSTATUS}
-        }
-    },
-    {
-        .name = "NtDelayExecution", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "Alertable", .dir = DIR_IN, .dir_opt = "", .type = BOOLEAN},
-            {.name = "DelayInterval", .dir = DIR_IN, .dir_opt = "", .type = PLARGE_INTEGER}
-        }
-    },
-    {
-        .name = "NtDeleteAtom", .ret = NTSTATUS, .num_args = 1, .args =
-        {
-            {.name = "Atom", .dir = DIR_IN, .dir_opt = "", .type = RTL_ATOM}
-        }
-    },
-    {
-        .name = "NtDeleteBootEntry", .ret = NTSTATUS, .num_args = 1, .args =
-        {
-            {.name = "Id", .dir = DIR_IN, .dir_opt = "", .type = ULONG}
-        }
-    },
-    {
-        .name = "NtDeleteDriverEntry", .ret = NTSTATUS, .num_args = 1, .args =
-        {
-            {.name = "Id", .dir = DIR_IN, .dir_opt = "", .type = ULONG}
-        }
-    },
-    {
-        .name = "NtDeleteFile", .ret = NTSTATUS, .num_args = 1, .args =
-        {
-            {.name = "ObjectAttributes", .dir = DIR_IN, .dir_opt = "", .type = POBJECT_ATTRIBUTES}
-        }
-    },
-    {
-        .name = "NtDeleteKey", .ret = NTSTATUS, .num_args = 1, .args =
-        {
-            {.name = "KeyHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE}
-        }
-    },
-    {
-        .name = "NtDeleteObjectAuditAlarm", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "SubsystemName", .dir = DIR_IN, .dir_opt = "", .type = PUNICODE_STRING},
-            {.name = "HandleId", .dir = DIR_IN, .dir_opt = "opt", .type = PVOID},
-            {.name = "GenerateOnClose", .dir = DIR_IN, .dir_opt = "", .type = BOOLEAN}
-        }
-    },
-    {
-        .name = "NtDeletePrivateNamespace", .ret = NTSTATUS, .num_args = 1, .args =
-        {
-            {.name = "NamespaceHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE}
-        }
-    },
-    {
-        .name = "NtDeleteValueKey", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "KeyHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "ValueName", .dir = DIR_IN, .dir_opt = "", .type = PUNICODE_STRING}
-        }
-    },
-    {
-        .name = "NtDeviceIoControlFile", .ret = NTSTATUS, .num_args = 10, .args =
-        {
-            {.name = "FileHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "Event", .dir = DIR_IN, .dir_opt = "opt", .type = HANDLE},
-            {.name = "ApcRoutine", .dir = DIR_IN, .dir_opt = "opt", .type = PIO_APC_ROUTINE},
-            {.name = "ApcContext", .dir = DIR_IN, .dir_opt = "opt", .type = PVOID},
-            {.name = "IoStatusBlock", .dir = DIR_OUT, .dir_opt = "", .type = PIO_STATUS_BLOCK},
-            {.name = "IoControlCode", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "InputBuffer", .dir = DIR_IN, .dir_opt = "bcount_opt(InputBufferLength)", .type = PVOID},
-            {.name = "InputBufferLength", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "OutputBuffer", .dir = DIR_OUT, .dir_opt = "bcount_opt(OutputBufferLength)", .type = PVOID},
-            {.name = "OutputBufferLength", .dir = DIR_IN, .dir_opt = "", .type = ULONG}
-        }
-    },
-    { .name = "NtDisableLastKnownGood", .ret = NTSTATUS, .num_args = 0  },
-    {
-        .name = "NtDisplayString", .ret = NTSTATUS, .num_args = 1, .args =
-        {
-            {.name = "String", .dir = DIR_IN, .dir_opt = "", .type = PUNICODE_STRING}
-        }
-    },
-    {
-        .name = "NtDrawText", .ret = NTSTATUS, .num_args = 1, .args =
-        {
-            {.name = "Text", .dir = DIR_IN, .dir_opt = "", .type = PUNICODE_STRING}
-        }
-    },
-    {
-        .name = "NtDuplicateObject", .ret = NTSTATUS, .num_args = 7, .args =
-        {
-            {.name = "SourceProcessHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "SourceHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "TargetProcessHandle", .dir = DIR_IN, .dir_opt = "opt", .type = HANDLE},
-            {.name = "TargetHandle", .dir = DIR_OUT, .dir_opt = "opt", .type = PHANDLE},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "HandleAttributes", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "Options", .dir = DIR_IN, .dir_opt = "", .type = ULONG}
-        }
-    },
-    {
-        .name = "NtDuplicateToken", .ret = NTSTATUS, .num_args = 6, .args =
-        {
-            {.name = "ExistingTokenHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "ObjectAttributes", .dir = DIR_IN, .dir_opt = "", .type = POBJECT_ATTRIBUTES},
-            {.name = "EffectiveOnly", .dir = DIR_IN, .dir_opt = "", .type = BOOLEAN},
-            {.name = "TokenType", .dir = DIR_IN, .dir_opt = "", .type = TOKEN_TYPE},
-            {.name = "NewTokenHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE}
-        }
-    },
-    { .name = "NtEnableLastKnownGood", .ret = NTSTATUS, .num_args = 0  },
-    {
-        .name = "NtEnumerateBootEntries", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "Buffer", .dir = DIR_OUT, .dir_opt = "bcount_opt(*BufferLength)", .type = PVOID},
-            {.name = "BufferLength", .dir = DIR_INOUT, .dir_opt = "", .type = PULONG}
-        }
-    },
-    {
-        .name = "NtEnumerateDriverEntries", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "Buffer", .dir = DIR_OUT, .dir_opt = "bcount(*BufferLength)", .type = PVOID},
-            {.name = "BufferLength", .dir = DIR_INOUT, .dir_opt = "", .type = PULONG}
-        }
-    },
-    {
-        .name = "NtEnumerateKey", .ret = NTSTATUS, .num_args = 6, .args =
-        {
-            {.name = "KeyHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "Index", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "KeyInformationClass", .dir = DIR_IN, .dir_opt = "", .type = KEY_INFORMATION_CLASS},
-            {.name = "KeyInformation", .dir = DIR_OUT, .dir_opt = "bcount_opt(Length)", .type = PVOID},
-            {.name = "Length", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "ResultLength", .dir = DIR_OUT, .dir_opt = "", .type = PULONG}
-        }
-    },
-    {
-        .name = "NtEnumerateSystemEnvironmentValuesEx", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "InformationClass", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "Buffer", .dir = DIR_OUT, .dir_opt = "", .type = PVOID},
-            {.name = "BufferLength", .dir = DIR_INOUT, .dir_opt = "", .type = PULONG}
-        }
-    },
-    {
-        .name = "NtEnumerateTransactionObject", .ret = NTSTATUS, .num_args = 5, .args =
-        {
-            {.name = "RootObjectHandle", .dir = DIR_IN, .dir_opt = "opt", .type = HANDLE},
-            {.name = "QueryType", .dir = DIR_IN, .dir_opt = "", .type = KTMOBJECT_TYPE},
-            {.name = "ObjectCursor", .dir = DIR_INOUT, .dir_opt = "bcount(ObjectCursorLength)", .type = PKTMOBJECT_CURSOR},
-            {.name = "ObjectCursorLength", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "ReturnLength", .dir = DIR_OUT, .dir_opt = "", .type = PULONG}
-        }
-    },
-    {
-        .name = "NtEnumerateValueKey", .ret = NTSTATUS, .num_args = 6, .args =
-        {
-            {.name = "KeyHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "Index", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "KeyValueInformationClass", .dir = DIR_IN, .dir_opt = "", .type = KEY_VALUE_INFORMATION_CLASS},
-            {.name = "KeyValueInformation", .dir = DIR_OUT, .dir_opt = "bcount_opt(Length)", .type = PVOID},
-            {.name = "Length", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "ResultLength", .dir = DIR_OUT, .dir_opt = "", .type = PULONG}
-        }
-    },
-    {
-        .name = "NtExtendSection", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "SectionHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "NewSectionSize", .dir = DIR_INOUT, .dir_opt = "", .type = PLARGE_INTEGER}
-        }
-    },
-    {
-        .name = "NtFilterToken", .ret = NTSTATUS, .num_args = 6, .args =
-        {
-            {.name = "ExistingTokenHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "Flags", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "SidsToDisable", .dir = DIR_IN, .dir_opt = "opt", .type = PTOKEN_GROUPS},
-            {.name = "PrivilegesToDelete", .dir = DIR_IN, .dir_opt = "opt", .type = PTOKEN_PRIVILEGES},
-            {.name = "RestrictedSids", .dir = DIR_IN, .dir_opt = "opt", .type = PTOKEN_GROUPS},
-            {.name = "NewTokenHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE}
-        }
-    },
-    {
-        .name = "NtFindAtom", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "AtomName", .dir = DIR_IN, .dir_opt = "bcount_opt(Length)", .type = PWSTR},
-            {.name = "Length", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "Atom", .dir = DIR_OUT, .dir_opt = "opt", .type = PRTL_ATOM}
-        }
-    },
-    {
-        .name = "NtFlushBuffersFile", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "FileHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "IoStatusBlock", .dir = DIR_OUT, .dir_opt = "", .type = PIO_STATUS_BLOCK}
-        }
-    },
-    {
-        .name = "NtFlushInstallUILanguage", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "InstallUILanguage", .dir = DIR_IN, .dir_opt = "", .type = LANGID},
-            {.name = "SetComittedFlag", .dir = DIR_IN, .dir_opt = "", .type = ULONG}
-        }
-    },
-    {
-        .name = "NtFlushInstructionCache", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "ProcessHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "BaseAddress", .dir = DIR_IN, .dir_opt = "opt", .type = PVOID},
-            {.name = "Length", .dir = DIR_IN, .dir_opt = "", .type = SIZE_T}
-        }
-    },
-    {
-        .name = "NtFlushKey", .ret = NTSTATUS, .num_args = 1, .args =
-        {
-            {.name = "KeyHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE}
-        }
-    },
-    { .name = "NtFlushProcessWriteBuffers", .ret = VOID, .num_args = 0  },
-    {
-        .name = "NtFlushVirtualMemory", .ret = NTSTATUS, .num_args = 4, .args =
-        {
-            {.name = "ProcessHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "*BaseAddress", .dir = DIR_INOUT, .dir_opt = "", .type = PVOID},
-            {.name = "RegionSize", .dir = DIR_INOUT, .dir_opt = "", .type = PSIZE_T},
-            {.name = "IoStatus", .dir = DIR_OUT, .dir_opt = "", .type = PIO_STATUS_BLOCK}
-        }
-    },
-    { .name = "NtFlushWriteBuffer", .ret = NTSTATUS, .num_args = 0  },
-    {
-        .name = "NtFreeUserPhysicalPages", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "ProcessHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "NumberOfPages", .dir = DIR_INOUT, .dir_opt = "", .type = PULONG_PTR},
-            {.name = "UserPfnArra;", .dir = DIR_IN, .dir_opt = "ecount(*NumberOfPages)", .type = PULONG_PTR}
-        }
-    },
-    {
-        .name = "NtFreeVirtualMemory", .ret = NTSTATUS, .num_args = 4, .args =
-        {
-            {.name = "ProcessHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "*BaseAddress", .dir = DIR_INOUT, .dir_opt = "", .type = PVOID},
-            {.name = "RegionSize", .dir = DIR_INOUT, .dir_opt = "", .type = PSIZE_T},
-            {.name = "FreeType", .dir = DIR_IN, .dir_opt = "", .type = ULONG}
-        }
-    },
-    {
-        .name = "NtFreezeRegistry", .ret = NTSTATUS, .num_args = 1, .args =
-        {
-            {.name = "TimeOutInSeconds", .dir = DIR_IN, .dir_opt = "", .type = ULONG}
-        }
-    },
-    {
-        .name = "NtFreezeTransactions", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "FreezeTimeout", .dir = DIR_IN, .dir_opt = "", .type = PLARGE_INTEGER},
-            {.name = "ThawTimeout", .dir = DIR_IN, .dir_opt = "", .type = PLARGE_INTEGER}
-        }
-    },
-    {
-        .name = "NtFsControlFile", .ret = NTSTATUS, .num_args = 10, .args =
-        {
-            {.name = "FileHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "Event", .dir = DIR_IN, .dir_opt = "opt", .type = HANDLE},
-            {.name = "ApcRoutine", .dir = DIR_IN, .dir_opt = "opt", .type = PIO_APC_ROUTINE},
-            {.name = "ApcContext", .dir = DIR_IN, .dir_opt = "opt", .type = PVOID},
-            {.name = "IoStatusBlock", .dir = DIR_OUT, .dir_opt = "", .type = PIO_STATUS_BLOCK},
-            {.name = "IoControlCode", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "InputBuffer", .dir = DIR_IN, .dir_opt = "bcount_opt(InputBufferLength)", .type = PVOID},
-            {.name = "InputBufferLength", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "OutputBuffer", .dir = DIR_OUT, .dir_opt = "bcount_opt(OutputBufferLength)", .type = PVOID},
-            {.name = "OutputBufferLength", .dir = DIR_IN, .dir_opt = "", .type = ULONG}
-        }
-    },
-    {
-        .name = "NtGetContextThread", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "ThreadHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "ThreadContext", .dir = DIR_INOUT, .dir_opt = "", .type = PCONTEXT}
-        }
-    },
-    { .name = "NtGetCurrentProcessorNumber", .ret = ULONG, .num_args = 0  },
-    {
-        .name = "NtGetDevicePowerState", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "Device", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "*State", .dir = DIR_OUT, .dir_opt = "", .type = DEVICE_POWER_STATE}
-        }
-    },
-    {
-        .name = "NtGetMUIRegistryInfo", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "Flags", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "DataSize", .dir = DIR_INOUT, .dir_opt = "", .type = PULONG},
-            {.name = "Data", .dir = DIR_OUT, .dir_opt = "", .type = PVOID}
-        }
-    },
-    {
-        .name = "NtGetNextProcess", .ret = NTSTATUS, .num_args = 5, .args =
-        {
-            {.name = "ProcessHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "HandleAttributes", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "Flags", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "NewProcessHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE}
-        }
-    },
-    {
-        .name = "NtGetNextThread", .ret = NTSTATUS, .num_args = 6, .args =
-        {
-            {.name = "ProcessHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "ThreadHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "HandleAttributes", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "Flags", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "NewThreadHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE}
-        }
-    },
-    {
-        .name = "NtGetNlsSectionPtr", .ret = NTSTATUS, .num_args = 5, .args =
-        {
-            {.name = "SectionType", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "SectionData", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "ContextData", .dir = DIR_IN, .dir_opt = "", .type = PVOID},
-            {.name = "*SectionPointer", .dir = DIR_OUT, .dir_opt = "", .type = PVOID},
-            {.name = "SectionSize", .dir = DIR_OUT, .dir_opt = "", .type = PULONG}
-        }
-    },
-    {
-        .name = "NtGetNotificationResourceManager", .ret = NTSTATUS, .num_args = 7, .args =
-        {
-            {.name = "ResourceManagerHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "TransactionNotification", .dir = DIR_OUT, .dir_opt = "", .type = PTRANSACTION_NOTIFICATION},
-            {.name = "NotificationLength", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "Timeout", .dir = DIR_IN, .dir_opt = "opt", .type = PLARGE_INTEGER},
-            {.name = "ReturnLength", .dir = DIR_OUT, .dir_opt = "opt", .type = PULONG},
-            {.name = "Asynchronous", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "AsynchronousContext", .dir = DIR_IN, .dir_opt = "opt", .type = ULONG_PTR}
-        }
-    },
-    {
-        .name = "NtGetPlugPlayEvent", .ret = NTSTATUS, .num_args = 4, .args =
-        {
-            {.name = "EventHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "Context", .dir = DIR_IN, .dir_opt = "opt", .type = PVOID},
-            {.name = "EventBlock", .dir = DIR_OUT, .dir_opt = "bcount(EventBufferSize)", .type = PPLUGPLAY_EVENT_BLOCK},
-            {.name = "EventBufferSize", .dir = DIR_IN, .dir_opt = "", .type = ULONG}
-        }
-    },
-    {
-        .name = "NtGetWriteWatch", .ret = NTSTATUS, .num_args = 7, .args =
-        {
-            {.name = "ProcessHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "Flags", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "BaseAddress", .dir = DIR_IN, .dir_opt = "", .type = PVOID},
-            {.name = "RegionSize", .dir = DIR_IN, .dir_opt = "", .type = SIZE_T},
-            {.name = "*UserAddressArray", .dir = DIR_OUT, .dir_opt = "ecount(*EntriesInUserAddressArray)", .type = PVOID},
-            {.name = "EntriesInUserAddressArray", .dir = DIR_INOUT, .dir_opt = "", .type = PULONG_PTR},
-            {.name = "Granularity", .dir = DIR_OUT, .dir_opt = "", .type = PULONG}
-        }
-    },
-    {
-        .name = "NtImpersonateAnonymousToken", .ret = NTSTATUS, .num_args = 1, .args =
-        {
-            {.name = "ThreadHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE}
-        }
-    },
-    {
-        .name = "NtImpersonateClientOfPort", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "PortHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "Message", .dir = DIR_IN, .dir_opt = "", .type = PPORT_MESSAGE}
-        }
-    },
-    {
-        .name = "NtImpersonateThread", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "ServerThreadHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "ClientThreadHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "SecurityQos", .dir = DIR_IN, .dir_opt = "", .type = PSECURITY_QUALITY_OF_SERVICE}
-        }
-    },
-    {
-        .name = "NtInitializeNlsFiles", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "*BaseAddress", .dir = DIR_OUT, .dir_opt = "", .type = PVOID},
-            {.name = "DefaultLocaleId", .dir = DIR_OUT, .dir_opt = "", .type = PLCID},
-            {.name = "DefaultCasingTableSize", .dir = DIR_OUT, .dir_opt = "", .type = PLARGE_INTEGER}
-        }
-    },
-    {
-        .name = "NtInitializeRegistry", .ret = NTSTATUS, .num_args = 1, .args =
-        {
-            {.name = "BootCondition", .dir = DIR_IN, .dir_opt = "", .type = USHORT}
-        }
-    },
-    {
-        .name = "NtInitiatePowerAction", .ret = NTSTATUS, .num_args = 4, .args =
-        {
-            {.name = "SystemAction", .dir = DIR_IN, .dir_opt = "", .type = POWER_ACTION},
-            {.name = "MinSystemState", .dir = DIR_IN, .dir_opt = "", .type = SYSTEM_POWER_STATE},
-            {.name = "Flags", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "Asynchronous", .dir = DIR_IN, .dir_opt = "", .type = BOOLEAN}
-        }
-    },
-    {
-        .name = "NtIsProcessInJob", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "ProcessHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "JobHandle", .dir = DIR_IN, .dir_opt = "opt", .type = HANDLE}
-        }
-    },
-    { .name = "NtIsSystemResumeAutomatic", .ret = BOOLEAN, .num_args = 0  },
-    { .name = "NtIsUILanguageComitted", .ret = NTSTATUS, .num_args = 0  },
-    {
-        .name = "NtListenPort", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "PortHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "ConnectionRequest", .dir = DIR_OUT, .dir_opt = "", .type = PPORT_MESSAGE}
-        }
-    },
-    {
-        .name = "NtLoadDriver", .ret = NTSTATUS, .num_args = 1, .args =
-        {
-            {.name = "DriverServiceName", .dir = DIR_IN, .dir_opt = "", .type = PUNICODE_STRING}
-        }
-    },
-    {
-        .name = "NtLoadKey2", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "TargetKey", .dir = DIR_IN, .dir_opt = "", .type = POBJECT_ATTRIBUTES},
-            {.name = "SourceFile", .dir = DIR_IN, .dir_opt = "", .type = POBJECT_ATTRIBUTES},
-            {.name = "Flags", .dir = DIR_IN, .dir_opt = "", .type = ULONG}
-        }
-    },
-    {
-        .name = "NtLoadKeyEx", .ret = NTSTATUS, .num_args = 4, .args =
-        {
-            {.name = "TargetKey", .dir = DIR_IN, .dir_opt = "", .type = POBJECT_ATTRIBUTES},
-            {.name = "SourceFile", .dir = DIR_IN, .dir_opt = "", .type = POBJECT_ATTRIBUTES},
-            {.name = "Flags", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "TrustClassKey", .dir = DIR_IN, .dir_opt = "opt", .type = HANDLE}
-        }
-    },
-    {
-        .name = "NtLoadKey", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "TargetKey", .dir = DIR_IN, .dir_opt = "", .type = POBJECT_ATTRIBUTES},
-            {.name = "SourceFile", .dir = DIR_IN, .dir_opt = "", .type = POBJECT_ATTRIBUTES}
-        }
-    },
-    {
-        .name = "NtLockFile", .ret = NTSTATUS, .num_args = 10, .args =
-        {
-            {.name = "FileHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "Event", .dir = DIR_IN, .dir_opt = "opt", .type = HANDLE},
-            {.name = "ApcRoutine", .dir = DIR_IN, .dir_opt = "opt", .type = PIO_APC_ROUTINE},
-            {.name = "ApcContext", .dir = DIR_IN, .dir_opt = "opt", .type = PVOID},
-            {.name = "IoStatusBlock", .dir = DIR_OUT, .dir_opt = "", .type = PIO_STATUS_BLOCK},
-            {.name = "ByteOffset", .dir = DIR_IN, .dir_opt = "", .type = PLARGE_INTEGER},
-            {.name = "Length", .dir = DIR_IN, .dir_opt = "", .type = PLARGE_INTEGER},
-            {.name = "Key", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "FailImmediately", .dir = DIR_IN, .dir_opt = "", .type = BOOLEAN},
-            {.name = "ExclusiveLock", .dir = DIR_IN, .dir_opt = "", .type = BOOLEAN}
-        }
-    },
-    {
-        .name = "NtLockProductActivationKeys", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "*pPrivateVer", .dir = DIR_INOUT, .dir_opt = "opt", .type = ULONG},
-            {.name = "*pSafeMode", .dir = DIR_OUT, .dir_opt = "opt", .type = ULONG}
-        }
-    },
-    {
-        .name = "NtLockRegistryKey", .ret = NTSTATUS, .num_args = 1, .args =
-        {
-            {.name = "KeyHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE}
-        }
-    },
-    {
-        .name = "NtLockVirtualMemory", .ret = NTSTATUS, .num_args = 4, .args =
-        {
-            {.name = "ProcessHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "*BaseAddress", .dir = DIR_INOUT, .dir_opt = "", .type = PVOID},
-            {.name = "RegionSize", .dir = DIR_INOUT, .dir_opt = "", .type = PSIZE_T},
-            {.name = "MapType", .dir = DIR_IN, .dir_opt = "", .type = ULONG}
-        }
-    },
-    {
-        .name = "NtMakePermanentObject", .ret = NTSTATUS, .num_args = 1, .args =
-        {
-            {.name = "Handle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE}
-        }
-    },
-    {
-        .name = "NtMakeTemporaryObject", .ret = NTSTATUS, .num_args = 1, .args =
-        {
-            {.name = "Handle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE}
-        }
-    },
-    {
-        .name = "NtMapCMFModule", .ret = NTSTATUS, .num_args = 6, .args =
-        {
-            {.name = "What", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "Index", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "CacheIndexOut", .dir = DIR_OUT, .dir_opt = "opt", .type = PULONG},
-            {.name = "CacheFlagsOut", .dir = DIR_OUT, .dir_opt = "opt", .type = PULONG},
-            {.name = "ViewSizeOut", .dir = DIR_OUT, .dir_opt = "opt", .type = PULONG},
-            {.name = "*BaseAddress", .dir = DIR_OUT, .dir_opt = "opt", .type = PVOID}
-        }
-    },
-    {
-        .name = "NtMapUserPhysicalPages", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "VirtualAddress", .dir = DIR_IN, .dir_opt = "", .type = PVOID},
-            {.name = "NumberOfPages", .dir = DIR_IN, .dir_opt = "", .type = ULONG_PTR},
-            {.name = "UserPfnArra;", .dir = DIR_IN, .dir_opt = "ecount_opt(NumberOfPages)", .type = PULONG_PTR}
-        }
-    },
-    {
-        .name = "NtMapUserPhysicalPagesScatter", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "*VirtualAddresses", .dir = DIR_IN, .dir_opt = "ecount(NumberOfPages)", .type = PVOID},
-            {.name = "NumberOfPages", .dir = DIR_IN, .dir_opt = "", .type = ULONG_PTR},
-            {.name = "UserPfnArray", .dir = DIR_IN, .dir_opt = "ecount_opt(NumberOfPages)", .type = PULONG_PTR}
-        }
-    },
-    {
-        .name = "NtMapViewOfSection", .ret = NTSTATUS, .num_args = 10, .args =
-        {
-            {.name = "SectionHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "ProcessHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "*BaseAddress", .dir = DIR_INOUT, .dir_opt = "", .type = PVOID},
-            {.name = "ZeroBits", .dir = DIR_IN, .dir_opt = "", .type = ULONG_PTR},
-            {.name = "CommitSize", .dir = DIR_IN, .dir_opt = "", .type = SIZE_T},
-            {.name = "SectionOffset", .dir = DIR_INOUT, .dir_opt = "opt", .type = PLARGE_INTEGER},
-            {.name = "ViewSize", .dir = DIR_INOUT, .dir_opt = "", .type = PSIZE_T},
-            {.name = "InheritDisposition", .dir = DIR_IN, .dir_opt = "", .type = SECTION_INHERIT},
-            {.name = "AllocationType", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "Win32Protect", .dir = DIR_IN, .dir_opt = "", .type = WIN32_PROTECTION_MASK}
-        }
-    },
-    {
-        .name = "NtModifyBootEntry", .ret = NTSTATUS, .num_args = 1, .args =
-        {
-            {.name = "BootEntry", .dir = DIR_IN, .dir_opt = "", .type = PBOOT_ENTRY}
-        }
-    },
-    {
-        .name = "NtModifyDriverEntry", .ret = NTSTATUS, .num_args = 1, .args =
-        {
-            {.name = "DriverEntry", .dir = DIR_IN, .dir_opt = "", .type = PEFI_DRIVER_ENTRY}
-        }
-    },
-    {
-        .name = "NtNotifyChangeDirectoryFile", .ret = NTSTATUS, .num_args = 9, .args =
-        {
-            {.name = "FileHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "Event", .dir = DIR_IN, .dir_opt = "opt", .type = HANDLE},
-            {.name = "ApcRoutine", .dir = DIR_IN, .dir_opt = "opt", .type = PIO_APC_ROUTINE},
-            {.name = "ApcContext", .dir = DIR_IN, .dir_opt = "opt", .type = PVOID},
-            {.name = "IoStatusBlock", .dir = DIR_OUT, .dir_opt = "", .type = PIO_STATUS_BLOCK},
-            {.name = "Buffer", .dir = DIR_OUT, .dir_opt = "bcount(Length)", .type = PVOID},
-            {.name = "Length", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "CompletionFilter", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "WatchTree", .dir = DIR_IN, .dir_opt = "", .type = BOOLEAN}
-        }
-    },
-    {
-        .name = "NtNotifyChangeKey", .ret = NTSTATUS, .num_args = 10, .args =
-        {
-            {.name = "KeyHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "Event", .dir = DIR_IN, .dir_opt = "opt", .type = HANDLE},
-            {.name = "ApcRoutine", .dir = DIR_IN, .dir_opt = "opt", .type = PIO_APC_ROUTINE},
-            {.name = "ApcContext", .dir = DIR_IN, .dir_opt = "opt", .type = PVOID},
-            {.name = "IoStatusBlock", .dir = DIR_OUT, .dir_opt = "", .type = PIO_STATUS_BLOCK},
-            {.name = "CompletionFilter", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "WatchTree", .dir = DIR_IN, .dir_opt = "", .type = BOOLEAN},
-            {.name = "Buffer", .dir = DIR_OUT, .dir_opt = "bcount_opt(BufferSize)", .type = PVOID},
-            {.name = "BufferSize", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "Asynchronous", .dir = DIR_IN, .dir_opt = "", .type = BOOLEAN}
-        }
-    },
-    {
-        .name = "NtNotifyChangeMultipleKeys", .ret = NTSTATUS, .num_args = 12, .args =
-        {
-            {.name = "MasterKeyHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "Count", .dir = DIR_IN, .dir_opt = "opt", .type = ULONG},
-            {.name = "SlaveObjects[]", .dir = DIR_IN, .dir_opt = "ecount_opt(Count)", .type = OBJECT_ATTRIBUTES},
-            {.name = "Event", .dir = DIR_IN, .dir_opt = "opt", .type = HANDLE},
-            {.name = "ApcRoutine", .dir = DIR_IN, .dir_opt = "opt", .type = PIO_APC_ROUTINE},
-            {.name = "ApcContext", .dir = DIR_IN, .dir_opt = "opt", .type = PVOID},
-            {.name = "IoStatusBlock", .dir = DIR_OUT, .dir_opt = "", .type = PIO_STATUS_BLOCK},
-            {.name = "CompletionFilter", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "WatchTree", .dir = DIR_IN, .dir_opt = "", .type = BOOLEAN},
-            {.name = "Buffer", .dir = DIR_OUT, .dir_opt = "bcount_opt(BufferSize)", .type = PVOID},
-            {.name = "BufferSize", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "Asynchronous", .dir = DIR_IN, .dir_opt = "", .type = BOOLEAN}
-        }
-    },
-    {
-        .name = "NtNotifyChangeSession", .ret = NTSTATUS, .num_args = 8, .args =
-        {
-            {.name = "Session", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "IoStateSequence", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "Reserved", .dir = DIR_IN, .dir_opt = "", .type = PVOID},
-            {.name = "Action", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "IoState", .dir = DIR_IN, .dir_opt = "", .type = IO_SESSION_STATE},
-            {.name = "IoState2", .dir = DIR_IN, .dir_opt = "", .type = IO_SESSION_STATE},
-            {.name = "Buffer", .dir = DIR_IN, .dir_opt = "", .type = PVOID},
-            {.name = "BufferSize", .dir = DIR_IN, .dir_opt = "", .type = ULONG}
-        }
-    },
-    {
-        .name = "NtOpenDirectoryObject", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "DirectoryHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "ObjectAttributes", .dir = DIR_IN, .dir_opt = "", .type = POBJECT_ATTRIBUTES}
-        }
-    },
-    {
-        .name = "NtOpenEnlistment", .ret = NTSTATUS, .num_args = 5, .args =
-        {
-            {.name = "EnlistmentHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "ResourceManagerHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "EnlistmentGuid", .dir = DIR_IN, .dir_opt = "", .type = LPGUID},
-            {.name = "ObjectAttributes", .dir = DIR_IN, .dir_opt = "opt", .type = POBJECT_ATTRIBUTES}
-        }
-    },
-    {
-        .name = "NtOpenEvent", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "EventHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "ObjectAttributes", .dir = DIR_IN, .dir_opt = "", .type = POBJECT_ATTRIBUTES}
-        }
-    },
-    {
-        .name = "NtOpenEventPair", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "EventPairHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "ObjectAttributes", .dir = DIR_IN, .dir_opt = "", .type = POBJECT_ATTRIBUTES}
-        }
-    },
-    {
-        .name = "NtOpenFile", .ret = NTSTATUS, .num_args = 6, .args =
-        {
-            {.name = "FileHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "ObjectAttributes", .dir = DIR_IN, .dir_opt = "", .type = POBJECT_ATTRIBUTES},
-            {.name = "IoStatusBlock", .dir = DIR_OUT, .dir_opt = "", .type = PIO_STATUS_BLOCK},
-            {.name = "ShareAccess", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "OpenOptions", .dir = DIR_IN, .dir_opt = "", .type = ULONG}
-        }
-    },
-    {
-        .name = "NtOpenIoCompletion", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "IoCompletionHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "ObjectAttributes", .dir = DIR_IN, .dir_opt = "", .type = POBJECT_ATTRIBUTES}
-        }
-    },
-    {
-        .name = "NtOpenJobObject", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "JobHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "ObjectAttributes", .dir = DIR_IN, .dir_opt = "", .type = POBJECT_ATTRIBUTES}
-        }
-    },
-    {
-        .name = "NtOpenKeyedEvent", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "KeyedEventHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "ObjectAttributes", .dir = DIR_IN, .dir_opt = "", .type = POBJECT_ATTRIBUTES}
-        }
-    },
-    {
-        .name = "NtOpenKeyEx", .ret = NTSTATUS, .num_args = 4, .args =
-        {
-            {.name = "KeyHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "ObjectAttributes", .dir = DIR_IN, .dir_opt = "", .type = POBJECT_ATTRIBUTES},
-            {.name = "OpenOptions", .dir = DIR_IN, .dir_opt = "", .type = ULONG}
-        }
-    },
-    {
-        .name = "NtOpenKey", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "KeyHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "ObjectAttributes", .dir = DIR_IN, .dir_opt = "", .type = POBJECT_ATTRIBUTES}
-        }
-    },
-    {
-        .name = "NtOpenKeyTransactedEx", .ret = NTSTATUS, .num_args = 5, .args =
-        {
-            {.name = "KeyHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "ObjectAttributes", .dir = DIR_IN, .dir_opt = "", .type = POBJECT_ATTRIBUTES},
-            {.name = "OpenOptions", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "TransactionHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE}
-        }
-    },
-    {
-        .name = "NtOpenKeyTransacted", .ret = NTSTATUS, .num_args = 4, .args =
-        {
-            {.name = "KeyHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "ObjectAttributes", .dir = DIR_IN, .dir_opt = "", .type = POBJECT_ATTRIBUTES},
-            {.name = "TransactionHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE}
-        }
-    },
-    {
-        .name = "NtOpenMutant", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "MutantHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "ObjectAttributes", .dir = DIR_IN, .dir_opt = "", .type = POBJECT_ATTRIBUTES}
-        }
-    },
-    {
-        .name = "NtOpenObjectAuditAlarm", .ret = NTSTATUS, .num_args = 12, .args =
-        {
-            {.name = "SubsystemName", .dir = DIR_IN, .dir_opt = "", .type = PUNICODE_STRING},
-            {.name = "HandleId", .dir = DIR_IN, .dir_opt = "opt", .type = PVOID},
-            {.name = "ObjectTypeName", .dir = DIR_IN, .dir_opt = "", .type = PUNICODE_STRING},
-            {.name = "ObjectName", .dir = DIR_IN, .dir_opt = "", .type = PUNICODE_STRING},
-            {.name = "SecurityDescriptor", .dir = DIR_IN, .dir_opt = "opt", .type = PSECURITY_DESCRIPTOR},
-            {.name = "ClientToken", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "GrantedAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "Privileges", .dir = DIR_IN, .dir_opt = "opt", .type = PPRIVILEGE_SET},
-            {.name = "ObjectCreation", .dir = DIR_IN, .dir_opt = "", .type = BOOLEAN},
-            {.name = "AccessGranted", .dir = DIR_IN, .dir_opt = "", .type = BOOLEAN},
-            {.name = "GenerateOnClose", .dir = DIR_OUT, .dir_opt = "", .type = PBOOLEAN}
-        }
-    },
-    {
-        .name = "NtOpenPrivateNamespace", .ret = NTSTATUS, .num_args = 4, .args =
-        {
-            {.name = "NamespaceHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "ObjectAttributes", .dir = DIR_IN, .dir_opt = "opt", .type = POBJECT_ATTRIBUTES},
-            {.name = "BoundaryDescriptor", .dir = DIR_IN, .dir_opt = "", .type = PVOID}
-        }
-    },
-    {
-        .name = "NtOpenProcess", .ret = NTSTATUS, .num_args = 4, .args =
-        {
-            {.name = "ProcessHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "ObjectAttributes", .dir = DIR_IN, .dir_opt = "", .type = POBJECT_ATTRIBUTES},
-            {.name = "ClientId", .dir = DIR_IN, .dir_opt = "opt", .type = PCLIENT_ID}
-        }
-    },
-    {
-        .name = "NtOpenProcessTokenEx", .ret = NTSTATUS, .num_args = 4, .args =
-        {
-            {.name = "ProcessHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "HandleAttributes", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "TokenHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE}
-        }
-    },
-    {
-        .name = "NtOpenProcessToken", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "ProcessHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "TokenHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE}
-        }
-    },
-    {
-        .name = "NtOpenResourceManager", .ret = NTSTATUS, .num_args = 5, .args =
-        {
-            {.name = "ResourceManagerHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "TmHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "ResourceManagerGuid", .dir = DIR_IN, .dir_opt = "opt", .type = LPGUID},
-            {.name = "ObjectAttributes", .dir = DIR_IN, .dir_opt = "opt", .type = POBJECT_ATTRIBUTES}
-        }
-    },
-    {
-        .name = "NtOpenSection", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "SectionHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "ObjectAttributes", .dir = DIR_IN, .dir_opt = "", .type = POBJECT_ATTRIBUTES}
-        }
-    },
-    {
-        .name = "NtOpenSemaphore", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "SemaphoreHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "ObjectAttributes", .dir = DIR_IN, .dir_opt = "", .type = POBJECT_ATTRIBUTES}
-        }
-    },
-    {
-        .name = "NtOpenSession", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "SessionHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "ObjectAttributes", .dir = DIR_IN, .dir_opt = "", .type = POBJECT_ATTRIBUTES}
-        }
-    },
-    {
-        .name = "NtOpenSymbolicLinkObject", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "LinkHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "ObjectAttributes", .dir = DIR_IN, .dir_opt = "", .type = POBJECT_ATTRIBUTES}
-        }
-    },
-    {
-        .name = "NtOpenThread", .ret = NTSTATUS, .num_args = 4, .args =
-        {
-            {.name = "ThreadHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "ObjectAttributes", .dir = DIR_IN, .dir_opt = "", .type = POBJECT_ATTRIBUTES},
-            {.name = "ClientId", .dir = DIR_IN, .dir_opt = "opt", .type = PCLIENT_ID}
-        }
-    },
-    {
-        .name = "NtOpenThreadTokenEx", .ret = NTSTATUS, .num_args = 5, .args =
-        {
-            {.name = "ThreadHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "OpenAsSelf", .dir = DIR_IN, .dir_opt = "", .type = BOOLEAN},
-            {.name = "HandleAttributes", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "TokenHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE}
-        }
-    },
-    {
-        .name = "NtOpenThreadToken", .ret = NTSTATUS, .num_args = 4, .args =
-        {
-            {.name = "ThreadHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "OpenAsSelf", .dir = DIR_IN, .dir_opt = "", .type = BOOLEAN},
-            {.name = "TokenHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE}
-        }
-    },
-    {
-        .name = "NtOpenTimer", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "TimerHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "ObjectAttributes", .dir = DIR_IN, .dir_opt = "", .type = POBJECT_ATTRIBUTES}
-        }
-    },
-    {
-        .name = "NtOpenTransactionManager", .ret = NTSTATUS, .num_args = 6, .args =
-        {
-            {.name = "TmHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "ObjectAttributes", .dir = DIR_IN, .dir_opt = "opt", .type = POBJECT_ATTRIBUTES},
-            {.name = "LogFileName", .dir = DIR_IN, .dir_opt = "opt", .type = PUNICODE_STRING},
-            {.name = "TmIdentity", .dir = DIR_IN, .dir_opt = "opt", .type = LPGUID},
-            {.name = "OpenOptions", .dir = DIR_IN, .dir_opt = "opt", .type = ULONG}
-        }
-    },
-    {
-        .name = "NtOpenTransaction", .ret = NTSTATUS, .num_args = 5, .args =
-        {
-            {.name = "TransactionHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "ObjectAttributes", .dir = DIR_IN, .dir_opt = "", .type = POBJECT_ATTRIBUTES},
-            {.name = "Uow", .dir = DIR_IN, .dir_opt = "", .type = LPGUID},
-            {.name = "TmHandle", .dir = DIR_IN, .dir_opt = "opt", .type = HANDLE}
-        }
-    },
-    {
-        .name = "NtPlugPlayControl", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "PnPControlClass", .dir = DIR_IN, .dir_opt = "", .type = PLUGPLAY_CONTROL_CLASS},
-            {.name = "PnPControlData", .dir = DIR_INOUT, .dir_opt = "bcount(PnPControlDataLength)", .type = PVOID},
-            {.name = "PnPControlDataLength", .dir = DIR_IN, .dir_opt = "", .type = ULONG}
-        }
-    },
-    {
-        .name = "NtPowerInformation", .ret = NTSTATUS, .num_args = 5, .args =
-        {
-            {.name = "InformationLevel", .dir = DIR_IN, .dir_opt = "", .type = POWER_INFORMATION_LEVEL},
-            {.name = "InputBuffer", .dir = DIR_IN, .dir_opt = "bcount_opt(InputBufferLength)", .type = PVOID},
-            {.name = "InputBufferLength", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "OutputBuffer", .dir = DIR_OUT, .dir_opt = "bcount_opt(OutputBufferLength)", .type = PVOID},
-            {.name = "OutputBufferLength", .dir = DIR_IN, .dir_opt = "", .type = ULONG}
-        }
-    },
-    {
-        .name = "NtPrepareComplete", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "EnlistmentHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "TmVirtualClock", .dir = DIR_IN, .dir_opt = "opt", .type = PLARGE_INTEGER}
-        }
-    },
-    {
-        .name = "NtPrepareEnlistment", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "EnlistmentHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "TmVirtualClock", .dir = DIR_IN, .dir_opt = "opt", .type = PLARGE_INTEGER}
-        }
-    },
-    {
-        .name = "NtPrePrepareComplete", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "EnlistmentHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "TmVirtualClock", .dir = DIR_IN, .dir_opt = "opt", .type = PLARGE_INTEGER}
-        }
-    },
-    {
-        .name = "NtPrePrepareEnlistment", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "EnlistmentHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "TmVirtualClock", .dir = DIR_IN, .dir_opt = "opt", .type = PLARGE_INTEGER}
-        }
-    },
-    {
-        .name = "NtPrivilegeCheck", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "ClientToken", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "RequiredPrivileges", .dir = DIR_INOUT, .dir_opt = "", .type = PPRIVILEGE_SET},
-            {.name = "Result", .dir = DIR_OUT, .dir_opt = "", .type = PBOOLEAN}
-        }
-    },
-    {
-        .name = "NtPrivilegedServiceAuditAlarm", .ret = NTSTATUS, .num_args = 5, .args =
-        {
-            {.name = "SubsystemName", .dir = DIR_IN, .dir_opt = "", .type = PUNICODE_STRING},
-            {.name = "ServiceName", .dir = DIR_IN, .dir_opt = "", .type = PUNICODE_STRING},
-            {.name = "ClientToken", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "Privileges", .dir = DIR_IN, .dir_opt = "", .type = PPRIVILEGE_SET},
-            {.name = "AccessGranted", .dir = DIR_IN, .dir_opt = "", .type = BOOLEAN}
-        }
-    },
-    {
-        .name = "NtPrivilegeObjectAuditAlarm", .ret = NTSTATUS, .num_args = 6, .args =
-        {
-            {.name = "SubsystemName", .dir = DIR_IN, .dir_opt = "", .type = PUNICODE_STRING},
-            {.name = "HandleId", .dir = DIR_IN, .dir_opt = "opt", .type = PVOID},
-            {.name = "ClientToken", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "DesiredAccess", .dir = DIR_IN, .dir_opt = "", .type = ACCESS_MASK},
-            {.name = "Privileges", .dir = DIR_IN, .dir_opt = "", .type = PPRIVILEGE_SET},
-            {.name = "AccessGranted", .dir = DIR_IN, .dir_opt = "", .type = BOOLEAN}
-        }
-    },
-    {
-        .name = "NtPropagationComplete", .ret = NTSTATUS, .num_args = 4, .args =
-        {
-            {.name = "ResourceManagerHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "RequestCookie", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "BufferLength", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "Buffer", .dir = DIR_IN, .dir_opt = "", .type = PVOID}
-        }
-    },
-    {
-        .name = "NtPropagationFailed", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "ResourceManagerHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "RequestCookie", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "PropStatus", .dir = DIR_IN, .dir_opt = "", .type = NTSTATUS}
-        }
-    },
-    {
-        .name = "NtProtectVirtualMemory", .ret = NTSTATUS, .num_args = 5, .args =
-        {
-            {.name = "ProcessHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "*BaseAddress", .dir = DIR_INOUT, .dir_opt = "", .type = PVOID},
-            {.name = "RegionSize", .dir = DIR_INOUT, .dir_opt = "", .type = PSIZE_T},
-            {.name = "NewProtectWin32", .dir = DIR_IN, .dir_opt = "", .type = WIN32_PROTECTION_MASK},
-            {.name = "OldProtect", .dir = DIR_OUT, .dir_opt = "", .type = PULONG}
-        }
-    },
-    {
-        .name = "NtPulseEvent", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "EventHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "PreviousState", .dir = DIR_OUT, .dir_opt = "opt", .type = PLONG}
-        }
-    },
-    {
-        .name = "NtQueryAttributesFile", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "ObjectAttributes", .dir = DIR_IN, .dir_opt = "", .type = POBJECT_ATTRIBUTES},
-            {.name = "FileInformation", .dir = DIR_OUT, .dir_opt = "", .type = PFILE_BASIC_INFORMATION}
-        }
-    },
-    {
-        .name = "NtQueryBootEntryOrder", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "Ids", .dir = DIR_OUT, .dir_opt = "ecount_opt(*Count)", .type = PULONG},
-            {.name = "Count", .dir = DIR_INOUT, .dir_opt = "", .type = PULONG}
-        }
-    },
-    {
-        .name = "NtQueryBootOptions", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "BootOptions", .dir = DIR_OUT, .dir_opt = "bcount_opt(*BootOptionsLength)", .type = PBOOT_OPTIONS},
-            {.name = "BootOptionsLength", .dir = DIR_INOUT, .dir_opt = "", .type = PULONG}
-        }
-    },
-    {
-        .name = "NtQueryDebugFilterState", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "ComponentId", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "Level", .dir = DIR_IN, .dir_opt = "", .type = ULONG}
-        }
-    },
-    {
-        .name = "NtQueryDefaultLocale", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "UserProfile", .dir = DIR_IN, .dir_opt = "", .type = BOOLEAN},
-            {.name = "DefaultLocaleId", .dir = DIR_OUT, .dir_opt = "", .type = PLCID}
-        }
-    },
-    {
-        .name = "NtQueryDefaultUILanguage", .ret = NTSTATUS, .num_args = 1, .args =
-        {
-            {.name = "*DefaultUILanguageId", .dir = DIR_OUT, .dir_opt = "", .type = LANGID}
-        }
-    },
-    {
-        .name = "NtQueryDirectoryFile", .ret = NTSTATUS, .num_args = 11, .args =
-        {
-            {.name = "FileHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "Event", .dir = DIR_IN, .dir_opt = "opt", .type = HANDLE},
-            {.name = "ApcRoutine", .dir = DIR_IN, .dir_opt = "opt", .type = PIO_APC_ROUTINE},
-            {.name = "ApcContext", .dir = DIR_IN, .dir_opt = "opt", .type = PVOID},
-            {.name = "IoStatusBlock", .dir = DIR_OUT, .dir_opt = "", .type = PIO_STATUS_BLOCK},
-            {.name = "FileInformation", .dir = DIR_OUT, .dir_opt = "bcount(Length)", .type = PVOID},
-            {.name = "Length", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "FileInformationClass", .dir = DIR_IN, .dir_opt = "", .type = FILE_INFORMATION_CLASS},
-            {.name = "ReturnSingleEntry", .dir = DIR_IN, .dir_opt = "", .type = BOOLEAN},
-            {.name = "FileName", .dir = DIR_IN, .dir_opt = "", .type = PUNICODE_STRING},
-            {.name = "RestartScan", .dir = DIR_IN, .dir_opt = "", .type = BOOLEAN}
-        }
-    },
-    {
-        .name = "NtQueryDirectoryObject", .ret = NTSTATUS, .num_args = 7, .args =
-        {
-            {.name = "DirectoryHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "Buffer", .dir = DIR_OUT, .dir_opt = "bcount_opt(Length)", .type = PVOID},
-            {.name = "Length", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "ReturnSingleEntry", .dir = DIR_IN, .dir_opt = "", .type = BOOLEAN},
-            {.name = "RestartScan", .dir = DIR_IN, .dir_opt = "", .type = BOOLEAN},
-            {.name = "Context", .dir = DIR_INOUT, .dir_opt = "", .type = PULONG},
-            {.name = "ReturnLength", .dir = DIR_OUT, .dir_opt = "opt", .type = PULONG}
-        }
-    },
-    {
-        .name = "NtQueryDriverEntryOrder", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "Ids", .dir = DIR_OUT, .dir_opt = "ecount(*Count)", .type = PULONG},
-            {.name = "Count", .dir = DIR_INOUT, .dir_opt = "", .type = PULONG}
-        }
-    },
-    {
-        .name = "NtQueryEaFile", .ret = NTSTATUS, .num_args = 9, .args =
-        {
-            {.name = "FileHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "IoStatusBlock", .dir = DIR_OUT, .dir_opt = "", .type = PIO_STATUS_BLOCK},
-            {.name = "Buffer", .dir = DIR_OUT, .dir_opt = "bcount(Length)", .type = PVOID},
-            {.name = "Length", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "ReturnSingleEntry", .dir = DIR_IN, .dir_opt = "", .type = BOOLEAN},
-            {.name = "EaList", .dir = DIR_IN, .dir_opt = "bcount_opt(EaListLength)", .type = PVOID},
-            {.name = "EaListLength", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "EaIndex", .dir = DIR_IN, .dir_opt = "opt", .type = PULONG},
-            {.name = "RestartScan", .dir = DIR_IN, .dir_opt = "", .type = BOOLEAN}
-        }
-    },
-    {
-        .name = "NtQueryEvent", .ret = NTSTATUS, .num_args = 5, .args =
-        {
-            {.name = "EventHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "EventInformationClass", .dir = DIR_IN, .dir_opt = "", .type = EVENT_INFORMATION_CLASS},
-            {.name = "EventInformation", .dir = DIR_OUT, .dir_opt = "bcount(EventInformationLength)", .type = PVOID},
-            {.name = "EventInformationLength", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "ReturnLength", .dir = DIR_OUT, .dir_opt = "opt", .type = PULONG}
-        }
-    },
-    {
-        .name = "NtQueryFullAttributesFile", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "ObjectAttributes", .dir = DIR_IN, .dir_opt = "", .type = POBJECT_ATTRIBUTES},
-            {.name = "FileInformation", .dir = DIR_OUT, .dir_opt = "", .type = PFILE_NETWORK_OPEN_INFORMATION}
-        }
-    },
-    {
-        .name = "NtQueryInformationAtom", .ret = NTSTATUS, .num_args = 5, .args =
-        {
-            {.name = "Atom", .dir = DIR_IN, .dir_opt = "", .type = RTL_ATOM},
-            {.name = "InformationClass", .dir = DIR_IN, .dir_opt = "", .type = ATOM_INFORMATION_CLASS},
-            {.name = "AtomInformation", .dir = DIR_OUT, .dir_opt = "bcount(AtomInformationLength)", .type = PVOID},
-            {.name = "AtomInformationLength", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "ReturnLength", .dir = DIR_OUT, .dir_opt = "opt", .type = PULONG}
-        }
-    },
-    {
-        .name = "NtQueryInformationEnlistment", .ret = NTSTATUS, .num_args = 5, .args =
-        {
-            {.name = "EnlistmentHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "EnlistmentInformationClass", .dir = DIR_IN, .dir_opt = "", .type = ENLISTMENT_INFORMATION_CLASS},
-            {.name = "EnlistmentInformation", .dir = DIR_OUT, .dir_opt = "bcount(EnlistmentInformationLength)", .type = PVOID},
-            {.name = "EnlistmentInformationLength", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "ReturnLength", .dir = DIR_OUT, .dir_opt = "opt", .type = PULONG}
-        }
-    },
-    {
-        .name = "NtQueryInformationFile", .ret = NTSTATUS, .num_args = 5, .args =
-        {
-            {.name = "FileHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "IoStatusBlock", .dir = DIR_OUT, .dir_opt = "", .type = PIO_STATUS_BLOCK},
-            {.name = "FileInformation", .dir = DIR_OUT, .dir_opt = "bcount(Length)", .type = PVOID},
-            {.name = "Length", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "FileInformationClass", .dir = DIR_IN, .dir_opt = "", .type = FILE_INFORMATION_CLASS}
-        }
-    },
-    {
-        .name = "NtQueryInformationJobObject", .ret = NTSTATUS, .num_args = 5, .args =
-        {
-            {.name = "JobHandle", .dir = DIR_IN, .dir_opt = "opt", .type = HANDLE},
-            {.name = "JobObjectInformationClass", .dir = DIR_IN, .dir_opt = "", .type = JOBOBJECTINFOCLASS},
-            {.name = "JobObjectInformation", .dir = DIR_OUT, .dir_opt = "bcount(JobObjectInformationLength)", .type = PVOID},
-            {.name = "JobObjectInformationLength", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "ReturnLength", .dir = DIR_OUT, .dir_opt = "opt", .type = PULONG}
-        }
-    },
-    {
-        .name = "NtQueryInformationPort", .ret = NTSTATUS, .num_args = 5, .args =
-        {
-            {.name = "PortHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "PortInformationClass", .dir = DIR_IN, .dir_opt = "", .type = PORT_INFORMATION_CLASS},
-            {.name = "PortInformation", .dir = DIR_OUT, .dir_opt = "bcount(Length)", .type = PVOID},
-            {.name = "Length", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "ReturnLength", .dir = DIR_OUT, .dir_opt = "opt", .type = PULONG}
-        }
-    },
-    {
-        .name = "NtQueryInformationProcess", .ret = NTSTATUS, .num_args = 5, .args =
-        {
-            {.name = "ProcessHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "ProcessInformationClass", .dir = DIR_IN, .dir_opt = "", .type = PROCESSINFOCLASS},
-            {.name = "ProcessInformation", .dir = DIR_OUT, .dir_opt = "bcount(ProcessInformationLength)", .type = PVOID},
-            {.name = "ProcessInformationLength", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "ReturnLength", .dir = DIR_OUT, .dir_opt = "opt", .type = PULONG}
-        }
-    },
-    {
-        .name = "NtQueryInformationResourceManager", .ret = NTSTATUS, .num_args = 5, .args =
-        {
-            {.name = "ResourceManagerHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "ResourceManagerInformationClass", .dir = DIR_IN, .dir_opt = "", .type = RESOURCEMANAGER_INFORMATION_CLASS},
-            {.name = "ResourceManagerInformation", .dir = DIR_OUT, .dir_opt = "bcount(ResourceManagerInformationLength)", .type = PVOID},
-            {.name = "ResourceManagerInformationLength", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "ReturnLength", .dir = DIR_OUT, .dir_opt = "opt", .type = PULONG}
-        }
-    },
-    {
-        .name = "NtQueryInformationThread", .ret = NTSTATUS, .num_args = 5, .args =
-        {
-            {.name = "ThreadHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "ThreadInformationClass", .dir = DIR_IN, .dir_opt = "", .type = THREADINFOCLASS},
-            {.name = "ThreadInformation", .dir = DIR_OUT, .dir_opt = "bcount(ThreadInformationLength)", .type = PVOID},
-            {.name = "ThreadInformationLength", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "ReturnLength", .dir = DIR_OUT, .dir_opt = "opt", .type = PULONG}
-        }
-    },
-    {
-        .name = "NtQueryInformationToken", .ret = NTSTATUS, .num_args = 5, .args =
-        {
-            {.name = "TokenHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "TokenInformationClass", .dir = DIR_IN, .dir_opt = "", .type = TOKEN_INFORMATION_CLASS},
-            {.name = "TokenInformation", .dir = DIR_OUT, .dir_opt = "bcount_part_opt(TokenInformationLength,*ReturnLength)", .type = PVOID},
-            {.name = "TokenInformationLength", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "ReturnLength", .dir = DIR_OUT, .dir_opt = "", .type = PULONG}
-        }
-    },
-    {
-        .name = "NtQueryInformationTransaction", .ret = NTSTATUS, .num_args = 5, .args =
-        {
-            {.name = "TransactionHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "TransactionInformationClass", .dir = DIR_IN, .dir_opt = "", .type = TRANSACTION_INFORMATION_CLASS},
-            {.name = "TransactionInformation", .dir = DIR_OUT, .dir_opt = "bcount(TransactionInformationLength)", .type = PVOID},
-            {.name = "TransactionInformationLength", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "ReturnLength", .dir = DIR_OUT, .dir_opt = "opt", .type = PULONG}
-        }
-    },
-    {
-        .name = "NtQueryInformationTransactionManager", .ret = NTSTATUS, .num_args = 5, .args =
-        {
-            {.name = "TransactionManagerHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "TransactionManagerInformationClass", .dir = DIR_IN, .dir_opt = "", .type = TRANSACTIONMANAGER_INFORMATION_CLASS},
-            {.name = "TransactionManagerInformation", .dir = DIR_OUT, .dir_opt = "bcount(TransactionManagerInformationLength)", .type = PVOID},
-            {.name = "TransactionManagerInformationLength", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "ReturnLength", .dir = DIR_OUT, .dir_opt = "opt", .type = PULONG}
-        }
-    },
-    {
-        .name = "NtQueryInformationWorkerFactory", .ret = NTSTATUS, .num_args = 5, .args =
-        {
-            {.name = "WorkerFactoryHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "WorkerFactoryInformationClass", .dir = DIR_IN, .dir_opt = "", .type = WORKERFACTORYINFOCLASS},
-            {.name = "WorkerFactoryInformation", .dir = DIR_OUT, .dir_opt = "bcount(WorkerFactoryInformationLength)", .type = PVOID},
-            {.name = "WorkerFactoryInformationLength", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "ReturnLength", .dir = DIR_OUT, .dir_opt = "opt", .type = PULONG}
-        }
-    },
-    {
-        .name = "NtQueryInstallUILanguage", .ret = NTSTATUS, .num_args = 1, .args =
-        {
-            {.name = "*InstallUILanguageId", .dir = DIR_OUT, .dir_opt = "", .type = LANGID}
-        }
-    },
-    {
-        .name = "NtQueryIntervalProfile", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "ProfileSource", .dir = DIR_IN, .dir_opt = "", .type = KPROFILE_SOURCE},
-            {.name = "Interval", .dir = DIR_OUT, .dir_opt = "", .type = PULONG}
-        }
-    },
-    {
-        .name = "NtQueryIoCompletion", .ret = NTSTATUS, .num_args = 5, .args =
-        {
-            {.name = "IoCompletionHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "IoCompletionInformationClass", .dir = DIR_IN, .dir_opt = "", .type = IO_COMPLETION_INFORMATION_CLASS},
-            {.name = "IoCompletionInformation", .dir = DIR_OUT, .dir_opt = "bcount(IoCompletionInformationLength)", .type = PVOID},
-            {.name = "IoCompletionInformationLength", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "ReturnLength", .dir = DIR_OUT, .dir_opt = "opt", .type = PULONG}
-        }
-    },
-    {
-        .name = "NtQueryKey", .ret = NTSTATUS, .num_args = 5, .args =
-        {
-            {.name = "KeyHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "KeyInformationClass", .dir = DIR_IN, .dir_opt = "", .type = KEY_INFORMATION_CLASS},
-            {.name = "KeyInformation", .dir = DIR_OUT, .dir_opt = "bcount_opt(Length)", .type = PVOID},
-            {.name = "Length", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "ResultLength", .dir = DIR_OUT, .dir_opt = "", .type = PULONG}
-        }
-    },
-    {
-        .name = "NtQueryLicenseValue", .ret = NTSTATUS, .num_args = 5, .args =
-        {
-            {.name = "Name", .dir = DIR_IN, .dir_opt = "", .type = PUNICODE_STRING},
-            {.name = "Type", .dir = DIR_OUT, .dir_opt = "opt", .type = PULONG},
-            {.name = "Buffer", .dir = DIR_OUT, .dir_opt = "bcount(ReturnedLength)", .type = PVOID},
-            {.name = "Length", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "ReturnedLength", .dir = DIR_OUT, .dir_opt = "", .type = PULONG}
-        }
-    },
-    {
-        .name = "NtQueryMultipleValueKey", .ret = NTSTATUS, .num_args = 6, .args =
-        {
-            {.name = "KeyHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "ValueEntries", .dir = DIR_INOUT, .dir_opt = "ecount(EntryCount)", .type = PKEY_VALUE_ENTRY},
-            {.name = "EntryCount", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "ValueBuffer", .dir = DIR_OUT, .dir_opt = "bcount(*BufferLength)", .type = PVOID},
-            {.name = "BufferLength", .dir = DIR_INOUT, .dir_opt = "", .type = PULONG},
-            {.name = "RequiredBufferLength", .dir = DIR_OUT, .dir_opt = "opt", .type = PULONG}
-        }
-    },
-    {
-        .name = "NtQueryMutant", .ret = NTSTATUS, .num_args = 5, .args =
-        {
-            {.name = "MutantHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "MutantInformationClass", .dir = DIR_IN, .dir_opt = "", .type = MUTANT_INFORMATION_CLASS},
-            {.name = "MutantInformation", .dir = DIR_OUT, .dir_opt = "bcount(MutantInformationLength)", .type = PVOID},
-            {.name = "MutantInformationLength", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "ReturnLength", .dir = DIR_OUT, .dir_opt = "opt", .type = PULONG}
-        }
-    },
-    {
-        .name = "NtQueryObject", .ret = NTSTATUS, .num_args = 5, .args =
-        {
-            {.name = "Handle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "ObjectInformationClass", .dir = DIR_IN, .dir_opt = "", .type = OBJECT_INFORMATION_CLASS},
-            {.name = "ObjectInformation", .dir = DIR_OUT, .dir_opt = "bcount_opt(ObjectInformationLength)", .type = PVOID},
-            {.name = "ObjectInformationLength", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "ReturnLength", .dir = DIR_OUT, .dir_opt = "opt", .type = PULONG}
-        }
-    },
-    {
-        .name = "NtQueryOpenSubKeysEx", .ret = NTSTATUS, .num_args = 4, .args =
-        {
-            {.name = "TargetKey", .dir = DIR_IN, .dir_opt = "", .type = POBJECT_ATTRIBUTES},
-            {.name = "BufferLength", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "Buffer", .dir = DIR_OUT, .dir_opt = "bcount(BufferLength)", .type = PVOID},
-            {.name = "RequiredSize", .dir = DIR_OUT, .dir_opt = "", .type = PULONG}
-        }
-    },
-    {
-        .name = "NtQueryOpenSubKeys", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "TargetKey", .dir = DIR_IN, .dir_opt = "", .type = POBJECT_ATTRIBUTES},
-            {.name = "HandleCount", .dir = DIR_OUT, .dir_opt = "", .type = PULONG}
-        }
-    },
-    {
-        .name = "NtQueryPerformanceCounter", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "PerformanceCounter", .dir = DIR_OUT, .dir_opt = "", .type = PLARGE_INTEGER},
-            {.name = "PerformanceFrequency", .dir = DIR_OUT, .dir_opt = "opt", .type = PLARGE_INTEGER}
-        }
-    },
-    { .name = "NtQueryPortInformationProcess", .ret = NTSTATUS, .num_args = 0  },
-    {
-        .name = "NtQueryQuotaInformationFile", .ret = NTSTATUS, .num_args = 9, .args =
-        {
-            {.name = "FileHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "IoStatusBlock", .dir = DIR_OUT, .dir_opt = "", .type = PIO_STATUS_BLOCK},
-            {.name = "Buffer", .dir = DIR_OUT, .dir_opt = "bcount(Length)", .type = PVOID},
-            {.name = "Length", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "ReturnSingleEntry", .dir = DIR_IN, .dir_opt = "", .type = BOOLEAN},
-            {.name = "SidList", .dir = DIR_IN, .dir_opt = "bcount_opt(SidListLength)", .type = PVOID},
-            {.name = "SidListLength", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "StartSid", .dir = DIR_IN, .dir_opt = "opt", .type = PULONG},
-            {.name = "RestartScan", .dir = DIR_IN, .dir_opt = "", .type = BOOLEAN}
-        }
-    },
-    {
-        .name = "NtQuerySection", .ret = NTSTATUS, .num_args = 5, .args =
-        {
-            {.name = "SectionHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "SectionInformationClass", .dir = DIR_IN, .dir_opt = "", .type = SECTION_INFORMATION_CLASS},
-            {.name = "SectionInformation", .dir = DIR_OUT, .dir_opt = "bcount(SectionInformationLength)", .type = PVOID},
-            {.name = "SectionInformationLength", .dir = DIR_IN, .dir_opt = "", .type = SIZE_T},
-            {.name = "ReturnLength", .dir = DIR_OUT, .dir_opt = "opt", .type = PSIZE_T}
-        }
-    },
-    {
-        .name = "NtQuerySecurityAttributesToken", .ret = NTSTATUS, .num_args = 6, .args =
-        {
-            {.name = "TokenHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "Attributes", .dir = DIR_IN, .dir_opt = "ecount_opt(NumberOfAttributes)", .type = PUNICODE_STRING},
-            {.name = "NumberOfAttributes", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "Buffer", .dir = DIR_OUT, .dir_opt = "bcount(Length)", .type = PVOID},
-            {.name = "Length", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "ReturnLength", .dir = DIR_OUT, .dir_opt = "", .type = PULONG}
-        }
-    },
-    {
-        .name = "NtQuerySecurityObject", .ret = NTSTATUS, .num_args = 5, .args =
-        {
-            {.name = "Handle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "SecurityInformation", .dir = DIR_IN, .dir_opt = "", .type = SECURITY_INFORMATION},
-            {.name = "SecurityDescriptor", .dir = DIR_OUT, .dir_opt = "bcount_opt(Length)", .type = PSECURITY_DESCRIPTOR},
-            {.name = "Length", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "LengthNeeded", .dir = DIR_OUT, .dir_opt = "", .type = PULONG}
-        }
-    },
-    {
-        .name = "NtQuerySemaphore", .ret = NTSTATUS, .num_args = 5, .args =
-        {
-            {.name = "SemaphoreHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "SemaphoreInformationClass", .dir = DIR_IN, .dir_opt = "", .type = SEMAPHORE_INFORMATION_CLASS},
-            {.name = "SemaphoreInformation", .dir = DIR_OUT, .dir_opt = "bcount(SemaphoreInformationLength)", .type = PVOID},
-            {.name = "SemaphoreInformationLength", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "ReturnLength", .dir = DIR_OUT, .dir_opt = "opt", .type = PULONG}
-        }
-    },
-    {
-        .name = "NtQuerySymbolicLinkObject", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "LinkHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "LinkTarget", .dir = DIR_INOUT, .dir_opt = "", .type = PUNICODE_STRING},
-            {.name = "ReturnedLength", .dir = DIR_OUT, .dir_opt = "opt", .type = PULONG}
-        }
-    },
-    {
-        .name = "NtQuerySystemEnvironmentValueEx", .ret = NTSTATUS, .num_args = 5, .args =
-        {
-            {.name = "VariableName", .dir = DIR_IN, .dir_opt = "", .type = PUNICODE_STRING},
-            {.name = "VendorGuid", .dir = DIR_IN, .dir_opt = "", .type = LPGUID},
-            {.name = "Value", .dir = DIR_OUT, .dir_opt = "bcount_opt(*ValueLength)", .type = PVOID},
-            {.name = "ValueLength", .dir = DIR_INOUT, .dir_opt = "", .type = PULONG},
-            {.name = "Attributes", .dir = DIR_OUT, .dir_opt = "opt", .type = PULONG}
-        }
-    },
-    {
-        .name = "NtQuerySystemEnvironmentValue", .ret = NTSTATUS, .num_args = 4, .args =
-        {
-            {.name = "VariableName", .dir = DIR_IN, .dir_opt = "", .type = PUNICODE_STRING},
-            {.name = "VariableValue", .dir = DIR_OUT, .dir_opt = "bcount(ValueLength)", .type = PWSTR},
-            {.name = "ValueLength", .dir = DIR_IN, .dir_opt = "", .type = USHORT},
-            {.name = "ReturnLength", .dir = DIR_OUT, .dir_opt = "opt", .type = PUSHORT}
-        }
-    },
-    {
-        .name = "NtQuerySystemInformationEx", .ret = NTSTATUS, .num_args = 6, .args =
-        {
-            {.name = "SystemInformationClass", .dir = DIR_IN, .dir_opt = "", .type = SYSTEM_INFORMATION_CLASS},
-            {.name = "QueryInformation", .dir = DIR_IN, .dir_opt = "bcount(QueryInformationLength)", .type = PVOID},
-            {.name = "QueryInformationLength", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "SystemInformation", .dir = DIR_OUT, .dir_opt = "bcount_opt(SystemInformationLength)", .type = PVOID},
-            {.name = "SystemInformationLength", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "ReturnLength", .dir = DIR_OUT, .dir_opt = "opt", .type = PULONG}
-        }
-    },
-    {
-        .name = "NtQuerySystemInformation", .ret = NTSTATUS, .num_args = 4, .args =
-        {
-            {.name = "SystemInformationClass", .dir = DIR_IN, .dir_opt = "", .type = SYSTEM_INFORMATION_CLASS},
-            {.name = "SystemInformation", .dir = DIR_OUT, .dir_opt = "bcount_opt(SystemInformationLength)", .type = PVOID},
-            {.name = "SystemInformationLength", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "ReturnLength", .dir = DIR_OUT, .dir_opt = "opt", .type = PULONG}
-        }
-    },
-    {
-        .name = "NtQuerySystemTime", .ret = NTSTATUS, .num_args = 1, .args =
-        {
-            {.name = "SystemTime", .dir = DIR_OUT, .dir_opt = "", .type = PLARGE_INTEGER}
-        }
-    },
-    {
-        .name = "NtQueryTimer", .ret = NTSTATUS, .num_args = 5, .args =
-        {
-            {.name = "TimerHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "TimerInformationClass", .dir = DIR_IN, .dir_opt = "", .type = TIMER_INFORMATION_CLASS},
-            {.name = "TimerInformation", .dir = DIR_OUT, .dir_opt = "bcount(TimerInformationLength)", .type = PVOID},
-            {.name = "TimerInformationLength", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "ReturnLength", .dir = DIR_OUT, .dir_opt = "opt", .type = PULONG}
-        }
-    },
-    {
-        .name = "NtQueryTimerResolution", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "MaximumTime", .dir = DIR_OUT, .dir_opt = "", .type = PULONG},
-            {.name = "MinimumTime", .dir = DIR_OUT, .dir_opt = "", .type = PULONG},
-            {.name = "CurrentTime", .dir = DIR_OUT, .dir_opt = "", .type = PULONG}
-        }
-    },
-    {
-        .name = "NtQueryValueKey", .ret = NTSTATUS, .num_args = 6, .args =
-        {
-            {.name = "KeyHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "ValueName", .dir = DIR_IN, .dir_opt = "", .type = PUNICODE_STRING},
-            {.name = "KeyValueInformationClass", .dir = DIR_IN, .dir_opt = "", .type = KEY_VALUE_INFORMATION_CLASS},
-            {.name = "KeyValueInformation", .dir = DIR_OUT, .dir_opt = "bcount_opt(Length)", .type = PVOID},
-            {.name = "Length", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "ResultLength", .dir = DIR_OUT, .dir_opt = "", .type = PULONG}
-        }
-    },
-    {
-        .name = "NtQueryVirtualMemory", .ret = NTSTATUS, .num_args = 6, .args =
-        {
-            {.name = "ProcessHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "BaseAddress", .dir = DIR_IN, .dir_opt = "", .type = PVOID},
-            {.name = "MemoryInformationClass", .dir = DIR_IN, .dir_opt = "", .type = MEMORY_INFORMATION_CLASS},
-            {.name = "MemoryInformation", .dir = DIR_OUT, .dir_opt = "bcount(MemoryInformationLength)", .type = PVOID},
-            {.name = "MemoryInformationLength", .dir = DIR_IN, .dir_opt = "", .type = SIZE_T},
-            {.name = "ReturnLength", .dir = DIR_OUT, .dir_opt = "opt", .type = PSIZE_T}
-        }
-    },
-    {
-        .name = "NtQueryVolumeInformationFile", .ret = NTSTATUS, .num_args = 5, .args =
-        {
-            {.name = "FileHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "IoStatusBlock", .dir = DIR_OUT, .dir_opt = "", .type = PIO_STATUS_BLOCK},
-            {.name = "FsInformation", .dir = DIR_OUT, .dir_opt = "bcount(Length)", .type = PVOID},
-            {.name = "Length", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "FsInformationClass", .dir = DIR_IN, .dir_opt = "", .type = FS_INFORMATION_CLASS}
-        }
-    },
-    {
-        .name = "NtQueueApcThreadEx", .ret = NTSTATUS, .num_args = 6, .args =
-        {
-            {.name = "ThreadHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "UserApcReserveHandle", .dir = DIR_IN, .dir_opt = "opt", .type = HANDLE},
-            {.name = "ApcRoutine", .dir = DIR_IN, .dir_opt = "", .type = PPS_APC_ROUTINE},
-            {.name = "ApcArgument1", .dir = DIR_IN, .dir_opt = "opt", .type = PVOID},
-            {.name = "ApcArgument2", .dir = DIR_IN, .dir_opt = "opt", .type = PVOID},
-            {.name = "ApcArgument3", .dir = DIR_IN, .dir_opt = "opt", .type = PVOID}
-        }
-    },
-    {
-        .name = "NtQueueApcThread", .ret = NTSTATUS, .num_args = 5, .args =
-        {
-            {.name = "ThreadHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "ApcRoutine", .dir = DIR_IN, .dir_opt = "", .type = PPS_APC_ROUTINE},
-            {.name = "ApcArgument1", .dir = DIR_IN, .dir_opt = "opt", .type = PVOID},
-            {.name = "ApcArgument2", .dir = DIR_IN, .dir_opt = "opt", .type = PVOID},
-            {.name = "ApcArgument3", .dir = DIR_IN, .dir_opt = "opt", .type = PVOID}
-        }
-    },
-    {
-        .name = "NtRaiseException", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "ExceptionRecord", .dir = DIR_OUT, .dir_opt = "", .type = PEXCEPTION_RECORD},
-            {.name = "ContextRecord", .dir = DIR_OUT, .dir_opt = "", .type = PCONTEXT},
-            {.name = "FirstChance", .dir = DIR_OUT, .dir_opt = "", .type = BOOLEAN}
-        }
-    },
-    {
-        .name = "NtRaiseHardError", .ret = NTSTATUS, .num_args = 6, .args =
-        {
-            {.name = "ErrorStatus", .dir = DIR_IN, .dir_opt = "", .type = NTSTATUS},
-            {.name = "NumberOfParameters", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "UnicodeStringParameterMask", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "Parameters", .dir = DIR_IN, .dir_opt = "ecount(NumberOfParameters)", .type = PULONG_PTR},
-            {.name = "ValidResponseOptions", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "Response", .dir = DIR_OUT, .dir_opt = "", .type = PULONG}
-        }
-    },
-    {
-        .name = "NtReadFile", .ret = NTSTATUS, .num_args = 9, .args =
-        {
-            {.name = "FileHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "Event", .dir = DIR_IN, .dir_opt = "opt", .type = HANDLE},
-            {.name = "ApcRoutine", .dir = DIR_IN, .dir_opt = "opt", .type = PIO_APC_ROUTINE},
-            {.name = "ApcContext", .dir = DIR_IN, .dir_opt = "opt", .type = PVOID},
-            {.name = "IoStatusBlock", .dir = DIR_OUT, .dir_opt = "", .type = PIO_STATUS_BLOCK},
-            {.name = "Buffer", .dir = DIR_OUT, .dir_opt = "bcount(Length)", .type = PVOID},
-            {.name = "Length", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "ByteOffset", .dir = DIR_IN, .dir_opt = "opt", .type = PLARGE_INTEGER},
-            {.name = "Key", .dir = DIR_IN, .dir_opt = "opt", .type = PULONG}
-        }
-    },
-    {
-        .name = "NtReadFileScatter", .ret = NTSTATUS, .num_args = 9, .args =
-        {
-            {.name = "FileHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "Event", .dir = DIR_IN, .dir_opt = "opt", .type = HANDLE},
-            {.name = "ApcRoutine", .dir = DIR_IN, .dir_opt = "opt", .type = PIO_APC_ROUTINE},
-            {.name = "ApcContext", .dir = DIR_IN, .dir_opt = "opt", .type = PVOID},
-            {.name = "IoStatusBlock", .dir = DIR_OUT, .dir_opt = "", .type = PIO_STATUS_BLOCK},
-            {.name = "SegmentArray", .dir = DIR_IN, .dir_opt = "", .type = PFILE_SEGMENT_ELEMENT},
-            {.name = "Length", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "ByteOffset", .dir = DIR_IN, .dir_opt = "opt", .type = PLARGE_INTEGER},
-            {.name = "Key", .dir = DIR_IN, .dir_opt = "opt", .type = PULONG}
-        }
-    },
-    {
-        .name = "NtReadOnlyEnlistment", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "EnlistmentHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "TmVirtualClock", .dir = DIR_IN, .dir_opt = "opt", .type = PLARGE_INTEGER}
-        }
-    },
-    {
-        .name = "NtReadRequestData", .ret = NTSTATUS, .num_args = 6, .args =
-        {
-            {.name = "PortHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "Message", .dir = DIR_IN, .dir_opt = "", .type = PPORT_MESSAGE},
-            {.name = "DataEntryIndex", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "Buffer", .dir = DIR_OUT, .dir_opt = "bcount(BufferSize)", .type = PVOID},
-            {.name = "BufferSize", .dir = DIR_IN, .dir_opt = "", .type = SIZE_T},
-            {.name = "NumberOfBytesRead", .dir = DIR_OUT, .dir_opt = "opt", .type = PSIZE_T}
-        }
-    },
-    {
-        .name = "NtReadVirtualMemory", .ret = NTSTATUS, .num_args = 5, .args =
-        {
-            {.name = "ProcessHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "BaseAddress", .dir = DIR_IN, .dir_opt = "opt", .type = PVOID},
-            {.name = "Buffer", .dir = DIR_OUT, .dir_opt = "bcount(BufferSize)", .type = PVOID},
-            {.name = "BufferSize", .dir = DIR_IN, .dir_opt = "", .type = SIZE_T},
-            {.name = "NumberOfBytesRead", .dir = DIR_OUT, .dir_opt = "opt", .type = PSIZE_T}
-        }
-    },
-    {
-        .name = "NtRecoverEnlistment", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "EnlistmentHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "EnlistmentKey", .dir = DIR_IN, .dir_opt = "opt", .type = PVOID}
-        }
-    },
-    {
-        .name = "NtRecoverResourceManager", .ret = NTSTATUS, .num_args = 1, .args =
-        {
-            {.name = "ResourceManagerHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE}
-        }
-    },
-    {
-        .name = "NtRecoverTransactionManager", .ret = NTSTATUS, .num_args = 1, .args =
-        {
-            {.name = "TransactionManagerHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE}
-        }
-    },
-    {
-        .name = "NtRegisterProtocolAddressInformation", .ret = NTSTATUS, .num_args = 5, .args =
-        {
-            {.name = "ResourceManager", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "ProtocolId", .dir = DIR_IN, .dir_opt = "", .type = PCRM_PROTOCOL_ID},
-            {.name = "ProtocolInformationSize", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "ProtocolInformation", .dir = DIR_IN, .dir_opt = "", .type = PVOID},
-            {.name = "CreateOptions", .dir = DIR_IN, .dir_opt = "opt", .type = ULONG}
-        }
-    },
-    {
-        .name = "NtRegisterThreadTerminatePort", .ret = NTSTATUS, .num_args = 1, .args =
-        {
-            {.name = "PortHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE}
-        }
-    },
-    {
-        .name = "NtReleaseKeyedEvent", .ret = NTSTATUS, .num_args = 4, .args =
-        {
-            {.name = "KeyedEventHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "KeyValue", .dir = DIR_IN, .dir_opt = "", .type = PVOID},
-            {.name = "Alertable", .dir = DIR_IN, .dir_opt = "", .type = BOOLEAN},
-            {.name = "Timeout", .dir = DIR_IN, .dir_opt = "opt", .type = PLARGE_INTEGER}
-        }
-    },
-    {
-        .name = "NtReleaseMutant", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "MutantHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "PreviousCount", .dir = DIR_OUT, .dir_opt = "opt", .type = PLONG}
-        }
-    },
-    {
-        .name = "NtReleaseSemaphore", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "SemaphoreHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "ReleaseCount", .dir = DIR_IN, .dir_opt = "", .type = LONG},
-            {.name = "PreviousCount", .dir = DIR_OUT, .dir_opt = "opt", .type = PLONG}
-        }
-    },
-    {
-        .name = "NtReleaseWorkerFactoryWorker", .ret = NTSTATUS, .num_args = 1, .args =
-        {
-            {.name = "WorkerFactoryHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE}
-        }
-    },
-    {
-        .name = "NtRemoveIoCompletionEx", .ret = NTSTATUS, .num_args = 6, .args =
-        {
-            {.name = "IoCompletionHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "IoCompletionInformation", .dir = DIR_OUT, .dir_opt = "ecount(Count)", .type = PFILE_IO_COMPLETION_INFORMATION},
-            {.name = "Count", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "NumEntriesRemoved", .dir = DIR_OUT, .dir_opt = "", .type = PULONG},
-            {.name = "Timeout", .dir = DIR_IN, .dir_opt = "opt", .type = PLARGE_INTEGER},
-            {.name = "Alertable", .dir = DIR_IN, .dir_opt = "", .type = BOOLEAN}
-        }
-    },
-    {
-        .name = "NtRemoveIoCompletion", .ret = NTSTATUS, .num_args = 5, .args =
-        {
-            {.name = "IoCompletionHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "*KeyContext", .dir = DIR_OUT, .dir_opt = "", .type = PVOID},
-            {.name = "*ApcContext", .dir = DIR_OUT, .dir_opt = "", .type = PVOID},
-            {.name = "IoStatusBlock", .dir = DIR_OUT, .dir_opt = "", .type = PIO_STATUS_BLOCK},
-            {.name = "Timeout", .dir = DIR_IN, .dir_opt = "opt", .type = PLARGE_INTEGER}
-        }
-    },
-    {
-        .name = "NtRemoveProcessDebug", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "ProcessHandle", .dir = DIR_OUT, .dir_opt = "", .type = HANDLE},
-            {.name = "DebugObjectHandle", .dir = DIR_OUT, .dir_opt = "", .type = HANDLE}
-        }
-    },
-    {
-        .name = "NtRenameKey", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "KeyHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "NewName", .dir = DIR_IN, .dir_opt = "", .type = PUNICODE_STRING}
-        }
-    },
-    {
-        .name = "NtRenameTransactionManager", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "LogFileName", .dir = DIR_IN, .dir_opt = "", .type = PUNICODE_STRING},
-            {.name = "ExistingTransactionManagerGuid", .dir = DIR_IN, .dir_opt = "", .type = LPGUID}
-        }
-    },
-    {
-        .name = "NtReplaceKey", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "NewFile", .dir = DIR_IN, .dir_opt = "", .type = POBJECT_ATTRIBUTES},
-            {.name = "TargetHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "OldFile", .dir = DIR_IN, .dir_opt = "", .type = POBJECT_ATTRIBUTES}
-        }
-    },
-    {
-        .name = "NtReplacePartitionUnit", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "TargetInstancePath", .dir = DIR_IN, .dir_opt = "", .type = PUNICODE_STRING},
-            {.name = "SpareInstancePath", .dir = DIR_IN, .dir_opt = "", .type = PUNICODE_STRING},
-            {.name = "Flags", .dir = DIR_IN, .dir_opt = "", .type = ULONG}
-        }
-    },
-    {
-        .name = "NtReplyPort", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "PortHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "ReplyMessage", .dir = DIR_IN, .dir_opt = "", .type = PPORT_MESSAGE}
-        }
-    },
-    {
-        .name = "NtReplyWaitReceivePortEx", .ret = NTSTATUS, .num_args = 5, .args =
-        {
-            {.name = "PortHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "*PortContext", .dir = DIR_OUT, .dir_opt = "opt", .type = PVOID},
-            {.name = "ReplyMessage", .dir = DIR_IN, .dir_opt = "opt", .type = PPORT_MESSAGE},
-            {.name = "ReceiveMessage", .dir = DIR_OUT, .dir_opt = "", .type = PPORT_MESSAGE},
-            {.name = "Timeout", .dir = DIR_IN, .dir_opt = "opt", .type = PLARGE_INTEGER}
-        }
-    },
-    {
-        .name = "NtReplyWaitReceivePort", .ret = NTSTATUS, .num_args = 4, .args =
-        {
-            {.name = "PortHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "*PortContext", .dir = DIR_OUT, .dir_opt = "opt", .type = PVOID},
-            {.name = "ReplyMessage", .dir = DIR_IN, .dir_opt = "opt", .type = PPORT_MESSAGE},
-            {.name = "ReceiveMessage", .dir = DIR_OUT, .dir_opt = "", .type = PPORT_MESSAGE}
-        }
-    },
-    {
-        .name = "NtReplyWaitReplyPort", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "PortHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "ReplyMessage", .dir = DIR_INOUT, .dir_opt = "", .type = PPORT_MESSAGE}
-        }
-    },
-    {
-        .name = "NtRequestPort", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "PortHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "RequestMessage", .dir = DIR_IN, .dir_opt = "", .type = PPORT_MESSAGE}
-        }
-    },
-    {
-        .name = "NtRequestWaitReplyPort", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "PortHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "RequestMessage", .dir = DIR_IN, .dir_opt = "", .type = PPORT_MESSAGE},
-            {.name = "ReplyMessage", .dir = DIR_OUT, .dir_opt = "", .type = PPORT_MESSAGE}
-        }
-    },
-    {
-        .name = "NtResetEvent", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "EventHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "PreviousState", .dir = DIR_OUT, .dir_opt = "opt", .type = PLONG}
-        }
-    },
-    {
-        .name = "NtResetWriteWatch", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "ProcessHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "BaseAddress", .dir = DIR_IN, .dir_opt = "", .type = PVOID},
-            {.name = "RegionSize", .dir = DIR_IN, .dir_opt = "", .type = SIZE_T}
-        }
-    },
-    {
-        .name = "NtRestoreKey", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "KeyHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "FileHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "Flags", .dir = DIR_IN, .dir_opt = "", .type = ULONG}
-        }
-    },
-    {
-        .name = "NtResumeProcess", .ret = NTSTATUS, .num_args = 1, .args =
-        {
-            {.name = "ProcessHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE}
-        }
-    },
-    {
-        .name = "NtResumeThread", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "ThreadHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "PreviousSuspendCount", .dir = DIR_OUT, .dir_opt = "opt", .type = PULONG}
-        }
-    },
-    {
-        .name = "NtRollbackComplete", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "EnlistmentHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "TmVirtualClock", .dir = DIR_IN, .dir_opt = "opt", .type = PLARGE_INTEGER}
-        }
-    },
-    {
-        .name = "NtRollbackEnlistment", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "EnlistmentHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "TmVirtualClock", .dir = DIR_IN, .dir_opt = "opt", .type = PLARGE_INTEGER}
-        }
-    },
-    {
-        .name = "NtRollbackTransaction", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "TransactionHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "Wait", .dir = DIR_IN, .dir_opt = "", .type = BOOLEAN}
-        }
-    },
-    {
-        .name = "NtRollforwardTransactionManager", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "TransactionManagerHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "TmVirtualClock", .dir = DIR_IN, .dir_opt = "opt", .type = PLARGE_INTEGER}
-        }
-    },
-    {
-        .name = "NtSaveKeyEx", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "KeyHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "FileHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "Format", .dir = DIR_IN, .dir_opt = "", .type = ULONG}
-        }
-    },
-    {
-        .name = "NtSaveKey", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "KeyHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "FileHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE}
-        }
-    },
-    {
-        .name = "NtSaveMergedKeys", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "HighPrecedenceKeyHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "LowPrecedenceKeyHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "FileHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE}
-        }
-    },
-    {
-        .name = "NtSecureConnectPort", .ret = NTSTATUS, .num_args = 9, .args =
-        {
-            {.name = "PortHandle", .dir = DIR_OUT, .dir_opt = "", .type = PHANDLE},
-            {.name = "PortName", .dir = DIR_IN, .dir_opt = "", .type = PUNICODE_STRING},
-            {.name = "SecurityQos", .dir = DIR_IN, .dir_opt = "", .type = PSECURITY_QUALITY_OF_SERVICE},
-            {.name = "ClientView", .dir = DIR_INOUT, .dir_opt = "opt", .type = PPORT_VIEW},
-            {.name = "RequiredServerSid", .dir = DIR_IN, .dir_opt = "opt", .type = PSID},
-            {.name = "ServerView", .dir = DIR_INOUT, .dir_opt = "opt", .type = PREMOTE_PORT_VIEW},
-            {.name = "MaxMessageLength", .dir = DIR_OUT, .dir_opt = "opt", .type = PULONG},
-            {.name = "ConnectionInformation", .dir = DIR_INOUT, .dir_opt = "opt", .type = PVOID},
-            {.name = "ConnectionInformationLength", .dir = DIR_INOUT, .dir_opt = "opt", .type = PULONG}
-        }
-    },
-    { .name = "NtSerializeBoot", .ret = NTSTATUS, .num_args = 0  },
-    {
-        .name = "NtSetBootEntryOrder", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "Ids", .dir = DIR_IN, .dir_opt = "ecount(Count)", .type = PULONG},
-            {.name = "Count", .dir = DIR_IN, .dir_opt = "", .type = ULONG}
-        }
-    },
-    {
-        .name = "NtSetBootOptions", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "BootOptions", .dir = DIR_IN, .dir_opt = "", .type = PBOOT_OPTIONS},
-            {.name = "FieldsToChange", .dir = DIR_IN, .dir_opt = "", .type = ULONG}
-        }
-    },
-    {
-        .name = "NtSetContextThread", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "ThreadHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "ThreadContext", .dir = DIR_IN, .dir_opt = "", .type = PCONTEXT}
-        }
-    },
-    {
-        .name = "NtSetDebugFilterState", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "ComponentId", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "Level", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "State", .dir = DIR_IN, .dir_opt = "", .type = BOOLEAN}
-        }
-    },
-    {
-        .name = "NtSetDefaultHardErrorPort", .ret = NTSTATUS, .num_args = 1, .args =
-        {
-            {.name = "DefaultHardErrorPort", .dir = DIR_IN, .dir_opt = "", .type = HANDLE}
-        }
-    },
-    {
-        .name = "NtSetDefaultLocale", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "UserProfile", .dir = DIR_IN, .dir_opt = "", .type = BOOLEAN},
-            {.name = "DefaultLocaleId", .dir = DIR_IN, .dir_opt = "", .type = LCID}
-        }
-    },
-    {
-        .name = "NtSetDefaultUILanguage", .ret = NTSTATUS, .num_args = 1, .args =
-        {
-            {.name = "DefaultUILanguageId", .dir = DIR_IN, .dir_opt = "", .type = LANGID}
-        }
-    },
-    {
-        .name = "NtSetDriverEntryOrder", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "Ids", .dir = DIR_IN, .dir_opt = "ecount(Count)", .type = PULONG},
-            {.name = "Count", .dir = DIR_IN, .dir_opt = "", .type = ULONG}
-        }
-    },
-    {
-        .name = "NtSetEaFile", .ret = NTSTATUS, .num_args = 4, .args =
-        {
-            {.name = "FileHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "IoStatusBlock", .dir = DIR_OUT, .dir_opt = "", .type = PIO_STATUS_BLOCK},
-            {.name = "Buffer", .dir = DIR_IN, .dir_opt = "bcount(Length)", .type = PVOID},
-            {.name = "Length", .dir = DIR_IN, .dir_opt = "", .type = ULONG}
-        }
-    },
-    {
-        .name = "NtSetEventBoostPriority", .ret = NTSTATUS, .num_args = 1, .args =
-        {
-            {.name = "EventHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE}
-        }
-    },
-    {
-        .name = "NtSetEvent", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "EventHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "PreviousState", .dir = DIR_OUT, .dir_opt = "opt", .type = PLONG}
-        }
-    },
-    {
-        .name = "NtSetHighEventPair", .ret = NTSTATUS, .num_args = 1, .args =
-        {
-            {.name = "EventPairHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE}
-        }
-    },
-    {
-        .name = "NtSetHighWaitLowEventPair", .ret = NTSTATUS, .num_args = 1, .args =
-        {
-            {.name = "EventPairHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE}
-        }
-    },
-    {
-        .name = "NtSetInformationDebugObject", .ret = NTSTATUS, .num_args = 5, .args =
-        {
-            {.name = "DebugObjectHandle", .dir = DIR_OUT, .dir_opt = "", .type = HANDLE},
-            {.name = "DebugObjectInformationClass", .dir = DIR_OUT, .dir_opt = "", .type = DEBUGOBJECTINFOCLASS},
-            {.name = "DebugInformation", .dir = DIR_OUT, .dir_opt = "", .type = PVOID},
-            {.name = "DebugInformationLength", .dir = DIR_OUT, .dir_opt = "", .type = ULONG},
-            {.name = "ReturnLength", .dir = DIR_OUT, .dir_opt = "", .type = PULONG}
-        }
-    },
-    {
-        .name = "NtSetInformationEnlistment", .ret = NTSTATUS, .num_args = 4, .args =
-        {
-            {.name = "EnlistmentHandle", .dir = DIR_IN, .dir_opt = "opt", .type = HANDLE},
-            {.name = "EnlistmentInformationClass", .dir = DIR_IN, .dir_opt = "", .type = ENLISTMENT_INFORMATION_CLASS},
-            {.name = "EnlistmentInformation", .dir = DIR_IN, .dir_opt = "bcount(EnlistmentInformationLength)", .type = PVOID},
-            {.name = "EnlistmentInformationLength", .dir = DIR_IN, .dir_opt = "", .type = ULONG}
-        }
-    },
-    {
-        .name = "NtSetInformationFile", .ret = NTSTATUS, .num_args = 5, .args =
-        {
-            {.name = "FileHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "IoStatusBlock", .dir = DIR_OUT, .dir_opt = "", .type = PIO_STATUS_BLOCK},
-            {.name = "FileInformation", .dir = DIR_IN, .dir_opt = "bcount(Length)", .type = PVOID},
-            {.name = "Length", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "FileInformationClass", .dir = DIR_IN, .dir_opt = "", .type = FILE_INFORMATION_CLASS}
-        }
-    },
-    {
-        .name = "NtSetInformationJobObject", .ret = NTSTATUS, .num_args = 4, .args =
-        {
-            {.name = "JobHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "JobObjectInformationClass", .dir = DIR_IN, .dir_opt = "", .type = JOBOBJECTINFOCLASS},
-            {.name = "JobObjectInformation", .dir = DIR_IN, .dir_opt = "bcount(JobObjectInformationLength)", .type = PVOID},
-            {.name = "JobObjectInformationLength", .dir = DIR_IN, .dir_opt = "", .type = ULONG}
-        }
-    },
-    {
-        .name = "NtSetInformationKey", .ret = NTSTATUS, .num_args = 4, .args =
-        {
-            {.name = "KeyHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "KeySetInformationClass", .dir = DIR_IN, .dir_opt = "", .type = KEY_SET_INFORMATION_CLASS},
-            {.name = "KeySetInformation", .dir = DIR_IN, .dir_opt = "bcount(KeySetInformationLength)", .type = PVOID},
-            {.name = "KeySetInformationLength", .dir = DIR_IN, .dir_opt = "", .type = ULONG}
-        }
-    },
-    {
-        .name = "NtSetInformationObject", .ret = NTSTATUS, .num_args = 4, .args =
-        {
-            {.name = "Handle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "ObjectInformationClass", .dir = DIR_IN, .dir_opt = "", .type = OBJECT_INFORMATION_CLASS},
-            {.name = "ObjectInformation", .dir = DIR_IN, .dir_opt = "bcount(ObjectInformationLength)", .type = PVOID},
-            {.name = "ObjectInformationLength", .dir = DIR_IN, .dir_opt = "", .type = ULONG}
-        }
-    },
-    {
-        .name = "NtSetInformationProcess", .ret = NTSTATUS, .num_args = 4, .args =
-        {
-            {.name = "ProcessHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "ProcessInformationClass", .dir = DIR_IN, .dir_opt = "", .type = PROCESSINFOCLASS},
-            {.name = "ProcessInformation", .dir = DIR_IN, .dir_opt = "bcount(ProcessInformationLength)", .type = PVOID},
-            {.name = "ProcessInformationLength", .dir = DIR_IN, .dir_opt = "", .type = ULONG}
-        }
-    },
-    {
-        .name = "NtSetInformationResourceManager", .ret = NTSTATUS, .num_args = 4, .args =
-        {
-            {.name = "ResourceManagerHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "ResourceManagerInformationClass", .dir = DIR_IN, .dir_opt = "", .type = RESOURCEMANAGER_INFORMATION_CLASS},
-            {.name = "ResourceManagerInformation", .dir = DIR_IN, .dir_opt = "bcount(ResourceManagerInformationLength)", .type = PVOID},
-            {.name = "ResourceManagerInformationLength", .dir = DIR_IN, .dir_opt = "", .type = ULONG}
-        }
-    },
-    {
-        .name = "NtSetInformationThread", .ret = NTSTATUS, .num_args = 4, .args =
-        {
-            {.name = "ThreadHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "ThreadInformationClass", .dir = DIR_IN, .dir_opt = "", .type = THREADINFOCLASS},
-            {.name = "ThreadInformation", .dir = DIR_IN, .dir_opt = "bcount(ThreadInformationLength)", .type = PVOID},
-            {.name = "ThreadInformationLength", .dir = DIR_IN, .dir_opt = "", .type = ULONG}
-        }
-    },
-    {
-        .name = "NtSetInformationToken", .ret = NTSTATUS, .num_args = 4, .args =
-        {
-            {.name = "TokenHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "TokenInformationClass", .dir = DIR_IN, .dir_opt = "", .type = TOKEN_INFORMATION_CLASS},
-            {.name = "TokenInformation", .dir = DIR_IN, .dir_opt = "bcount(TokenInformationLength)", .type = PVOID},
-            {.name = "TokenInformationLength", .dir = DIR_IN, .dir_opt = "", .type = ULONG}
-        }
-    },
-    {
-        .name = "NtSetInformationTransaction", .ret = NTSTATUS, .num_args = 4, .args =
-        {
-            {.name = "TransactionHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "TransactionInformationClass", .dir = DIR_IN, .dir_opt = "", .type = TRANSACTION_INFORMATION_CLASS},
-            {.name = "TransactionInformation", .dir = DIR_IN, .dir_opt = "bcount(TransactionInformationLength)", .type = PVOID},
-            {.name = "TransactionInformationLength", .dir = DIR_IN, .dir_opt = "", .type = ULONG}
-        }
-    },
-    {
-        .name = "NtSetInformationTransactionManager", .ret = NTSTATUS, .num_args = 4, .args =
-        {
-            {.name = "TmHandle", .dir = DIR_IN, .dir_opt = "opt", .type = HANDLE},
-            {.name = "TransactionManagerInformationClass", .dir = DIR_IN, .dir_opt = "", .type = TRANSACTIONMANAGER_INFORMATION_CLASS},
-            {.name = "TransactionManagerInformation", .dir = DIR_IN, .dir_opt = "bcount(TransactionManagerInformationLength)", .type = PVOID},
-            {.name = "TransactionManagerInformationLength", .dir = DIR_IN, .dir_opt = "", .type = ULONG}
-        }
-    },
-    {
-        .name = "NtSetInformationWorkerFactory", .ret = NTSTATUS, .num_args = 4, .args =
-        {
-            {.name = "WorkerFactoryHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "WorkerFactoryInformationClass", .dir = DIR_IN, .dir_opt = "", .type = WORKERFACTORYINFOCLASS},
-            {.name = "WorkerFactoryInformation", .dir = DIR_IN, .dir_opt = "bcount(WorkerFactoryInformationLength)", .type = PVOID},
-            {.name = "WorkerFactoryInformationLength", .dir = DIR_IN, .dir_opt = "", .type = ULONG}
-        }
-    },
-    {
-        .name = "NtSetIntervalProfile", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "Interval", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "Source", .dir = DIR_IN, .dir_opt = "", .type = KPROFILE_SOURCE}
-        }
-    },
-    {
-        .name = "NtSetIoCompletionEx", .ret = NTSTATUS, .num_args = 6, .args =
-        {
-            {.name = "IoCompletionHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "IoCompletionReserveHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "KeyContext", .dir = DIR_IN, .dir_opt = "", .type = PVOID},
-            {.name = "ApcContext", .dir = DIR_IN, .dir_opt = "opt", .type = PVOID},
-            {.name = "IoStatus", .dir = DIR_IN, .dir_opt = "", .type = NTSTATUS},
-            {.name = "IoStatusInformation", .dir = DIR_IN, .dir_opt = "", .type = ULONG_PTR}
-        }
-    },
-    {
-        .name = "NtSetIoCompletion", .ret = NTSTATUS, .num_args = 5, .args =
-        {
-            {.name = "IoCompletionHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "KeyContext", .dir = DIR_IN, .dir_opt = "", .type = PVOID},
-            {.name = "ApcContext", .dir = DIR_IN, .dir_opt = "opt", .type = PVOID},
-            {.name = "IoStatus", .dir = DIR_IN, .dir_opt = "", .type = NTSTATUS},
-            {.name = "IoStatusInformation", .dir = DIR_IN, .dir_opt = "", .type = ULONG_PTR}
-        }
-    },
-    {
-        .name = "NtSetLdtEntries", .ret = NTSTATUS, .num_args = 6, .args =
-        {
-            {.name = "Selector0", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "Entry0Low", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "Entry0Hi", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "Selector1", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "Entry1Low", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "Entry1Hi", .dir = DIR_IN, .dir_opt = "", .type = ULONG}
-        }
-    },
-    {
-        .name = "NtSetLowEventPair", .ret = NTSTATUS, .num_args = 1, .args =
-        {
-            {.name = "EventPairHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE}
-        }
-    },
-    {
-        .name = "NtSetLowWaitHighEventPair", .ret = NTSTATUS, .num_args = 1, .args =
-        {
-            {.name = "EventPairHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE}
-        }
-    },
-    {
-        .name = "NtSetQuotaInformationFile", .ret = NTSTATUS, .num_args = 4, .args =
-        {
-            {.name = "FileHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "IoStatusBlock", .dir = DIR_OUT, .dir_opt = "", .type = PIO_STATUS_BLOCK},
-            {.name = "Buffer", .dir = DIR_IN, .dir_opt = "bcount(Length)", .type = PVOID},
-            {.name = "Length", .dir = DIR_IN, .dir_opt = "", .type = ULONG}
-        }
-    },
-    {
-        .name = "NtSetSecurityObject", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "Handle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "SecurityInformation", .dir = DIR_IN, .dir_opt = "", .type = SECURITY_INFORMATION},
-            {.name = "SecurityDescriptor", .dir = DIR_IN, .dir_opt = "", .type = PSECURITY_DESCRIPTOR}
-        }
-    },
-    {
-        .name = "NtSetSystemEnvironmentValueEx", .ret = NTSTATUS, .num_args = 5, .args =
-        {
-            {.name = "VariableName", .dir = DIR_IN, .dir_opt = "", .type = PUNICODE_STRING},
-            {.name = "VendorGuid", .dir = DIR_IN, .dir_opt = "", .type = LPGUID},
-            {.name = "Value", .dir = DIR_IN, .dir_opt = "bcount_opt(ValueLength)", .type = PVOID},
-            {.name = "ValueLength", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "Attributes", .dir = DIR_IN, .dir_opt = "", .type = ULONG}
-        }
-    },
-    {
-        .name = "NtSetSystemEnvironmentValue", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "VariableName", .dir = DIR_IN, .dir_opt = "", .type = PUNICODE_STRING},
-            {.name = "VariableValue", .dir = DIR_IN, .dir_opt = "", .type = PUNICODE_STRING}
-        }
-    },
-    {
-        .name = "NtSetSystemInformation", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "SystemInformationClass", .dir = DIR_IN, .dir_opt = "", .type = SYSTEM_INFORMATION_CLASS},
-            {.name = "SystemInformation", .dir = DIR_IN, .dir_opt = "bcount_opt(SystemInformationLength)", .type = PVOID},
-            {.name = "SystemInformationLength", .dir = DIR_IN, .dir_opt = "", .type = ULONG}
-        }
-    },
-    {
-        .name = "NtSetSystemPowerState", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "SystemAction", .dir = DIR_IN, .dir_opt = "", .type = POWER_ACTION},
-            {.name = "MinSystemState", .dir = DIR_IN, .dir_opt = "", .type = SYSTEM_POWER_STATE},
-            {.name = "Flags", .dir = DIR_IN, .dir_opt = "", .type = ULONG}
-        }
-    },
-    {
-        .name = "NtSetSystemTime", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "SystemTime", .dir = DIR_IN, .dir_opt = "opt", .type = PLARGE_INTEGER},
-            {.name = "PreviousTime", .dir = DIR_OUT, .dir_opt = "opt", .type = PLARGE_INTEGER}
-        }
-    },
-    {
-        .name = "NtSetThreadExecutionState", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "esFlags", .dir = DIR_IN, .dir_opt = "", .type = EXECUTION_STATE},
-            {.name = "*PreviousFlags", .dir = DIR_OUT, .dir_opt = "", .type = EXECUTION_STATE}
-        }
-    },
-    {
-        .name = "NtSetTimerEx", .ret = NTSTATUS, .num_args = 4, .args =
-        {
-            {.name = "TimerHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "TimerSetInformationClass", .dir = DIR_IN, .dir_opt = "", .type = TIMER_SET_INFORMATION_CLASS},
-            {.name = "TimerSetInformation", .dir = DIR_INOUT, .dir_opt = "bcount(TimerSetInformationLength)", .type = PVOID},
-            {.name = "TimerSetInformationLength", .dir = DIR_IN, .dir_opt = "", .type = ULONG}
-        }
-    },
-    {
-        .name = "NtSetTimer", .ret = NTSTATUS, .num_args = 7, .args =
-        {
-            {.name = "TimerHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "DueTime", .dir = DIR_IN, .dir_opt = "", .type = PLARGE_INTEGER},
-            {.name = "TimerApcRoutine", .dir = DIR_IN, .dir_opt = "opt", .type = PTIMER_APC_ROUTINE},
-            {.name = "TimerContext", .dir = DIR_IN, .dir_opt = "opt", .type = PVOID},
-            {.name = "WakeTimer", .dir = DIR_IN, .dir_opt = "", .type = BOOLEAN},
-            {.name = "Period", .dir = DIR_IN, .dir_opt = "opt", .type = LONG},
-            {.name = "PreviousState", .dir = DIR_OUT, .dir_opt = "opt", .type = PBOOLEAN}
-        }
-    },
-    {
-        .name = "NtSetTimerResolution", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "DesiredTime", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "SetResolution", .dir = DIR_IN, .dir_opt = "", .type = BOOLEAN},
-            {.name = "ActualTime", .dir = DIR_OUT, .dir_opt = "", .type = PULONG}
-        }
-    },
-    {
-        .name = "NtSetUuidSeed", .ret = NTSTATUS, .num_args = 1, .args =
-        {
-            {.name = "Seed", .dir = DIR_IN, .dir_opt = "", .type = PCHAR}
-        }
-    },
-    {
-        .name = "NtSetValueKey", .ret = NTSTATUS, .num_args = 6, .args =
-        {
-            {.name = "KeyHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "ValueName", .dir = DIR_IN, .dir_opt = "", .type = PUNICODE_STRING},
-            {.name = "TitleIndex", .dir = DIR_IN, .dir_opt = "opt", .type = ULONG},
-            {.name = "Type", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "Data", .dir = DIR_IN, .dir_opt = "bcount_opt(DataSize)", .type = PVOID},
-            {.name = "DataSize", .dir = DIR_IN, .dir_opt = "", .type = ULONG}
-        }
-    },
-    {
-        .name = "NtSetVolumeInformationFile", .ret = NTSTATUS, .num_args = 5, .args =
-        {
-            {.name = "FileHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "IoStatusBlock", .dir = DIR_OUT, .dir_opt = "", .type = PIO_STATUS_BLOCK},
-            {.name = "FsInformation", .dir = DIR_IN, .dir_opt = "bcount(Length)", .type = PVOID},
-            {.name = "Length", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "FsInformationClass", .dir = DIR_IN, .dir_opt = "", .type = FS_INFORMATION_CLASS}
-        }
-    },
-    {
-        .name = "NtShutdownSystem", .ret = NTSTATUS, .num_args = 1, .args =
-        {
-            {.name = "Action", .dir = DIR_IN, .dir_opt = "", .type = SHUTDOWN_ACTION}
-        }
-    },
-    {
-        .name = "NtShutdownWorkerFactory", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "WorkerFactoryHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "*PendingWorkerCount", .dir = DIR_INOUT, .dir_opt = "", .type = LONG}
-        }
-    },
-    {
-        .name = "NtSignalAndWaitForSingleObject", .ret = NTSTATUS, .num_args = 4, .args =
-        {
-            {.name = "SignalHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "WaitHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "Alertable", .dir = DIR_IN, .dir_opt = "", .type = BOOLEAN},
-            {.name = "Timeout", .dir = DIR_IN, .dir_opt = "opt", .type = PLARGE_INTEGER}
-        }
-    },
-    {
-        .name = "NtSinglePhaseReject", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "EnlistmentHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "TmVirtualClock", .dir = DIR_IN, .dir_opt = "opt", .type = PLARGE_INTEGER}
-        }
-    },
-    {
-        .name = "NtStartProfile", .ret = NTSTATUS, .num_args = 1, .args =
-        {
-            {.name = "ProfileHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE}
-        }
-    },
-    {
-        .name = "NtStopProfile", .ret = NTSTATUS, .num_args = 1, .args =
-        {
-            {.name = "ProfileHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE}
-        }
-    },
-    {
-        .name = "NtSuspendProcess", .ret = NTSTATUS, .num_args = 1, .args =
-        {
-            {.name = "ProcessHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE}
-        }
-    },
-    {
-        .name = "NtSuspendThread", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "ThreadHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "PreviousSuspendCount", .dir = DIR_OUT, .dir_opt = "opt", .type = PULONG}
-        }
-    },
-    {
-        .name = "NtSystemDebugControl", .ret = NTSTATUS, .num_args = 6, .args =
-        {
-            {.name = "Command", .dir = DIR_IN, .dir_opt = "", .type = SYSDBG_COMMAND},
-            {.name = "InputBuffer", .dir = DIR_INOUT, .dir_opt = "bcount_opt(InputBufferLength)", .type = PVOID},
-            {.name = "InputBufferLength", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "OutputBuffer", .dir = DIR_OUT, .dir_opt = "bcount_opt(OutputBufferLength)", .type = PVOID},
-            {.name = "OutputBufferLength", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "ReturnLength", .dir = DIR_OUT, .dir_opt = "opt", .type = PULONG}
-        }
-    },
-    {
-        .name = "NtTerminateJobObject", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "JobHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "ExitStatus", .dir = DIR_IN, .dir_opt = "", .type = NTSTATUS}
-        }
-    },
-    {
-        .name = "NtTerminateProcess", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "ProcessHandle", .dir = DIR_IN, .dir_opt = "opt", .type = HANDLE},
-            {.name = "ExitStatus", .dir = DIR_IN, .dir_opt = "", .type = NTSTATUS}
-        }
-    },
-    {
-        .name = "NtTerminateThread", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "ThreadHandle", .dir = DIR_IN, .dir_opt = "opt", .type = HANDLE},
-            {.name = "ExitStatus", .dir = DIR_IN, .dir_opt = "", .type = NTSTATUS}
-        }
-    },
-    { .name = "NtTestAlert", .ret = NTSTATUS, .num_args = 0  },
-    { .name = "NtThawRegistry", .ret = NTSTATUS, .num_args = 0  },
-    { .name = "NtThawTransactions", .ret = NTSTATUS, .num_args = 0  },
-    {
-        .name = "NtTraceControl", .ret = NTSTATUS, .num_args = 6, .args =
-        {
-            {.name = "FunctionCode", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "InBuffer", .dir = DIR_IN, .dir_opt = "bcount_opt(InBufferLen)", .type = PVOID},
-            {.name = "InBufferLen", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "OutBuffer", .dir = DIR_OUT, .dir_opt = "bcount_opt(OutBufferLen)", .type = PVOID},
-            {.name = "OutBufferLen", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "ReturnLength", .dir = DIR_OUT, .dir_opt = "", .type = PULONG}
-        }
-    },
-    {
-        .name = "NtTraceEvent", .ret = NTSTATUS, .num_args = 4, .args =
-        {
-            {.name = "TraceHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "Flags", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "FieldSize", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "Fields", .dir = DIR_IN, .dir_opt = "", .type = PVOID}
-        }
-    },
-    {
-        .name = "NtTranslateFilePath", .ret = NTSTATUS, .num_args = 4, .args =
-        {
-            {.name = "InputFilePath", .dir = DIR_IN, .dir_opt = "", .type = PFILE_PATH},
-            {.name = "OutputType", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "OutputFilePath", .dir = DIR_OUT, .dir_opt = "bcount_opt(*OutputFilePathLength)", .type = PFILE_PATH},
-            {.name = "OutputFilePathLength", .dir = DIR_INOUT, .dir_opt = "opt", .type = PULONG}
-        }
-    },
-    { .name = "NtUmsThreadYield", .ret = NTSTATUS, .num_args = 0  },
-    {
-        .name = "NtUnloadDriver", .ret = NTSTATUS, .num_args = 1, .args =
-        {
-            {.name = "DriverServiceName", .dir = DIR_IN, .dir_opt = "", .type = PUNICODE_STRING}
-        }
-    },
-    {
-        .name = "NtUnloadKey2", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "TargetKey", .dir = DIR_IN, .dir_opt = "", .type = POBJECT_ATTRIBUTES},
-            {.name = "Flags", .dir = DIR_IN, .dir_opt = "", .type = ULONG}
-        }
-    },
-    {
-        .name = "NtUnloadKeyEx", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "TargetKey", .dir = DIR_IN, .dir_opt = "", .type = POBJECT_ATTRIBUTES},
-            {.name = "Event", .dir = DIR_IN, .dir_opt = "opt", .type = HANDLE}
-        }
-    },
-    {
-        .name = "NtUnloadKey", .ret = NTSTATUS, .num_args = 1, .args =
-        {
-            {.name = "TargetKey", .dir = DIR_IN, .dir_opt = "", .type = POBJECT_ATTRIBUTES}
-        }
-    },
-    {
-        .name = "NtUnlockFile", .ret = NTSTATUS, .num_args = 5, .args =
-        {
-            {.name = "FileHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "IoStatusBlock", .dir = DIR_OUT, .dir_opt = "", .type = PIO_STATUS_BLOCK},
-            {.name = "ByteOffset", .dir = DIR_IN, .dir_opt = "", .type = PLARGE_INTEGER},
-            {.name = "Length", .dir = DIR_IN, .dir_opt = "", .type = PLARGE_INTEGER},
-            {.name = "Key", .dir = DIR_IN, .dir_opt = "", .type = ULONG}
-        }
-    },
-    {
-        .name = "NtUnlockVirtualMemory", .ret = NTSTATUS, .num_args = 4, .args =
-        {
-            {.name = "ProcessHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "*BaseAddress", .dir = DIR_INOUT, .dir_opt = "", .type = PVOID},
-            {.name = "RegionSize", .dir = DIR_INOUT, .dir_opt = "", .type = PSIZE_T},
-            {.name = "MapType", .dir = DIR_IN, .dir_opt = "", .type = ULONG}
-        }
-    },
-    {
-        .name = "NtUnmapViewOfSection", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "ProcessHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "BaseAddress", .dir = DIR_IN, .dir_opt = "", .type = PVOID}
-        }
-    },
-    {
-        .name = "NtVdmControl", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "Service", .dir = DIR_IN, .dir_opt = "", .type = VDMSERVICECLASS},
-            {.name = "ServiceData", .dir = DIR_INOUT, .dir_opt = "", .type = PVOID}
-        }
-    },
-    {
-        .name = "NtWaitForDebugEvent", .ret = NTSTATUS, .num_args = 4, .args =
-        {
-            {.name = "DebugObjectHandle", .dir = DIR_OUT, .dir_opt = "", .type = HANDLE},
-            {.name = "Alertable", .dir = DIR_OUT, .dir_opt = "", .type = BOOLEAN},
-            {.name = "Timeout", .dir = DIR_OUT, .dir_opt = "", .type = PLARGE_INTEGER},
-            {.name = "WaitStateChange", .dir = DIR_OUT, .dir_opt = "", .type = PDBGUI_WAIT_STATE_CHANGE}
-        }
-    },
-    {
-        .name = "NtWaitForKeyedEvent", .ret = NTSTATUS, .num_args = 4, .args =
-        {
-            {.name = "KeyedEventHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "KeyValue", .dir = DIR_IN, .dir_opt = "", .type = PVOID},
-            {.name = "Alertable", .dir = DIR_IN, .dir_opt = "", .type = BOOLEAN},
-            {.name = "Timeout", .dir = DIR_IN, .dir_opt = "opt", .type = PLARGE_INTEGER}
-        }
-    },
-    {
-        .name = "NtWaitForMultipleObjects32", .ret = NTSTATUS, .num_args = 5, .args =
-        {
-            {.name = "Count", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "Handles[]", .dir = DIR_IN, .dir_opt = "ecount(Count)", .type = LONG},
-            {.name = "WaitType", .dir = DIR_IN, .dir_opt = "", .type = WAIT_TYPE},
-            {.name = "Alertable", .dir = DIR_IN, .dir_opt = "", .type = BOOLEAN},
-            {.name = "Timeout", .dir = DIR_IN, .dir_opt = "opt", .type = PLARGE_INTEGER}
-        }
-    },
-    {
-        .name = "NtWaitForMultipleObjects", .ret = NTSTATUS, .num_args = 5, .args =
-        {
-            {.name = "Count", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "Handles[]", .dir = DIR_IN, .dir_opt = "ecount(Count)", .type = HANDLE},
-            {.name = "WaitType", .dir = DIR_IN, .dir_opt = "", .type = WAIT_TYPE},
-            {.name = "Alertable", .dir = DIR_IN, .dir_opt = "", .type = BOOLEAN},
-            {.name = "Timeout", .dir = DIR_IN, .dir_opt = "opt", .type = PLARGE_INTEGER}
-        }
-    },
-    {
-        .name = "NtWaitForSingleObject", .ret = NTSTATUS, .num_args = 3, .args =
-        {
-            {.name = "Handle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "Alertable", .dir = DIR_IN, .dir_opt = "", .type = BOOLEAN},
-            {.name = "Timeout", .dir = DIR_IN, .dir_opt = "opt", .type = PLARGE_INTEGER}
-        }
-    },
-    {
-        .name = "NtWaitForWorkViaWorkerFactory", .ret = NTSTATUS, .num_args = 2, .args =
-        {
-            {.name = "WorkerFactoryHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "MiniPacket", .dir = DIR_OUT, .dir_opt = "", .type = PFILE_IO_COMPLETION_INFORMATION}
-        }
-    },
-    {
-        .name = "NtWaitHighEventPair", .ret = NTSTATUS, .num_args = 1, .args =
-        {
-            {.name = "EventPairHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE}
-        }
-    },
-    {
-        .name = "NtWaitLowEventPair", .ret = NTSTATUS, .num_args = 1, .args =
-        {
-            {.name = "EventPairHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE}
-        }
-    },
-    {
-        .name = "NtWorkerFactoryWorkerReady", .ret = NTSTATUS, .num_args = 1, .args =
-        {
-            {.name = "WorkerFactoryHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE}
-        }
-    },
-    {
-        .name = "NtWriteFileGather", .ret = NTSTATUS, .num_args = 9, .args =
-        {
-            {.name = "FileHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "Event", .dir = DIR_IN, .dir_opt = "opt", .type = HANDLE},
-            {.name = "ApcRoutine", .dir = DIR_IN, .dir_opt = "opt", .type = PIO_APC_ROUTINE},
-            {.name = "ApcContext", .dir = DIR_IN, .dir_opt = "opt", .type = PVOID},
-            {.name = "IoStatusBlock", .dir = DIR_OUT, .dir_opt = "", .type = PIO_STATUS_BLOCK},
-            {.name = "SegmentArray", .dir = DIR_IN, .dir_opt = "", .type = PFILE_SEGMENT_ELEMENT},
-            {.name = "Length", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "ByteOffset", .dir = DIR_IN, .dir_opt = "opt", .type = PLARGE_INTEGER},
-            {.name = "Key", .dir = DIR_IN, .dir_opt = "opt", .type = PULONG}
-        }
-    },
-    {
-        .name = "NtWriteFile", .ret = NTSTATUS, .num_args = 9, .args =
-        {
-            {.name = "FileHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "Event", .dir = DIR_IN, .dir_opt = "opt", .type = HANDLE},
-            {.name = "ApcRoutine", .dir = DIR_IN, .dir_opt = "opt", .type = PIO_APC_ROUTINE},
-            {.name = "ApcContext", .dir = DIR_IN, .dir_opt = "opt", .type = PVOID},
-            {.name = "IoStatusBlock", .dir = DIR_OUT, .dir_opt = "", .type = PIO_STATUS_BLOCK},
-            {.name = "Buffer", .dir = DIR_IN, .dir_opt = "bcount(Length)", .type = PVOID},
-            {.name = "Length", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "ByteOffset", .dir = DIR_IN, .dir_opt = "opt", .type = PLARGE_INTEGER},
-            {.name = "Key", .dir = DIR_IN, .dir_opt = "opt", .type = PULONG}
-        }
-    },
-    {
-        .name = "NtWriteRequestData", .ret = NTSTATUS, .num_args = 6, .args =
-        {
-            {.name = "PortHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "Message", .dir = DIR_IN, .dir_opt = "", .type = PPORT_MESSAGE},
-            {.name = "DataEntryIndex", .dir = DIR_IN, .dir_opt = "", .type = ULONG},
-            {.name = "Buffer", .dir = DIR_IN, .dir_opt = "bcount(BufferSize)", .type = PVOID},
-            {.name = "BufferSize", .dir = DIR_IN, .dir_opt = "", .type = SIZE_T},
-            {.name = "NumberOfBytesWritten", .dir = DIR_OUT, .dir_opt = "opt", .type = PSIZE_T}
-        }
-    },
-    {
-        .name = "NtWriteVirtualMemory", .ret = NTSTATUS, .num_args = 5, .args =
-        {
-            {.name = "ProcessHandle", .dir = DIR_IN, .dir_opt = "", .type = HANDLE},
-            {.name = "BaseAddress", .dir = DIR_IN, .dir_opt = "opt", .type = PVOID},
-            {.name = "Buffer", .dir = DIR_IN, .dir_opt = "bcount(BufferSize)", .type = PVOID},
-            {.name = "BufferSize", .dir = DIR_IN, .dir_opt = "", .type = SIZE_T},
-            {.name = "NumberOfBytesWritten", .dir = DIR_OUT, .dir_opt = "opt", .type = PSIZE_T}
-        }
-    },
-
-    // TODO: create full description for these functions
-    { .name = "NtYieldExecution", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtAcquireProcessActivityReference", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtAddAtomEx", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtAlertThreadByThreadId", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtAllocateVirtualMemoryEx", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtAlpcConnectPortEx", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtAlpcImpersonateClientContainerOfPort", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtAssociateWaitCompletionPacket", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtCallEnclave", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtCancelTimer2", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtCancelWaitCompletionPacket", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtCommitRegistryTransaction", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtCompareObjects", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtCompareSigningLevels", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtConvertBetweenAuxiliaryCounterAndPerformanceCounter", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtCreateDirectoryObjectEx", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtCreateEnclave", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtCreateIRTimer", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtCreateLowBoxToken", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtCreatePartition", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtCreateRegistryTransaction", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtCreateTimer2", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtCreateTokenEx", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtCreateWaitCompletionPacket", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtCreateWnfStateName", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDeleteWnfStateData", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDeleteWnfStateName", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtFilterBootOption", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtFlushBuffersFileEx", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGetCachedSigningLevel", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGetCompleteWnfStateSubscription", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGetCurrentProcessorNumberEx", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtInitializeEnclave", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtLoadEnclaveData", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtLoadHotPatch", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtManagePartition", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtMapViewOfSectionEx", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtNotifyChangeDirectoryFileEx", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtOpenPartition", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtOpenRegistryTransaction", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtQueryAuxiliaryCounterFrequency", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtQueryDirectoryFileEx", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtQueryInformationByName", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtQuerySecurityPolicy", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtQueryWnfStateData", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtQueryWnfStateNameInformation", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtRevertContainerImpersonation", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtRollbackRegistryTransaction", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtSetCachedSigningLevel", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtSetCachedSigningLevel2", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtSetIRTimer", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtSetInformationSymbolicLink", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtSetInformationVirtualMemory", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtSetTimer2", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtSetWnfProcessNotificationEvent", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtSubscribeWnfStateChange", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtTerminateEnclave", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUnmapViewOfSectionEx", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUnsubscribeWnfStateChange", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUpdateWnfStateData", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtWaitForAlertByThreadId", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtCreateSectionEx", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtManageHotPatch", .ret = NTSTATUS, .num_args = 0 },
-
-    // TODO: investigate what these functions are and why they appear in the SSDT (Windows 10)
-    { .name = "BvgaSetVirtualFrameBuffer", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "CmpCleanUpHigherLayerKcbCachesPreCallback", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "GetPnpProperty", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "ArbPreprocessEntry", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "ArbAddReserved", .ret = NTSTATUS, .num_args = 0 },
+	&NtFlushProcessWriteBuffers,
+	&NtGetCurrentProcessorNumber,
+	&NtGetEnvironmentVariableEx,
+	&NtIsSystemResumeAutomatic,
+	&NtQueryEnvironmentVariableInfoEx,
+	&NtAcceptConnectPort,
+	&NtAccessCheckAndAuditAlarm,
+	&NtAccessCheckByTypeAndAuditAlarm,
+	&NtAccessCheckByType,
+	&NtAccessCheckByTypeResultListAndAuditAlarmByHandle,
+	&NtAccessCheckByTypeResultListAndAuditAlarm,
+	&NtAccessCheckByTypeResultList,
+	&NtAccessCheck,
+	&NtAddAtom,
+	&NtAddBootEntry,
+	&NtAddDriverEntry,
+	&NtAdjustGroupsToken,
+	&NtAdjustPrivilegesToken,
+	&NtAlertResumeThread,
+	&NtAlertThread,
+	&NtAllocateLocallyUniqueId,
+	&NtAllocateReserveObject,
+	&NtAllocateUserPhysicalPages,
+	&NtAllocateUuids,
+	&NtAllocateVirtualMemory,
+	&NtAlpcAcceptConnectPort,
+	&NtAlpcCancelMessage,
+	&NtAlpcConnectPort,
+	&NtAlpcCreatePort,
+	&NtAlpcCreatePortSection,
+	&NtAlpcCreateResourceReserve,
+	&NtAlpcCreateSectionView,
+	&NtAlpcCreateSecurityContext,
+	&NtAlpcDeletePortSection,
+	&NtAlpcDeleteResourceReserve,
+	&NtAlpcDeleteSectionView,
+	&NtAlpcDeleteSecurityContext,
+	&NtAlpcDisconnectPort,
+	&NtAlpcImpersonateClientOfPort,
+	&NtAlpcOpenSenderProcess,
+	&NtAlpcOpenSenderThread,
+	&NtAlpcQueryInformation,
+	&NtAlpcQueryInformationMessage,
+	&NtAlpcRevokeSecurityContext,
+	&NtAlpcSendWaitReceivePort,
+	&NtAlpcSetInformation,
+	&NtApphelpCacheControl,
+	&NtAreMappedFilesTheSame,
+	&NtAssignProcessToJobObject,
+	&NtCallbackReturn,
+	&NtCancelIoFileEx,
+	&NtCancelIoFile,
+	&NtCancelSynchronousIoFile,
+	&NtCancelTimer,
+	&NtClearEvent,
+	&NtClose,
+	&NtCloseObjectAuditAlarm,
+	&NtCommitComplete,
+	&NtCommitEnlistment,
+	&NtCommitTransaction,
+	&NtCompactKeys,
+	&NtCompareTokens,
+	&NtCompleteConnectPort,
+	&NtCompressKey,
+	&NtConnectPort,
+	&NtContinue,
+	&NtCreateDebugObject,
+	&NtCreateDirectoryObject,
+	&NtCreateEnlistment,
+	&NtCreateEvent,
+	&NtCreateEventPair,
+	&NtCreateFile,
+	&NtCreateIoCompletion,
+	&NtCreateJobObject,
+	&NtCreateJobSet,
+	&NtCreateKeyedEvent,
+	&NtCreateKey,
+	&NtCreateKeyTransacted,
+	&NtCreateMailslotFile,
+	&NtCreateMutant,
+	&NtCreateNamedPipeFile,
+	&NtCreatePagingFile,
+	&NtCreatePort,
+	&NtCreatePrivateNamespace,
+	&NtCreateProcessEx,
+	&NtCreateProcess,
+	&NtCreateProfileEx,
+	&NtCreateProfile,
+	&NtCreateResourceManager,
+	&NtCreateSection,
+	&NtCreateSemaphore,
+	&NtCreateSymbolicLinkObject,
+	&NtCreateThreadEx,
+	&NtCreateThread,
+	&NtCreateTimer,
+	&NtCreateToken,
+	&NtCreateTransactionManager,
+	&NtCreateTransaction,
+	&NtCreateUserProcess,
+	&NtCreateWaitablePort,
+	&NtCreateWorkerFactory,
+	&NtDebugActiveProcess,
+	&NtDebugContinue,
+	&NtDelayExecution,
+	&NtDeleteAtom,
+	&NtDeleteBootEntry,
+	&NtDeleteDriverEntry,
+	&NtDeleteFile,
+	&NtDeleteKey,
+	&NtDeleteObjectAuditAlarm,
+	&NtDeletePrivateNamespace,
+	&NtDeleteValueKey,
+	&NtDeviceIoControlFile,
+	&NtDisableLastKnownGood,
+	&NtDisplayString,
+	&NtDrawText,
+	&NtDuplicateObject,
+	&NtDuplicateToken,
+	&NtEnableLastKnownGood,
+	&NtEnumerateBootEntries,
+	&NtEnumerateDriverEntries,
+	&NtEnumerateKey,
+	&NtEnumerateSystemEnvironmentValuesEx,
+	&NtEnumerateTransactionObject,
+	&NtEnumerateValueKey,
+	&NtExtendSection,
+	&NtFilterToken,
+	&NtFindAtom,
+	&NtFlushBuffersFile,
+	&NtFlushInstallUILanguage,
+	&NtFlushInstructionCache,
+	&NtFlushKey,
+	&NtFlushProcessWriteBuffers,
+	&NtFlushVirtualMemory,
+	&NtFlushWriteBuffer,
+	&NtFreeUserPhysicalPages,
+	&NtFreeVirtualMemory,
+	&NtFreezeRegistry,
+	&NtFreezeTransactions,
+	&NtFsControlFile,
+	&NtGetContextThread,
+	&NtGetCurrentProcessorNumber,
+	&NtGetDevicePowerState,
+	&NtGetMUIRegistryInfo,
+	&NtGetNextProcess,
+	&NtGetNextThread,
+	&NtGetNlsSectionPtr,
+	&NtGetNotificationResourceManager,
+	&NtGetPlugPlayEvent,
+	&NtGetWriteWatch,
+	&NtImpersonateAnonymousToken,
+	&NtImpersonateClientOfPort,
+	&NtImpersonateThread,
+	&NtInitializeNlsFiles,
+	&NtInitializeRegistry,
+	&NtInitiatePowerAction,
+	&NtIsProcessInJob,
+	&NtIsSystemResumeAutomatic,
+	&NtIsUILanguageComitted,
+	&NtListenPort,
+	&NtLoadDriver,
+	&NtLoadKey2,
+	&NtLoadKeyEx,
+	&NtLoadKey,
+	&NtLockFile,
+	&NtLockProductActivationKeys,
+	&NtLockRegistryKey,
+	&NtLockVirtualMemory,
+	&NtMakePermanentObject,
+	&NtMakeTemporaryObject,
+	&NtMapCMFModule,
+	&NtMapUserPhysicalPages,
+	&NtMapUserPhysicalPagesScatter,
+	&NtMapViewOfSection,
+	&NtModifyBootEntry,
+	&NtModifyDriverEntry,
+	&NtNotifyChangeDirectoryFile,
+	&NtNotifyChangeKey,
+	&NtNotifyChangeMultipleKeys,
+	&NtNotifyChangeSession,
+	&NtOpenDirectoryObject,
+	&NtOpenEnlistment,
+	&NtOpenEvent,
+	&NtOpenEventPair,
+	&NtOpenFile,
+	&NtOpenIoCompletion,
+	&NtOpenJobObject,
+	&NtOpenKeyedEvent,
+	&NtOpenKeyEx,
+	&NtOpenKey,
+	&NtOpenKeyTransactedEx,
+	&NtOpenKeyTransacted,
+	&NtOpenMutant,
+	&NtOpenObjectAuditAlarm,
+	&NtOpenPrivateNamespace,
+	&NtOpenProcess,
+	&NtOpenProcessTokenEx,
+	&NtOpenProcessToken,
+	&NtOpenResourceManager,
+	&NtOpenSection,
+	&NtOpenSemaphore,
+	&NtOpenSession,
+	&NtOpenSymbolicLinkObject,
+	&NtOpenThread,
+	&NtOpenThreadTokenEx,
+	&NtOpenThreadToken,
+	&NtOpenTimer,
+	&NtOpenTransactionManager,
+	&NtOpenTransaction,
+	&NtPlugPlayControl,
+	&NtPowerInformation,
+	&NtPrepareComplete,
+	&NtPrepareEnlistment,
+	&NtPrePrepareComplete,
+	&NtPrePrepareEnlistment,
+	&NtPrivilegeCheck,
+	&NtPrivilegedServiceAuditAlarm,
+	&NtPrivilegeObjectAuditAlarm,
+	&NtPropagationComplete,
+	&NtPropagationFailed,
+	&NtProtectVirtualMemory,
+	&NtPulseEvent,
+	&NtQueryAttributesFile,
+	&NtQueryBootEntryOrder,
+	&NtQueryBootOptions,
+	&NtQueryDebugFilterState,
+	&NtQueryDefaultLocale,
+	&NtQueryDefaultUILanguage,
+	&NtQueryDirectoryFile,
+	&NtQueryDirectoryObject,
+	&NtQueryDriverEntryOrder,
+	&NtQueryEaFile,
+	&NtQueryEvent,
+	&NtQueryFullAttributesFile,
+	&NtQueryInformationAtom,
+	&NtQueryInformationEnlistment,
+	&NtQueryInformationFile,
+	&NtQueryInformationJobObject,
+	&NtQueryInformationPort,
+	&NtQueryInformationProcess,
+	&NtQueryInformationResourceManager,
+	&NtQueryInformationThread,
+	&NtQueryInformationToken,
+	&NtQueryInformationTransaction,
+	&NtQueryInformationTransactionManager,
+	&NtQueryInformationWorkerFactory,
+	&NtQueryInstallUILanguage,
+	&NtQueryIntervalProfile,
+	&NtQueryIoCompletion,
+	&NtQueryKey,
+	&NtQueryLicenseValue,
+	&NtQueryMultipleValueKey,
+	&NtQueryMutant,
+	&NtQueryObject,
+	&NtQueryOpenSubKeysEx,
+	&NtQueryOpenSubKeys,
+	&NtQueryPerformanceCounter,
+	&NtQueryPortInformationProcess,
+	&NtQueryQuotaInformationFile,
+	&NtQuerySection,
+	&NtQuerySecurityAttributesToken,
+	&NtQuerySecurityObject,
+	&NtQuerySemaphore,
+	&NtQuerySymbolicLinkObject,
+	&NtQuerySystemEnvironmentValueEx,
+	&NtQuerySystemEnvironmentValue,
+	&NtQuerySystemInformationEx,
+	&NtQuerySystemInformation,
+	&NtQuerySystemTime,
+	&NtQueryTimer,
+	&NtQueryTimerResolution,
+	&NtQueryValueKey,
+	&NtQueryVirtualMemory,
+	&NtQueryVolumeInformationFile,
+	&NtQueueApcThreadEx,
+	&NtQueueApcThread,
+	&NtRaiseException,
+	&NtRaiseHardError,
+	&NtReadFile,
+	&NtReadFileScatter,
+	&NtReadOnlyEnlistment,
+	&NtReadRequestData,
+	&NtReadVirtualMemory,
+	&NtRecoverEnlistment,
+	&NtRecoverResourceManager,
+	&NtRecoverTransactionManager,
+	&NtRegisterProtocolAddressInformation,
+	&NtRegisterThreadTerminatePort,
+	&NtReleaseKeyedEvent,
+	&NtReleaseMutant,
+	&NtReleaseSemaphore,
+	&NtReleaseWorkerFactoryWorker,
+	&NtRemoveIoCompletionEx,
+	&NtRemoveIoCompletion,
+	&NtRemoveProcessDebug,
+	&NtRenameKey,
+	&NtRenameTransactionManager,
+	&NtReplaceKey,
+	&NtReplacePartitionUnit,
+	&NtReplyPort,
+	&NtReplyWaitReceivePortEx,
+	&NtReplyWaitReceivePort,
+	&NtReplyWaitReplyPort,
+	&NtRequestPort,
+	&NtRequestWaitReplyPort,
+	&NtResetEvent,
+	&NtResetWriteWatch,
+	&NtRestoreKey,
+	&NtResumeProcess,
+	&NtResumeThread,
+	&NtRollbackComplete,
+	&NtRollbackEnlistment,
+	&NtRollbackTransaction,
+	&NtRollforwardTransactionManager,
+	&NtSaveKeyEx,
+	&NtSaveKey,
+	&NtSaveMergedKeys,
+	&NtSecureConnectPort,
+	&NtSerializeBoot,
+	&NtSetBootEntryOrder,
+	&NtSetBootOptions,
+	&NtSetContextThread,
+	&NtSetDebugFilterState,
+	&NtSetDefaultHardErrorPort,
+	&NtSetDefaultLocale,
+	&NtSetDefaultUILanguage,
+	&NtSetDriverEntryOrder,
+	&NtSetEaFile,
+	&NtSetEventBoostPriority,
+	&NtSetEvent,
+	&NtSetHighEventPair,
+	&NtSetHighWaitLowEventPair,
+	&NtSetInformationDebugObject,
+	&NtSetInformationEnlistment,
+	&NtSetInformationFile,
+	&NtSetInformationJobObject,
+	&NtSetInformationKey,
+	&NtSetInformationObject,
+	&NtSetInformationProcess,
+	&NtSetInformationResourceManager,
+	&NtSetInformationThread,
+	&NtSetInformationToken,
+	&NtSetInformationTransaction,
+	&NtSetInformationTransactionManager,
+	&NtSetInformationWorkerFactory,
+	&NtSetIntervalProfile,
+	&NtSetIoCompletionEx,
+	&NtSetIoCompletion,
+	&NtSetLdtEntries,
+	&NtSetLowEventPair,
+	&NtSetLowWaitHighEventPair,
+	&NtSetQuotaInformationFile,
+	&NtSetSecurityObject,
+	&NtSetSystemEnvironmentValueEx,
+	&NtSetSystemEnvironmentValue,
+	&NtSetSystemInformation,
+	&NtSetSystemPowerState,
+	&NtSetSystemTime,
+	&NtSetThreadExecutionState,
+	&NtSetTimerEx,
+	&NtSetTimer,
+	&NtSetTimerResolution,
+	&NtSetUuidSeed,
+	&NtSetValueKey,
+	&NtSetVolumeInformationFile,
+	&NtShutdownSystem,
+	&NtShutdownWorkerFactory,
+	&NtSignalAndWaitForSingleObject,
+	&NtSinglePhaseReject,
+	&NtStartProfile,
+	&NtStopProfile,
+	&NtSuspendProcess,
+	&NtSuspendThread,
+	&NtSystemDebugControl,
+	&NtTerminateJobObject,
+	&NtTerminateProcess,
+	&NtTerminateThread,
+	&NtTestAlert,
+	&NtThawRegistry,
+	&NtThawTransactions,
+	&NtTraceControl,
+	&NtTraceEvent,
+	&NtTranslateFilePath,
+	&NtUmsThreadYield,
+	&NtUnloadDriver,
+	&NtUnloadKey2,
+	&NtUnloadKeyEx,
+	&NtUnloadKey,
+	&NtUnlockFile,
+	&NtUnlockVirtualMemory,
+	&NtUnmapViewOfSection,
+	&NtVdmControl,
+	&NtWaitForDebugEvent,
+	&NtWaitForKeyedEvent,
+	&NtWaitForMultipleObjects32,
+	&NtWaitForMultipleObjects,
+	&NtWaitForSingleObject,
+	&NtWaitForWorkViaWorkerFactory,
+	&NtWaitHighEventPair,
+	&NtWaitLowEventPair,
+	&NtWorkerFactoryWorkerReady,
+	&NtWriteFileGather,
+	&NtWriteFile,
+	&NtWriteRequestData,
+	&NtWriteVirtualMemory,
+	&NtYieldExecution,
+	&NtAcquireProcessActivityReference,
+	&NtAddAtomEx,
+	&NtAlertThreadByThreadId,
+	&NtAllocateVirtualMemoryEx,
+	&NtAlpcConnectPortEx,
+	&NtAlpcImpersonateClientContainerOfPort,
+	&NtAssociateWaitCompletionPacket,
+	&NtCallEnclave,
+	&NtCancelTimer2,
+	&NtCancelWaitCompletionPacket,
+	&NtCommitRegistryTransaction,
+	&NtCompareObjects,
+	&NtCompareSigningLevels,
+	&NtConvertBetweenAuxiliaryCounterAndPerformanceCounter,
+	&NtCreateDirectoryObjectEx,
+	&NtCreateEnclave,
+	&NtCreateIRTimer,
+	&NtCreateLowBoxToken,
+	&NtCreatePartition,
+	&NtCreateRegistryTransaction,
+	&NtCreateTimer2,
+	&NtCreateTokenEx,
+	&NtCreateWaitCompletionPacket,
+	&NtCreateWnfStateName,
+	&NtDeleteWnfStateData,
+	&NtDeleteWnfStateName,
+	&NtFilterBootOption,
+	&NtFlushBuffersFileEx,
+	&NtGetCachedSigningLevel,
+	&NtGetCompleteWnfStateSubscription,
+	&NtGetCurrentProcessorNumberEx,
+	&NtInitializeEnclave,
+	&NtLoadEnclaveData,
+	&NtLoadHotPatch,
+	&NtManagePartition,
+	&NtMapViewOfSectionEx,
+	&NtNotifyChangeDirectoryFileEx,
+	&NtOpenPartition,
+	&NtOpenRegistryTransaction,
+	&NtQueryAuxiliaryCounterFrequency,
+	&NtQueryDirectoryFileEx,
+	&NtQueryInformationByName,
+	&NtQuerySecurityPolicy,
+	&NtQueryWnfStateData,
+	&NtQueryWnfStateNameInformation,
+	&NtRevertContainerImpersonation,
+	&NtRollbackRegistryTransaction,
+	&NtSetCachedSigningLevel,
+	&NtSetCachedSigningLevel2,
+	&NtSetIRTimer,
+	&NtSetInformationSymbolicLink,
+	&NtSetInformationVirtualMemory,
+	&NtSetTimer2,
+	&NtSetWnfProcessNotificationEvent,
+	&NtSubscribeWnfStateChange,
+	&NtTerminateEnclave,
+	&NtUnmapViewOfSectionEx,
+	&NtUnsubscribeWnfStateChange,
+	&NtUpdateWnfStateData,
+	&NtWaitForAlertByThreadId,
+	&NtCreateSectionEx,
+	&NtManageHotPatch,
+	&BvgaSetVirtualFrameBuffer,
+	&CmpCleanUpHigherLayerKcbCachesPreCallback,
+	&GetPnpProperty,
+	&ArbPreprocessEntry,
+	&ArbAddReserved,
 };
 
-static const syscall_definition_t win32k[] =
+static const syscall_t* win32k[] =
 {
-    { .name = "NtBindCompositionSurface", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtCloseCompositionInputSink", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtCompositionInputThread", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtCompositionSetDropTarget", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtConfigureInputSpace", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtCreateCompositionInputSink", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtCreateCompositionSurfaceHandle", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtCreateImplicitCompositionInputSink", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionAddCrossDeviceVisualChild", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionAddVisualChild", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionAttachMouseWheelToHwnd", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionBeginFrame", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionCapturePointer", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionCommitChannel", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionCommitSynchronizationObject", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionConfirmFrame", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionConnectPipe", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionCreateAndBindSharedSection", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionCreateChannel", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionCreateConnection", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionCreateConnectionContext", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionCreateDwmChannel", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionCreateResource", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionCreateSharedResourceHandle", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionCreateSharedVisualHandle", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionCreateSynchronizationObject", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionCurrentBatchId", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionDestroyChannel", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionDestroyConnection", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionDestroyConnectionContext", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionDiscardFrame", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionDuplicateHandleToProcess", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionDuplicateSwapchainHandleToDwm", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionDwmSyncFlush", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionEnableDDASupport", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionEnableMMCSS", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionGetAnimationTime", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionGetBatchId", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionGetChannels", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionGetConnectionBatch", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionGetConnectionContextBatch", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionGetDeletedResources", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionGetFrameLegacyTokens", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionGetFrameStatistics", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionGetFrameSurfaceUpdates", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionGetMaterialProperty", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionOpenSharedResource", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionOpenSharedResourceHandle", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionProcessChannelBatchBuffer", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionReferenceSharedResourceOnDwmChannel", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionRegisterThumbnailVisual", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionRegisterVirtualDesktopVisual", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionReleaseAllResources", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionReleaseResource", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionRemoveCrossDeviceVisualChild", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionRemoveVisualChild", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionReplaceVisualChildren", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionRetireFrame", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionSetChannelCallbackId", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionSetChannelCommitCompletionEvent", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionSetChannelConnectionId", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionSetChildRootVisual", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionSetDebugCounter", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionSetMaterialProperty", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionSetResourceAnimationProperty", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionSetResourceBufferProperty", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionSetResourceCallbackId", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionSetResourceDeletedNotificationTag", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionSetResourceFloatProperty", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionSetResourceHandleProperty", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionSetResourceIntegerProperty", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionSetResourceReferenceArrayProperty", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionSetResourceReferenceProperty", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionSetVisualInputSink", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionSignalGpuFence", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionSubmitDWMBatch", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionSuspendAnimations", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionSynchronize", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionTelemetryAnimationScenarioBegin", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionTelemetryAnimationScenarioReference", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionTelemetryAnimationScenarioUnreference", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionTelemetrySetApplicationId", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionTelemetryTouchInteractionBegin", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionTelemetryTouchInteractionEnd", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionTelemetryTouchInteractionUpdate", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionUpdatePointerCapture", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionValidateAndReferenceSystemVisualForHwndTarget", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDCompositionWaitForChannel", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDWMBindCursorToOutputConfig", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDWMCommitInputSystemOutputConfig", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDWMSetCursorOrientation", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDWMSetInputSystemOutputConfig", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDesktopCaptureBits", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDuplicateCompositionInputSink", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDxgkCreateTrackedWorkload", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDxgkDestroyTrackedWorkload", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDxgkDispMgrOperation", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDxgkEndTrackedWorkload", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDxgkGetAvailableTrackedWorkloadIndex", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDxgkGetProcessList", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDxgkGetTrackedWorkloadStatistics", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDxgkOutputDuplPresentToHwQueue", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDxgkRegisterVailProcess", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDxgkResetTrackedWorkload", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDxgkSubmitPresentBltToHwQueue", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDxgkSubmitPresentToHwQueue", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDxgkUpdateTrackedWorkload", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDxgkVailConnect", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDxgkVailDisconnect", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtDxgkVailPromoteCompositionSurface", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtEnableOneCoreTransformMode", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtFlipObjectAddContent", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtFlipObjectAddPoolBuffer", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtFlipObjectConsumerAcquirePresent", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtFlipObjectConsumerAdjustUsageReference", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtFlipObjectConsumerBeginProcessPresent", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtFlipObjectConsumerEndProcessPresent", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtFlipObjectConsumerPostMessage", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtFlipObjectConsumerQueryBufferInfo", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtFlipObjectCreate", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtFlipObjectDisconnectEndpoint", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtFlipObjectOpen", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtFlipObjectPresentCancel", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtFlipObjectQueryBufferAvailableEvent", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtFlipObjectQueryEndpointConnected", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtFlipObjectQueryNextMessageToProducer", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtFlipObjectReadNextMessageToProducer", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtFlipObjectRemoveContent", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtFlipObjectRemovePoolBuffer", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtFlipObjectSetContent", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiAbortDoc", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiAbortPath", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiAddEmbFontToDC", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiAddFontMemResourceEx", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiAddFontResourceW", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiAddInitialFonts", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiAddRemoteFontToDC", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiAddRemoteMMInstanceToDC", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiAlphaBlend", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiAngleArc", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiAnyLinkedFonts", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiArcInternal", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiBRUSHOBJ_DeleteRbrush", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiBRUSHOBJ_hGetColorTransform", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiBRUSHOBJ_pvAllocRbrush", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiBRUSHOBJ_pvGetRbrush", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiBRUSHOBJ_ulGetBrushColor", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiBeginGdiRendering", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiBeginPath", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiBitBlt", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiCLIPOBJ_bEnum", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiCLIPOBJ_cEnumStart", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiCLIPOBJ_ppoGetPath", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiCancelDC", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiChangeGhostFont", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiCheckBitmapBits", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiClearBitmapAttributes", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiClearBrushAttributes", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiCloseFigure", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiColorCorrectPalette", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiCombineRgn", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiCombineTransform", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiComputeXformCoefficients", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiConfigureOPMProtectedOutput", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiConsoleTextOut", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiConvertMetafileRect", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiCreateBitmap", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiCreateBitmapFromDxSurface", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiCreateBitmapFromDxSurface2", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiCreateClientObj", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiCreateColorSpace", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiCreateColorTransform", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiCreateCompatibleBitmap", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiCreateCompatibleDC", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiCreateDIBBrush", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiCreateDIBSection", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiCreateDIBitmapInternal", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiCreateEllipticRgn", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiCreateHalftonePalette", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiCreateHatchBrushInternal", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiCreateMetafileDC", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiCreateOPMProtectedOutput", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiCreateOPMProtectedOutputs", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiCreatePaletteInternal", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiCreatePatternBrushInternal", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiCreatePen", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiCreateRectRgn", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiCreateRoundRectRgn", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiCreateServerMetaFile", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiCreateSessionMappedDIBSection", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiCreateSolidBrush", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiD3dContextCreate", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiD3dContextDestroy", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiD3dContextDestroyAll", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiD3dDrawPrimitives2", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiD3dValidateTextureStageState", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDDCCIGetCapabilitiesString", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDDCCIGetCapabilitiesStringLength", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDDCCIGetTimingReport", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDDCCIGetVCPFeature", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDDCCISaveCurrentSettings", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDDCCISetVCPFeature", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdAddAttachedSurface", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdAlphaBlt", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdAttachSurface", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdBeginMoCompFrame", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdBlt", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdCanCreateD3DBuffer", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdCanCreateSurface", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdColorControl", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdCreateD3DBuffer", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdCreateDirectDrawObject", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdCreateFullscreenSprite", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdCreateMoComp", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdCreateSurface", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdCreateSurfaceEx", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdCreateSurfaceObject", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIAbandonSwapChain", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIAcquireKeyedMutex", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIAcquireKeyedMutex2", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIAcquireSwapChain", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIAddSurfaceToSwapChain", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIAdjustFullscreenGamma", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDICacheHybridQueryValue", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIChangeVideoMemoryReservation", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDICheckExclusiveOwnership", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDICheckMonitorPowerState", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDICheckMultiPlaneOverlaySupport", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDICheckMultiPlaneOverlaySupport2", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDICheckMultiPlaneOverlaySupport3", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDICheckOcclusion", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDICheckSharedResourceAccess", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDICheckVidPnExclusiveOwnership", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDICloseAdapter", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIConfigureSharedResource", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDICreateAllocation", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDICreateBundleObject", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDICreateContext", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDICreateContextVirtual", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDICreateDCFromMemory", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDICreateDevice", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDICreateHwContext", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDICreateHwQueue", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDICreateKeyedMutex", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDICreateKeyedMutex2", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDICreateOutputDupl", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDICreateOverlay", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDICreatePagingQueue", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDICreateProtectedSession", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDICreateSwapChain", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDICreateSynchronizationObject", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIDDisplayEnum", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIDestroyAllocation", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIDestroyAllocation2", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIDestroyContext", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIDestroyDCFromMemory", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIDestroyDevice", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIDestroyHwContext", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIDestroyHwQueue", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIDestroyKeyedMutex", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIDestroyOutputDupl", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIDestroyOverlay", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIDestroyPagingQueue", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIDestroyProtectedSession", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIDestroySynchronizationObject", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIDispMgrCreate", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIDispMgrSourceOperation", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIDispMgrTargetOperation", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIEnumAdapters", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIEnumAdapters2", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIEscape", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIEvict", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIExtractBundleObject", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIFlipOverlay", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIFlushHeapTransitions", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIFreeGpuVirtualAddress", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIGetAllocationPriority", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIGetCachedHybridQueryValue", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIGetContextInProcessSchedulingPriority", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIGetContextSchedulingPriority", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIGetDWMVerticalBlankEvent", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIGetDeviceState", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIGetDisplayModeList", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIGetMemoryBudgetTarget", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIGetMultiPlaneOverlayCaps", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIGetMultisampleMethodList", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIGetOverlayState", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIGetPostCompositionCaps", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIGetPresentHistory", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIGetPresentQueueEvent", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIGetProcessDeviceLostSupport", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIGetProcessDeviceRemovalSupport", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIGetProcessSchedulingPriorityBand", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIGetProcessSchedulingPriorityClass", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIGetResourcePresentPrivateDriverData", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIGetRuntimeData", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIGetScanLine", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIGetSetSwapChainMetadata", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIGetSharedPrimaryHandle", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIGetSharedResourceAdapterLuid", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIGetSharedResourceAdapterLuidFlipManager", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIGetYieldPercentage", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIInvalidateActiveVidPn", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIInvalidateCache", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDILock", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDILock2", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIMakeResident", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIMapGpuVirtualAddress", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIMarkDeviceAsError", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDINetDispGetNextChunkInfo", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDINetDispQueryMiracastDisplayDeviceStatus", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDINetDispQueryMiracastDisplayDeviceSupport", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDINetDispStartMiracastDisplayDevice", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDINetDispStartMiracastDisplayDeviceEx", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDINetDispStopMiracastDisplayDevice", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDINetDispStopSessions", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIOfferAllocations", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIOpenAdapterFromDeviceName", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIOpenAdapterFromHdc", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIOpenAdapterFromLuid", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIOpenBundleObjectNtHandleFromName", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIOpenKeyedMutex", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIOpenKeyedMutex2", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIOpenKeyedMutexFromNtHandle", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIOpenNtHandleFromName", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIOpenProtectedSessionFromNtHandle", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIOpenResource", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIOpenResourceFromNtHandle", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIOpenSwapChain", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIOpenSyncObjectFromNtHandle", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIOpenSyncObjectFromNtHandle2", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIOpenSyncObjectNtHandleFromName", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIOpenSynchronizationObject", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIOutputDuplGetFrameInfo", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIOutputDuplGetMetaData", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIOutputDuplGetPointerShapeData", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIOutputDuplPresent", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIOutputDuplReleaseFrame", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIPinDirectFlipResources", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIPollDisplayChildren", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIPresent", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIPresentMultiPlaneOverlay", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIPresentMultiPlaneOverlay2", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIPresentMultiPlaneOverlay3", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIPresentRedirected", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIQueryAdapterInfo", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIQueryAllocationResidency", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIQueryClockCalibration", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIQueryFSEBlock", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIQueryProcessOfferInfo", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIQueryProtectedSessionInfoFromNtHandle", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIQueryProtectedSessionStatus", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIQueryRemoteVidPnSourceFromGdiDisplayName", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIQueryResourceInfo", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIQueryResourceInfoFromNtHandle", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIQueryStatistics", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIQueryVidPnExclusiveOwnership", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIQueryVideoMemoryInfo", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIReclaimAllocations", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIReclaimAllocations2", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIReleaseKeyedMutex", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIReleaseKeyedMutex2", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIReleaseProcessVidPnSourceOwners", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIReleaseSwapChain", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIRemoveSurfaceFromSwapChain", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIRender", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIReserveGpuVirtualAddress", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDISetAllocationPriority", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDISetContextInProcessSchedulingPriority", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDISetContextSchedulingPriority", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDISetDeviceLostSupport", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDISetDisplayMode", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDISetDisplayPrivateDriverFormat", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDISetDodIndirectSwapchain", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDISetFSEBlock", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDISetGammaRamp", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDISetHwProtectionTeardownRecovery", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDISetMemoryBudgetTarget", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDISetMonitorColorSpaceTransform", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDISetProcessDeviceRemovalSupport", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDISetProcessSchedulingPriorityBand", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDISetProcessSchedulingPriorityClass", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDISetQueuedLimit", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDISetStablePowerState", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDISetStereoEnabled", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDISetSyncRefreshCountWaitTarget", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDISetVidPnSourceHwProtection", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDISetVidPnSourceOwner", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDISetVidPnSourceOwner1", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDISetYieldPercentage", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIShareObjects", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDISharedPrimaryLockNotification", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDISharedPrimaryUnLockNotification", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDISignalSynchronizationObject", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDISignalSynchronizationObjectFromCpu", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDISignalSynchronizationObjectFromGpu", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDISignalSynchronizationObjectFromGpu2", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDISubmitCommand", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDISubmitCommandToHwQueue", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDISubmitSignalSyncObjectsToHwQueue", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDISubmitWaitForSyncObjectsToHwQueue", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDITrimProcessCommitment", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIUnOrderedPresentSwapChain", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIUnlock", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIUnlock2", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIUnpinDirectFlipResources", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIUpdateAllocationProperty", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIUpdateGpuVirtualAddress", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIUpdateOverlay", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIWaitForIdle", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIWaitForSynchronizationObject", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIWaitForSynchronizationObjectFromCpu", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIWaitForSynchronizationObjectFromGpu", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIWaitForVerticalBlankEvent", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDDIWaitForVerticalBlankEvent2", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDeleteDirectDrawObject", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDeleteSurfaceObject", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDestroyD3DBuffer", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDestroyFullscreenSprite", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDestroyMoComp", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdDestroySurface", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdEndMoCompFrame", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdFlip", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdFlipToGDISurface", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdGetAvailDriverMemory", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdGetBltStatus", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdGetDC", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdGetDriverInfo", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdGetDriverState", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdGetDxHandle", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdGetFlipStatus", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdGetInternalMoCompInfo", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdGetMoCompBuffInfo", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdGetMoCompFormats", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdGetMoCompGuids", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdGetScanLine", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdLock", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdLockD3D", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdNotifyFullscreenSpriteUpdate", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdQueryDirectDrawObject", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdQueryMoCompStatus", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdQueryVisRgnUniqueness", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdReenableDirectDrawObject", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdReleaseDC", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdRenderMoComp", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdResetVisrgn", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdSetColorKey", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdSetExclusiveMode", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdSetGammaRamp", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdSetOverlayPosition", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdUnattachSurface", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdUnlock", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdUnlockD3D", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdUpdateOverlay", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDdWaitForVerticalBlank", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDeleteClientObj", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDeleteColorSpace", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDeleteColorTransform", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDeleteObjectApp", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDescribePixelFormat", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDestroyOPMProtectedOutput", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDestroyPhysicalMonitor", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDoBanding", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDoPalette", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDrawEscape", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDrawStream", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDvpAcquireNotification", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDvpCanCreateVideoPort", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDvpColorControl", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDvpCreateVideoPort", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDvpDestroyVideoPort", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDvpFlipVideoPort", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDvpGetVideoPortBandwidth", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDvpGetVideoPortConnectInfo", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDvpGetVideoPortField", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDvpGetVideoPortFlipStatus", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDvpGetVideoPortInputFormats", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDvpGetVideoPortLine", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDvpGetVideoPortOutputFormats", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDvpGetVideoSignalStatus", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDvpReleaseNotification", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDvpUpdateVideoPort", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDvpWaitForVideoPortSync", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDwmCreatedBitmapRemotingOutput", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDwmGetDirtyRgn", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDwmGetSurfaceData", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiDxgGenericThunk", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiEllipse", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiEnableEudc", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiEndDoc", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiEndGdiRendering", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiEndPage", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiEndPath", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiEngAlphaBlend", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiEngAssociateSurface", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiEngBitBlt", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiEngCheckAbort", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiEngComputeGlyphSet", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiEngCopyBits", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiEngCreateBitmap", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiEngCreateClip", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiEngCreateDeviceBitmap", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiEngCreateDeviceSurface", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiEngCreatePalette", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiEngDeleteClip", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiEngDeletePalette", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiEngDeletePath", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiEngDeleteSurface", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiEngEraseSurface", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiEngFillPath", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiEngGradientFill", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiEngLineTo", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiEngLockSurface", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiEngMarkBandingSurface", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiEngPaint", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiEngPlgBlt", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiEngStretchBlt", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiEngStretchBltROP", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiEngStrokeAndFillPath", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiEngStrokePath", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiEngTextOut", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiEngTransparentBlt", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiEngUnlockSurface", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiEnsureDpiDepDefaultGuiFontForPlateau", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiEnumFontChunk", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiEnumFontClose", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiEnumFontOpen", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiEnumFonts", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiEnumObjects", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiEqualRgn", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiEudcLoadUnloadLink", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiExcludeClipRect", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiExtCreatePen", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiExtCreateRegion", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiExtEscape", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiExtFloodFill", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiExtGetObjectW", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiExtSelectClipRgn", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiExtTextOutW", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiFONTOBJ_cGetAllGlyphHandles", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiFONTOBJ_cGetGlyphs", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiFONTOBJ_pQueryGlyphAttrs", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiFONTOBJ_pfdg", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiFONTOBJ_pifi", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiFONTOBJ_pvTrueTypeFontFile", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiFONTOBJ_pxoGetXform", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiFONTOBJ_vGetInfo", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiFillPath", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiFillRgn", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiFlattenPath", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiFlush", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiFontIsLinked", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiForceUFIMapping", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiFrameRgn", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiFullscreenControl", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetAndSetDCDword", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetAppClipBox", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetAppliedDeviceGammaRamp", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetBitmapBits", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetBitmapDimension", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetBitmapDpiScaleValue", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetBoundsRect", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetCOPPCompatibleOPMInformation", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetCertificate", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetCertificateByHandle", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetCertificateSize", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetCertificateSizeByHandle", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetCharABCWidthsW", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetCharSet", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetCharWidthInfo", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetCharWidthW", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetCharacterPlacementW", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetColorAdjustment", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetColorSpaceforBitmap", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetCurrentDpiInfo", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetDCDpiScaleValue", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetDCDword", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetDCObject", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetDCPoint", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetDCforBitmap", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetDIBitsInternal", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetDeviceCaps", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetDeviceCapsAll", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetDeviceGammaRamp", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetDeviceWidth", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetDhpdev", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetETM", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetEmbUFI", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetEmbedFonts", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetEntry", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetEudcTimeStampEx", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetFontData", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetFontFileData", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetFontFileInfo", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetFontResourceInfoInternalW", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetFontUnicodeRanges", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetGammaRampCapability", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetGlyphIndicesW", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetGlyphIndicesWInternal", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetGlyphOutline", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetKerningPairs", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetLinkedUFIs", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetMiterLimit", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetMonitorID", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetNearestColor", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetNearestPaletteIndex", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetNumberOfPhysicalMonitors", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetOPMInformation", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetOPMRandomNumber", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetObjectBitmapHandle", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetOutlineTextMetricsInternalW", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetPath", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetPerBandInfo", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetPhysicalMonitorDescription", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetPhysicalMonitors", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetPixel", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetProcessSessionFonts", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetPublicFontTableChangeCookie", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetRandomRgn", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetRasterizerCaps", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetRealizationInfo", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetRegionData", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetRgnBox", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetServerMetaFileBits", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetSpoolMessage", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetStats", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetStockObject", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetStringBitmapW", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetSuggestedOPMProtectedOutputArraySize", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetSystemPaletteUse", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetTextCharsetInfo", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetTextExtent", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetTextExtentExW", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetTextFaceW", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetTextMetricsW", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetTransform", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetUFI", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetUFIPathname", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGetWidthTable", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiGradientFill", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiHLSurfGetInformation", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiHLSurfSetInformation", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiHT_Get8BPPFormatPalette", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiHT_Get8BPPMaskPalette", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiHfontCreate", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiIcmBrushInfo", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiInit", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiInitSpool", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiIntersectClipRect", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiInvertRgn", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiLineTo", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiMakeFontDir", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiMakeInfoDC", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiMakeObjectUnXferable", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiMakeObjectXferable", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiMaskBlt", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiMirrorWindowOrg", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiModifyWorldTransform", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiMonoBitmap", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiMoveTo", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiOffsetClipRgn", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiOffsetRgn", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiOpenDCW", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiPATHOBJ_bEnum", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiPATHOBJ_bEnumClipLines", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiPATHOBJ_vEnumStart", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiPATHOBJ_vEnumStartClipLines", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiPATHOBJ_vGetBounds", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiPatBlt", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiPathToRegion", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiPlgBlt", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiPolyDraw", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiPolyPatBlt", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiPolyPolyDraw", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiPolyTextOutW", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiPtInRegion", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiPtVisible", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiQueryFontAssocInfo", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiQueryFonts", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiRectInRegion", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiRectVisible", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiRectangle", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiRemoveFontMemResourceEx", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiRemoveFontResourceW", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiRemoveMergeFont", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiResetDC", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiResizePalette", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiRestoreDC", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiRoundRect", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiSTROBJ_bEnum", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiSTROBJ_bEnumPositionsOnly", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiSTROBJ_bGetAdvanceWidths", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiSTROBJ_dwGetCodePage", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiSTROBJ_vEnumStart", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiSaveDC", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiScaleRgn", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiScaleValues", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiScaleViewportExtEx", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiScaleWindowExtEx", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiSelectBitmap", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiSelectBrush", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiSelectClipPath", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiSelectFont", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiSelectPen", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiSetBitmapAttributes", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiSetBitmapBits", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiSetBitmapDimension", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiSetBoundsRect", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiSetBrushAttributes", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiSetBrushOrg", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiSetColorAdjustment", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiSetColorSpace", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiSetDIBitsToDeviceInternal", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiSetDeviceGammaRamp", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiSetFontEnumeration", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiSetFontXform", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiSetIcmMode", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiSetLayout", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiSetLinkedUFIs", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiSetMagicColors", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiSetMetaRgn", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiSetMiterLimit", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiSetOPMSigningKeyAndSequenceNumbers", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiSetPUMPDOBJ", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiSetPixel", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiSetPixelFormat", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiSetPrivateDeviceGammaRamp", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiSetRectRgn", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiSetSizeDevice", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiSetSystemPaletteUse", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiSetTextJustification", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiSetUMPDSandboxState", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiSetVirtualResolution", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiSetupPublicCFONT", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiSfmGetNotificationTokens", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiStartDoc", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiStartPage", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiStretchBlt", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiStretchDIBitsInternal", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiStrokeAndFillPath", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiStrokePath", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiSwapBuffers", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiTransformPoints", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiTransparentBlt", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiUMPDEngFreeUserMem", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiUnloadPrinterDriver", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiUnmapMemFont", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiUnrealizeObject", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiUpdateColors", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiUpdateTransform", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiWidenPath", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiXFORMOBJ_bApplyXform", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiXFORMOBJ_iGetXform", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiXLATEOBJ_cGetPalette", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiXLATEOBJ_hGetColorTransform", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtGdiXLATEOBJ_iXlate", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtHWCursorUpdatePointer", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtIsOneCoreTransformMode", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtMITActivateInputProcessing", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtMITBindInputTypeToMonitors", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtMITCoreMsgKGetConnectionHandle", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtMITCoreMsgKOpenConnectionTo", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtMITCoreMsgKSend", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtMITDeactivateInputProcessing", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtMITDisableMouseIntercept", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtMITDispatchCompletion", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtMITEnableMouseIntercept", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtMITGetCursorUpdateHandle", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtMITSetInputCallbacks", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtMITSetInputDelegationMode", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtMITSetInputSuppressionState", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtMITSetKeyboardInputRoutingPolicy", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtMITSetKeyboardOverriderState", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtMITSetLastInputRecipient", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtMITSynthesizeKeyboardInput", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtMITSynthesizeMouseInput", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtMITSynthesizeMouseWheel", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtMITSynthesizeTouchInput", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtMITUpdateInputGlobals", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtMITWaitForMultipleObjectsEx", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtMapVisualRelativePoints", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtNotifyPresentToCompositionSurface", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtOpenCompositionSurfaceDirtyRegion", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtOpenCompositionSurfaceSectionInfo", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtOpenCompositionSurfaceSwapChainHandleInfo", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtQueryCompositionInputIsImplicit", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtQueryCompositionInputQueueAndTransform", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtQueryCompositionInputSink", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtQueryCompositionInputSinkLuid", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtQueryCompositionInputSinkViewId", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtQueryCompositionSurfaceBinding", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtQueryCompositionSurfaceHDRMetaData", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtQueryCompositionSurfaceRenderingRealization", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtQueryCompositionSurfaceStatistics", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtRIMAddInputObserver", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtRIMAreSiblingDevices", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtRIMDeviceIoControl", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtRIMEnableMonitorMappingForDevice", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtRIMFreeInputBuffer", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtRIMGetDevicePreparsedData", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtRIMGetDevicePreparsedDataLockfree", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtRIMGetDeviceProperties", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtRIMGetDevicePropertiesLockfree", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtRIMGetPhysicalDeviceRect", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtRIMGetSourceProcessId", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtRIMObserveNextInput", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtRIMOnPnpNotification", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtRIMOnTimerNotification", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtRIMReadInput", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtRIMRegisterForInput", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtRIMRemoveInputObserver", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtRIMSetExtendedDeviceProperty", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtRIMSetTestModeStatus", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtRIMUnregisterForInput", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtRIMUpdateInputObserverRegistration", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtSetCompositionSurfaceAnalogExclusive", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtSetCompositionSurfaceBufferCompositionMode", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtSetCompositionSurfaceBufferCompositionModeAndOrientation", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtSetCompositionSurfaceBufferUsage", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtSetCompositionSurfaceDirectFlipState", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtSetCompositionSurfaceHDRMetaData", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtSetCompositionSurfaceIndependentFlipInfo", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtSetCompositionSurfaceOutOfFrameDirectFlipNotification", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtSetCompositionSurfaceStatistics", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtSetCursorInputSpace", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtSetPointerDeviceInputSpace", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtSetShellCursorState", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtTokenManagerConfirmOutstandingAnalogToken", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtTokenManagerCreateCompositionTokenHandle", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtTokenManagerCreateFlipObjectReturnTokenHandle", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtTokenManagerCreateFlipObjectTokenHandle", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtTokenManagerDeleteOutstandingDirectFlipTokens", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtTokenManagerGetAnalogExclusiveSurfaceUpdates", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtTokenManagerGetAnalogExclusiveTokenEvent", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtTokenManagerGetOutOfFrameDirectFlipSurfaceUpdates", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtTokenManagerOpenEvent", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtTokenManagerOpenSection", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtTokenManagerOpenSectionAndEvents", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtTokenManagerThread", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUnBindCompositionSurface", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUpdateInputSinkTransforms", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserAcquireIAMKey", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserAcquireInteractiveControlBackgroundAccess", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserActivateKeyboardLayout", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserAddClipboardFormatListener", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserAddVisualIdentifier", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserAlterWindowStyle", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserAssociateInputContext", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserAttachThreadInput", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserAutoPromoteMouseInPointer", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserAutoRotateScreen", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserBeginLayoutUpdate", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserBeginPaint", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserBitBltSysBmp", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserBlockInput", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserBroadcastThemeChangeEvent", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserBuildHimcList", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserBuildHwndList", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserBuildNameList", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserBuildPropList", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserCalcMenuBar", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserCalculatePopupWindowPosition", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserCallHwnd", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserCallHwndLock", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserCallHwndLockSafe", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserCallHwndOpt", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserCallHwndParam", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserCallHwndParamLock", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserCallHwndParamLockSafe", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserCallHwndSafe", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserCallMsgFilter", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserCallNextHookEx", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserCallNoParam", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserCallOneParam", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserCallTwoParam", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserCanBrokerForceForeground", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserChangeClipboardChain", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserChangeDisplaySettings", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserChangeWindowMessageFilterEx", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserCheckAccessForIntegrityLevel", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserCheckDesktopByThreadId", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserCheckImeHotKey", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserCheckMenuItem", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserCheckProcessForClipboardAccess", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserCheckProcessSession", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserCheckWindowThreadDesktop", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserChildWindowFromPointEx", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserClearForeground", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserClipCursor", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserCloseClipboard", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserCloseDesktop", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserCloseWindowStation", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserCompositionInputSinkLuidFromPoint", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserCompositionInputSinkViewInstanceIdFromPoint", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserConfigureActivationObject", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserConfirmResizeCommit", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserConsoleControl", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserConvertMemHandle", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserCopyAcceleratorTable", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserCountClipboardFormats", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserCreateAcceleratorTable", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserCreateActivationObject", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserCreateCaret", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserCreateDCompositionHwndTarget", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserCreateDesktop", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserCreateDesktopEx", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserCreateEmptyCursorObject", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserCreateInputContext", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserCreateLocalMemHandle", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserCreatePalmRejectionDelayZone", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserCreateWindowEx", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserCreateWindowGroup", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserCreateWindowStation", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserCtxDisplayIOCtl", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserDdeGetQualityOfService", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserDdeInitialize", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserDdeSetQualityOfService", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserDefSetText", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserDeferWindowDpiChanges", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserDeferWindowPos", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserDeferWindowPosAndBand", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserDelegateCapturePointers", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserDelegateInput", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserDeleteMenu", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserDeleteWindowGroup", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserDestroyAcceleratorTable", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserDestroyActivationObject", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserDestroyCursor", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserDestroyDCompositionHwndTarget", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserDestroyInputContext", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserDestroyMenu", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserDestroyPalmRejectionDelayZone", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserDestroyWindow", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserDisableImmersiveOwner", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserDisableProcessWindowFiltering", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserDisableThreadIme", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserDiscardPointerFrameMessages", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserDispatchMessage", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserDisplayConfigGetDeviceInfo", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserDisplayConfigSetDeviceInfo", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserDoSoundConnect", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserDoSoundDisconnect", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserDownlevelTouchpad", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserDragDetect", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserDragObject", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserDrawAnimatedRects", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserDrawCaption", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserDrawCaptionTemp", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserDrawIconEx", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserDrawMenuBarTemp", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserDwmGetDxRgn", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserDwmGetRemoteSessionOcclusionEvent", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserDwmGetRemoteSessionOcclusionState", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserDwmHintDxUpdate", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserDwmKernelShutdown", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserDwmKernelStartup", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserDwmStartRedirection", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserDwmStopRedirection", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserDwmValidateWindow", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserEmptyClipboard", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserEnableChildWindowDpiMessage", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserEnableIAMAccess", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserEnableMenuItem", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserEnableMouseInPointer", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserEnableMouseInputForCursorSuppression", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserEnableNonClientDpiScaling", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserEnableResizeLayoutSynchronization", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserEnableScrollBar", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserEnableSoftwareCursorForScreenCapture", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserEnableTouchPad", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserEnableWindowGDIScaledDpiMessage", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserEnableWindowGroupPolicy", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserEnableWindowResizeOptimization", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserEndDeferWindowPosEx", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserEndMenu", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserEndPaint", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserEndTouchOperation", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserEnumDisplayDevices", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserEnumDisplayMonitors", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserEnumDisplaySettings", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserEvent", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserExcludeUpdateRgn", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserFillWindow", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserFindExistingCursorIcon", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserFindWindowEx", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserFlashWindowEx", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserForceWindowToDpiForTest", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserFrostCrashedWindow", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserFunctionalizeDisplayConfig", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetActiveProcessesDpis", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetAltTabInfo", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetAncestor", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetAppImeLevel", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetAsyncKeyState", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetAtomName", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetAutoRotationState", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetCIMSSM", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetCPD", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetCaretBlinkTime", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetCaretPos", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetClassInfoEx", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetClassName", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetClipCursor", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetClipboardAccessToken", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetClipboardData", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetClipboardFormatName", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetClipboardOwner", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetClipboardSequenceNumber", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetClipboardViewer", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetComboBoxInfo", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetControlBrush", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetControlColor", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetCurrentDpiInfoForWindow", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetCurrentInputMessageSource", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetCursor", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetCursorDims", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetCursorFrameInfo", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetCursorInfo", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetDC", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetDCEx", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetDManipHookInitFunction", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetDesktopID", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetDisplayAutoRotationPreferences", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetDisplayAutoRotationPreferencesByProcessId", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetDisplayConfigBufferSizes", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetDoubleClickTime", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetDpiForCurrentProcess", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetDpiForMonitor", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetDpiSystemMetrics", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetExtendedPointerDeviceProperty", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetForegroundWindow", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetGUIThreadInfo", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetGestureConfig", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetGestureExtArgs", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetGestureInfo", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetGlobalIMEStatus", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetGuiResources", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetHDevName", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetHimetricScaleFactorFromPixelLocation", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetIconInfo", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetIconSize", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetImeHotKey", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetImeInfoEx", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetInputContainerId", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetInputLocaleInfo", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetInteractiveControlDeviceInfo", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetInteractiveControlInfo", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetInteractiveCtrlSupportedWaveforms", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetInternalWindowPos", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetKeyNameText", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetKeyState", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetKeyboardLayout", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetKeyboardLayoutList", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetKeyboardLayoutName", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetKeyboardState", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetLayeredWindowAttributes", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetListBoxInfo", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetMenuBarInfo", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetMenuIndex", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetMenuItemRect", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetMessage", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetMonitorBrightness", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetMouseMovePointsEx", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetObjectInformation", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetOemBitmapSize", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetOpenClipboardWindow", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetOwnerTransformedMonitorRect", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetPhysicalDeviceRect", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetPointerCursorId", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetPointerDevice", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetPointerDeviceCursors", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetPointerDeviceOrientation", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetPointerDeviceProperties", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetPointerDeviceRects", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetPointerDevices", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetPointerFrameArrivalTimes", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetPointerFrameTimes", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetPointerInfoList", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetPointerInputTransform", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetPointerProprietaryId", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetPointerType", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetPrecisionTouchPadConfiguration", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetPriorityClipboardFormat", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetProcessDpiAwareness", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetProcessDpiAwarenessContext", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetProcessUIContextInformation", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetProcessWindowStation", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetProp", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetQueueEventStatus", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetQueueStatusReadonly", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetRawInputBuffer", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetRawInputData", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetRawInputDeviceInfo", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetRawInputDeviceList", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetRawPointerDeviceData", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetRegisteredRawInputDevices", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetRequiredCursorSizes", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetResizeDCompositionSynchronizationObject", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetScrollBarInfo", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetSystemDpiForProcess", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetSystemMenu", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetThreadDesktop", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetThreadState", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetTitleBarInfo", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetTopLevelWindow", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetTouchInputInfo", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetTouchValidationStatus", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetUniformSpaceMapping", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetUpdateRect", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetUpdateRgn", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetUpdatedClipboardFormats", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetWOWClass", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetWindowBand", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetWindowCompositionAttribute", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetWindowCompositionInfo", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetWindowDC", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetWindowDisplayAffinity", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetWindowFeedbackSetting", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetWindowGroupId", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetWindowMinimizeRect", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetWindowPlacement", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetWindowProcessHandle", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGetWindowRgnEx", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserGhostWindowFromHungWindow", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserHandleDelegatedInput", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserHardErrorControl", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserHideCaret", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserHidePointerContactVisualization", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserHiliteMenuItem", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserHungWindowFromGhostWindow", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserHwndQueryRedirectionInfo", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserHwndSetRedirectionInfo", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserImpersonateDdeClientWindow", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserInheritWindowMonitor", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserInitTask", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserInitialize", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserInitializeClientPfnArrays", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserInitializeGenericHidInjection", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserInitializeInputDeviceInjection", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserInitializePointerDeviceInjection", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserInitializePointerDeviceInjectionEx", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserInitializeTouchInjection", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserInjectDeviceInput", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserInjectGenericHidInput", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserInjectGesture", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserInjectKeyboardInput", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserInjectMouseInput", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserInjectPointerInput", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserInjectTouchInput", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserInteractiveControlQueryUsage", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserInternalClipCursor", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserInternalGetWindowIcon", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserInternalGetWindowText", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserInvalidateRect", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserInvalidateRgn", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserIsChildWindowDpiMessageEnabled", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserIsClipboardFormatAvailable", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserIsMouseInPointerEnabled", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserIsMouseInputEnabled", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserIsNonClientDpiScalingEnabled", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserIsResizeLayoutSynchronizationEnabled", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserIsTopLevelWindow", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserIsTouchWindow", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserIsWindowBroadcastingDpiToChildren", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserIsWindowGDIScaledDpiMessageEnabled", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserKillTimer", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserLayoutCompleted", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserLinkDpiCursor", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserLoadKeyboardLayoutEx", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserLockCursor", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserLockWindowStation", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserLockWindowUpdate", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserLockWorkStation", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserLogicalToPerMonitorDPIPhysicalPoint", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserLogicalToPhysicalDpiPointForWindow", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserLogicalToPhysicalPoint", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserMNDragLeave", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserMNDragOver", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserMagControl", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserMagGetContextInformation", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserMagSetContextInformation", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserManageGestureHandlerWindow", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserMapPointsByVisualIdentifier", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserMapVirtualKeyEx", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserMenuItemFromPoint", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserMessageCall", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserMinMaximize", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserModifyUserStartupInfoFlags", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserModifyWindowTouchCapability", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserMoveWindow", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserMsgWaitForMultipleObjectsEx", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserNavigateFocus", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserNotifyIMEStatus", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserNotifyProcessCreate", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserNotifyWinEvent", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserOpenClipboard", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserOpenDesktop", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserOpenInputDesktop", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserOpenThreadDesktop", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserOpenWindowStation", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserPaintDesktop", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserPaintMenuBar", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserPaintMonitor", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserPeekMessage", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserPerMonitorDPIPhysicalToLogicalPoint", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserPhysicalToLogicalDpiPointForWindow", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserPhysicalToLogicalPoint", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserPostMessage", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserPostThreadMessage", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserPrintWindow", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserProcessConnect", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserProcessInkFeedbackCommand", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserPromoteMouseInPointer", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserPromotePointer", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserQueryActivationObject", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserQueryBSDRWindow", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserQueryDisplayConfig", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserQueryInformationThread", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserQueryInputContext", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserQuerySendMessage", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserQueryWindow", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserRealChildWindowFromPoint", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserRealInternalGetMessage", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserRealWaitMessageEx", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserRedrawWindow", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserRegisterBSDRWindow", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserRegisterClassExWOW", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserRegisterDManipHook", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserRegisterEdgy", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserRegisterErrorReportingDialog", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserRegisterHotKey", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserRegisterManipulationThread", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserRegisterPointerDeviceNotifications", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserRegisterPointerInputTarget", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserRegisterRawInputDevices", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserRegisterServicesProcess", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserRegisterSessionPort", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserRegisterShellPTPListener", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserRegisterTasklist", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserRegisterTouchHitTestingWindow", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserRegisterTouchPadCapable", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserRegisterUserApiHook", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserRegisterWindowMessage", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserReleaseDC", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserReleaseDwmHitTestWaiters", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserRemoteConnect", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserRemoteRedrawRectangle", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserRemoteRedrawScreen", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserRemoteStopScreenUpdates", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserRemoveClipboardFormatListener", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserRemoveInjectionDevice", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserRemoveMenu", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserRemoveProp", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserRemoveVisualIdentifier", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserReportInertia", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserRequestMoveSizeOperation", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserResolveDesktop", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserResolveDesktopForWOW", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserRestoreWindowDpiChanges", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSBGetParms", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserScrollDC", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserScrollWindowEx", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSelectPalette", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSendEventMessage", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSendInput", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSendInteractiveControlHapticsReport", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSendTouchInput", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetActivationFilter", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetActiveProcess", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetActiveProcessForMonitor", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetActiveWindow", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetAppImeLevel", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetAutoRotation", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetBridgeWindowChild", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetBrokeredForeground", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetCalibrationData", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetCapture", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetChildWindowNoActivate", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetClassLong", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetClassLongPtr", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetClassWord", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetClipboardData", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetClipboardViewer", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetConsoleReserveKeys", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetCoreWindow", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetCoreWindowPartner", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetCursor", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetCursorContents", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetCursorIconData", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetCursorPos", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetDesktopColorTransform", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetDialogControlDpiChangeBehavior", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetDimUndimTransitionTime", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetDisplayAutoRotationPreferences", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetDisplayConfig", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetDisplayMapping", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetFallbackForeground", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetFeatureReportResponse", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetFocus", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetForegroundWindowForApplication", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetGestureConfig", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetImeHotKey", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetImeInfoEx", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetImeOwnerWindow", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetImmersiveBackgroundWindow", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetInformationProcess", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetInformationThread", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetInteractiveControlFocus", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetInteractiveCtrlRotationAngle", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetInternalWindowPos", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetKeyboardState", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetLayeredWindowAttributes", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetLogonNotifyWindow", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetMagnificationDesktopMagnifierOffsetsDWMUpdated", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetManipulationInputTarget", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetMenu", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetMenuContextHelpId", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetMenuDefaultItem", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetMenuFlagRtoL", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetMirrorRendering", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetMonitorBrightness", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetObjectInformation", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetParent", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetPrecisionTouchPadConfiguration", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetProcessDPIAware", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetProcessDpiAwareness", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetProcessDpiAwarenessContext", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetProcessInteractionFlags", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetProcessMousewheelRoutingMode", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetProcessRestrictionExemption", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetProcessUIAccessZorder", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetProcessWindowStation", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetProp", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetScrollInfo", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetSensorPresence", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetShellWindowEx", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetSysColors", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetSystemCursor", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetSystemMenu", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetSystemTimer", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetTargetForResourceBrokering", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetThreadDesktop", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetThreadInputBlocked", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetThreadLayoutHandles", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetThreadState", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetTimer", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetWinEventHook", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetWindowArrangement", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetWindowBand", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetWindowCompositionAttribute", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetWindowCompositionTransition", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetWindowDisplayAffinity", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetWindowFNID", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetWindowFeedbackSetting", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetWindowGroup", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetWindowLong", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetWindowLongPtr", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetWindowPlacement", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetWindowPos", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetWindowRgn", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetWindowRgnEx", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetWindowShowState", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetWindowStationUser", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetWindowWord", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetWindowsHookAW", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSetWindowsHookEx", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSfmDestroyLogicalSurfaceBinding", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSfmDxBindSwapChain", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSfmDxGetSwapChainStats", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSfmDxOpenSwapChain", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSfmDxQuerySwapChainBindingStatus", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSfmDxReleaseSwapChain", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSfmDxReportPendingBindingsToDwm", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSfmDxSetSwapChainBindingStatus", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSfmDxSetSwapChainStats", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSfmGetLogicalSurfaceBinding", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserShowCaret", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserShowCursor", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserShowScrollBar", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserShowSystemCursor", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserShowWindow", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserShowWindowAsync", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserShutdownBlockReasonCreate", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserShutdownBlockReasonQuery", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserShutdownReasonDestroy", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSignalRedirectionStartComplete", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSlicerControl", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSoundSentry", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserStopAndEndInertia", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSwitchDesktop", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSystemParametersInfo", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserSystemParametersInfoForDpi", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserTestForInteractiveUser", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserThunkedMenuInfo", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserThunkedMenuItemInfo", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserToUnicodeEx", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserTrackMouseEvent", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserTrackPopupMenuEx", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserTransformPoint", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserTransformRect", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserTranslateAccelerator", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserTranslateMessage", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserUndelegateInput", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserUnhookWinEvent", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserUnhookWindowsHookEx", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserUnloadKeyboardLayout", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserUnlockWindowStation", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserUnregisterClass", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserUnregisterHotKey", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserUnregisterSessionPort", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserUnregisterUserApiHook", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserUpdateDefaultDesktopThumbnail", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserUpdateInputContext", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserUpdateInstance", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserUpdateLayeredWindow", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserUpdatePerUserSystemParameters", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserUpdateWindowInputSinkHints", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserUpdateWindowTrackingInfo", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserUpdateWindowTransform", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserUserHandleGrantAccess", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserValidateHandleSecure", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserValidateRect", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserValidateTimerCallback", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserVkKeyScanEx", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserWOWCleanup", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserWaitAvailableMessageEx", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserWaitForInputIdle", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserWaitForMsgAndEvent", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserWaitForRedirectionStartComplete", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserWaitMessage", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserWin32PoolAllocationStats", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserWindowFromDC", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserWindowFromPhysicalPoint", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserWindowFromPoint", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtUserYieldTask", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtValidateCompositionSurfaceHandle", .ret = NTSTATUS, .num_args = 0 },
-    { .name = "NtVisualCaptureBits", .ret = NTSTATUS, .num_args = 0 },
+	&NtBindCompositionSurface,
+	&NtCloseCompositionInputSink,
+	&NtCompositionInputThread,
+	&NtCompositionSetDropTarget,
+	&NtConfigureInputSpace,
+	&NtCreateCompositionInputSink,
+	&NtCreateCompositionSurfaceHandle,
+	&NtCreateImplicitCompositionInputSink,
+	&NtDCompositionAddCrossDeviceVisualChild,
+	&NtDCompositionAddVisualChild,
+	&NtDCompositionAttachMouseWheelToHwnd,
+	&NtDCompositionBeginFrame,
+	&NtDCompositionCapturePointer,
+	&NtDCompositionCommitChannel,
+	&NtDCompositionCommitSynchronizationObject,
+	&NtDCompositionConfirmFrame,
+	&NtDCompositionConnectPipe,
+	&NtDCompositionCreateAndBindSharedSection,
+	&NtDCompositionCreateChannel,
+	&NtDCompositionCreateConnection,
+	&NtDCompositionCreateConnectionContext,
+	&NtDCompositionCreateDwmChannel,
+	&NtDCompositionCreateResource,
+	&NtDCompositionCreateSharedResourceHandle,
+	&NtDCompositionCreateSharedVisualHandle,
+	&NtDCompositionCreateSynchronizationObject,
+	&NtDCompositionCurrentBatchId,
+	&NtDCompositionDestroyChannel,
+	&NtDCompositionDestroyConnection,
+	&NtDCompositionDestroyConnectionContext,
+	&NtDCompositionDiscardFrame,
+	&NtDCompositionDuplicateHandleToProcess,
+	&NtDCompositionDuplicateSwapchainHandleToDwm,
+	&NtDCompositionDwmSyncFlush,
+	&NtDCompositionEnableDDASupport,
+	&NtDCompositionEnableMMCSS,
+	&NtDCompositionGetAnimationTime,
+	&NtDCompositionGetBatchId,
+	&NtDCompositionGetChannels,
+	&NtDCompositionGetConnectionBatch,
+	&NtDCompositionGetConnectionContextBatch,
+	&NtDCompositionGetDeletedResources,
+	&NtDCompositionGetFrameLegacyTokens,
+	&NtDCompositionGetFrameStatistics,
+	&NtDCompositionGetFrameSurfaceUpdates,
+	&NtDCompositionGetMaterialProperty,
+	&NtDCompositionOpenSharedResource,
+	&NtDCompositionOpenSharedResourceHandle,
+	&NtDCompositionProcessChannelBatchBuffer,
+	&NtDCompositionReferenceSharedResourceOnDwmChannel,
+	&NtDCompositionRegisterThumbnailVisual,
+	&NtDCompositionRegisterVirtualDesktopVisual,
+	&NtDCompositionReleaseAllResources,
+	&NtDCompositionReleaseResource,
+	&NtDCompositionRemoveCrossDeviceVisualChild,
+	&NtDCompositionRemoveVisualChild,
+	&NtDCompositionReplaceVisualChildren,
+	&NtDCompositionRetireFrame,
+	&NtDCompositionSetChannelCallbackId,
+	&NtDCompositionSetChannelCommitCompletionEvent,
+	&NtDCompositionSetChannelConnectionId,
+	&NtDCompositionSetChildRootVisual,
+	&NtDCompositionSetDebugCounter,
+	&NtDCompositionSetMaterialProperty,
+	&NtDCompositionSetResourceAnimationProperty,
+	&NtDCompositionSetResourceBufferProperty,
+	&NtDCompositionSetResourceCallbackId,
+	&NtDCompositionSetResourceDeletedNotificationTag,
+	&NtDCompositionSetResourceFloatProperty,
+	&NtDCompositionSetResourceHandleProperty,
+	&NtDCompositionSetResourceIntegerProperty,
+	&NtDCompositionSetResourceReferenceArrayProperty,
+	&NtDCompositionSetResourceReferenceProperty,
+	&NtDCompositionSetVisualInputSink,
+	&NtDCompositionSignalGpuFence,
+	&NtDCompositionSubmitDWMBatch,
+	&NtDCompositionSuspendAnimations,
+	&NtDCompositionSynchronize,
+	&NtDCompositionTelemetryAnimationScenarioBegin,
+	&NtDCompositionTelemetryAnimationScenarioReference,
+	&NtDCompositionTelemetryAnimationScenarioUnreference,
+	&NtDCompositionTelemetrySetApplicationId,
+	&NtDCompositionTelemetryTouchInteractionBegin,
+	&NtDCompositionTelemetryTouchInteractionEnd,
+	&NtDCompositionTelemetryTouchInteractionUpdate,
+	&NtDCompositionUpdatePointerCapture,
+	&NtDCompositionValidateAndReferenceSystemVisualForHwndTarget,
+	&NtDCompositionWaitForChannel,
+	&NtDWMBindCursorToOutputConfig,
+	&NtDWMCommitInputSystemOutputConfig,
+	&NtDWMSetCursorOrientation,
+	&NtDWMSetInputSystemOutputConfig,
+	&NtDesktopCaptureBits,
+	&NtDuplicateCompositionInputSink,
+	&NtDxgkCreateTrackedWorkload,
+	&NtDxgkDestroyTrackedWorkload,
+	&NtDxgkDispMgrOperation,
+	&NtDxgkEndTrackedWorkload,
+	&NtDxgkGetAvailableTrackedWorkloadIndex,
+	&NtDxgkGetProcessList,
+	&NtDxgkGetTrackedWorkloadStatistics,
+	&NtDxgkOutputDuplPresentToHwQueue,
+	&NtDxgkRegisterVailProcess,
+	&NtDxgkResetTrackedWorkload,
+	&NtDxgkSubmitPresentBltToHwQueue,
+	&NtDxgkSubmitPresentToHwQueue,
+	&NtDxgkUpdateTrackedWorkload,
+	&NtDxgkVailConnect,
+	&NtDxgkVailDisconnect,
+	&NtDxgkVailPromoteCompositionSurface,
+	&NtEnableOneCoreTransformMode,
+	&NtFlipObjectAddContent,
+	&NtFlipObjectAddPoolBuffer,
+	&NtFlipObjectConsumerAcquirePresent,
+	&NtFlipObjectConsumerAdjustUsageReference,
+	&NtFlipObjectConsumerBeginProcessPresent,
+	&NtFlipObjectConsumerEndProcessPresent,
+	&NtFlipObjectConsumerPostMessage,
+	&NtFlipObjectConsumerQueryBufferInfo,
+	&NtFlipObjectCreate,
+	&NtFlipObjectDisconnectEndpoint,
+	&NtFlipObjectOpen,
+	&NtFlipObjectPresentCancel,
+	&NtFlipObjectQueryBufferAvailableEvent,
+	&NtFlipObjectQueryEndpointConnected,
+	&NtFlipObjectQueryNextMessageToProducer,
+	&NtFlipObjectReadNextMessageToProducer,
+	&NtFlipObjectRemoveContent,
+	&NtFlipObjectRemovePoolBuffer,
+	&NtFlipObjectSetContent,
+	&NtGdiAbortDoc,
+	&NtGdiAbortPath,
+	&NtGdiAddEmbFontToDC,
+	&NtGdiAddFontMemResourceEx,
+	&NtGdiAddFontResourceW,
+	&NtGdiAddInitialFonts,
+	&NtGdiAddRemoteFontToDC,
+	&NtGdiAddRemoteMMInstanceToDC,
+	&NtGdiAlphaBlend,
+	&NtGdiAngleArc,
+	&NtGdiAnyLinkedFonts,
+	&NtGdiArcInternal,
+	&NtGdiBRUSHOBJ_DeleteRbrush,
+	&NtGdiBRUSHOBJ_hGetColorTransform,
+	&NtGdiBRUSHOBJ_pvAllocRbrush,
+	&NtGdiBRUSHOBJ_pvGetRbrush,
+	&NtGdiBRUSHOBJ_ulGetBrushColor,
+	&NtGdiBeginGdiRendering,
+	&NtGdiBeginPath,
+	&NtGdiBitBlt,
+	&NtGdiCLIPOBJ_bEnum,
+	&NtGdiCLIPOBJ_cEnumStart,
+	&NtGdiCLIPOBJ_ppoGetPath,
+	&NtGdiCancelDC,
+	&NtGdiChangeGhostFont,
+	&NtGdiCheckBitmapBits,
+	&NtGdiClearBitmapAttributes,
+	&NtGdiClearBrushAttributes,
+	&NtGdiCloseFigure,
+	&NtGdiColorCorrectPalette,
+	&NtGdiCombineRgn,
+	&NtGdiCombineTransform,
+	&NtGdiComputeXformCoefficients,
+	&NtGdiConfigureOPMProtectedOutput,
+	&NtGdiConsoleTextOut,
+	&NtGdiConvertMetafileRect,
+	&NtGdiCreateBitmap,
+	&NtGdiCreateBitmapFromDxSurface,
+	&NtGdiCreateBitmapFromDxSurface2,
+	&NtGdiCreateClientObj,
+	&NtGdiCreateColorSpace,
+	&NtGdiCreateColorTransform,
+	&NtGdiCreateCompatibleBitmap,
+	&NtGdiCreateCompatibleDC,
+	&NtGdiCreateDIBBrush,
+	&NtGdiCreateDIBSection,
+	&NtGdiCreateDIBitmapInternal,
+	&NtGdiCreateEllipticRgn,
+	&NtGdiCreateHalftonePalette,
+	&NtGdiCreateHatchBrushInternal,
+	&NtGdiCreateMetafileDC,
+	&NtGdiCreateOPMProtectedOutput,
+	&NtGdiCreateOPMProtectedOutputs,
+	&NtGdiCreatePaletteInternal,
+	&NtGdiCreatePatternBrushInternal,
+	&NtGdiCreatePen,
+	&NtGdiCreateRectRgn,
+	&NtGdiCreateRoundRectRgn,
+	&NtGdiCreateServerMetaFile,
+	&NtGdiCreateSessionMappedDIBSection,
+	&NtGdiCreateSolidBrush,
+	&NtGdiD3dContextCreate,
+	&NtGdiD3dContextDestroy,
+	&NtGdiD3dContextDestroyAll,
+	&NtGdiD3dDrawPrimitives2,
+	&NtGdiD3dValidateTextureStageState,
+	&NtGdiDDCCIGetCapabilitiesString,
+	&NtGdiDDCCIGetCapabilitiesStringLength,
+	&NtGdiDDCCIGetTimingReport,
+	&NtGdiDDCCIGetVCPFeature,
+	&NtGdiDDCCISaveCurrentSettings,
+	&NtGdiDDCCISetVCPFeature,
+	&NtGdiDdAddAttachedSurface,
+	&NtGdiDdAlphaBlt,
+	&NtGdiDdAttachSurface,
+	&NtGdiDdBeginMoCompFrame,
+	&NtGdiDdBlt,
+	&NtGdiDdCanCreateD3DBuffer,
+	&NtGdiDdCanCreateSurface,
+	&NtGdiDdColorControl,
+	&NtGdiDdCreateD3DBuffer,
+	&NtGdiDdCreateDirectDrawObject,
+	&NtGdiDdCreateFullscreenSprite,
+	&NtGdiDdCreateMoComp,
+	&NtGdiDdCreateSurface,
+	&NtGdiDdCreateSurfaceEx,
+	&NtGdiDdCreateSurfaceObject,
+	&NtGdiDdDDIAbandonSwapChain,
+	&NtGdiDdDDIAcquireKeyedMutex,
+	&NtGdiDdDDIAcquireKeyedMutex2,
+	&NtGdiDdDDIAcquireSwapChain,
+	&NtGdiDdDDIAddSurfaceToSwapChain,
+	&NtGdiDdDDIAdjustFullscreenGamma,
+	&NtGdiDdDDICacheHybridQueryValue,
+	&NtGdiDdDDIChangeVideoMemoryReservation,
+	&NtGdiDdDDICheckExclusiveOwnership,
+	&NtGdiDdDDICheckMonitorPowerState,
+	&NtGdiDdDDICheckMultiPlaneOverlaySupport,
+	&NtGdiDdDDICheckMultiPlaneOverlaySupport2,
+	&NtGdiDdDDICheckMultiPlaneOverlaySupport3,
+	&NtGdiDdDDICheckOcclusion,
+	&NtGdiDdDDICheckSharedResourceAccess,
+	&NtGdiDdDDICheckVidPnExclusiveOwnership,
+	&NtGdiDdDDICloseAdapter,
+	&NtGdiDdDDIConfigureSharedResource,
+	&NtGdiDdDDICreateAllocation,
+	&NtGdiDdDDICreateBundleObject,
+	&NtGdiDdDDICreateContext,
+	&NtGdiDdDDICreateContextVirtual,
+	&NtGdiDdDDICreateDCFromMemory,
+	&NtGdiDdDDICreateDevice,
+	&NtGdiDdDDICreateHwContext,
+	&NtGdiDdDDICreateHwQueue,
+	&NtGdiDdDDICreateKeyedMutex,
+	&NtGdiDdDDICreateKeyedMutex2,
+	&NtGdiDdDDICreateOutputDupl,
+	&NtGdiDdDDICreateOverlay,
+	&NtGdiDdDDICreatePagingQueue,
+	&NtGdiDdDDICreateProtectedSession,
+	&NtGdiDdDDICreateSwapChain,
+	&NtGdiDdDDICreateSynchronizationObject,
+	&NtGdiDdDDIDDisplayEnum,
+	&NtGdiDdDDIDestroyAllocation,
+	&NtGdiDdDDIDestroyAllocation2,
+	&NtGdiDdDDIDestroyContext,
+	&NtGdiDdDDIDestroyDCFromMemory,
+	&NtGdiDdDDIDestroyDevice,
+	&NtGdiDdDDIDestroyHwContext,
+	&NtGdiDdDDIDestroyHwQueue,
+	&NtGdiDdDDIDestroyKeyedMutex,
+	&NtGdiDdDDIDestroyOutputDupl,
+	&NtGdiDdDDIDestroyOverlay,
+	&NtGdiDdDDIDestroyPagingQueue,
+	&NtGdiDdDDIDestroyProtectedSession,
+	&NtGdiDdDDIDestroySynchronizationObject,
+	&NtGdiDdDDIDispMgrCreate,
+	&NtGdiDdDDIDispMgrSourceOperation,
+	&NtGdiDdDDIDispMgrTargetOperation,
+	&NtGdiDdDDIEnumAdapters,
+	&NtGdiDdDDIEnumAdapters2,
+	&NtGdiDdDDIEscape,
+	&NtGdiDdDDIEvict,
+	&NtGdiDdDDIExtractBundleObject,
+	&NtGdiDdDDIFlipOverlay,
+	&NtGdiDdDDIFlushHeapTransitions,
+	&NtGdiDdDDIFreeGpuVirtualAddress,
+	&NtGdiDdDDIGetAllocationPriority,
+	&NtGdiDdDDIGetCachedHybridQueryValue,
+	&NtGdiDdDDIGetContextInProcessSchedulingPriority,
+	&NtGdiDdDDIGetContextSchedulingPriority,
+	&NtGdiDdDDIGetDWMVerticalBlankEvent,
+	&NtGdiDdDDIGetDeviceState,
+	&NtGdiDdDDIGetDisplayModeList,
+	&NtGdiDdDDIGetMemoryBudgetTarget,
+	&NtGdiDdDDIGetMultiPlaneOverlayCaps,
+	&NtGdiDdDDIGetMultisampleMethodList,
+	&NtGdiDdDDIGetOverlayState,
+	&NtGdiDdDDIGetPostCompositionCaps,
+	&NtGdiDdDDIGetPresentHistory,
+	&NtGdiDdDDIGetPresentQueueEvent,
+	&NtGdiDdDDIGetProcessDeviceLostSupport,
+	&NtGdiDdDDIGetProcessDeviceRemovalSupport,
+	&NtGdiDdDDIGetProcessSchedulingPriorityBand,
+	&NtGdiDdDDIGetProcessSchedulingPriorityClass,
+	&NtGdiDdDDIGetResourcePresentPrivateDriverData,
+	&NtGdiDdDDIGetRuntimeData,
+	&NtGdiDdDDIGetScanLine,
+	&NtGdiDdDDIGetSetSwapChainMetadata,
+	&NtGdiDdDDIGetSharedPrimaryHandle,
+	&NtGdiDdDDIGetSharedResourceAdapterLuid,
+	&NtGdiDdDDIGetSharedResourceAdapterLuidFlipManager,
+	&NtGdiDdDDIGetYieldPercentage,
+	&NtGdiDdDDIInvalidateActiveVidPn,
+	&NtGdiDdDDIInvalidateCache,
+	&NtGdiDdDDILock,
+	&NtGdiDdDDILock2,
+	&NtGdiDdDDIMakeResident,
+	&NtGdiDdDDIMapGpuVirtualAddress,
+	&NtGdiDdDDIMarkDeviceAsError,
+	&NtGdiDdDDINetDispGetNextChunkInfo,
+	&NtGdiDdDDINetDispQueryMiracastDisplayDeviceStatus,
+	&NtGdiDdDDINetDispQueryMiracastDisplayDeviceSupport,
+	&NtGdiDdDDINetDispStartMiracastDisplayDevice,
+	&NtGdiDdDDINetDispStartMiracastDisplayDeviceEx,
+	&NtGdiDdDDINetDispStopMiracastDisplayDevice,
+	&NtGdiDdDDINetDispStopSessions,
+	&NtGdiDdDDIOfferAllocations,
+	&NtGdiDdDDIOpenAdapterFromDeviceName,
+	&NtGdiDdDDIOpenAdapterFromHdc,
+	&NtGdiDdDDIOpenAdapterFromLuid,
+	&NtGdiDdDDIOpenBundleObjectNtHandleFromName,
+	&NtGdiDdDDIOpenKeyedMutex,
+	&NtGdiDdDDIOpenKeyedMutex2,
+	&NtGdiDdDDIOpenKeyedMutexFromNtHandle,
+	&NtGdiDdDDIOpenNtHandleFromName,
+	&NtGdiDdDDIOpenProtectedSessionFromNtHandle,
+	&NtGdiDdDDIOpenResource,
+	&NtGdiDdDDIOpenResourceFromNtHandle,
+	&NtGdiDdDDIOpenSwapChain,
+	&NtGdiDdDDIOpenSyncObjectFromNtHandle,
+	&NtGdiDdDDIOpenSyncObjectFromNtHandle2,
+	&NtGdiDdDDIOpenSyncObjectNtHandleFromName,
+	&NtGdiDdDDIOpenSynchronizationObject,
+	&NtGdiDdDDIOutputDuplGetFrameInfo,
+	&NtGdiDdDDIOutputDuplGetMetaData,
+	&NtGdiDdDDIOutputDuplGetPointerShapeData,
+	&NtGdiDdDDIOutputDuplPresent,
+	&NtGdiDdDDIOutputDuplReleaseFrame,
+	&NtGdiDdDDIPinDirectFlipResources,
+	&NtGdiDdDDIPollDisplayChildren,
+	&NtGdiDdDDIPresent,
+	&NtGdiDdDDIPresentMultiPlaneOverlay,
+	&NtGdiDdDDIPresentMultiPlaneOverlay2,
+	&NtGdiDdDDIPresentMultiPlaneOverlay3,
+	&NtGdiDdDDIPresentRedirected,
+	&NtGdiDdDDIQueryAdapterInfo,
+	&NtGdiDdDDIQueryAllocationResidency,
+	&NtGdiDdDDIQueryClockCalibration,
+	&NtGdiDdDDIQueryFSEBlock,
+	&NtGdiDdDDIQueryProcessOfferInfo,
+	&NtGdiDdDDIQueryProtectedSessionInfoFromNtHandle,
+	&NtGdiDdDDIQueryProtectedSessionStatus,
+	&NtGdiDdDDIQueryRemoteVidPnSourceFromGdiDisplayName,
+	&NtGdiDdDDIQueryResourceInfo,
+	&NtGdiDdDDIQueryResourceInfoFromNtHandle,
+	&NtGdiDdDDIQueryStatistics,
+	&NtGdiDdDDIQueryVidPnExclusiveOwnership,
+	&NtGdiDdDDIQueryVideoMemoryInfo,
+	&NtGdiDdDDIReclaimAllocations,
+	&NtGdiDdDDIReclaimAllocations2,
+	&NtGdiDdDDIReleaseKeyedMutex,
+	&NtGdiDdDDIReleaseKeyedMutex2,
+	&NtGdiDdDDIReleaseProcessVidPnSourceOwners,
+	&NtGdiDdDDIReleaseSwapChain,
+	&NtGdiDdDDIRemoveSurfaceFromSwapChain,
+	&NtGdiDdDDIRender,
+	&NtGdiDdDDIReserveGpuVirtualAddress,
+	&NtGdiDdDDISetAllocationPriority,
+	&NtGdiDdDDISetContextInProcessSchedulingPriority,
+	&NtGdiDdDDISetContextSchedulingPriority,
+	&NtGdiDdDDISetDeviceLostSupport,
+	&NtGdiDdDDISetDisplayMode,
+	&NtGdiDdDDISetDisplayPrivateDriverFormat,
+	&NtGdiDdDDISetDodIndirectSwapchain,
+	&NtGdiDdDDISetFSEBlock,
+	&NtGdiDdDDISetGammaRamp,
+	&NtGdiDdDDISetHwProtectionTeardownRecovery,
+	&NtGdiDdDDISetMemoryBudgetTarget,
+	&NtGdiDdDDISetMonitorColorSpaceTransform,
+	&NtGdiDdDDISetProcessDeviceRemovalSupport,
+	&NtGdiDdDDISetProcessSchedulingPriorityBand,
+	&NtGdiDdDDISetProcessSchedulingPriorityClass,
+	&NtGdiDdDDISetQueuedLimit,
+	&NtGdiDdDDISetStablePowerState,
+	&NtGdiDdDDISetStereoEnabled,
+	&NtGdiDdDDISetSyncRefreshCountWaitTarget,
+	&NtGdiDdDDISetVidPnSourceHwProtection,
+	&NtGdiDdDDISetVidPnSourceOwner,
+	&NtGdiDdDDISetVidPnSourceOwner1,
+	&NtGdiDdDDISetYieldPercentage,
+	&NtGdiDdDDIShareObjects,
+	&NtGdiDdDDISharedPrimaryLockNotification,
+	&NtGdiDdDDISharedPrimaryUnLockNotification,
+	&NtGdiDdDDISignalSynchronizationObject,
+	&NtGdiDdDDISignalSynchronizationObjectFromCpu,
+	&NtGdiDdDDISignalSynchronizationObjectFromGpu,
+	&NtGdiDdDDISignalSynchronizationObjectFromGpu2,
+	&NtGdiDdDDISubmitCommand,
+	&NtGdiDdDDISubmitCommandToHwQueue,
+	&NtGdiDdDDISubmitSignalSyncObjectsToHwQueue,
+	&NtGdiDdDDISubmitWaitForSyncObjectsToHwQueue,
+	&NtGdiDdDDITrimProcessCommitment,
+	&NtGdiDdDDIUnOrderedPresentSwapChain,
+	&NtGdiDdDDIUnlock,
+	&NtGdiDdDDIUnlock2,
+	&NtGdiDdDDIUnpinDirectFlipResources,
+	&NtGdiDdDDIUpdateAllocationProperty,
+	&NtGdiDdDDIUpdateGpuVirtualAddress,
+	&NtGdiDdDDIUpdateOverlay,
+	&NtGdiDdDDIWaitForIdle,
+	&NtGdiDdDDIWaitForSynchronizationObject,
+	&NtGdiDdDDIWaitForSynchronizationObjectFromCpu,
+	&NtGdiDdDDIWaitForSynchronizationObjectFromGpu,
+	&NtGdiDdDDIWaitForVerticalBlankEvent,
+	&NtGdiDdDDIWaitForVerticalBlankEvent2,
+	&NtGdiDdDeleteDirectDrawObject,
+	&NtGdiDdDeleteSurfaceObject,
+	&NtGdiDdDestroyD3DBuffer,
+	&NtGdiDdDestroyFullscreenSprite,
+	&NtGdiDdDestroyMoComp,
+	&NtGdiDdDestroySurface,
+	&NtGdiDdEndMoCompFrame,
+	&NtGdiDdFlip,
+	&NtGdiDdFlipToGDISurface,
+	&NtGdiDdGetAvailDriverMemory,
+	&NtGdiDdGetBltStatus,
+	&NtGdiDdGetDC,
+	&NtGdiDdGetDriverInfo,
+	&NtGdiDdGetDriverState,
+	&NtGdiDdGetDxHandle,
+	&NtGdiDdGetFlipStatus,
+	&NtGdiDdGetInternalMoCompInfo,
+	&NtGdiDdGetMoCompBuffInfo,
+	&NtGdiDdGetMoCompFormats,
+	&NtGdiDdGetMoCompGuids,
+	&NtGdiDdGetScanLine,
+	&NtGdiDdLock,
+	&NtGdiDdLockD3D,
+	&NtGdiDdNotifyFullscreenSpriteUpdate,
+	&NtGdiDdQueryDirectDrawObject,
+	&NtGdiDdQueryMoCompStatus,
+	&NtGdiDdQueryVisRgnUniqueness,
+	&NtGdiDdReenableDirectDrawObject,
+	&NtGdiDdReleaseDC,
+	&NtGdiDdRenderMoComp,
+	&NtGdiDdResetVisrgn,
+	&NtGdiDdSetColorKey,
+	&NtGdiDdSetExclusiveMode,
+	&NtGdiDdSetGammaRamp,
+	&NtGdiDdSetOverlayPosition,
+	&NtGdiDdUnattachSurface,
+	&NtGdiDdUnlock,
+	&NtGdiDdUnlockD3D,
+	&NtGdiDdUpdateOverlay,
+	&NtGdiDdWaitForVerticalBlank,
+	&NtGdiDeleteClientObj,
+	&NtGdiDeleteColorSpace,
+	&NtGdiDeleteColorTransform,
+	&NtGdiDeleteObjectApp,
+	&NtGdiDescribePixelFormat,
+	&NtGdiDestroyOPMProtectedOutput,
+	&NtGdiDestroyPhysicalMonitor,
+	&NtGdiDoBanding,
+	&NtGdiDoPalette,
+	&NtGdiDrawEscape,
+	&NtGdiDrawStream,
+	&NtGdiDvpAcquireNotification,
+	&NtGdiDvpCanCreateVideoPort,
+	&NtGdiDvpColorControl,
+	&NtGdiDvpCreateVideoPort,
+	&NtGdiDvpDestroyVideoPort,
+	&NtGdiDvpFlipVideoPort,
+	&NtGdiDvpGetVideoPortBandwidth,
+	&NtGdiDvpGetVideoPortConnectInfo,
+	&NtGdiDvpGetVideoPortField,
+	&NtGdiDvpGetVideoPortFlipStatus,
+	&NtGdiDvpGetVideoPortInputFormats,
+	&NtGdiDvpGetVideoPortLine,
+	&NtGdiDvpGetVideoPortOutputFormats,
+	&NtGdiDvpGetVideoSignalStatus,
+	&NtGdiDvpReleaseNotification,
+	&NtGdiDvpUpdateVideoPort,
+	&NtGdiDvpWaitForVideoPortSync,
+	&NtGdiDwmCreatedBitmapRemotingOutput,
+	&NtGdiDwmGetDirtyRgn,
+	&NtGdiDwmGetSurfaceData,
+	&NtGdiDxgGenericThunk,
+	&NtGdiEllipse,
+	&NtGdiEnableEudc,
+	&NtGdiEndDoc,
+	&NtGdiEndGdiRendering,
+	&NtGdiEndPage,
+	&NtGdiEndPath,
+	&NtGdiEngAlphaBlend,
+	&NtGdiEngAssociateSurface,
+	&NtGdiEngBitBlt,
+	&NtGdiEngCheckAbort,
+	&NtGdiEngComputeGlyphSet,
+	&NtGdiEngCopyBits,
+	&NtGdiEngCreateBitmap,
+	&NtGdiEngCreateClip,
+	&NtGdiEngCreateDeviceBitmap,
+	&NtGdiEngCreateDeviceSurface,
+	&NtGdiEngCreatePalette,
+	&NtGdiEngDeleteClip,
+	&NtGdiEngDeletePalette,
+	&NtGdiEngDeletePath,
+	&NtGdiEngDeleteSurface,
+	&NtGdiEngEraseSurface,
+	&NtGdiEngFillPath,
+	&NtGdiEngGradientFill,
+	&NtGdiEngLineTo,
+	&NtGdiEngLockSurface,
+	&NtGdiEngMarkBandingSurface,
+	&NtGdiEngPaint,
+	&NtGdiEngPlgBlt,
+	&NtGdiEngStretchBlt,
+	&NtGdiEngStretchBltROP,
+	&NtGdiEngStrokeAndFillPath,
+	&NtGdiEngStrokePath,
+	&NtGdiEngTextOut,
+	&NtGdiEngTransparentBlt,
+	&NtGdiEngUnlockSurface,
+	&NtGdiEnsureDpiDepDefaultGuiFontForPlateau,
+	&NtGdiEnumFontChunk,
+	&NtGdiEnumFontClose,
+	&NtGdiEnumFontOpen,
+	&NtGdiEnumFonts,
+	&NtGdiEnumObjects,
+	&NtGdiEqualRgn,
+	&NtGdiEudcLoadUnloadLink,
+	&NtGdiExcludeClipRect,
+	&NtGdiExtCreatePen,
+	&NtGdiExtCreateRegion,
+	&NtGdiExtEscape,
+	&NtGdiExtFloodFill,
+	&NtGdiExtGetObjectW,
+	&NtGdiExtSelectClipRgn,
+	&NtGdiExtTextOutW,
+	&NtGdiFONTOBJ_cGetAllGlyphHandles,
+	&NtGdiFONTOBJ_cGetGlyphs,
+	&NtGdiFONTOBJ_pQueryGlyphAttrs,
+	&NtGdiFONTOBJ_pfdg,
+	&NtGdiFONTOBJ_pifi,
+	&NtGdiFONTOBJ_pvTrueTypeFontFile,
+	&NtGdiFONTOBJ_pxoGetXform,
+	&NtGdiFONTOBJ_vGetInfo,
+	&NtGdiFillPath,
+	&NtGdiFillRgn,
+	&NtGdiFlattenPath,
+	&NtGdiFlush,
+	&NtGdiFontIsLinked,
+	&NtGdiForceUFIMapping,
+	&NtGdiFrameRgn,
+	&NtGdiFullscreenControl,
+	&NtGdiGetAndSetDCDword,
+	&NtGdiGetAppClipBox,
+	&NtGdiGetAppliedDeviceGammaRamp,
+	&NtGdiGetBitmapBits,
+	&NtGdiGetBitmapDimension,
+	&NtGdiGetBitmapDpiScaleValue,
+	&NtGdiGetBoundsRect,
+	&NtGdiGetCOPPCompatibleOPMInformation,
+	&NtGdiGetCertificate,
+	&NtGdiGetCertificateByHandle,
+	&NtGdiGetCertificateSize,
+	&NtGdiGetCertificateSizeByHandle,
+	&NtGdiGetCharABCWidthsW,
+	&NtGdiGetCharSet,
+	&NtGdiGetCharWidthInfo,
+	&NtGdiGetCharWidthW,
+	&NtGdiGetCharacterPlacementW,
+	&NtGdiGetColorAdjustment,
+	&NtGdiGetColorSpaceforBitmap,
+	&NtGdiGetCurrentDpiInfo,
+	&NtGdiGetDCDpiScaleValue,
+	&NtGdiGetDCDword,
+	&NtGdiGetDCObject,
+	&NtGdiGetDCPoint,
+	&NtGdiGetDCforBitmap,
+	&NtGdiGetDIBitsInternal,
+	&NtGdiGetDeviceCaps,
+	&NtGdiGetDeviceCapsAll,
+	&NtGdiGetDeviceGammaRamp,
+	&NtGdiGetDeviceWidth,
+	&NtGdiGetDhpdev,
+	&NtGdiGetETM,
+	&NtGdiGetEmbUFI,
+	&NtGdiGetEmbedFonts,
+	&NtGdiGetEntry,
+	&NtGdiGetEudcTimeStampEx,
+	&NtGdiGetFontData,
+	&NtGdiGetFontFileData,
+	&NtGdiGetFontFileInfo,
+	&NtGdiGetFontResourceInfoInternalW,
+	&NtGdiGetFontUnicodeRanges,
+	&NtGdiGetGammaRampCapability,
+	&NtGdiGetGlyphIndicesW,
+	&NtGdiGetGlyphIndicesWInternal,
+	&NtGdiGetGlyphOutline,
+	&NtGdiGetKerningPairs,
+	&NtGdiGetLinkedUFIs,
+	&NtGdiGetMiterLimit,
+	&NtGdiGetMonitorID,
+	&NtGdiGetNearestColor,
+	&NtGdiGetNearestPaletteIndex,
+	&NtGdiGetNumberOfPhysicalMonitors,
+	&NtGdiGetOPMInformation,
+	&NtGdiGetOPMRandomNumber,
+	&NtGdiGetObjectBitmapHandle,
+	&NtGdiGetOutlineTextMetricsInternalW,
+	&NtGdiGetPath,
+	&NtGdiGetPerBandInfo,
+	&NtGdiGetPhysicalMonitorDescription,
+	&NtGdiGetPhysicalMonitors,
+	&NtGdiGetPixel,
+	&NtGdiGetProcessSessionFonts,
+	&NtGdiGetPublicFontTableChangeCookie,
+	&NtGdiGetRandomRgn,
+	&NtGdiGetRasterizerCaps,
+	&NtGdiGetRealizationInfo,
+	&NtGdiGetRegionData,
+	&NtGdiGetRgnBox,
+	&NtGdiGetServerMetaFileBits,
+	&NtGdiGetSpoolMessage,
+	&NtGdiGetStats,
+	&NtGdiGetStockObject,
+	&NtGdiGetStringBitmapW,
+	&NtGdiGetSuggestedOPMProtectedOutputArraySize,
+	&NtGdiGetSystemPaletteUse,
+	&NtGdiGetTextCharsetInfo,
+	&NtGdiGetTextExtent,
+	&NtGdiGetTextExtentExW,
+	&NtGdiGetTextFaceW,
+	&NtGdiGetTextMetricsW,
+	&NtGdiGetTransform,
+	&NtGdiGetUFI,
+	&NtGdiGetUFIPathname,
+	&NtGdiGetWidthTable,
+	&NtGdiGradientFill,
+	&NtGdiHLSurfGetInformation,
+	&NtGdiHLSurfSetInformation,
+	&NtGdiHT_Get8BPPFormatPalette,
+	&NtGdiHT_Get8BPPMaskPalette,
+	&NtGdiHfontCreate,
+	&NtGdiIcmBrushInfo,
+	&NtGdiInit,
+	&NtGdiInitSpool,
+	&NtGdiIntersectClipRect,
+	&NtGdiInvertRgn,
+	&NtGdiLineTo,
+	&NtGdiMakeFontDir,
+	&NtGdiMakeInfoDC,
+	&NtGdiMakeObjectUnXferable,
+	&NtGdiMakeObjectXferable,
+	&NtGdiMaskBlt,
+	&NtGdiMirrorWindowOrg,
+	&NtGdiModifyWorldTransform,
+	&NtGdiMonoBitmap,
+	&NtGdiMoveTo,
+	&NtGdiOffsetClipRgn,
+	&NtGdiOffsetRgn,
+	&NtGdiOpenDCW,
+	&NtGdiPATHOBJ_bEnum,
+	&NtGdiPATHOBJ_bEnumClipLines,
+	&NtGdiPATHOBJ_vEnumStart,
+	&NtGdiPATHOBJ_vEnumStartClipLines,
+	&NtGdiPATHOBJ_vGetBounds,
+	&NtGdiPatBlt,
+	&NtGdiPathToRegion,
+	&NtGdiPlgBlt,
+	&NtGdiPolyDraw,
+	&NtGdiPolyPatBlt,
+	&NtGdiPolyPolyDraw,
+	&NtGdiPolyTextOutW,
+	&NtGdiPtInRegion,
+	&NtGdiPtVisible,
+	&NtGdiQueryFontAssocInfo,
+	&NtGdiQueryFonts,
+	&NtGdiRectInRegion,
+	&NtGdiRectVisible,
+	&NtGdiRectangle,
+	&NtGdiRemoveFontMemResourceEx,
+	&NtGdiRemoveFontResourceW,
+	&NtGdiRemoveMergeFont,
+	&NtGdiResetDC,
+	&NtGdiResizePalette,
+	&NtGdiRestoreDC,
+	&NtGdiRoundRect,
+	&NtGdiSTROBJ_bEnum,
+	&NtGdiSTROBJ_bEnumPositionsOnly,
+	&NtGdiSTROBJ_bGetAdvanceWidths,
+	&NtGdiSTROBJ_dwGetCodePage,
+	&NtGdiSTROBJ_vEnumStart,
+	&NtGdiSaveDC,
+	&NtGdiScaleRgn,
+	&NtGdiScaleValues,
+	&NtGdiScaleViewportExtEx,
+	&NtGdiScaleWindowExtEx,
+	&NtGdiSelectBitmap,
+	&NtGdiSelectBrush,
+	&NtGdiSelectClipPath,
+	&NtGdiSelectFont,
+	&NtGdiSelectPen,
+	&NtGdiSetBitmapAttributes,
+	&NtGdiSetBitmapBits,
+	&NtGdiSetBitmapDimension,
+	&NtGdiSetBoundsRect,
+	&NtGdiSetBrushAttributes,
+	&NtGdiSetBrushOrg,
+	&NtGdiSetColorAdjustment,
+	&NtGdiSetColorSpace,
+	&NtGdiSetDIBitsToDeviceInternal,
+	&NtGdiSetDeviceGammaRamp,
+	&NtGdiSetFontEnumeration,
+	&NtGdiSetFontXform,
+	&NtGdiSetIcmMode,
+	&NtGdiSetLayout,
+	&NtGdiSetLinkedUFIs,
+	&NtGdiSetMagicColors,
+	&NtGdiSetMetaRgn,
+	&NtGdiSetMiterLimit,
+	&NtGdiSetOPMSigningKeyAndSequenceNumbers,
+	&NtGdiSetPUMPDOBJ,
+	&NtGdiSetPixel,
+	&NtGdiSetPixelFormat,
+	&NtGdiSetPrivateDeviceGammaRamp,
+	&NtGdiSetRectRgn,
+	&NtGdiSetSizeDevice,
+	&NtGdiSetSystemPaletteUse,
+	&NtGdiSetTextJustification,
+	&NtGdiSetUMPDSandboxState,
+	&NtGdiSetVirtualResolution,
+	&NtGdiSetupPublicCFONT,
+	&NtGdiSfmGetNotificationTokens,
+	&NtGdiStartDoc,
+	&NtGdiStartPage,
+	&NtGdiStretchBlt,
+	&NtGdiStretchDIBitsInternal,
+	&NtGdiStrokeAndFillPath,
+	&NtGdiStrokePath,
+	&NtGdiSwapBuffers,
+	&NtGdiTransformPoints,
+	&NtGdiTransparentBlt,
+	&NtGdiUMPDEngFreeUserMem,
+	&NtGdiUnloadPrinterDriver,
+	&NtGdiUnmapMemFont,
+	&NtGdiUnrealizeObject,
+	&NtGdiUpdateColors,
+	&NtGdiUpdateTransform,
+	&NtGdiWidenPath,
+	&NtGdiXFORMOBJ_bApplyXform,
+	&NtGdiXFORMOBJ_iGetXform,
+	&NtGdiXLATEOBJ_cGetPalette,
+	&NtGdiXLATEOBJ_hGetColorTransform,
+	&NtGdiXLATEOBJ_iXlate,
+	&NtHWCursorUpdatePointer,
+	&NtIsOneCoreTransformMode,
+	&NtMITActivateInputProcessing,
+	&NtMITBindInputTypeToMonitors,
+	&NtMITCoreMsgKGetConnectionHandle,
+	&NtMITCoreMsgKOpenConnectionTo,
+	&NtMITCoreMsgKSend,
+	&NtMITDeactivateInputProcessing,
+	&NtMITDisableMouseIntercept,
+	&NtMITDispatchCompletion,
+	&NtMITEnableMouseIntercept,
+	&NtMITGetCursorUpdateHandle,
+	&NtMITSetInputCallbacks,
+	&NtMITSetInputDelegationMode,
+	&NtMITSetInputSuppressionState,
+	&NtMITSetKeyboardInputRoutingPolicy,
+	&NtMITSetKeyboardOverriderState,
+	&NtMITSetLastInputRecipient,
+	&NtMITSynthesizeKeyboardInput,
+	&NtMITSynthesizeMouseInput,
+	&NtMITSynthesizeMouseWheel,
+	&NtMITSynthesizeTouchInput,
+	&NtMITUpdateInputGlobals,
+	&NtMITWaitForMultipleObjectsEx,
+	&NtMapVisualRelativePoints,
+	&NtNotifyPresentToCompositionSurface,
+	&NtOpenCompositionSurfaceDirtyRegion,
+	&NtOpenCompositionSurfaceSectionInfo,
+	&NtOpenCompositionSurfaceSwapChainHandleInfo,
+	&NtQueryCompositionInputIsImplicit,
+	&NtQueryCompositionInputQueueAndTransform,
+	&NtQueryCompositionInputSink,
+	&NtQueryCompositionInputSinkLuid,
+	&NtQueryCompositionInputSinkViewId,
+	&NtQueryCompositionSurfaceBinding,
+	&NtQueryCompositionSurfaceHDRMetaData,
+	&NtQueryCompositionSurfaceRenderingRealization,
+	&NtQueryCompositionSurfaceStatistics,
+	&NtRIMAddInputObserver,
+	&NtRIMAreSiblingDevices,
+	&NtRIMDeviceIoControl,
+	&NtRIMEnableMonitorMappingForDevice,
+	&NtRIMFreeInputBuffer,
+	&NtRIMGetDevicePreparsedData,
+	&NtRIMGetDevicePreparsedDataLockfree,
+	&NtRIMGetDeviceProperties,
+	&NtRIMGetDevicePropertiesLockfree,
+	&NtRIMGetPhysicalDeviceRect,
+	&NtRIMGetSourceProcessId,
+	&NtRIMObserveNextInput,
+	&NtRIMOnPnpNotification,
+	&NtRIMOnTimerNotification,
+	&NtRIMReadInput,
+	&NtRIMRegisterForInput,
+	&NtRIMRemoveInputObserver,
+	&NtRIMSetExtendedDeviceProperty,
+	&NtRIMSetTestModeStatus,
+	&NtRIMUnregisterForInput,
+	&NtRIMUpdateInputObserverRegistration,
+	&NtSetCompositionSurfaceAnalogExclusive,
+	&NtSetCompositionSurfaceBufferCompositionMode,
+	&NtSetCompositionSurfaceBufferCompositionModeAndOrientation,
+	&NtSetCompositionSurfaceBufferUsage,
+	&NtSetCompositionSurfaceDirectFlipState,
+	&NtSetCompositionSurfaceHDRMetaData,
+	&NtSetCompositionSurfaceIndependentFlipInfo,
+	&NtSetCompositionSurfaceOutOfFrameDirectFlipNotification,
+	&NtSetCompositionSurfaceStatistics,
+	&NtSetCursorInputSpace,
+	&NtSetPointerDeviceInputSpace,
+	&NtSetShellCursorState,
+	&NtTokenManagerConfirmOutstandingAnalogToken,
+	&NtTokenManagerCreateCompositionTokenHandle,
+	&NtTokenManagerCreateFlipObjectReturnTokenHandle,
+	&NtTokenManagerCreateFlipObjectTokenHandle,
+	&NtTokenManagerDeleteOutstandingDirectFlipTokens,
+	&NtTokenManagerGetAnalogExclusiveSurfaceUpdates,
+	&NtTokenManagerGetAnalogExclusiveTokenEvent,
+	&NtTokenManagerGetOutOfFrameDirectFlipSurfaceUpdates,
+	&NtTokenManagerOpenEvent,
+	&NtTokenManagerOpenSection,
+	&NtTokenManagerOpenSectionAndEvents,
+	&NtTokenManagerThread,
+	&NtUnBindCompositionSurface,
+	&NtUpdateInputSinkTransforms,
+	&NtUserAcquireIAMKey,
+	&NtUserAcquireInteractiveControlBackgroundAccess,
+	&NtUserActivateKeyboardLayout,
+	&NtUserAddClipboardFormatListener,
+	&NtUserAddVisualIdentifier,
+	&NtUserAlterWindowStyle,
+	&NtUserAssociateInputContext,
+	&NtUserAttachThreadInput,
+	&NtUserAutoPromoteMouseInPointer,
+	&NtUserAutoRotateScreen,
+	&NtUserBeginLayoutUpdate,
+	&NtUserBeginPaint,
+	&NtUserBitBltSysBmp,
+	&NtUserBlockInput,
+	&NtUserBroadcastThemeChangeEvent,
+	&NtUserBuildHimcList,
+	&NtUserBuildHwndList,
+	&NtUserBuildNameList,
+	&NtUserBuildPropList,
+	&NtUserCalcMenuBar,
+	&NtUserCalculatePopupWindowPosition,
+	&NtUserCallHwnd,
+	&NtUserCallHwndLock,
+	&NtUserCallHwndLockSafe,
+	&NtUserCallHwndOpt,
+	&NtUserCallHwndParam,
+	&NtUserCallHwndParamLock,
+	&NtUserCallHwndParamLockSafe,
+	&NtUserCallHwndSafe,
+	&NtUserCallMsgFilter,
+	&NtUserCallNextHookEx,
+	&NtUserCallNoParam,
+	&NtUserCallOneParam,
+	&NtUserCallTwoParam,
+	&NtUserCanBrokerForceForeground,
+	&NtUserChangeClipboardChain,
+	&NtUserChangeDisplaySettings,
+	&NtUserChangeWindowMessageFilterEx,
+	&NtUserCheckAccessForIntegrityLevel,
+	&NtUserCheckDesktopByThreadId,
+	&NtUserCheckImeHotKey,
+	&NtUserCheckMenuItem,
+	&NtUserCheckProcessForClipboardAccess,
+	&NtUserCheckProcessSession,
+	&NtUserCheckWindowThreadDesktop,
+	&NtUserChildWindowFromPointEx,
+	&NtUserClearForeground,
+	&NtUserClipCursor,
+	&NtUserCloseClipboard,
+	&NtUserCloseDesktop,
+	&NtUserCloseWindowStation,
+	&NtUserCompositionInputSinkLuidFromPoint,
+	&NtUserCompositionInputSinkViewInstanceIdFromPoint,
+	&NtUserConfigureActivationObject,
+	&NtUserConfirmResizeCommit,
+	&NtUserConsoleControl,
+	&NtUserConvertMemHandle,
+	&NtUserCopyAcceleratorTable,
+	&NtUserCountClipboardFormats,
+	&NtUserCreateAcceleratorTable,
+	&NtUserCreateActivationObject,
+	&NtUserCreateCaret,
+	&NtUserCreateDCompositionHwndTarget,
+	&NtUserCreateDesktop,
+	&NtUserCreateDesktopEx,
+	&NtUserCreateEmptyCursorObject,
+	&NtUserCreateInputContext,
+	&NtUserCreateLocalMemHandle,
+	&NtUserCreatePalmRejectionDelayZone,
+	&NtUserCreateWindowEx,
+	&NtUserCreateWindowGroup,
+	&NtUserCreateWindowStation,
+	&NtUserCtxDisplayIOCtl,
+	&NtUserDdeGetQualityOfService,
+	&NtUserDdeInitialize,
+	&NtUserDdeSetQualityOfService,
+	&NtUserDefSetText,
+	&NtUserDeferWindowDpiChanges,
+	&NtUserDeferWindowPos,
+	&NtUserDeferWindowPosAndBand,
+	&NtUserDelegateCapturePointers,
+	&NtUserDelegateInput,
+	&NtUserDeleteMenu,
+	&NtUserDeleteWindowGroup,
+	&NtUserDestroyAcceleratorTable,
+	&NtUserDestroyActivationObject,
+	&NtUserDestroyCursor,
+	&NtUserDestroyDCompositionHwndTarget,
+	&NtUserDestroyInputContext,
+	&NtUserDestroyMenu,
+	&NtUserDestroyPalmRejectionDelayZone,
+	&NtUserDestroyWindow,
+	&NtUserDisableImmersiveOwner,
+	&NtUserDisableProcessWindowFiltering,
+	&NtUserDisableThreadIme,
+	&NtUserDiscardPointerFrameMessages,
+	&NtUserDispatchMessage,
+	&NtUserDisplayConfigGetDeviceInfo,
+	&NtUserDisplayConfigSetDeviceInfo,
+	&NtUserDoSoundConnect,
+	&NtUserDoSoundDisconnect,
+	&NtUserDownlevelTouchpad,
+	&NtUserDragDetect,
+	&NtUserDragObject,
+	&NtUserDrawAnimatedRects,
+	&NtUserDrawCaption,
+	&NtUserDrawCaptionTemp,
+	&NtUserDrawIconEx,
+	&NtUserDrawMenuBarTemp,
+	&NtUserDwmGetDxRgn,
+	&NtUserDwmGetRemoteSessionOcclusionEvent,
+	&NtUserDwmGetRemoteSessionOcclusionState,
+	&NtUserDwmHintDxUpdate,
+	&NtUserDwmKernelShutdown,
+	&NtUserDwmKernelStartup,
+	&NtUserDwmStartRedirection,
+	&NtUserDwmStopRedirection,
+	&NtUserDwmValidateWindow,
+	&NtUserEmptyClipboard,
+	&NtUserEnableChildWindowDpiMessage,
+	&NtUserEnableIAMAccess,
+	&NtUserEnableMenuItem,
+	&NtUserEnableMouseInPointer,
+	&NtUserEnableMouseInputForCursorSuppression,
+	&NtUserEnableNonClientDpiScaling,
+	&NtUserEnableResizeLayoutSynchronization,
+	&NtUserEnableScrollBar,
+	&NtUserEnableSoftwareCursorForScreenCapture,
+	&NtUserEnableTouchPad,
+	&NtUserEnableWindowGDIScaledDpiMessage,
+	&NtUserEnableWindowGroupPolicy,
+	&NtUserEnableWindowResizeOptimization,
+	&NtUserEndDeferWindowPosEx,
+	&NtUserEndMenu,
+	&NtUserEndPaint,
+	&NtUserEndTouchOperation,
+	&NtUserEnumDisplayDevices,
+	&NtUserEnumDisplayMonitors,
+	&NtUserEnumDisplaySettings,
+	&NtUserEvent,
+	&NtUserExcludeUpdateRgn,
+	&NtUserFillWindow,
+	&NtUserFindExistingCursorIcon,
+	&NtUserFindWindowEx,
+	&NtUserFlashWindowEx,
+	&NtUserForceWindowToDpiForTest,
+	&NtUserFrostCrashedWindow,
+	&NtUserFunctionalizeDisplayConfig,
+	&NtUserGetActiveProcessesDpis,
+	&NtUserGetAltTabInfo,
+	&NtUserGetAncestor,
+	&NtUserGetAppImeLevel,
+	&NtUserGetAsyncKeyState,
+	&NtUserGetAtomName,
+	&NtUserGetAutoRotationState,
+	&NtUserGetCIMSSM,
+	&NtUserGetCPD,
+	&NtUserGetCaretBlinkTime,
+	&NtUserGetCaretPos,
+	&NtUserGetClassInfoEx,
+	&NtUserGetClassName,
+	&NtUserGetClipCursor,
+	&NtUserGetClipboardAccessToken,
+	&NtUserGetClipboardData,
+	&NtUserGetClipboardFormatName,
+	&NtUserGetClipboardOwner,
+	&NtUserGetClipboardSequenceNumber,
+	&NtUserGetClipboardViewer,
+	&NtUserGetComboBoxInfo,
+	&NtUserGetControlBrush,
+	&NtUserGetControlColor,
+	&NtUserGetCurrentDpiInfoForWindow,
+	&NtUserGetCurrentInputMessageSource,
+	&NtUserGetCursor,
+	&NtUserGetCursorDims,
+	&NtUserGetCursorFrameInfo,
+	&NtUserGetCursorInfo,
+	&NtUserGetDC,
+	&NtUserGetDCEx,
+	&NtUserGetDManipHookInitFunction,
+	&NtUserGetDesktopID,
+	&NtUserGetDisplayAutoRotationPreferences,
+	&NtUserGetDisplayAutoRotationPreferencesByProcessId,
+	&NtUserGetDisplayConfigBufferSizes,
+	&NtUserGetDoubleClickTime,
+	&NtUserGetDpiForCurrentProcess,
+	&NtUserGetDpiForMonitor,
+	&NtUserGetDpiSystemMetrics,
+	&NtUserGetExtendedPointerDeviceProperty,
+	&NtUserGetForegroundWindow,
+	&NtUserGetGUIThreadInfo,
+	&NtUserGetGestureConfig,
+	&NtUserGetGestureExtArgs,
+	&NtUserGetGestureInfo,
+	&NtUserGetGlobalIMEStatus,
+	&NtUserGetGuiResources,
+	&NtUserGetHDevName,
+	&NtUserGetHimetricScaleFactorFromPixelLocation,
+	&NtUserGetIconInfo,
+	&NtUserGetIconSize,
+	&NtUserGetImeHotKey,
+	&NtUserGetImeInfoEx,
+	&NtUserGetInputContainerId,
+	&NtUserGetInputLocaleInfo,
+	&NtUserGetInteractiveControlDeviceInfo,
+	&NtUserGetInteractiveControlInfo,
+	&NtUserGetInteractiveCtrlSupportedWaveforms,
+	&NtUserGetInternalWindowPos,
+	&NtUserGetKeyNameText,
+	&NtUserGetKeyState,
+	&NtUserGetKeyboardLayout,
+	&NtUserGetKeyboardLayoutList,
+	&NtUserGetKeyboardLayoutName,
+	&NtUserGetKeyboardState,
+	&NtUserGetLayeredWindowAttributes,
+	&NtUserGetListBoxInfo,
+	&NtUserGetMenuBarInfo,
+	&NtUserGetMenuIndex,
+	&NtUserGetMenuItemRect,
+	&NtUserGetMessage,
+	&NtUserGetMonitorBrightness,
+	&NtUserGetMouseMovePointsEx,
+	&NtUserGetObjectInformation,
+	&NtUserGetOemBitmapSize,
+	&NtUserGetOpenClipboardWindow,
+	&NtUserGetOwnerTransformedMonitorRect,
+	&NtUserGetPhysicalDeviceRect,
+	&NtUserGetPointerCursorId,
+	&NtUserGetPointerDevice,
+	&NtUserGetPointerDeviceCursors,
+	&NtUserGetPointerDeviceOrientation,
+	&NtUserGetPointerDeviceProperties,
+	&NtUserGetPointerDeviceRects,
+	&NtUserGetPointerDevices,
+	&NtUserGetPointerFrameArrivalTimes,
+	&NtUserGetPointerFrameTimes,
+	&NtUserGetPointerInfoList,
+	&NtUserGetPointerInputTransform,
+	&NtUserGetPointerProprietaryId,
+	&NtUserGetPointerType,
+	&NtUserGetPrecisionTouchPadConfiguration,
+	&NtUserGetPriorityClipboardFormat,
+	&NtUserGetProcessDpiAwareness,
+	&NtUserGetProcessDpiAwarenessContext,
+	&NtUserGetProcessUIContextInformation,
+	&NtUserGetProcessWindowStation,
+	&NtUserGetProp,
+	&NtUserGetQueueEventStatus,
+	&NtUserGetQueueStatusReadonly,
+	&NtUserGetRawInputBuffer,
+	&NtUserGetRawInputData,
+	&NtUserGetRawInputDeviceInfo,
+	&NtUserGetRawInputDeviceList,
+	&NtUserGetRawPointerDeviceData,
+	&NtUserGetRegisteredRawInputDevices,
+	&NtUserGetRequiredCursorSizes,
+	&NtUserGetResizeDCompositionSynchronizationObject,
+	&NtUserGetScrollBarInfo,
+	&NtUserGetSystemDpiForProcess,
+	&NtUserGetSystemMenu,
+	&NtUserGetThreadDesktop,
+	&NtUserGetThreadState,
+	&NtUserGetTitleBarInfo,
+	&NtUserGetTopLevelWindow,
+	&NtUserGetTouchInputInfo,
+	&NtUserGetTouchValidationStatus,
+	&NtUserGetUniformSpaceMapping,
+	&NtUserGetUpdateRect,
+	&NtUserGetUpdateRgn,
+	&NtUserGetUpdatedClipboardFormats,
+	&NtUserGetWOWClass,
+	&NtUserGetWindowBand,
+	&NtUserGetWindowCompositionAttribute,
+	&NtUserGetWindowCompositionInfo,
+	&NtUserGetWindowDC,
+	&NtUserGetWindowDisplayAffinity,
+	&NtUserGetWindowFeedbackSetting,
+	&NtUserGetWindowGroupId,
+	&NtUserGetWindowMinimizeRect,
+	&NtUserGetWindowPlacement,
+	&NtUserGetWindowProcessHandle,
+	&NtUserGetWindowRgnEx,
+	&NtUserGhostWindowFromHungWindow,
+	&NtUserHandleDelegatedInput,
+	&NtUserHardErrorControl,
+	&NtUserHideCaret,
+	&NtUserHidePointerContactVisualization,
+	&NtUserHiliteMenuItem,
+	&NtUserHungWindowFromGhostWindow,
+	&NtUserHwndQueryRedirectionInfo,
+	&NtUserHwndSetRedirectionInfo,
+	&NtUserImpersonateDdeClientWindow,
+	&NtUserInheritWindowMonitor,
+	&NtUserInitTask,
+	&NtUserInitialize,
+	&NtUserInitializeClientPfnArrays,
+	&NtUserInitializeGenericHidInjection,
+	&NtUserInitializeInputDeviceInjection,
+	&NtUserInitializePointerDeviceInjection,
+	&NtUserInitializePointerDeviceInjectionEx,
+	&NtUserInitializeTouchInjection,
+	&NtUserInjectDeviceInput,
+	&NtUserInjectGenericHidInput,
+	&NtUserInjectGesture,
+	&NtUserInjectKeyboardInput,
+	&NtUserInjectMouseInput,
+	&NtUserInjectPointerInput,
+	&NtUserInjectTouchInput,
+	&NtUserInteractiveControlQueryUsage,
+	&NtUserInternalClipCursor,
+	&NtUserInternalGetWindowIcon,
+	&NtUserInternalGetWindowText,
+	&NtUserInvalidateRect,
+	&NtUserInvalidateRgn,
+	&NtUserIsChildWindowDpiMessageEnabled,
+	&NtUserIsClipboardFormatAvailable,
+	&NtUserIsMouseInPointerEnabled,
+	&NtUserIsMouseInputEnabled,
+	&NtUserIsNonClientDpiScalingEnabled,
+	&NtUserIsResizeLayoutSynchronizationEnabled,
+	&NtUserIsTopLevelWindow,
+	&NtUserIsTouchWindow,
+	&NtUserIsWindowBroadcastingDpiToChildren,
+	&NtUserIsWindowGDIScaledDpiMessageEnabled,
+	&NtUserKillTimer,
+	&NtUserLayoutCompleted,
+	&NtUserLinkDpiCursor,
+	&NtUserLoadKeyboardLayoutEx,
+	&NtUserLockCursor,
+	&NtUserLockWindowStation,
+	&NtUserLockWindowUpdate,
+	&NtUserLockWorkStation,
+	&NtUserLogicalToPerMonitorDPIPhysicalPoint,
+	&NtUserLogicalToPhysicalDpiPointForWindow,
+	&NtUserLogicalToPhysicalPoint,
+	&NtUserMNDragLeave,
+	&NtUserMNDragOver,
+	&NtUserMagControl,
+	&NtUserMagGetContextInformation,
+	&NtUserMagSetContextInformation,
+	&NtUserManageGestureHandlerWindow,
+	&NtUserMapPointsByVisualIdentifier,
+	&NtUserMapVirtualKeyEx,
+	&NtUserMenuItemFromPoint,
+	&NtUserMessageCall,
+	&NtUserMinMaximize,
+	&NtUserModifyUserStartupInfoFlags,
+	&NtUserModifyWindowTouchCapability,
+	&NtUserMoveWindow,
+	&NtUserMsgWaitForMultipleObjectsEx,
+	&NtUserNavigateFocus,
+	&NtUserNotifyIMEStatus,
+	&NtUserNotifyProcessCreate,
+	&NtUserNotifyWinEvent,
+	&NtUserOpenClipboard,
+	&NtUserOpenDesktop,
+	&NtUserOpenInputDesktop,
+	&NtUserOpenThreadDesktop,
+	&NtUserOpenWindowStation,
+	&NtUserPaintDesktop,
+	&NtUserPaintMenuBar,
+	&NtUserPaintMonitor,
+	&NtUserPeekMessage,
+	&NtUserPerMonitorDPIPhysicalToLogicalPoint,
+	&NtUserPhysicalToLogicalDpiPointForWindow,
+	&NtUserPhysicalToLogicalPoint,
+	&NtUserPostMessage,
+	&NtUserPostThreadMessage,
+	&NtUserPrintWindow,
+	&NtUserProcessConnect,
+	&NtUserProcessInkFeedbackCommand,
+	&NtUserPromoteMouseInPointer,
+	&NtUserPromotePointer,
+	&NtUserQueryActivationObject,
+	&NtUserQueryBSDRWindow,
+	&NtUserQueryDisplayConfig,
+	&NtUserQueryInformationThread,
+	&NtUserQueryInputContext,
+	&NtUserQuerySendMessage,
+	&NtUserQueryWindow,
+	&NtUserRealChildWindowFromPoint,
+	&NtUserRealInternalGetMessage,
+	&NtUserRealWaitMessageEx,
+	&NtUserRedrawWindow,
+	&NtUserRegisterBSDRWindow,
+	&NtUserRegisterClassExWOW,
+	&NtUserRegisterDManipHook,
+	&NtUserRegisterEdgy,
+	&NtUserRegisterErrorReportingDialog,
+	&NtUserRegisterHotKey,
+	&NtUserRegisterManipulationThread,
+	&NtUserRegisterPointerDeviceNotifications,
+	&NtUserRegisterPointerInputTarget,
+	&NtUserRegisterRawInputDevices,
+	&NtUserRegisterServicesProcess,
+	&NtUserRegisterSessionPort,
+	&NtUserRegisterShellPTPListener,
+	&NtUserRegisterTasklist,
+	&NtUserRegisterTouchHitTestingWindow,
+	&NtUserRegisterTouchPadCapable,
+	&NtUserRegisterUserApiHook,
+	&NtUserRegisterWindowMessage,
+	&NtUserReleaseDC,
+	&NtUserReleaseDwmHitTestWaiters,
+	&NtUserRemoteConnect,
+	&NtUserRemoteRedrawRectangle,
+	&NtUserRemoteRedrawScreen,
+	&NtUserRemoteStopScreenUpdates,
+	&NtUserRemoveClipboardFormatListener,
+	&NtUserRemoveInjectionDevice,
+	&NtUserRemoveMenu,
+	&NtUserRemoveProp,
+	&NtUserRemoveVisualIdentifier,
+	&NtUserReportInertia,
+	&NtUserRequestMoveSizeOperation,
+	&NtUserResolveDesktop,
+	&NtUserResolveDesktopForWOW,
+	&NtUserRestoreWindowDpiChanges,
+	&NtUserSBGetParms,
+	&NtUserScrollDC,
+	&NtUserScrollWindowEx,
+	&NtUserSelectPalette,
+	&NtUserSendEventMessage,
+	&NtUserSendInput,
+	&NtUserSendInteractiveControlHapticsReport,
+	&NtUserSendTouchInput,
+	&NtUserSetActivationFilter,
+	&NtUserSetActiveProcess,
+	&NtUserSetActiveProcessForMonitor,
+	&NtUserSetActiveWindow,
+	&NtUserSetAppImeLevel,
+	&NtUserSetAutoRotation,
+	&NtUserSetBridgeWindowChild,
+	&NtUserSetBrokeredForeground,
+	&NtUserSetCalibrationData,
+	&NtUserSetCapture,
+	&NtUserSetChildWindowNoActivate,
+	&NtUserSetClassLong,
+	&NtUserSetClassLongPtr,
+	&NtUserSetClassWord,
+	&NtUserSetClipboardData,
+	&NtUserSetClipboardViewer,
+	&NtUserSetConsoleReserveKeys,
+	&NtUserSetCoreWindow,
+	&NtUserSetCoreWindowPartner,
+	&NtUserSetCursor,
+	&NtUserSetCursorContents,
+	&NtUserSetCursorIconData,
+	&NtUserSetCursorPos,
+	&NtUserSetDesktopColorTransform,
+	&NtUserSetDialogControlDpiChangeBehavior,
+	&NtUserSetDimUndimTransitionTime,
+	&NtUserSetDisplayAutoRotationPreferences,
+	&NtUserSetDisplayConfig,
+	&NtUserSetDisplayMapping,
+	&NtUserSetFallbackForeground,
+	&NtUserSetFeatureReportResponse,
+	&NtUserSetFocus,
+	&NtUserSetForegroundWindowForApplication,
+	&NtUserSetGestureConfig,
+	&NtUserSetImeHotKey,
+	&NtUserSetImeInfoEx,
+	&NtUserSetImeOwnerWindow,
+	&NtUserSetImmersiveBackgroundWindow,
+	&NtUserSetInformationProcess,
+	&NtUserSetInformationThread,
+	&NtUserSetInteractiveControlFocus,
+	&NtUserSetInteractiveCtrlRotationAngle,
+	&NtUserSetInternalWindowPos,
+	&NtUserSetKeyboardState,
+	&NtUserSetLayeredWindowAttributes,
+	&NtUserSetLogonNotifyWindow,
+	&NtUserSetMagnificationDesktopMagnifierOffsetsDWMUpdated,
+	&NtUserSetManipulationInputTarget,
+	&NtUserSetMenu,
+	&NtUserSetMenuContextHelpId,
+	&NtUserSetMenuDefaultItem,
+	&NtUserSetMenuFlagRtoL,
+	&NtUserSetMirrorRendering,
+	&NtUserSetMonitorBrightness,
+	&NtUserSetObjectInformation,
+	&NtUserSetParent,
+	&NtUserSetPrecisionTouchPadConfiguration,
+	&NtUserSetProcessDPIAware,
+	&NtUserSetProcessDpiAwareness,
+	&NtUserSetProcessDpiAwarenessContext,
+	&NtUserSetProcessInteractionFlags,
+	&NtUserSetProcessMousewheelRoutingMode,
+	&NtUserSetProcessRestrictionExemption,
+	&NtUserSetProcessUIAccessZorder,
+	&NtUserSetProcessWindowStation,
+	&NtUserSetProp,
+	&NtUserSetScrollInfo,
+	&NtUserSetSensorPresence,
+	&NtUserSetShellWindowEx,
+	&NtUserSetSysColors,
+	&NtUserSetSystemCursor,
+	&NtUserSetSystemMenu,
+	&NtUserSetSystemTimer,
+	&NtUserSetTargetForResourceBrokering,
+	&NtUserSetThreadDesktop,
+	&NtUserSetThreadInputBlocked,
+	&NtUserSetThreadLayoutHandles,
+	&NtUserSetThreadState,
+	&NtUserSetTimer,
+	&NtUserSetWinEventHook,
+	&NtUserSetWindowArrangement,
+	&NtUserSetWindowBand,
+	&NtUserSetWindowCompositionAttribute,
+	&NtUserSetWindowCompositionTransition,
+	&NtUserSetWindowDisplayAffinity,
+	&NtUserSetWindowFNID,
+	&NtUserSetWindowFeedbackSetting,
+	&NtUserSetWindowGroup,
+	&NtUserSetWindowLong,
+	&NtUserSetWindowLongPtr,
+	&NtUserSetWindowPlacement,
+	&NtUserSetWindowPos,
+	&NtUserSetWindowRgn,
+	&NtUserSetWindowRgnEx,
+	&NtUserSetWindowShowState,
+	&NtUserSetWindowStationUser,
+	&NtUserSetWindowWord,
+	&NtUserSetWindowsHookAW,
+	&NtUserSetWindowsHookEx,
+	&NtUserSfmDestroyLogicalSurfaceBinding,
+	&NtUserSfmDxBindSwapChain,
+	&NtUserSfmDxGetSwapChainStats,
+	&NtUserSfmDxOpenSwapChain,
+	&NtUserSfmDxQuerySwapChainBindingStatus,
+	&NtUserSfmDxReleaseSwapChain,
+	&NtUserSfmDxReportPendingBindingsToDwm,
+	&NtUserSfmDxSetSwapChainBindingStatus,
+	&NtUserSfmDxSetSwapChainStats,
+	&NtUserSfmGetLogicalSurfaceBinding,
+	&NtUserShowCaret,
+	&NtUserShowCursor,
+	&NtUserShowScrollBar,
+	&NtUserShowSystemCursor,
+	&NtUserShowWindow,
+	&NtUserShowWindowAsync,
+	&NtUserShutdownBlockReasonCreate,
+	&NtUserShutdownBlockReasonQuery,
+	&NtUserShutdownReasonDestroy,
+	&NtUserSignalRedirectionStartComplete,
+	&NtUserSlicerControl,
+	&NtUserSoundSentry,
+	&NtUserStopAndEndInertia,
+	&NtUserSwitchDesktop,
+	&NtUserSystemParametersInfo,
+	&NtUserSystemParametersInfoForDpi,
+	&NtUserTestForInteractiveUser,
+	&NtUserThunkedMenuInfo,
+	&NtUserThunkedMenuItemInfo,
+	&NtUserToUnicodeEx,
+	&NtUserTrackMouseEvent,
+	&NtUserTrackPopupMenuEx,
+	&NtUserTransformPoint,
+	&NtUserTransformRect,
+	&NtUserTranslateAccelerator,
+	&NtUserTranslateMessage,
+	&NtUserUndelegateInput,
+	&NtUserUnhookWinEvent,
+	&NtUserUnhookWindowsHookEx,
+	&NtUserUnloadKeyboardLayout,
+	&NtUserUnlockWindowStation,
+	&NtUserUnregisterClass,
+	&NtUserUnregisterHotKey,
+	&NtUserUnregisterSessionPort,
+	&NtUserUnregisterUserApiHook,
+	&NtUserUpdateDefaultDesktopThumbnail,
+	&NtUserUpdateInputContext,
+	&NtUserUpdateInstance,
+	&NtUserUpdateLayeredWindow,
+	&NtUserUpdatePerUserSystemParameters,
+	&NtUserUpdateWindowInputSinkHints,
+	&NtUserUpdateWindowTrackingInfo,
+	&NtUserUpdateWindowTransform,
+	&NtUserUserHandleGrantAccess,
+	&NtUserValidateHandleSecure,
+	&NtUserValidateRect,
+	&NtUserValidateTimerCallback,
+	&NtUserVkKeyScanEx,
+	&NtUserWOWCleanup,
+	&NtUserWaitAvailableMessageEx,
+	&NtUserWaitForInputIdle,
+	&NtUserWaitForMsgAndEvent,
+	&NtUserWaitForRedirectionStartComplete,
+	&NtUserWaitMessage,
+	&NtUserWin32PoolAllocationStats,
+	&NtUserWindowFromDC,
+	&NtUserWindowFromPhysicalPoint,
+	&NtUserWindowFromPoint,
+	&NtUserYieldTask,
+	&NtValidateCompositionSurfaceHandle,
+	&NtVisualCaptureBits,
 };
 
-#define NUM_SYSCALLS_NT sizeof(nt)/sizeof(syscall_definition_t)
-#define NUM_SYSCALLS_WIN32K sizeof(win32k)/sizeof(syscall_definition_t)
+#define NUM_SYSCALLS_NT sizeof(nt)/sizeof(syscall_t*)
+#define NUM_SYSCALLS_WIN32K sizeof(win32k)/sizeof(syscall_t*)
 
 #endif


### PR DESCRIPTION
The previous single-array setup required a 17-sized arg array to be allocated for each syscall, which was just a waste of memory. With a bit of macro-magic we just create a separate struct for each syscall & have a syscall argument struct for each, then collect their pointers into an array.