### PR TITLE
fix bug in syscalls output

### DIFF
--- a/src/plugins/syscalls/syscalls.cpp
+++ b/src/plugins/syscalls/syscalls.cpp
@@ -185,7 +185,7 @@ void print_header(output_format_t format, drakvuf_t drakvuf,
         case OUTPUT_JSON:
             // print_footer() puts single EOL at end of JSON doc to simplify parsing on other end
             type = syscall ? "syscall" : "sysret";
-            escaped_pname = drakvuf_escape_str(name);
+            escaped_pname = drakvuf_escape_str(info->proc_data.name);
             printf( "{"
                     "\"Type\" : \"%s\","
                     "\"TimeStamp\" :" "\"" FORMAT_TIMEVAL "\","
@@ -204,13 +204,13 @@ void print_header(output_format_t format, drakvuf_t drakvuf,
                     info->vcpu, info->regs->cr3, escaped_pname,
                     USERIDSTR(drakvuf), info->proc_data.userid,
                     info->proc_data.pid, info->proc_data.ppid, info->proc_data.tid,
-                    info->trap->breakpoint.module, info->trap->name);
+                    module, name);
 
             if ( syscall )
                 printf("\"Args\": [");
             else
                 printf("\"Ret\": %" PRIu64 ","
-                       "\"Info\": \"%s\",",
+                       "\"Info\": \"%s\"",
                         ret, extra_info ?: "");
 
             g_free(escaped_pname);


### PR DESCRIPTION
ProcessName, Module, Method had incorrect output from new changes. Dangling comma left in sysret args.

Before:
```
{"Type" : "syscall","TimeStamp" :"1585851942.406507","VCPU": 0,"CR3": 730857474,"ProcessName": "NtCancelTimer","UserName": SessionID,"UserId": 1"PID" : 876,"PPID": 504,"TID": 900,"Module": "(null)","Method": "(null)","Args": ["Args": [{"TimerHandle" :516},{"CurrentState" :0}] }
{"Type" : "sysret","TimeStamp" :"1585851942.406567","VCPU": 0,"CR3": 730857474,"ProcessName": "NtCancelTimer","UserName": SessionID,"UserId": 1"PID" : 876,"PPID": 504,"TID": 900,"Module": "nt","Method": "(null)","Args": ["Ret": 0,"Info": "STATUS_SUCCESS",] }
{"Type" : "syscall","TimeStamp" :"1585851942.406624","VCPU": 0,"CR3": 730857474,"ProcessName": "NtQueryInformationThread","UserName": SessionID,"UserId": 1"PID" : 876,"PPID": 504,"TID": 900,"Module": "(null)","Method": "(null)","Args": ["Args": [{"ThreadHandle" :18446744073709551614},{"ThreadInformationClass" :23},{"ThreadInformation" :818789479600},{"ThreadInformationLength" :16},{"ReturnLength" :0}] }
{"Type" : "sysret","TimeStamp" :"1585851942.406710","VCPU": 0,"CR3": 730857474,"ProcessName": "NtQueryInformationThread","UserName": SessionID,"UserId": 1"PID" : 876,"PPID": 504,"TID": 900,"Module": "nt","Method": "(null)","Args": ["Ret": 0,"Info": "STATUS_SUCCESS",] }
```

After:
```
{"Type" : "syscall","TimeStamp" :"1585852327.718668","VCPU": 0,"CR3": 730857474,"ProcessName": "\\Device\\HarddiskVolume2\\Windows\\System32\\dwm.exe","UserName": SessionID,"UserId": 1"PID" : 876,"PPID": 504,"TID": 900,"Module": "nt","Method": "NtQueryInformationThread","Args": ["Args": [{"ThreadHandle" :18446744073709551614},{"ThreadInformationClass" :23},{"ThreadInformation" :818789479600},{"ThreadInformationLength" :16},{"ReturnLength" :0}] }
{"Type" : "sysret","TimeStamp" :"1585852327.718730","VCPU": 0,"CR3": 730857474,"ProcessName": "\\Device\\HarddiskVolume2\\Windows\\System32\\dwm.exe","UserName": SessionID,"UserId": 1"PID" : 876,"PPID": 504,"TID": 900,"Module": "nt","Method": "NtQueryInformationThread","Args": ["Ret": 0,"Info": "STATUS_SUCCESS"] }
{"Type" : "syscall","TimeStamp" :"1585852327.718790","VCPU": 0,"CR3": 730857474,"ProcessName": "\\Device\\HarddiskVolume2\\Windows\\System32\\dwm.exe","UserName": SessionID,"UserId": 1"PID" : 876,"PPID": 504,"TID": 900,"Module": "nt","Method": "NtQueryPerformanceCounter","Args": ["Args": [{"PerformanceCounter" :818789479664},{"PerformanceFrequency" :0}] }
{"Type" : "sysret","TimeStamp" :"1585852327.718857","VCPU": 0,"CR3": 730857474,"ProcessName": "\\Device\\HarddiskVolume2\\Windows\\System32\\dwm.exe","UserName": SessionID,"UserId": 1"PID" : 876,"PPID": 504,"TID": 900,"Module": "nt","Method": "NtQueryPerformanceCounter","Args": ["Ret": 0,"Info": "STATUS_SUCCESS"] }

```