### PR TITLE
Adjust package build process for Ubuntu 20.04

### DIFF
--- a/package/Dockerfile-xen
+++ b/package/Dockerfile-xen
@@ -1,4 +1,5 @@
-FROM ubuntu:18.04
+ARG IMAGE
+FROM $IMAGE
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV USER root
@@ -8,11 +9,15 @@ RUN mkdir -p /log && \
     sed -i 's/# deb-src/deb-src/g' /etc/apt/sources.list && \
     apt-get update && \
     echo Running apt-get install, this may take a few minutes... && \
-    apt-get --quiet --yes install build-essential git wget curl cmake flex bison libjson-c-dev autoconf-archive clang && \
+    apt-get --quiet --yes install build-essential git wget curl cmake flex bison libjson-c-dev autoconf-archive clang python-dev gcc-7 g++-7 && \
+    ( [ ! -z "$(apt-cache search --names-only '^python-is-python2$')" ] && apt-get --quiet --yes install python-is-python2 ) || true && \
     apt-get --quiet --yes build-dep xen && \
     apt-get autoremove -y && \
     apt-get clean && \
-    rm -rf /var/lib/apt/lists* /tmp/* /var/tmp/*
+    rm -rf /var/lib/apt/lists* /tmp/* /var/tmp/* && \
+    rm /usr/bin/gcc /usr/bin/g++ && \
+    ln -s /usr/bin/gcc-7 /usr/bin/gcc && \
+    ln -s /usr/bin/g++-7 /usr/bin/g++
 
 COPY xen /build-xen
 COPY package/patch-xen.sh /build-xen

--- a/package/build.sh
+++ b/package/build.sh
@@ -2,24 +2,33 @@
 
 # run ./package/build.sh
 
+IMAGE="ubuntu:18.04"
+
+if [ ! -z "$1" ]
+then
+    IMAGE="$1"
+    echo "Overriding base image for build to: $IMAGE"
+    shift
+fi
+
 XEN_HASH=$(git ls-files -s xen | cut -f2 '-d ')
 
 mkdir -p package/cache
 mkdir -p package/log
 
-if [ ! -f "package/cache/xen-intermediate-$XEN_HASH.tar.gz" ]
+if [ ! -f "package/cache/xen-intermediate-$IMAGE-$XEN_HASH.tar.gz" ]
 then
     echo Building Xen intermediate $XEN_HASH...
-    docker build -f package/Dockerfile-xen -t xen-intermediate . 2>&1 >package/log/xen-build.log
+    docker build --build-arg "IMAGE=$IMAGE" -f package/Dockerfile-xen -t xen-intermediate . # 2>&1 >package/log/xen-build.log
     if [ $? -ne 0 ]; then echo Xen intermediate image build failed, build log tail below ; tail -n 200 package/log/xen-build.log ; exit 1 ; fi
     echo Removing old Xen intermediate image...
     rm -f package/cache/xen-intermediate-*.tar.gz
     echo Saving Xen intermediate...
-    docker save xen-intermediate | gzip -c > "package/cache/xen-intermediate-$XEN_HASH.tar.gz"
+    docker save xen-intermediate | gzip -c > "package/cache/xen-intermediate-$IMAGE-$XEN_HASH.tar.gz"
     if [ $? -ne 0 ]; then echo Failed to save Xen intermediate image ; rm package/cache/xen-intermediate-*.tar.gz ; exit 1 ; fi
 else
-    echo Loading cached Xen intermediate $XEN_HASH...
-    docker load < "package/cache/xen-intermediate-$XEN_HASH.tar.gz"
+    echo Loading cached Xen intermediate $IMAGE-$XEN_HASH...
+    docker load < "package/cache/xen-intermediate-$IMAGE-$XEN_HASH.tar.gz"
     if [ $? -ne 0 ]; then echo Failed to load Xen intermediate image ; exit 1 ; fi
 fi
 

--- a/package/mkdeb
+++ b/package/mkdeb
@@ -45,7 +45,7 @@ Source: drakvuf-bundle
 Version: $version
 Architecture: $arch
 Maintainer: Unmaintained snapshot
-Depends: libpixman-1-0, libpng16-16, libnettle6, libgnutls30, libfdt1, libglib2.0-0, libglib2.0-dev, libjson-c3, libyajl2, libaio1
+Depends: libpixman-1-0, libpng16-16, libnettle6 | libnettle7, libgnutls30, libfdt1, libglib2.0-0, libglib2.0-dev, libjson-c3 | libjson-c4, libyajl2, libaio1
 Conflicts: xen-hypervisor-4.6-amd64, xen-hypervisor-4.7-amd64, xen-hypervisor-4.8-amd64, xen-hypervisor-4.9-amd64, xen-hypervisor-4.10-amd64, xen-hypervisor-4.11-amd64, xen-hypervisor-4.12-amd64
 Section: admin
 Priority: optional


### PR DESCRIPTION
* `sh package/build.sh` can now have optional argument of a build base image, e.g. `sh package/build.sh ubuntu:20.04`, default is `ubuntu:18.04` (which produces package compatible with both Debian Buster and Ubuntu 18.04)
* implement patches required for Xen to compile/work under Ubuntu 20.04