### PR TITLE
add libdrakvuf functions to REPL

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -170,6 +170,9 @@ drakvuf_LDADD += librepl/librepl.la
 
 repl_LDADD = librepl/librepl.la
 repl_LDADD += libdrakvuf/libdrakvuf.la
+
+repl_CXXFLAGS = $(AM_CXXFLAGS) -fpie
+repl_LDFLAGS = $(AM_LDFLAGS) -Wl,-E
 endif
 
 xen_memclone_LDADD = xen_helper/libxenhelper.la

--- a/src/librepl/Makefile.am
+++ b/src/librepl/Makefile.am
@@ -148,4 +148,4 @@ librepl_la_SOURCES = $(sources)
 librepl_la_LIBADD = ../libdrakvuf/libdrakvuf.la
 
 all-local:
-	$(CTYPESGEN) $(top_srcdir)/src/libdrakvuf/libdrakvuf.h -I $(AM_CPPFLAGS) -o libdrakvuf.py
+	$(CTYPESGEN) $(top_srcdir)/src/libdrakvuf/libdrakvuf.h -I $(AM_CPPFLAGS) -o libdrakvuf.py -l repl -L $(abs_top_srcdir)/src 2> /dev/null


### PR DESCRIPTION
This PR adds all functions from libdrakvuf to librepl. This allows to pretty much do anything using REPL. I've also prepared a [usage guide](https://github.com/CERT-Polska/drakvuf/wiki/REPL-introduction-guide), which could be added to wiki.

Since ctypes expect a `.so` library to call functions and libdrakvuf doesn't build into .so I decided to be clever and compile `repl` binary with PIE and expose all functions, so that ctypes load repl binary just like `.so`.

This PR also adds ability to change `event_response`, which in theory allows to modify registers (not tested yet).