### PR TITLE
drakvuf-releases: make versions sortable

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -103,7 +103,7 @@
 #*************************************************************************#
 
 AC_PREREQ([2.60])
-AC_INIT([DRAKVUF], [0.7-m4_esyscmd_s([git describe --always])], [tamas@tklengyel.com], [], [https://drakvuf.com])
+AC_INIT([DRAKVUF], m4_join([], [0.7-git], m4_esyscmd_s([git log -1 --date=format:%Y%m%d%H%M%S --pretty=format:%cd]), [+], m4_esyscmd_s([git describe --always]), [-1]), [tamas@tklengyel.com], [], [https://drakvuf.com])
 AM_INIT_AUTOMAKE([1.10 no-define foreign subdir-objects])
 LT_INIT
 AC_CONFIG_HEADERS([config.h])

--- a/package/mkdeb
+++ b/package/mkdeb
@@ -13,7 +13,7 @@ fi
 
 if [ "$2" = "" ]
 then
-    version=0.0+git$(git log -1 --date=format:'%Y%m%d.%H%M%S' --pretty=format:%cd)+$(git rev-parse --short HEAD)-1
+    version=$(grep 'PACKAGE_VERSION' 'src/Makefile' | head -n 1 | cut -f2 "-d=" | xargs echo -n)
     echo "Auto-detected version: $version"
 
     if [ "$version" = "0.0+git+-1" ]

--- a/package/mkdeb
+++ b/package/mkdeb
@@ -16,7 +16,7 @@ then
     version=$(grep 'PACKAGE_VERSION' 'src/Makefile' | head -n 1 | cut -f2 "-d=" | xargs echo -n)
     echo "Auto-detected version: $version"
 
-    if [ "$version" = "0.0+git+-1" ]
+    if [ "$version" = "" ]
     then
         echo "Unable to recognize package version automatically, please provide it explicitly by the command line:"
        echo "package/mkdeb <distro> <version>"

--- a/package/mkdeb
+++ b/package/mkdeb
@@ -16,7 +16,7 @@ then
     version=0.0+git$(git log -1 --date=format:'%Y%m%d.%H%M%S' --pretty=format:%cd)+$(git rev-parse --short HEAD)-1
     echo "Auto-detected version: $version"
 
-    if [ "$version" = "" ]
+    if [ "$version" = "0.0+git+-1" ]
     then
         echo "Unable to recognize package version automatically, please provide it explicitly by the command line:"
        echo "package/mkdeb <distro> <version>"

--- a/package/mkdeb
+++ b/package/mkdeb
@@ -13,7 +13,7 @@ fi
 
 if [ "$2" = "" ]
 then
-    version=$(grep 'PACKAGE_VERSION' 'src/Makefile' | head -n 1 | cut -f2 "-d=" | xargs echo -n)
+    version=0.0+git$(git log -1 --date=format:'%Y%m%d.%H%M%S' --pretty=format:%cd)+$(git rev-parse --short HEAD)-1
     echo "Auto-detected version: $version"
 
     if [ "$version" = "" ]


### PR DESCRIPTION
For nightly Debian packages published with `drakvuf-releases`, the current version scheme is `0.7-<commit_hash>`. Having two debs with version `0.7` it's not possible to tell which one is more recent.

This PR changes the version scheme to: `0.7+git<year><month><day><hour><minute><second>+<git_short_hash>-1`. With such format (I hope) Debian will be able to understand which package is older and which is the upgraded version.

Example: `0.7+git20200425213254+ec3a0e7-1`