### PR TITLE
drakvuf-bundle: Automatically propose Xen Dom0 settings

### DIFF
--- a/package/extra/etc/default/grub.d/xen.cfg
+++ b/package/extra/etc/default/grub.d/xen.cfg
@@ -7,13 +7,34 @@ echo "Including Xen overrides from /etc/default/grub.d/xen.cfg"
 echo "Using DRAKVUF-optimized settings for Xen"
 
 #
+# Uncomment the following lines in order to set Domain 0 CPU and memory
+# manually instead of using default auto-detected settings.
+# The more resources you dedicate to the host system, the less remains
+# to the guest systems in virtual machines.
+# 
+# DRAK_DOM0_CPU=2
+# DRAK_DOM0_RAM=2048
+
+. drak-find-xen-defaults
+
+echo "------------------------------------------"
+echo ""
+echo "Resources dedicated to Dom0 (host system):"
+echo "-> CPU core(s): ${DRAK_DOM0_CPU}"
+echo "-> Memory: ${DRAK_DOM0_RAM} MB"
+echo ""
+echo "------------------------------------------"
+
+echo "You can edit these settings in /etc/default/grub.d/xen.cfg"
+
+#
 # When running update-grub with the Xen hypervisor installed, there are
 # some additional variables that can be used to pass options to the
 # hypervisor or the dom0 kernel.
 
 # The following two are used to generate arguments for the hypervisor:
 #
-GRUB_CMDLINE_XEN_DEFAULT="dom0_mem=2048M,max:2048M dom0_max_vcpus=4 dom0_vcpus_pin=1 force-ept=1 ept=pml=0 hap_1gb=0 hap_2mb=0 altp2m=1 smt=0"
+GRUB_CMDLINE_XEN_DEFAULT="dom0_mem=${DRAK_DOM0_RAM}M,max:${DRAK_DOM0_RAM}M dom0_max_vcpus=${DRAK_DOM0_CPU} dom0_vcpus_pin=1 force-ept=1 ept=pml=0 hap_1gb=0 hap_2mb=0 altp2m=1 smt=0"
 #GRUB_CMDLINE_XEN=""
 #
 # For example:

--- a/package/extra/etc/default/grub.d/xen.cfg
+++ b/package/extra/etc/default/grub.d/xen.cfg
@@ -11,7 +11,7 @@ echo "Using DRAKVUF-optimized settings for Xen"
 # manually instead of using default auto-detected settings.
 # The more resources you dedicate to the host system, the less remains
 # to the guest systems in virtual machines.
-# 
+#
 # DRAK_DOM0_CPU=2
 # DRAK_DOM0_RAM=2048
 

--- a/package/extra/usr/bin/drak-find-xen-defaults
+++ b/package/extra/usr/bin/drak-find-xen-defaults
@@ -36,4 +36,3 @@ then
 
     DRAK_DOM0_RAM=$(expr "$DRAK_TOTAL_RAM" / 2)
 fi
-

--- a/package/extra/usr/bin/drak-find-xen-defaults
+++ b/package/extra/usr/bin/drak-find-xen-defaults
@@ -2,6 +2,7 @@
 
 set -e
 
+IS_XEN=0
 xen-detect -N || IS_XEN=$?
 
 if [ $IS_XEN = 1 ]

--- a/package/extra/usr/bin/drak-find-xen-defaults
+++ b/package/extra/usr/bin/drak-find-xen-defaults
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+set -e
+
+xen-detect -N || IS_XEN=$?
+
+if [ $IS_XEN = 1 ]
+then
+    DRAK_TOTAL_CPU=$(xl info | grep nr_cpus | cut -f2 '-d:' | xargs)
+    DRAK_TOTAL_RAM=$(xl info | grep total_memory | cut -f2 '-d:' | xargs)
+else
+    DRAK_TOTAL_CPU=$(nproc --all)
+    DRAK_TOTAL_RAM=$(($(getconf _PHYS_PAGES) * $(getconf PAGE_SIZE) / (1024 * 1024)))
+fi
+
+if [ -z "$DRAK_DOM0_CPU" ]
+then
+    if [ $IS_XEN = 1 ]
+    then
+        DRAK_TOTAL_CPU=$(xl info | grep nr_cpus | cut -f2 '-d:' | xargs)
+    else
+        DRAK_TOTAL_CPU=$(nproc --all)
+    fi
+
+    DRAK_DOM0_CPU=$(expr "$DRAK_TOTAL_CPU" / 2)
+fi
+
+if [ -z "$DRAK_DOM0_RAM" ]
+then
+    if [ $IS_XEN = 1 ]
+    then
+        DRAK_TOTAL_RAM=$(xl info | grep total_memory | cut -f2 '-d:' | xargs)
+    else
+        DRAK_TOTAL_RAM=$(($(getconf _PHYS_PAGES) * $(getconf PAGE_SIZE) / (1024 * 1024)))
+    fi
+
+    DRAK_DOM0_RAM=$(expr "$DRAK_TOTAL_RAM" / 2)
+fi
+

--- a/package/mkdeb
+++ b/package/mkdeb
@@ -67,6 +67,7 @@ mkdir -p deb/etc/default/grub.d/
 mkdir -p deb/etc/modules-load.d/
 cp package/extra/etc/default/grub.d/xen.cfg deb/etc/default/grub.d/
 cp package/extra/etc/modules-load.d/xen.conf deb/etc/modules-load.d/
+cp package/extra/usr/bin/drak-find-xen-defaults deb/usr/bin/
 
 # Find all /etc files and add them to conffiles
 find deb/etc -type f -printf /etc/%P\\n >deb/DEBIAN/conffiles


### PR DESCRIPTION
Currently we ship xen.cfg with fixed 2048 MB / 4 CPU allocation for Dom0. This PR changes this behavior so half of the system resources will be dedicated to Dom0 and this could be manually overriden.

This is not extremely optimal, but I hope it's a user-friendly default. Something would work with these settings (better or worse) and then the user has the possibility to fine-tune.