### PR TITLE
added version 2 of type-safe printers + envmon with it

### DIFF
--- a/src/plugins/Makefile.am
+++ b/src/plugins/Makefile.am
@@ -249,6 +249,8 @@ sources += apimon/apimon.cpp
 sources += apimon/apimon.h
 sources += apimon/crypto.cpp
 sources += apimon/crypto.h
+sources += apimon/printers.cpp
+sources += apimon/printers.h
 endif
 
 if PLUGIN_PROCDUMP
@@ -263,7 +265,7 @@ endif
 ###############################################################################
 sources += plugins.cpp plugins.h plugins_ex.cpp plugins_ex.h plugin_utils.cpp plugin_utils.h private.h type_traits_helpers.h
 sources += output_format.h output_format/common.h output_format/csvfmt.h output_format/deffmt.h output_format/jsonfmt.h output_format/kvfmt.h
-sources += output_format/ostream.h output_format/ostream.cpp
+sources += output_format/xfmt.h output_format/ostream.h output_format/ostream.cpp
 
 AM_CPPFLAGS = -I$(top_srcdir) -I$(top_srcdir)/src -I$(srcdir)
 AM_CPPFLAGS += $(CPPFLAGS)

--- a/src/plugins/Makefile.am
+++ b/src/plugins/Makefile.am
@@ -261,7 +261,9 @@ sources += procdump/minidump.h
 endif
 
 ###############################################################################
-sources += plugins.cpp plugins.h plugins_ex.cpp plugins_ex.h plugin_utils.cpp plugin_utils.h private.h output_format.h
+sources += plugins.cpp plugins.h plugins_ex.cpp plugins_ex.h plugin_utils.cpp plugin_utils.h private.h
+sources += output_format.h output_format/common.h output_format/csvfmt.h output_format/deffmt.h output_format/jsonfmt.h output_format/kvfmt.h
+sources += output_format/ostream.h output_format/ostream.cpp
 
 AM_CPPFLAGS = -I$(top_srcdir) -I$(top_srcdir)/src -I$(srcdir)
 AM_CPPFLAGS += $(CPPFLAGS)

--- a/src/plugins/Makefile.am
+++ b/src/plugins/Makefile.am
@@ -249,8 +249,6 @@ sources += apimon/apimon.cpp
 sources += apimon/apimon.h
 sources += apimon/crypto.cpp
 sources += apimon/crypto.h
-sources += apimon/printers.cpp
-sources += apimon/printers.h
 endif
 
 if PLUGIN_PROCDUMP

--- a/src/plugins/Makefile.am
+++ b/src/plugins/Makefile.am
@@ -261,7 +261,7 @@ sources += procdump/minidump.h
 endif
 
 ###############################################################################
-sources += plugins.cpp plugins.h plugins_ex.cpp plugins_ex.h plugin_utils.cpp plugin_utils.h private.h
+sources += plugins.cpp plugins.h plugins_ex.cpp plugins_ex.h plugin_utils.cpp plugin_utils.h private.h type_traits_helpers.h
 sources += output_format.h output_format/common.h output_format/csvfmt.h output_format/deffmt.h output_format/jsonfmt.h output_format/kvfmt.h
 sources += output_format/ostream.h output_format/ostream.cpp
 

--- a/src/plugins/envmon/envmon.cpp
+++ b/src/plugins/envmon/envmon.cpp
@@ -412,8 +412,7 @@ static event_response_t trap_GetAdaptersAddresses_cb(drakvuf_t drakvuf, drakvuf_
         return VMI_EVENT_RESPONSE_NONE;
 
     const auto family = print::FieldToString(family_name_formats, drakvuf_get_function_argument(drakvuf, info, 1));
-    //const 
-    auto flags  = print::FieldToString(flags_name_formats, std::bitset<64>(drakvuf_get_function_argument(drakvuf, info, 2)));
+    const auto flags  = print::FieldToString(flags_name_formats, std::bitset<64>(drakvuf_get_function_argument(drakvuf, info, 2)));
 
     switch (p->m_output_format)
     {

--- a/src/plugins/envmon/envmon.cpp
+++ b/src/plugins/envmon/envmon.cpp
@@ -200,36 +200,10 @@ static event_response_t trap_SspipGetUserName_cb(drakvuf_t drakvuf, drakvuf_trap
         ex_name_fmt_str = extended_name_formats[ex_name_fmt];
 
 
-    switch (p->m_output_format)
-    {
-        case OUTPUT_CSV:
-            csvfmt::print("envmon", drakvuf, info,
-                          keyval("ExtendedNameFormat", fmt::Nval(ex_name_fmt)),
-                          keyval("ExtendedNameFormatStr", fmt::Qstr(ex_name_fmt_str))
-                         );
-            break;
-        case OUTPUT_KV:
-            kvfmt::print("envmon", drakvuf, info,
-                         keyval("ExtendedNameFormat", fmt::Nval(ex_name_fmt)),
-                         keyval("ExtendedNameFormatStr", fmt::Qstr(ex_name_fmt_str))
-                        );
-            break;
-        case OUTPUT_JSON:
-        {
-            jsonfmt::print("envmon", drakvuf, info,
-                           keyval("ExtendedNameFormat", fmt::Nval(ex_name_fmt)),
-                           keyval("ExtendedNameFormatStr", fmt::Qstr(ex_name_fmt_str))
-                          );
-            break;
-        }
-        default:
-        case OUTPUT_DEFAULT:
-            deffmt::print("envmon", drakvuf, info,
-                          keyval("ExtendedNameFormat", fmt::Nval(ex_name_fmt)),
-                          keyval("ExtendedNameFormatStr", fmt::Qstr(ex_name_fmt_str))
-                         );
-            break;
-    }
+    fmt::print(p->m_output_format, "envmon", drakvuf, info,
+               keyval("ExtendedNameFormat", fmt::Nval(ex_name_fmt)),
+               keyval("ExtendedNameFormatStr", fmt::Qstr(ex_name_fmt_str))
+    );
     return VMI_EVENT_RESPONSE_NONE;
 }
 
@@ -265,39 +239,11 @@ static event_response_t trap_DefineDosDeviceW_cb(drakvuf_t drakvuf, drakvuf_trap
 
     wmi_lock.unlock();
 
-    switch (p->m_output_format)
-    {
-        case OUTPUT_CSV:
-            csvfmt::print("envmon", drakvuf, info,
-                          keyval("Flags", fmt::Qstr(flags)),
-                          keyval("DeviceName", fmt::Qstr(device_name)),
-                          keyval("TargetPath", fmt::Qstr(target_path))
-                         );
-            break;
-        case OUTPUT_KV:
-            kvfmt::print("envmon", drakvuf, info,
-                         keyval("Flags", fmt::Qstr(flags)),
-                         keyval("DeviceName", fmt::Qstr(device_name)),
-                         keyval("TargetPath", fmt::Qstr(target_path))
-                        );
-            break;
-        case OUTPUT_JSON:
-        {
-            jsonfmt::print("envmon", drakvuf, info,
-                           keyval("Flags", fmt::Qstr(flags)),
-                           keyval("DeviceName", fmt::Qstr(device_name)),
-                           keyval("TargetPath", fmt::Qstr(target_path))
-                          );
-            break;
-        }
-        default:
-            deffmt::print("envmon", drakvuf, info,
-                          keyval("FLAGS", fmt::Qstr(flags)),
-                          keyval("DEVNAME", fmt::Qstr(device_name)),
-                          keyval("TARGETPATH", fmt::Qstr(target_path))
-                         );
-            break;
-    }
+    fmt::print(p->m_output_format, "envmon", drakvuf, info,
+                  keyval("Flags", fmt::Qstr(flags)),
+                  keyval("DeviceName", fmt::Qstr(device_name)),
+                  keyval("TargetPath", fmt::Qstr(target_path))
+                 );
 
     vmi_free_unicode_str(device_name_us);
     vmi_free_unicode_str(target_path_us);
@@ -311,24 +257,7 @@ static event_response_t trap_GetComputerNameW_cb(drakvuf_t drakvuf, drakvuf_trap
     if (!p)
         return VMI_EVENT_RESPONSE_NONE;
 
-    switch (p->m_output_format)
-    {
-        case OUTPUT_CSV:
-            csvfmt::print("envmon", drakvuf, info);
-            break;
-        case OUTPUT_KV:
-            kvfmt::print("envmon", drakvuf, info);
-            break;
-        case OUTPUT_JSON:
-        {
-            jsonfmt::print("envmon", drakvuf, info);
-            break;
-        }
-        default:
-        case OUTPUT_DEFAULT:
-            deffmt::print("envmon", drakvuf, info);
-            break;
-    }
+    fmt::print(p->m_output_format, "envmon", drakvuf, info);
     return VMI_EVENT_RESPONSE_NONE;
 }
 
@@ -338,24 +267,7 @@ static event_response_t trap_IsNativeVhdBoot_cb(drakvuf_t drakvuf, drakvuf_trap_
     if (!p)
         return VMI_EVENT_RESPONSE_NONE;
 
-    switch (p->m_output_format)
-    {
-        case OUTPUT_CSV:
-            csvfmt::print("envmon", drakvuf, info);
-            break;
-        case OUTPUT_KV:
-            kvfmt::print("envmon", drakvuf, info);
-            break;
-        case OUTPUT_JSON:
-        {
-            jsonfmt::print("envmon", drakvuf, info);
-            break;
-        }
-        default:
-        case OUTPUT_DEFAULT:
-            deffmt::print("envmon", drakvuf, info);
-            break;
-    }
+    fmt::print(p->m_output_format, "envmon", drakvuf, info);
     return VMI_EVENT_RESPONSE_NONE;
 }
 
@@ -372,36 +284,10 @@ static event_response_t trap_GetComputerNameExW_cb(drakvuf_t drakvuf, drakvuf_tr
     if (name_type < ComputerNameMax)
         name_type_str = computer_name_formats[name_type];
 
-    switch (p->m_output_format)
-    {
-        case OUTPUT_CSV:
-            csvfmt::print("envmon", drakvuf, info,
-                          keyval("NameType", fmt::Nval(name_type)),
-                          keyval("NameTypeStr", fmt::Qstr(name_type_str))
-                         );
-            break;
-        case OUTPUT_KV:
-            kvfmt::print("envmon", drakvuf, info,
-                         keyval("NameType", fmt::Nval(name_type)),
-                         keyval("NameTypeStr", fmt::Qstr(name_type_str))
-                        );
-            break;
-        case OUTPUT_JSON:
-        {
-            jsonfmt::print("envmon", drakvuf, info,
-                           keyval("NameType", fmt::Nval(name_type)),
-                           keyval("NameTypeStr", fmt::Qstr(name_type_str))
-                          );
-            break;
-        }
-        default:
-        case OUTPUT_DEFAULT:
-            deffmt::print("envmon", drakvuf, info,
-                          keyval("NAMETYPE", fmt::Nval(name_type)),
-                          keyval("NAMETYPESTR", fmt::Qstr(name_type_str))
-                         );
-            break;
-    }
+    fmt::print(p->m_output_format, "envmon", drakvuf, info,
+                  keyval("NameType", fmt::Nval(name_type)),
+                  keyval("NameTypeStr", fmt::Qstr(name_type_str))
+                 );
     return VMI_EVENT_RESPONSE_NONE;
 }
 
@@ -412,14 +298,17 @@ static event_response_t trap_GetAdaptersAddresses_cb(drakvuf_t drakvuf, drakvuf_
         return VMI_EVENT_RESPONSE_NONE;
 
     const auto family = print::FieldToString(family_name_formats, drakvuf_get_function_argument(drakvuf, info, 1));
-    const auto flags  = print::FieldToString(flags_name_formats, std::bitset<64>(drakvuf_get_function_argument(drakvuf, info, 2)));
+    //const 
+    auto flags  = print::FieldToString(flags_name_formats, std::bitset<64>(drakvuf_get_function_argument(drakvuf, info, 2)));
 
     switch (p->m_output_format)
     {
         case OUTPUT_CSV:
-            csvfmt::print("envmon", drakvuf, info,
-                          keyval("Family", fmt::Rstr(family)),
-                          keyval("Flags", fmt::Rstr(flags))
+        case OUTPUT_JSON:
+        case OUTPUT_DEFAULT:
+            fmt::print(p->m_output_format, "envmon", drakvuf, info,
+                          keyval("Family", fmt::Qstr(family)),
+                          keyval("Flags", fmt::Qstr(flags))
                          );
             break;
         case OUTPUT_KV:
@@ -427,21 +316,6 @@ static event_response_t trap_GetAdaptersAddresses_cb(drakvuf_t drakvuf, drakvuf_
                          keyval("Family", fmt::Rstr(family)),
                          fmt::Rstr(flags)
                         );
-            break;
-        case OUTPUT_JSON:
-        {
-            jsonfmt::print("envmon", drakvuf, info,
-                           keyval("Family", fmt::Qstr(family)),
-                           keyval("Flags", fmt::Qstr(flags))
-                          );
-            break;
-        }
-        default:
-        case OUTPUT_DEFAULT:
-            deffmt::print("envmon", drakvuf, info,
-                          keyval("FAMILY", fmt::Rstr(family)),
-                          keyval("FLAGS", fmt::Rstr(flags))
-                         );
             break;
     }
     return VMI_EVENT_RESPONSE_NONE;
@@ -454,32 +328,9 @@ static event_response_t trap_WNetGetProviderNameW_cb(drakvuf_t drakvuf, drakvuf_
         return VMI_EVENT_RESPONSE_NONE;
 
     const auto net_type = drakvuf_get_function_argument(drakvuf, info, 1);
-    switch (p->m_output_format)
-    {
-        case OUTPUT_CSV:
-            csvfmt::print("envmon", drakvuf, info,
-                          keyval("NetType", fmt::Nval(net_type))
-                         );
-            break;
-        case OUTPUT_KV:
-            kvfmt::print("envmon", drakvuf, info,
-                         keyval("NetType", fmt::Nval(net_type))
-                        );
-            break;
-        case OUTPUT_JSON:
-        {
-            jsonfmt::print("envmon", drakvuf, info,
-                           keyval("NetType", fmt::Nval(net_type))
-                          );
-            break;
-        }
-        default:
-        case OUTPUT_DEFAULT:
-            deffmt::print("envmon", drakvuf, info,
-                          keyval("NETTYPE", fmt::Nval(net_type))
-                         );
-            break;
-    }
+    fmt::print(p->m_output_format, "envmon", drakvuf, info,
+              keyval("NetType", fmt::Nval(net_type))
+             );
     return VMI_EVENT_RESPONSE_NONE;
 }
 

--- a/src/plugins/envmon/envmon.cpp
+++ b/src/plugins/envmon/envmon.cpp
@@ -204,30 +204,30 @@ static event_response_t trap_SspipGetUserName_cb(drakvuf_t drakvuf, drakvuf_trap
     {
         case OUTPUT_CSV:
             csvfmt::print("envmon", drakvuf, info,
-                          keyval("ExtendedNameFormat", ex_name_fmt),
-                          keyval("ExtendedNameFormatStr", std::quoted(ex_name_fmt_str))
+                          keyval("ExtendedNameFormat", fmt::nval(ex_name_fmt)),
+                          keyval("ExtendedNameFormatStr", fmt::qstr(ex_name_fmt_str))
                          );
             break;
         case OUTPUT_KV:
             kvfmt::print("envmon", drakvuf, info,
-                         keyval("ExtendedNameFormat", ex_name_fmt),
-                         keyval("ExtendedNameFormatStr", std::quoted(ex_name_fmt_str))
+                         keyval("ExtendedNameFormat", fmt::nval(ex_name_fmt)),
+                         keyval("ExtendedNameFormatStr", fmt::qstr(ex_name_fmt_str))
                         );
             break;
         case OUTPUT_JSON:
         {
             jsonfmt::print("envmon", drakvuf, info,
-                           keyval("ExtendedNameFormat", ex_name_fmt),
-                           keyval("ExtendedNameFormatStr", ex_name_fmt_str)
+                           keyval("ExtendedNameFormat", fmt::nval(ex_name_fmt)),
+                           keyval("ExtendedNameFormatStr", fmt::qstr(ex_name_fmt_str))
                           );
             break;
         }
         default:
         case OUTPUT_DEFAULT:
-            fmt::print("envmon", drakvuf, info,
-                       keyval("ExtendedNameFormat", ex_name_fmt),
-                       keyval("ExtendedNameFormatStr", std::quoted(ex_name_fmt_str))
-                      );
+            deffmt::print("envmon", drakvuf, info,
+                          keyval("ExtendedNameFormat", fmt::nval(ex_name_fmt)),
+                          keyval("ExtendedNameFormatStr", fmt::qstr(ex_name_fmt_str))
+                         );
             break;
     }
     return VMI_EVENT_RESPONSE_NONE;
@@ -269,33 +269,33 @@ static event_response_t trap_DefineDosDeviceW_cb(drakvuf_t drakvuf, drakvuf_trap
     {
         case OUTPUT_CSV:
             csvfmt::print("envmon", drakvuf, info,
-                          keyval("Flags", flags),
-                          keyval("DeviceName", std::quoted(device_name)),
-                          keyval("TargetPath", std::quoted(target_path))
+                          keyval("Flags", fmt::qstr(flags)),
+                          keyval("DeviceName", fmt::qstr(device_name)),
+                          keyval("TargetPath", fmt::qstr(target_path))
                          );
             break;
         case OUTPUT_KV:
             kvfmt::print("envmon", drakvuf, info,
-                         keyval("Flags", flags.c_str()),
-                         keyval("DeviceName", std::quoted(device_name)),
-                         keyval("TargetPath", std::quoted(target_path))
+                         keyval("Flags", fmt::qstr(flags)),
+                         keyval("DeviceName", fmt::qstr(device_name)),
+                         keyval("TargetPath", fmt::qstr(target_path))
                         );
             break;
         case OUTPUT_JSON:
         {
             jsonfmt::print("envmon", drakvuf, info,
-                           keyval("Flags", flags.c_str()),
-                           keyval("DeviceName", device_name),
-                           keyval("TargetPath", target_path)
+                           keyval("Flags", fmt::qstr(flags)),
+                           keyval("DeviceName", fmt::qstr(device_name)),
+                           keyval("TargetPath", fmt::qstr(target_path))
                           );
             break;
         }
         default:
-            fmt::print("envmon", drakvuf, info,
-                       keyval("Flags", flags.c_str()),
-                       keyval("DeviceName", std::quoted(device_name)),
-                       keyval("TargetPath", std::quoted(target_path))
-                      );
+            deffmt::print("envmon", drakvuf, info,
+                          keyval("FLAGS", fmt::qstr(flags)),
+                          keyval("DEVNAME", fmt::qstr(device_name)),
+                          keyval("TARGETPATH", fmt::qstr(target_path))
+                         );
             break;
     }
 
@@ -326,7 +326,7 @@ static event_response_t trap_GetComputerNameW_cb(drakvuf_t drakvuf, drakvuf_trap
         }
         default:
         case OUTPUT_DEFAULT:
-            fmt::print("envmon", drakvuf, info);
+            deffmt::print("envmon", drakvuf, info);
             break;
     }
     return VMI_EVENT_RESPONSE_NONE;
@@ -353,7 +353,7 @@ static event_response_t trap_IsNativeVhdBoot_cb(drakvuf_t drakvuf, drakvuf_trap_
         }
         default:
         case OUTPUT_DEFAULT:
-            fmt::print("envmon", drakvuf, info);
+            deffmt::print("envmon", drakvuf, info);
             break;
     }
     return VMI_EVENT_RESPONSE_NONE;
@@ -376,30 +376,30 @@ static event_response_t trap_GetComputerNameExW_cb(drakvuf_t drakvuf, drakvuf_tr
     {
         case OUTPUT_CSV:
             csvfmt::print("envmon", drakvuf, info,
-                          keyval("NameType", name_type),
-                          keyval("NameTypeStr", std::quoted(name_type_str))
+                          keyval("NameType", fmt::nval(name_type)),
+                          keyval("NameTypeStr", fmt::qstr(name_type_str))
                          );
             break;
         case OUTPUT_KV:
             kvfmt::print("envmon", drakvuf, info,
-                         keyval("NameType", name_type),
-                         keyval("NameTypeStr", std::quoted(name_type_str))
+                         keyval("NameType", fmt::nval(name_type)),
+                         keyval("NameTypeStr", fmt::qstr(name_type_str))
                         );
             break;
         case OUTPUT_JSON:
         {
             jsonfmt::print("envmon", drakvuf, info,
-                           keyval("NameType", name_type),
-                           keyval("NameTypeStr", name_type_str)
+                           keyval("NameType", fmt::nval(name_type)),
+                           keyval("NameTypeStr", fmt::qstr(name_type_str))
                           );
             break;
         }
         default:
         case OUTPUT_DEFAULT:
-            fmt::print("envmon", drakvuf, info,
-                       keyval("NameType", name_type),
-                       keyval("NameTypeStr", std::quoted(name_type_str))
-                      );
+            deffmt::print("envmon", drakvuf, info,
+                          keyval("NAMETYPE", fmt::nval(name_type)),
+                          keyval("NAMETYPESTR", fmt::qstr(name_type_str))
+                         );
             break;
     }
     return VMI_EVENT_RESPONSE_NONE;
@@ -418,30 +418,30 @@ static event_response_t trap_GetAdaptersAddresses_cb(drakvuf_t drakvuf, drakvuf_
     {
         case OUTPUT_CSV:
             csvfmt::print("envmon", drakvuf, info,
-                          keyval("Family", family.c_str()),
-                          keyval("Flags", flags.c_str())
+                          keyval("Family", fmt::rstr(family)),
+                          keyval("Flags", fmt::rstr(flags))
                          );
             break;
         case OUTPUT_KV:
             kvfmt::print("envmon", drakvuf, info,
-                         keyval("Family", family.c_str()),
-                         keyval("Flags", flags.c_str())
+                         keyval("Family", fmt::rstr(family)),
+                         fmt::rstr(flags)
                         );
             break;
         case OUTPUT_JSON:
         {
             jsonfmt::print("envmon", drakvuf, info,
-                           keyval("Family", family.c_str()),
-                           keyval("Flags", flags.c_str())
+                           keyval("Family", fmt::qstr(family)),
+                           keyval("Flags", fmt::qstr(flags))
                           );
             break;
         }
         default:
         case OUTPUT_DEFAULT:
-            fmt::print("envmon", drakvuf, info,
-                       keyval("Family", family.c_str()),
-                       keyval("Flags", flags.c_str())
-                      );
+            deffmt::print("envmon", drakvuf, info,
+                          keyval("FAMILY", fmt::rstr(family)),
+                          keyval("FLAGS", fmt::rstr(flags))
+                         );
             break;
     }
     return VMI_EVENT_RESPONSE_NONE;
@@ -458,26 +458,26 @@ static event_response_t trap_WNetGetProviderNameW_cb(drakvuf_t drakvuf, drakvuf_
     {
         case OUTPUT_CSV:
             csvfmt::print("envmon", drakvuf, info,
-                          keyval("NetType", net_type)
+                          keyval("NetType", fmt::nval(net_type))
                          );
             break;
         case OUTPUT_KV:
             kvfmt::print("envmon", drakvuf, info,
-                         keyval("NetType", net_type)
+                         keyval("NetType", fmt::nval(net_type))
                         );
             break;
         case OUTPUT_JSON:
         {
             jsonfmt::print("envmon", drakvuf, info,
-                           keyval("NetType", net_type)
+                           keyval("NetType", fmt::nval(net_type))
                           );
             break;
         }
         default:
         case OUTPUT_DEFAULT:
-            fmt::print("envmon", drakvuf, info,
-                       keyval("NetType", net_type)
-                      );
+            deffmt::print("envmon", drakvuf, info,
+                          keyval("NETTYPE", fmt::nval(net_type))
+                         );
             break;
     }
     return VMI_EVENT_RESPONSE_NONE;

--- a/src/plugins/envmon/envmon.cpp
+++ b/src/plugins/envmon/envmon.cpp
@@ -298,8 +298,7 @@ static event_response_t trap_GetAdaptersAddresses_cb(drakvuf_t drakvuf, drakvuf_
         return VMI_EVENT_RESPONSE_NONE;
 
     const auto family = print::FieldToString(family_name_formats, drakvuf_get_function_argument(drakvuf, info, 1));
-    //const 
-    auto flags  = print::FieldToString(flags_name_formats, std::bitset<64>(drakvuf_get_function_argument(drakvuf, info, 2)));
+    const auto flags  = print::FieldToString(flags_name_formats, std::bitset<64>(drakvuf_get_function_argument(drakvuf, info, 2)));
 
     switch (p->m_output_format)
     {

--- a/src/plugins/envmon/envmon.cpp
+++ b/src/plugins/envmon/envmon.cpp
@@ -204,29 +204,29 @@ static event_response_t trap_SspipGetUserName_cb(drakvuf_t drakvuf, drakvuf_trap
     {
         case OUTPUT_CSV:
             csvfmt::print("envmon", drakvuf, info,
-                          keyval("ExtendedNameFormat", fmt::nval(ex_name_fmt)),
-                          keyval("ExtendedNameFormatStr", fmt::qstr(ex_name_fmt_str))
+                          keyval("ExtendedNameFormat", fmt::Nval(ex_name_fmt)),
+                          keyval("ExtendedNameFormatStr", fmt::Qstr(ex_name_fmt_str))
                          );
             break;
         case OUTPUT_KV:
             kvfmt::print("envmon", drakvuf, info,
-                         keyval("ExtendedNameFormat", fmt::nval(ex_name_fmt)),
-                         keyval("ExtendedNameFormatStr", fmt::qstr(ex_name_fmt_str))
+                         keyval("ExtendedNameFormat", fmt::Nval(ex_name_fmt)),
+                         keyval("ExtendedNameFormatStr", fmt::Qstr(ex_name_fmt_str))
                         );
             break;
         case OUTPUT_JSON:
         {
             jsonfmt::print("envmon", drakvuf, info,
-                           keyval("ExtendedNameFormat", fmt::nval(ex_name_fmt)),
-                           keyval("ExtendedNameFormatStr", fmt::qstr(ex_name_fmt_str))
+                           keyval("ExtendedNameFormat", fmt::Nval(ex_name_fmt)),
+                           keyval("ExtendedNameFormatStr", fmt::Qstr(ex_name_fmt_str))
                           );
             break;
         }
         default:
         case OUTPUT_DEFAULT:
             deffmt::print("envmon", drakvuf, info,
-                          keyval("ExtendedNameFormat", fmt::nval(ex_name_fmt)),
-                          keyval("ExtendedNameFormatStr", fmt::qstr(ex_name_fmt_str))
+                          keyval("ExtendedNameFormat", fmt::Nval(ex_name_fmt)),
+                          keyval("ExtendedNameFormatStr", fmt::Qstr(ex_name_fmt_str))
                          );
             break;
     }
@@ -269,32 +269,32 @@ static event_response_t trap_DefineDosDeviceW_cb(drakvuf_t drakvuf, drakvuf_trap
     {
         case OUTPUT_CSV:
             csvfmt::print("envmon", drakvuf, info,
-                          keyval("Flags", fmt::qstr(flags)),
-                          keyval("DeviceName", fmt::qstr(device_name)),
-                          keyval("TargetPath", fmt::qstr(target_path))
+                          keyval("Flags", fmt::Qstr(flags)),
+                          keyval("DeviceName", fmt::Qstr(device_name)),
+                          keyval("TargetPath", fmt::Qstr(target_path))
                          );
             break;
         case OUTPUT_KV:
             kvfmt::print("envmon", drakvuf, info,
-                         keyval("Flags", fmt::qstr(flags)),
-                         keyval("DeviceName", fmt::qstr(device_name)),
-                         keyval("TargetPath", fmt::qstr(target_path))
+                         keyval("Flags", fmt::Qstr(flags)),
+                         keyval("DeviceName", fmt::Qstr(device_name)),
+                         keyval("TargetPath", fmt::Qstr(target_path))
                         );
             break;
         case OUTPUT_JSON:
         {
             jsonfmt::print("envmon", drakvuf, info,
-                           keyval("Flags", fmt::qstr(flags)),
-                           keyval("DeviceName", fmt::qstr(device_name)),
-                           keyval("TargetPath", fmt::qstr(target_path))
+                           keyval("Flags", fmt::Qstr(flags)),
+                           keyval("DeviceName", fmt::Qstr(device_name)),
+                           keyval("TargetPath", fmt::Qstr(target_path))
                           );
             break;
         }
         default:
             deffmt::print("envmon", drakvuf, info,
-                          keyval("FLAGS", fmt::qstr(flags)),
-                          keyval("DEVNAME", fmt::qstr(device_name)),
-                          keyval("TARGETPATH", fmt::qstr(target_path))
+                          keyval("FLAGS", fmt::Qstr(flags)),
+                          keyval("DEVNAME", fmt::Qstr(device_name)),
+                          keyval("TARGETPATH", fmt::Qstr(target_path))
                          );
             break;
     }
@@ -376,29 +376,29 @@ static event_response_t trap_GetComputerNameExW_cb(drakvuf_t drakvuf, drakvuf_tr
     {
         case OUTPUT_CSV:
             csvfmt::print("envmon", drakvuf, info,
-                          keyval("NameType", fmt::nval(name_type)),
-                          keyval("NameTypeStr", fmt::qstr(name_type_str))
+                          keyval("NameType", fmt::Nval(name_type)),
+                          keyval("NameTypeStr", fmt::Qstr(name_type_str))
                          );
             break;
         case OUTPUT_KV:
             kvfmt::print("envmon", drakvuf, info,
-                         keyval("NameType", fmt::nval(name_type)),
-                         keyval("NameTypeStr", fmt::qstr(name_type_str))
+                         keyval("NameType", fmt::Nval(name_type)),
+                         keyval("NameTypeStr", fmt::Qstr(name_type_str))
                         );
             break;
         case OUTPUT_JSON:
         {
             jsonfmt::print("envmon", drakvuf, info,
-                           keyval("NameType", fmt::nval(name_type)),
-                           keyval("NameTypeStr", fmt::qstr(name_type_str))
+                           keyval("NameType", fmt::Nval(name_type)),
+                           keyval("NameTypeStr", fmt::Qstr(name_type_str))
                           );
             break;
         }
         default:
         case OUTPUT_DEFAULT:
             deffmt::print("envmon", drakvuf, info,
-                          keyval("NAMETYPE", fmt::nval(name_type)),
-                          keyval("NAMETYPESTR", fmt::qstr(name_type_str))
+                          keyval("NAMETYPE", fmt::Nval(name_type)),
+                          keyval("NAMETYPESTR", fmt::Qstr(name_type_str))
                          );
             break;
     }
@@ -412,35 +412,36 @@ static event_response_t trap_GetAdaptersAddresses_cb(drakvuf_t drakvuf, drakvuf_
         return VMI_EVENT_RESPONSE_NONE;
 
     const auto family = print::FieldToString(family_name_formats, drakvuf_get_function_argument(drakvuf, info, 1));
-    const auto flags  = print::FieldToString(flags_name_formats, std::bitset<64>(drakvuf_get_function_argument(drakvuf, info, 2)));
+    //const 
+    auto flags  = print::FieldToString(flags_name_formats, std::bitset<64>(drakvuf_get_function_argument(drakvuf, info, 2)));
 
     switch (p->m_output_format)
     {
         case OUTPUT_CSV:
             csvfmt::print("envmon", drakvuf, info,
-                          keyval("Family", fmt::rstr(family)),
-                          keyval("Flags", fmt::rstr(flags))
+                          keyval("Family", fmt::Rstr(family)),
+                          keyval("Flags", fmt::Rstr(flags))
                          );
             break;
         case OUTPUT_KV:
             kvfmt::print("envmon", drakvuf, info,
-                         keyval("Family", fmt::rstr(family)),
-                         fmt::rstr(flags)
+                         keyval("Family", fmt::Rstr(family)),
+                         fmt::Rstr(flags)
                         );
             break;
         case OUTPUT_JSON:
         {
             jsonfmt::print("envmon", drakvuf, info,
-                           keyval("Family", fmt::qstr(family)),
-                           keyval("Flags", fmt::qstr(flags))
+                           keyval("Family", fmt::Qstr(family)),
+                           keyval("Flags", fmt::Qstr(flags))
                           );
             break;
         }
         default:
         case OUTPUT_DEFAULT:
             deffmt::print("envmon", drakvuf, info,
-                          keyval("FAMILY", fmt::rstr(family)),
-                          keyval("FLAGS", fmt::rstr(flags))
+                          keyval("FAMILY", fmt::Rstr(family)),
+                          keyval("FLAGS", fmt::Rstr(flags))
                          );
             break;
     }
@@ -458,25 +459,25 @@ static event_response_t trap_WNetGetProviderNameW_cb(drakvuf_t drakvuf, drakvuf_
     {
         case OUTPUT_CSV:
             csvfmt::print("envmon", drakvuf, info,
-                          keyval("NetType", fmt::nval(net_type))
+                          keyval("NetType", fmt::Nval(net_type))
                          );
             break;
         case OUTPUT_KV:
             kvfmt::print("envmon", drakvuf, info,
-                         keyval("NetType", fmt::nval(net_type))
+                         keyval("NetType", fmt::Nval(net_type))
                         );
             break;
         case OUTPUT_JSON:
         {
             jsonfmt::print("envmon", drakvuf, info,
-                           keyval("NetType", fmt::nval(net_type))
+                           keyval("NetType", fmt::Nval(net_type))
                           );
             break;
         }
         default:
         case OUTPUT_DEFAULT:
             deffmt::print("envmon", drakvuf, info,
-                          keyval("NETTYPE", fmt::nval(net_type))
+                          keyval("NETTYPE", fmt::Nval(net_type))
                          );
             break;
     }

--- a/src/plugins/output_format.h
+++ b/src/plugins/output_format.h
@@ -113,10 +113,4 @@
 
 #include "output_format/xfmt.h"
 
-#include "output_format/common_obs.h"
-#include "output_format/csvfmt_obs.h"
-#include "output_format/deffmt_obs.h"
-#include "output_format/jsonfmt_obs.h"
-#include "output_format/kvfmt_obs.h"
-
 #endif

--- a/src/plugins/output_format.h
+++ b/src/plugins/output_format.h
@@ -105,9 +105,18 @@
 #ifndef PLUGINS_OUTPUT_FORMAT_H
 #define PLUGINS_OUTPUT_FORMAT_H
 
+#include "output_format/common.h"
 #include "output_format/csvfmt.h"
 #include "output_format/deffmt.h"
 #include "output_format/jsonfmt.h"
 #include "output_format/kvfmt.h"
+
+#include "output_format/xfmt.h"
+
+#include "output_format/common_obs.h"
+#include "output_format/csvfmt_obs.h"
+#include "output_format/deffmt_obs.h"
+#include "output_format/jsonfmt_obs.h"
+#include "output_format/kvfmt_obs.h"
 
 #endif

--- a/src/plugins/output_format/common.h
+++ b/src/plugins/output_format/common.h
@@ -123,9 +123,10 @@
 #include <utility>
 #include <vector>
 
-struct TimeVal {
-  glong tv_sec;
-  glong tv_usec;
+struct TimeVal
+{
+    glong tv_sec;
+    glong tv_usec;
 };
 
 template<class Value>
@@ -134,7 +135,8 @@ auto keyval(const char* key, const Value& value)
     return std::make_pair(key, value);
 }
 
-namespace fmt {
+namespace fmt
+{
 
 template<class T>
 struct __val_holder

--- a/src/plugins/output_format/csvfmt.h
+++ b/src/plugins/output_format/csvfmt.h
@@ -107,7 +107,7 @@
 
 #include "common.h"
 
-#include <type_traits_helpers.h>
+#include "plugins/type_traits_helpers.h"
 
 namespace csvfmt
 {

--- a/src/plugins/output_format/csvfmt.h
+++ b/src/plugins/output_format/csvfmt.h
@@ -251,19 +251,19 @@ inline void print_common_data(fmt::ostream& os, drakvuf_trap_info_t* info)
 {
     if (info)
     {
-        std::optional<decltype(fmt::rstr(info->trap->name))> method;
+        std::optional<fmt::Rstr<decltype(info->trap->name)>> method;
         if (info->trap->name)
-            method = fmt::rstr(info->trap->name);
+            method = fmt::Rstr(info->trap->name);
 
         print_data(os,
                    keyval("Time", TimeVal{UNPACK_TIMEVAL(info->timestamp)}),
-                   keyval("VCPU", fmt::nval(info->vcpu)),
-                   keyval("CR3", fmt::xval(info->regs->cr3)),
-                   keyval("UserId", fmt::nval(info->proc_data.userid)),
-                   keyval("PID", fmt::nval(info->attached_proc_data.pid)),
-                   keyval("PPID", fmt::nval(info->attached_proc_data.ppid)),
-                   keyval("TID", fmt::nval(info->attached_proc_data.tid)),
-                   keyval("ProcessName", fmt::qstr(info->attached_proc_data.name)),
+                   keyval("VCPU", fmt::Nval(info->vcpu)),
+                   keyval("CR3", fmt::Xval(info->regs->cr3)),
+                   keyval("UserId", fmt::Nval(info->proc_data.userid)),
+                   keyval("PID", fmt::Nval(info->attached_proc_data.pid)),
+                   keyval("PPID", fmt::Nval(info->attached_proc_data.ppid)),
+                   keyval("TID", fmt::Nval(info->attached_proc_data.tid)),
+                   keyval("ProcessName", fmt::Qstr(info->attached_proc_data.name)),
                    keyval("Method", method)
                   );
     }

--- a/src/plugins/output_format/csvfmt.h
+++ b/src/plugins/output_format/csvfmt.h
@@ -113,14 +113,33 @@ namespace csvfmt
 {
 
 template <class T>
-constexpr bool print_data(fmt::ostream& os, const T& data, char sep = 0);
+constexpr bool print_data(std::ostream& os, const T& data, char sep);
 
+
+template<class T, std::size_t N>
+struct TuplePrinter
+{
+    static bool print(std::ostream& os, const T& data, char sep)
+    {
+        if constexpr (N > 0)
+        {
+            bool printed_prev = TuplePrinter<T, N-1>::print(os, data, sep);
+            if (printed_prev)
+                os << sep;
+            bool printed = print_data(os, std::get<N-1>(data), sep);
+            if (!printed && printed_prev)
+                fmt::unputc(os);
+            return printed;
+        }
+        return false;
+    }
+};
 
 template <class T, class = void, class...>
-struct data_printer
+struct DataPrinter
 {
 
-    static bool print(fmt::ostream& os, const TimeVal& t, char)
+    static bool print(std::ostream& os, const TimeVal& t, char)
     {
         os << t.tv_sec << ".";
 
@@ -131,14 +150,14 @@ struct data_printer
     }
 
     template <class Tv = T>
-    static bool print(fmt::ostream& os, const fmt::Nval<Tv>& data, char)
+    static bool print(std::ostream& os, const fmt::Nval<Tv>& data, char)
     {
         os << data.value;
         return true;
     }
 
     template <class Tv = T>
-    static bool print(fmt::ostream& os, const fmt::Xval<Tv>& data, char)
+    static bool print(std::ostream& os, const fmt::Xval<Tv>& data, char)
     {
         auto ff = os.flags();
         os << (data.withbase ? "0x" : "") << std::uppercase << std::hex << data.value;
@@ -147,7 +166,7 @@ struct data_printer
     }
 
     template <class Tv = T>
-    static bool print(fmt::ostream& os, const fmt::Fval<Tv>& data, char)
+    static bool print(std::ostream& os, const fmt::Fval<Tv>& data, char)
     {
         auto ff = os.flags();
         os << std::fixed << data.value;
@@ -156,21 +175,21 @@ struct data_printer
     }
 
     template <class Tv = T>
-    static bool print(fmt::ostream& os, const fmt::Rstr<Tv>& data, char)
+    static bool print(std::ostream& os, const fmt::Rstr<Tv>& data, char)
     {
         os << data.value;
         return true;
     }
 
     template <class Tv = T>
-    static bool print(fmt::ostream& os, const fmt::Qstr<Tv>& data, char)
+    static bool print(std::ostream& os, const fmt::Qstr<Tv>& data, char)
     {
         os << '"' << data.value << '"';
         return true;
     }
 
     template <class Tv = T>
-    static bool print(fmt::ostream& os, const std::function<bool(std::ostream&)>& printer, char)
+    static bool print(std::ostream& os, const std::function<bool(std::ostream&)>& printer, char)
     {
         std::ostringstream ss;
         bool printed = printer(ss);
@@ -180,7 +199,7 @@ struct data_printer
     }
 
     template <class Tv = T>
-    static bool print(fmt::ostream& os, const std::optional<Tv>& data, char sep)
+    static bool print(std::ostream& os, const std::optional<Tv>& data, char sep)
     {
         if (!data.has_value())
             return false;
@@ -189,7 +208,7 @@ struct data_printer
     }
 
     template <class Tk, class Tv>
-    static bool print(fmt::ostream& os, const std::pair<Tk, Tv>& data, char)
+    static bool print(std::ostream& os, const std::pair<Tk, Tv>& data, char)
     {
         if (print_data(os, data.second, ';'))
         {
@@ -197,38 +216,43 @@ struct data_printer
         }
         return false;
     }
+
+    template <class... Ts>
+    static bool print(std::ostream& os, const std::tuple<Ts...>& data, char sep)
+    {
+        return TuplePrinter<decltype(data), sizeof...(Ts)>::print(os, data, sep);
+    }
 };
 
 template <class T>
-struct data_printer<T, std::enable_if_t<is_iterable<T>::value, void>>
+struct DataPrinter<T, std::enable_if_t<is_iterable<T>::value, void>>
 {
-    static bool print(fmt::ostream& os, const T& data, char sep)
+    static bool print(std::ostream& os, const T& data, char sep)
     {
-        uint32_t i = 0;
         bool printed = false;
         for (const auto& v : data)
         {
+            bool printed_prev = printed;
             if (printed)
                 os << sep;
             printed = print_data(os, v, sep);
-            ++i;
+            if (!printed && printed_prev)
+                fmt::unputc(os);
         }
-        if (i > 0 && !printed)
-            os.unputc(sep);
         return true;
     }
 };
 
 template <class T>
-constexpr bool print_data(fmt::ostream& os, const T& data, char sep)
+constexpr bool print_data(std::ostream& os, const T& data, char sep)
 {
-    return data_printer<T>::print(os, data, sep);
+    return DataPrinter<T>::print(os, data, sep);
 }
 
 /**/
 
 template <class T, class... Ts>
-constexpr bool print_data(fmt::ostream& os, const T& data, const Ts& ... rest)
+constexpr bool print_data(std::ostream& os, const T& data, const Ts& ... rest)
 {
     constexpr char sep = ',';
     bool printed = print_data(os, data, sep);
@@ -240,14 +264,14 @@ constexpr bool print_data(fmt::ostream& os, const T& data, const Ts& ... rest)
             os << sep;
         printed_rest = print_data(os, rest...);
         if (!printed_rest && printed)
-            os.unputc(sep);
+            fmt::unputc(os);
     }
     return printed || printed_rest;
 }
 
 /**/
 
-inline void print_common_data(fmt::ostream& os, drakvuf_trap_info_t* info)
+inline void print_common_data(std::ostream& os, drakvuf_trap_info_t* info)
 {
     if (info)
     {
@@ -272,12 +296,12 @@ inline void print_common_data(fmt::ostream& os, drakvuf_trap_info_t* info)
 template<class... Args>
 void print(const char* plugin_name, drakvuf_t drakvuf, drakvuf_trap_info_t* info, const Args& ... args)
 {
-    fmt::out << plugin_name << ' ';
+    fmt::cout << plugin_name << ' ';
 
     bool printed = false;
     if (info)
     {
-        print_common_data(fmt::out, info);
+        print_common_data(fmt::cout, info);
         printed = true;
     }
 
@@ -285,13 +309,13 @@ void print(const char* plugin_name, drakvuf_t drakvuf, drakvuf_trap_info_t* info
     {
         constexpr char sep = ',';
         if (printed)
-            fmt::out << sep;
-        if (!print_data(fmt::out, args...))
-            fmt::out.unputc(sep);
+            fmt::cout << sep;
+        if (!print_data(fmt::cout, args...))
+            fmt::unputc(fmt::cout);
     }
 
-    fmt::out << "\n";
-    fmt::out.flush();
+    fmt::cout << "\n";
+    fmt::cout.flush();
 }
 
 } // namespace csvfmt

--- a/src/plugins/output_format/csvfmt.h
+++ b/src/plugins/output_format/csvfmt.h
@@ -206,7 +206,8 @@ struct data_printer<T, std::enable_if_t<is_iterable<T>::value, void>>
     {
         uint32_t i = 0;
         bool printed = false;
-        for (const auto& v : data) {
+        for (const auto& v : data)
+        {
             if (printed)
                 os << sep;
             printed = print_data(os, v, sep);
@@ -219,14 +220,16 @@ struct data_printer<T, std::enable_if_t<is_iterable<T>::value, void>>
 };
 
 template <class T>
-constexpr bool print_data(fmt::ostream& os, const T& data, char sep) {
+constexpr bool print_data(fmt::ostream& os, const T& data, char sep)
+{
     return data_printer<T>::print(os, data, sep);
 }
 
 /**/
 
 template <class T, class... Ts>
-constexpr bool print_data(fmt::ostream& os, const T& data, const Ts&... rest) {
+constexpr bool print_data(fmt::ostream& os, const T& data, const Ts& ... rest)
+{
     constexpr char sep = ',';
     bool printed = print_data(os, data, sep);
     bool printed_rest = false;
@@ -253,16 +256,16 @@ inline void print_common_data(fmt::ostream& os, drakvuf_trap_info_t* info)
             method = fmt::rstr(info->trap->name);
 
         print_data(os,
-            keyval("Time", TimeVal{UNPACK_TIMEVAL(info->timestamp)}),
-            keyval("VCPU", fmt::nval(info->vcpu)),
-            keyval("CR3", fmt::xval(info->regs->cr3)),
-            keyval("UserId", fmt::nval(info->proc_data.userid)),
-            keyval("PID", fmt::nval(info->attached_proc_data.pid)),
-            keyval("PPID", fmt::nval(info->attached_proc_data.ppid)),
-            keyval("TID", fmt::nval(info->attached_proc_data.tid)),
-            keyval("ProcessName", fmt::qstr(info->attached_proc_data.name)),
-            keyval("Method", method)
-        );
+                   keyval("Time", TimeVal{UNPACK_TIMEVAL(info->timestamp)}),
+                   keyval("VCPU", fmt::nval(info->vcpu)),
+                   keyval("CR3", fmt::xval(info->regs->cr3)),
+                   keyval("UserId", fmt::nval(info->proc_data.userid)),
+                   keyval("PID", fmt::nval(info->attached_proc_data.pid)),
+                   keyval("PPID", fmt::nval(info->attached_proc_data.ppid)),
+                   keyval("TID", fmt::nval(info->attached_proc_data.tid)),
+                   keyval("ProcessName", fmt::qstr(info->attached_proc_data.name)),
+                   keyval("Method", method)
+                  );
     }
 }
 

--- a/src/plugins/output_format/deffmt.h
+++ b/src/plugins/output_format/deffmt.h
@@ -107,20 +107,39 @@
 
 #include "common.h"
 
-#include "plugins/type_traits_helpers.h"
+#include "type_traits_helpers.h"
 
 namespace deffmt
 {
 
 template <class T>
-constexpr bool print_data(fmt::ostream& os, const T& data, char sep = 0);
+constexpr bool print_data(std::ostream& os, const T& data, char sep);
 
+
+template<class T, std::size_t N>
+struct TuplePrinter
+{
+    static bool print(std::ostream& os, const T& data, char sep)
+    {
+        if constexpr (N > 0)
+        {
+            bool printed_prev = TuplePrinter<T, N-1>::print(os, data, sep);
+            if (printed_prev)
+                os << sep;
+            bool printed = print_data(os, std::get<N-1>(data), sep);
+            if (!printed && printed_prev)
+                fmt::unputc(os);
+            return printed;
+        }
+        return false;
+    }
+};
 
 template <class T, class = void, class...>
-struct data_printer
+struct DataPrinter
 {
 
-    static bool print(fmt::ostream& os, const TimeVal& t, char)
+    static bool print(std::ostream& os, const TimeVal& t, char)
     {
         os << t.tv_sec << ".";
 
@@ -131,14 +150,14 @@ struct data_printer
     }
 
     template <class Tv = T>
-    static bool print(fmt::ostream& os, const fmt::Nval<Tv>& data, char)
+    static bool print(std::ostream& os, const fmt::Nval<Tv>& data, char)
     {
         os << data.value;
         return true;
     }
 
     template <class Tv = T>
-    static bool print(fmt::ostream& os, const fmt::Xval<Tv>& data, char)
+    static bool print(std::ostream& os, const fmt::Xval<Tv>& data, char)
     {
         auto ff = os.flags();
         os << (data.withbase ? "0x" : "") << std::uppercase << std::hex << data.value;
@@ -147,7 +166,7 @@ struct data_printer
     }
 
     template <class Tv = T>
-    static bool print(fmt::ostream& os, const fmt::Fval<Tv>& data, char)
+    static bool print(std::ostream& os, const fmt::Fval<Tv>& data, char)
     {
         auto ff = os.flags();
         os << std::fixed << data.value;
@@ -156,21 +175,21 @@ struct data_printer
     }
 
     template <class Tv = T>
-    static bool print(fmt::ostream& os, const fmt::Rstr<Tv>& data, char)
+    static bool print(std::ostream& os, const fmt::Rstr<Tv>& data, char)
     {
         os << data.value;
         return true;
     }
 
     template <class Tv = T>
-    static bool print(fmt::ostream& os, const fmt::Qstr<Tv>& data, char)
+    static bool print(std::ostream& os, const fmt::Qstr<Tv>& data, char)
     {
         os << '"' << data.value << '"';
         return true;
     }
 
     template <class Tv = T>
-    static bool print(fmt::ostream& os, const std::function<bool(std::ostream&)>& printer, char)
+    static bool print(std::ostream& os, const std::function<bool(std::ostream&)>& printer, char)
     {
         std::ostringstream ss;
         bool printed = printer(ss);
@@ -180,7 +199,7 @@ struct data_printer
     }
 
     template <class Tv = T>
-    static bool print(fmt::ostream& os, const std::optional<Tv>& data, char sep)
+    static bool print(std::ostream& os, const std::optional<Tv>& data, char sep)
     {
         if (!data.has_value())
             return false;
@@ -189,7 +208,7 @@ struct data_printer
     }
 
     template <class Tk, class Tv>
-    static bool print(fmt::ostream& os, const std::pair<Tk, Tv>& data, char)
+    static bool print(std::ostream& os, const std::pair<Tk, Tv>& data, char)
     {
         static_assert(
             std::is_same_v<Tk, const char*> ||
@@ -209,38 +228,43 @@ struct data_printer
         os.seekp(pos);
         return false;
     }
+
+    template <class... Ts>
+    static bool print(std::ostream& os, const std::tuple<Ts...>& data, char sep)
+    {
+        return TuplePrinter<decltype(data), sizeof...(Ts)>::print(os, data, sep);
+    }
 };
 
 template <class T>
-struct data_printer<T, std::enable_if_t<is_iterable<T>::value, void>>
+struct DataPrinter<T, std::enable_if_t<is_iterable<T>::value, void>>
 {
-    static bool print(fmt::ostream& os, const T& data, char sep)
+    static bool print(std::ostream& os, const T& data, char sep)
     {
-        uint32_t i = 0;
         bool printed = false;
         for (const auto& v : data)
         {
+            bool printed_prev = printed;
             if (printed)
                 os << sep;
             printed = print_data(os, v, sep);
-            ++i;
+            if (!printed && printed_prev)
+                fmt::unputc(os);
         }
-        if (i > 0 && !printed)
-            os.unputc(sep);
         return true;
     }
 };
 
 template <class T>
-constexpr bool print_data(fmt::ostream& os, const T& data, char sep)
+constexpr bool print_data(std::ostream& os, const T& data, char sep)
 {
-    return data_printer<T>::print(os, data, sep);
+    return DataPrinter<T>::print(os, data, sep);
 }
 
 /**/
 
 template <class T, class... Ts>
-constexpr bool print_data(fmt::ostream& os, const T& data, const Ts& ... rest)
+constexpr bool print_data(std::ostream& os, const T& data, const Ts& ... rest)
 {
     constexpr char sep = ' ';
     bool printed = print_data(os, data, sep);
@@ -252,14 +276,14 @@ constexpr bool print_data(fmt::ostream& os, const T& data, const Ts& ... rest)
             os << sep;
         printed_rest = print_data(os, rest...);
         if (!printed_rest && printed)
-            os.unputc(sep);
+            fmt::unputc(os);
     }
     return printed || printed_rest;
 }
 
 /**/
 
-inline void print_common_data(fmt::ostream& os, drakvuf_t drakvuf, drakvuf_trap_info_t* info)
+inline void print_common_data(std::ostream& os, drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 {
     if (info)
     {
@@ -290,12 +314,12 @@ void print(const char* plugin_name, drakvuf_t drakvuf, drakvuf_trap_info_t* info
         return std::toupper(c);
     });
 
-    fmt::out << '[' << up_name << ']' << ' ';
+    fmt::cout << '[' << up_name << ']' << ' ';
 
     bool printed = false;
     if (info)
     {
-        print_common_data(fmt::out, drakvuf, info);
+        print_common_data(fmt::cout, drakvuf, info);
         printed = true;
     }
 
@@ -303,13 +327,13 @@ void print(const char* plugin_name, drakvuf_t drakvuf, drakvuf_trap_info_t* info
     {
         constexpr char sep = ' ';
         if (printed)
-            fmt::out << sep;
-        if (!print_data(fmt::out, args...))
-            fmt::out.unputc(sep);
+            fmt::cout << sep;
+        if (!print_data(fmt::cout, args...))
+            fmt::unputc(fmt::cout);
     }
 
-    fmt::out << "\n";
-    fmt::out.flush();
+    fmt::cout << "\n";
+    fmt::cout.flush();
 }
 
 } // namespace deffmt

--- a/src/plugins/output_format/deffmt.h
+++ b/src/plugins/output_format/deffmt.h
@@ -102,12 +102,213 @@
 *                                                                         *
 ***************************************************************************/
 
-#ifndef PLUGINS_OUTPUT_FORMAT_H
-#define PLUGINS_OUTPUT_FORMAT_H
+#ifndef PLUGINS_OUTPUT_FORMAT_DEFFMT_H
+#define PLUGINS_OUTPUT_FORMAT_DEFFMT_H
 
-#include "output_format/csvfmt.h"
-#include "output_format/deffmt.h"
-#include "output_format/jsonfmt.h"
-#include "output_format/kvfmt.h"
+#include "common.h"
 
-#endif
+#include <type_traits_helpers.h>
+
+namespace deffmt
+{
+
+template <class T>
+constexpr bool print_data(fmt::ostream& os, const T& data, char sep = 0);
+
+
+template <class T, class = void, class...>
+struct data_printer
+{
+
+    static bool print(fmt::ostream& os, const TimeVal& t, char)
+    {
+        os << t.tv_sec << ".";
+
+        auto c = os.fill('0');
+        auto w = os.width(6);
+        os << t.tv_usec << std::setfill(c) << std::setw(w);
+        return true;
+    }
+
+    template <class Tv = T>
+    static bool print(fmt::ostream& os, const fmt::Nval<Tv>& data, char)
+    {
+        os << data.value;
+        return true;
+    }
+
+    template <class Tv = T>
+    static bool print(fmt::ostream& os, const fmt::Xval<Tv>& data, char)
+    {
+        auto ff = os.flags();
+        os << (data.withbase ? "0x" : "") << std::uppercase << std::hex << data.value;
+        os.flags(ff);
+        return true;
+    }
+
+    template <class Tv = T>
+    static bool print(fmt::ostream& os, const fmt::Fval<Tv>& data, char)
+    {
+        auto ff = os.flags();
+        os << std::fixed << data.value;
+        os.flags(ff);
+        return true;
+    }
+
+    template <class Tv = T>
+    static bool print(fmt::ostream& os, const fmt::Rstr<Tv>& data, char)
+    {
+        os << data.value;
+        return true;
+    }
+
+    template <class Tv = T>
+    static bool print(fmt::ostream& os, const fmt::Qstr<Tv>& data, char)
+    {
+        os << '"' << data.value << '"';
+        return true;
+    }
+
+    template <class Tv = T>
+    static bool print(fmt::ostream& os, const std::function<bool(std::ostream&)>& printer, char)
+    {
+        std::ostringstream ss;
+        bool printed = printer(ss);
+        if (printed)
+            os << ss.str();
+        return printed;
+    }
+
+    template <class Tv = T>
+    static bool print(fmt::ostream& os, const std::optional<Tv>& data, char sep)
+    {
+        if (!data.has_value())
+            return false;
+
+        return print_data(os, data.value(), sep);
+    }
+
+    template <class Tk, class Tv>
+    static bool print(fmt::ostream& os, const std::pair<Tk, Tv>& data, char)
+    {
+        static_assert(
+            std::is_same_v<Tk, const char*> ||
+            std::is_same_v<std::decay_t<Tk>, std::string> ||
+            std::is_same_v<std::decay_t<Tk>, std::string_view>,
+            "Unsupported DEFAULT printer key type");
+
+        auto pos = os.tellp();
+        if (print_data(os, fmt::rstr(data.first), 0))
+        {
+            os << ':';
+            if (print_data(os, data.second, ';'))
+            {
+                return true;
+            }
+        }
+        os.seekp(pos);
+        return false;
+    }
+};
+
+template <class T>
+struct data_printer<T, std::enable_if_t<is_iterable<T>::value, void>>
+{
+    static bool print(fmt::ostream& os, const T& data, char sep)
+    {
+        uint32_t i = 0;
+        bool printed = false;
+        for (const auto& v : data) {
+            if (printed)
+                os << sep;
+            printed = print_data(os, v, sep);
+            ++i;
+        }
+        if (i > 0 && !printed)
+            os.unputc(sep);
+        return true;
+    }
+};
+
+template <class T>
+constexpr bool print_data(fmt::ostream& os, const T& data, char sep) {
+    return data_printer<T>::print(os, data, sep);
+}
+
+/**/
+
+template <class T, class... Ts>
+constexpr bool print_data(fmt::ostream& os, const T& data, const Ts&... rest) {
+    constexpr char sep = ' ';
+    bool printed = print_data(os, data, sep);
+    bool printed_rest = false;
+
+    if constexpr (sizeof...(rest) > 0)
+    {
+        if (printed)
+            os << sep;
+        printed_rest = print_data(os, rest...);
+        if (!printed_rest && printed)
+            os.unputc(sep);
+    }
+    return printed || printed_rest;
+}
+
+/**/
+
+inline void print_common_data(fmt::ostream& os, drakvuf_t drakvuf, drakvuf_trap_info_t* info)
+{
+    if (info)
+    {
+        const char* method = info->trap->name ?: "";
+        std::string procname = "\"";
+        procname += info->attached_proc_data.name;
+        procname += "\"";
+
+        print_data(os,
+            keyval("TIME", TimeVal{UNPACK_TIMEVAL(info->timestamp)}),
+            keyval("VCPU", fmt::nval(info->vcpu)),
+            keyval("CR3", fmt::xval(info->regs->cr3)),
+            keyval(procname.c_str(), fmt::rstr(method)),
+            keyval(USERIDSTR(drakvuf), fmt::nval(info->proc_data.userid)),
+            keyval("PID", fmt::nval(info->attached_proc_data.pid)),
+            keyval("PPID", fmt::nval(info->attached_proc_data.ppid))
+        );
+    }
+}
+
+template<class... Args>
+void print(const char* plugin_name, drakvuf_t drakvuf, drakvuf_trap_info_t* info, const Args& ... args)
+{
+    std::string up_name(plugin_name);
+    std::transform(up_name.begin(), up_name.end(), up_name.begin(),
+                   [](uint8_t c)
+    {
+        return std::toupper(c);
+    });
+
+    fmt::out << '[' << up_name << ']' << ' ';
+
+    bool printed = false;
+    if (info)
+    {
+        print_common_data(fmt::out, drakvuf, info);
+        printed = true;
+    }
+
+    if constexpr (sizeof...(args) > 0)
+    {
+        constexpr char sep = ' ';
+        if (printed)
+            fmt::out << sep;
+        if (!print_data(fmt::out, args...))
+            fmt::out.unputc(sep);
+    }
+
+    fmt::out << "\n";
+    fmt::out.flush();
+}
+
+} // namespace deffmt
+
+#endif // PLUGINS_OUTPUT_FORMAT_DEFFMT_H

--- a/src/plugins/output_format/deffmt.h
+++ b/src/plugins/output_format/deffmt.h
@@ -107,7 +107,7 @@
 
 #include "common.h"
 
-#include <type_traits_helpers.h>
+#include "plugins/type_traits_helpers.h"
 
 namespace deffmt
 {

--- a/src/plugins/output_format/deffmt.h
+++ b/src/plugins/output_format/deffmt.h
@@ -198,7 +198,7 @@ struct data_printer
             "Unsupported DEFAULT printer key type");
 
         auto pos = os.tellp();
-        if (print_data(os, fmt::rstr(data.first), 0))
+        if (print_data(os, fmt::Rstr(data.first), 0))
         {
             os << ':';
             if (print_data(os, data.second, ';'))
@@ -270,12 +270,12 @@ inline void print_common_data(fmt::ostream& os, drakvuf_t drakvuf, drakvuf_trap_
 
         print_data(os,
                    keyval("TIME", TimeVal{UNPACK_TIMEVAL(info->timestamp)}),
-                   keyval("VCPU", fmt::nval(info->vcpu)),
-                   keyval("CR3", fmt::xval(info->regs->cr3)),
-                   keyval(procname.c_str(), fmt::rstr(method)),
-                   keyval(USERIDSTR(drakvuf), fmt::nval(info->proc_data.userid)),
-                   keyval("PID", fmt::nval(info->attached_proc_data.pid)),
-                   keyval("PPID", fmt::nval(info->attached_proc_data.ppid))
+                   keyval("VCPU", fmt::Nval(info->vcpu)),
+                   keyval("CR3", fmt::Xval(info->regs->cr3)),
+                   keyval(procname.c_str(), fmt::Rstr(method)),
+                   keyval(USERIDSTR(drakvuf), fmt::Nval(info->proc_data.userid)),
+                   keyval("PID", fmt::Nval(info->attached_proc_data.pid)),
+                   keyval("PPID", fmt::Nval(info->attached_proc_data.ppid))
                   );
     }
 }

--- a/src/plugins/output_format/deffmt.h
+++ b/src/plugins/output_format/deffmt.h
@@ -218,7 +218,8 @@ struct data_printer<T, std::enable_if_t<is_iterable<T>::value, void>>
     {
         uint32_t i = 0;
         bool printed = false;
-        for (const auto& v : data) {
+        for (const auto& v : data)
+        {
             if (printed)
                 os << sep;
             printed = print_data(os, v, sep);
@@ -231,14 +232,16 @@ struct data_printer<T, std::enable_if_t<is_iterable<T>::value, void>>
 };
 
 template <class T>
-constexpr bool print_data(fmt::ostream& os, const T& data, char sep) {
+constexpr bool print_data(fmt::ostream& os, const T& data, char sep)
+{
     return data_printer<T>::print(os, data, sep);
 }
 
 /**/
 
 template <class T, class... Ts>
-constexpr bool print_data(fmt::ostream& os, const T& data, const Ts&... rest) {
+constexpr bool print_data(fmt::ostream& os, const T& data, const Ts& ... rest)
+{
     constexpr char sep = ' ';
     bool printed = print_data(os, data, sep);
     bool printed_rest = false;
@@ -266,14 +269,14 @@ inline void print_common_data(fmt::ostream& os, drakvuf_t drakvuf, drakvuf_trap_
         procname += "\"";
 
         print_data(os,
-            keyval("TIME", TimeVal{UNPACK_TIMEVAL(info->timestamp)}),
-            keyval("VCPU", fmt::nval(info->vcpu)),
-            keyval("CR3", fmt::xval(info->regs->cr3)),
-            keyval(procname.c_str(), fmt::rstr(method)),
-            keyval(USERIDSTR(drakvuf), fmt::nval(info->proc_data.userid)),
-            keyval("PID", fmt::nval(info->attached_proc_data.pid)),
-            keyval("PPID", fmt::nval(info->attached_proc_data.ppid))
-        );
+                   keyval("TIME", TimeVal{UNPACK_TIMEVAL(info->timestamp)}),
+                   keyval("VCPU", fmt::nval(info->vcpu)),
+                   keyval("CR3", fmt::xval(info->regs->cr3)),
+                   keyval(procname.c_str(), fmt::rstr(method)),
+                   keyval(USERIDSTR(drakvuf), fmt::nval(info->proc_data.userid)),
+                   keyval("PID", fmt::nval(info->attached_proc_data.pid)),
+                   keyval("PPID", fmt::nval(info->attached_proc_data.ppid))
+                  );
     }
 }
 

--- a/src/plugins/output_format/jsonfmt.h
+++ b/src/plugins/output_format/jsonfmt.h
@@ -107,7 +107,7 @@
 
 #include "common.h"
 
-#include <type_traits_helpers.h>
+#include "plugins/type_traits_helpers.h"
 
 namespace jsonfmt
 {

--- a/src/plugins/output_format/jsonfmt.h
+++ b/src/plugins/output_format/jsonfmt.h
@@ -102,12 +102,211 @@
 *                                                                         *
 ***************************************************************************/
 
-#ifndef PLUGINS_OUTPUT_FORMAT_H
-#define PLUGINS_OUTPUT_FORMAT_H
+#ifndef PLUGINS_OUTPUT_FORMAT_JSONFMT_H
+#define PLUGINS_OUTPUT_FORMAT_JSONFMT_H
 
-#include "output_format/csvfmt.h"
-#include "output_format/deffmt.h"
-#include "output_format/jsonfmt.h"
-#include "output_format/kvfmt.h"
+#include "common.h"
 
-#endif
+#include <type_traits_helpers.h>
+
+namespace jsonfmt
+{
+
+template <class T>
+constexpr bool print_data(fmt::ostream& os, const T& data, char sep = 0);
+
+
+template <class T, class = void, class...>
+struct data_printer
+{
+
+    static bool print(fmt::ostream& os, const TimeVal& t, char)
+    {
+        os << '"';
+        os << t.tv_sec << ".";
+
+        auto c = os.fill('0');
+        auto w = os.width(6);
+        os << t.tv_usec << std::setfill(c) << std::setw(w);
+        os << '"';
+        return true;
+    }
+
+    template <class Tv = T>
+    static bool print(fmt::ostream& os, const fmt::Nval<Tv>& data, char)
+    {
+        os << data.value;
+        return true;
+    }
+
+    template <class Tv = T>
+    static bool print(fmt::ostream& os, const fmt::Xval<Tv>& data, char)
+    {
+        auto ff = os.flags();
+        os << (data.withbase ? "0x" : "") << std::uppercase << std::hex << data.value;
+        os.flags(ff);
+        return true;
+    }
+
+    template <class Tv = T>
+    static bool print(fmt::ostream& os, const fmt::Fval<Tv>& data, char)
+    {
+        auto ff = os.flags();
+        os << std::fixed << data.value;
+        os.flags(ff);
+        return true;
+    }
+
+    template <class Tv = T>
+    static bool print(fmt::ostream& os, const fmt::Rstr<Tv>& data, char)
+    {
+        os << data.value;
+        return true;
+    }
+
+    template <class Tv = T>
+    static bool print(fmt::ostream& os, const fmt::Qstr<Tv>& data, char)
+    {
+        os << std::quoted(data.value);
+        return true;
+    }
+
+    template <class Tv = T>
+    static bool print(fmt::ostream& os, const std::function<bool(std::ostream&)>& printer, char)
+    {
+        std::ostringstream ss;
+        bool printed = printer(ss);
+        if (printed)
+            os << ss.str();
+        return printed;
+    }
+
+    template <class Tv = T>
+    static bool print(fmt::ostream& os, const std::optional<Tv>& data, char sep)
+    {
+        if (!data.has_value())
+        {
+            os << "null";
+            return true;
+        }
+        return print_data(os, data.value(), sep);
+    }
+
+    template <class Tk, class Tv>
+    static bool print(fmt::ostream& os, const std::pair<Tk, Tv>& data, char)
+    {
+        static_assert(
+            std::is_same_v<Tk, const char*> ||
+            std::is_same_v<std::decay_t<Tk>, std::string> ||
+            std::is_same_v<std::decay_t<Tk>, std::string_view>,
+            "Unsupported JSON printer key type");
+
+        auto pos = os.tellp();
+        if (print_data(os, fmt::qstr(data.first), 0))
+        {
+            os << ':';
+            if (print_data(os, data.second, ','))
+            {
+                return true;
+            }
+        }
+        os.seekp(pos);
+        return false;
+    }
+};
+
+template <class T>
+struct data_printer<T, std::enable_if_t<is_iterable<T>::value, void>>
+{
+    static bool print(fmt::ostream& os, const T& data, char sep)
+    {
+        uint32_t i = 0;
+        bool printed = false;
+        for (const auto& v : data) {
+            if (printed)
+                os << sep;
+            printed = print_data(os, v, sep);
+            ++i;
+        }
+        if (i > 0 && !printed)
+            os.unputc(sep);
+        return true;
+    }
+};
+
+template <class T>
+constexpr bool print_data(fmt::ostream& os, const T& data, char sep) {
+    return data_printer<T>::print(os, data, sep);
+}
+
+/**/
+
+template <class T, class... Ts>
+constexpr bool print_data(fmt::ostream& os, const T& data, const Ts&... rest) {
+    constexpr char sep = ',';
+    bool printed = print_data(os, data, sep);
+    bool printed_rest = false;
+
+    if constexpr (sizeof...(rest) > 0)
+    {
+        if (printed)
+            os << sep;
+        printed_rest = print_data(os, rest...);
+        if (!printed_rest && printed)
+            os.unputc(sep);
+    }
+    return printed || printed_rest;
+}
+
+/**/
+
+inline void print_common_data(fmt::ostream& os, const char* plugin_name, drakvuf_t drakvuf, drakvuf_trap_info_t* info)
+{
+    if (info)
+    {
+        std::optional<decltype(fmt::qstr(info->trap->name))> method;
+        if (info->trap->name)
+            method = fmt::qstr(info->trap->name);
+
+        print_data(os,
+            keyval("Plugin", fmt::qstr(plugin_name)),
+            keyval("Time", TimeVal{UNPACK_TIMEVAL(info->timestamp)}),
+            keyval("PID", fmt::nval(info->attached_proc_data.pid)),
+            keyval("PPID", fmt::nval(info->attached_proc_data.ppid)),
+            keyval("TID", fmt::nval(info->attached_proc_data.tid)),
+            keyval("UserName", fmt::qstr(USERIDSTR(drakvuf))),
+            keyval("UserId", fmt::nval(info->proc_data.userid)),
+            keyval("ProcessName", fmt::qstr(info->attached_proc_data.name)),
+            keyval("Method", method)
+        );
+    }
+}
+
+template<class... Args>
+void print(const char* plugin_name, drakvuf_t drakvuf, drakvuf_trap_info_t* info, const Args& ... args)
+{
+    fmt::out << '{';
+
+    bool printed = false;
+    if (info)
+    {
+        print_common_data(fmt::out, plugin_name, drakvuf, info);
+        printed = true;
+    }
+
+    if constexpr (sizeof...(args) > 0)
+    {
+        constexpr char sep = ',';
+        if (printed)
+            fmt::out << sep;
+        if (!print_data(fmt::out, args...))
+            fmt::out.unputc(sep);
+    }
+
+    fmt::out << "}\n";
+    fmt::out.flush();
+}
+
+} // namespace jsonfmt
+
+#endif // PLUGINS_OUTPUT_FORMAT_JSONFMT_H

--- a/src/plugins/output_format/jsonfmt.h
+++ b/src/plugins/output_format/jsonfmt.h
@@ -202,7 +202,7 @@ struct data_printer
             "Unsupported JSON printer key type");
 
         auto pos = os.tellp();
-        if (print_data(os, fmt::qstr(data.first), 0))
+        if (print_data(os, fmt::Qstr(data.first), 0))
         {
             os << ':';
             if (print_data(os, data.second, ','))
@@ -267,19 +267,19 @@ inline void print_common_data(fmt::ostream& os, const char* plugin_name, drakvuf
 {
     if (info)
     {
-        std::optional<decltype(fmt::qstr(info->trap->name))> method;
+        std::optional<fmt::Qstr<decltype(info->trap->name)>> method;
         if (info->trap->name)
-            method = fmt::qstr(info->trap->name);
+            method = fmt::Qstr(info->trap->name);
 
         print_data(os,
-                   keyval("Plugin", fmt::qstr(plugin_name)),
+                   keyval("Plugin", fmt::Qstr(plugin_name)),
                    keyval("Time", TimeVal{UNPACK_TIMEVAL(info->timestamp)}),
-                   keyval("PID", fmt::nval(info->attached_proc_data.pid)),
-                   keyval("PPID", fmt::nval(info->attached_proc_data.ppid)),
-                   keyval("TID", fmt::nval(info->attached_proc_data.tid)),
-                   keyval("UserName", fmt::qstr(USERIDSTR(drakvuf))),
-                   keyval("UserId", fmt::nval(info->proc_data.userid)),
-                   keyval("ProcessName", fmt::qstr(info->attached_proc_data.name)),
+                   keyval("PID", fmt::Nval(info->attached_proc_data.pid)),
+                   keyval("PPID", fmt::Nval(info->attached_proc_data.ppid)),
+                   keyval("TID", fmt::Nval(info->attached_proc_data.tid)),
+                   keyval("UserName", fmt::Qstr(USERIDSTR(drakvuf))),
+                   keyval("UserId", fmt::Nval(info->proc_data.userid)),
+                   keyval("ProcessName", fmt::Qstr(info->attached_proc_data.name)),
                    keyval("Method", method)
                   );
     }

--- a/src/plugins/output_format/jsonfmt.h
+++ b/src/plugins/output_format/jsonfmt.h
@@ -222,7 +222,8 @@ struct data_printer<T, std::enable_if_t<is_iterable<T>::value, void>>
     {
         uint32_t i = 0;
         bool printed = false;
-        for (const auto& v : data) {
+        for (const auto& v : data)
+        {
             if (printed)
                 os << sep;
             printed = print_data(os, v, sep);
@@ -235,14 +236,16 @@ struct data_printer<T, std::enable_if_t<is_iterable<T>::value, void>>
 };
 
 template <class T>
-constexpr bool print_data(fmt::ostream& os, const T& data, char sep) {
+constexpr bool print_data(fmt::ostream& os, const T& data, char sep)
+{
     return data_printer<T>::print(os, data, sep);
 }
 
 /**/
 
 template <class T, class... Ts>
-constexpr bool print_data(fmt::ostream& os, const T& data, const Ts&... rest) {
+constexpr bool print_data(fmt::ostream& os, const T& data, const Ts& ... rest)
+{
     constexpr char sep = ',';
     bool printed = print_data(os, data, sep);
     bool printed_rest = false;
@@ -269,16 +272,16 @@ inline void print_common_data(fmt::ostream& os, const char* plugin_name, drakvuf
             method = fmt::qstr(info->trap->name);
 
         print_data(os,
-            keyval("Plugin", fmt::qstr(plugin_name)),
-            keyval("Time", TimeVal{UNPACK_TIMEVAL(info->timestamp)}),
-            keyval("PID", fmt::nval(info->attached_proc_data.pid)),
-            keyval("PPID", fmt::nval(info->attached_proc_data.ppid)),
-            keyval("TID", fmt::nval(info->attached_proc_data.tid)),
-            keyval("UserName", fmt::qstr(USERIDSTR(drakvuf))),
-            keyval("UserId", fmt::nval(info->proc_data.userid)),
-            keyval("ProcessName", fmt::qstr(info->attached_proc_data.name)),
-            keyval("Method", method)
-        );
+                   keyval("Plugin", fmt::qstr(plugin_name)),
+                   keyval("Time", TimeVal{UNPACK_TIMEVAL(info->timestamp)}),
+                   keyval("PID", fmt::nval(info->attached_proc_data.pid)),
+                   keyval("PPID", fmt::nval(info->attached_proc_data.ppid)),
+                   keyval("TID", fmt::nval(info->attached_proc_data.tid)),
+                   keyval("UserName", fmt::qstr(USERIDSTR(drakvuf))),
+                   keyval("UserId", fmt::nval(info->proc_data.userid)),
+                   keyval("ProcessName", fmt::qstr(info->attached_proc_data.name)),
+                   keyval("Method", method)
+                  );
     }
 }
 

--- a/src/plugins/output_format/kvfmt.h
+++ b/src/plugins/output_format/kvfmt.h
@@ -216,7 +216,8 @@ struct data_printer<T, std::enable_if_t<is_iterable<T>::value, void>>
     {
         uint32_t i = 0;
         bool printed = false;
-        for (const auto& v : data) {
+        for (const auto& v : data)
+        {
             if (printed)
                 os << sep;
             printed = print_data(os, v, sep);
@@ -229,14 +230,16 @@ struct data_printer<T, std::enable_if_t<is_iterable<T>::value, void>>
 };
 
 template <class T>
-constexpr bool print_data(fmt::ostream& os, const T& data, char sep) {
+constexpr bool print_data(fmt::ostream& os, const T& data, char sep)
+{
     return data_printer<T>::print(os, data, sep);
 }
 
 /**/
 
 template <class T, class... Ts>
-constexpr bool print_data(fmt::ostream& os, const T& data, const Ts&... rest) {
+constexpr bool print_data(fmt::ostream& os, const T& data, const Ts& ... rest)
+{
     constexpr char sep = ',';
     bool printed = print_data(os, data, sep);
     bool printed_rest = false;
@@ -263,13 +266,13 @@ inline void print_common_data(fmt::ostream& os, drakvuf_trap_info_t* info)
             method = fmt::rstr(info->trap->name);
 
         print_data(os,
-            keyval("Time", TimeVal{UNPACK_TIMEVAL(info->timestamp)}),
-            keyval("PID", fmt::nval(info->attached_proc_data.pid)),
-            keyval("PPID", fmt::nval(info->attached_proc_data.ppid)),
-            keyval("TID", fmt::nval(info->attached_proc_data.tid)),
-            keyval("ProcessName", fmt::qstr(info->attached_proc_data.name)),
-            keyval("Method", method)
-        );
+                   keyval("Time", TimeVal{UNPACK_TIMEVAL(info->timestamp)}),
+                   keyval("PID", fmt::nval(info->attached_proc_data.pid)),
+                   keyval("PPID", fmt::nval(info->attached_proc_data.ppid)),
+                   keyval("TID", fmt::nval(info->attached_proc_data.tid)),
+                   keyval("ProcessName", fmt::qstr(info->attached_proc_data.name)),
+                   keyval("Method", method)
+                  );
     }
 }
 

--- a/src/plugins/output_format/kvfmt.h
+++ b/src/plugins/output_format/kvfmt.h
@@ -113,14 +113,33 @@ namespace kvfmt
 {
 
 template <class T>
-constexpr bool print_data(fmt::ostream& os, const T& data, char sep = 0);
+constexpr bool print_data(std::ostream& os, const T& data, char sep);
 
+
+template<class T, std::size_t N>
+struct TuplePrinter
+{
+    static bool print(std::ostream& os, const T& data, char sep)
+    {
+        if constexpr (N > 0)
+        {
+            bool printed_prev = TuplePrinter<T, N-1>::print(os, data, sep);
+            if (printed_prev)
+                os << sep;
+            bool printed = print_data(os, std::get<N-1>(data), sep);
+            if (!printed && printed_prev)
+                fmt::unputc(os);
+            return printed;
+        }
+        return false;
+    }
+};
 
 template <class T, class = void, class...>
-struct data_printer
+struct DataPrinter
 {
 
-    static bool print(fmt::ostream& os, const TimeVal& t, char)
+    static bool print(std::ostream& os, const TimeVal& t, char)
     {
         os << t.tv_sec << ".";
 
@@ -131,21 +150,21 @@ struct data_printer
     }
 
     template <class Tv = T>
-    static bool print(fmt::ostream& os, const fmt::Nval<Tv>& data, char)
+    static bool print(std::ostream& os, const fmt::Nval<Tv>& data, char)
     {
         os << data.value;
         return true;
     }
 
     template <class Tv = T>
-    static bool print(fmt::ostream& os, const fmt::Xval<Tv>& data, char)
+    static bool print(std::ostream& os, const fmt::Xval<Tv>& data, char)
     {
         os << data.value;
         return true;
     }
 
     template <class Tv = T>
-    static bool print(fmt::ostream& os, const fmt::Fval<Tv>& data, char)
+    static bool print(std::ostream& os, const fmt::Fval<Tv>& data, char)
     {
         auto ff = os.flags();
         os << std::fixed << data.value;
@@ -154,21 +173,21 @@ struct data_printer
     }
 
     template <class Tv = T>
-    static bool print(fmt::ostream& os, const fmt::Rstr<Tv>& data, char)
+    static bool print(std::ostream& os, const fmt::Rstr<Tv>& data, char)
     {
         os << data.value;
         return true;
     }
 
     template <class Tv = T>
-    static bool print(fmt::ostream& os, const fmt::Qstr<Tv>& data, char)
+    static bool print(std::ostream& os, const fmt::Qstr<Tv>& data, char)
     {
         os << '"' << data.value << '"';
         return true;
     }
 
     template <class Tv = T>
-    static bool print(fmt::ostream& os, const std::function<bool(std::ostream&)>& printer, char)
+    static bool print(std::ostream& os, const std::function<bool(std::ostream&)>& printer, char)
     {
         std::ostringstream ss;
         bool printed = printer(ss);
@@ -178,7 +197,7 @@ struct data_printer
     }
 
     template <class Tv = T>
-    static bool print(fmt::ostream& os, const std::optional<Tv>& data, char sep)
+    static bool print(std::ostream& os, const std::optional<Tv>& data, char sep)
     {
         if (!data.has_value())
             return false;
@@ -187,7 +206,7 @@ struct data_printer
     }
 
     template <class Tk, class Tv>
-    static bool print(fmt::ostream& os, const std::pair<Tk, Tv>& data, char)
+    static bool print(std::ostream& os, const std::pair<Tk, Tv>& data, char)
     {
         static_assert(
             std::is_same_v<Tk, const char*> ||
@@ -207,38 +226,43 @@ struct data_printer
         os.seekp(pos);
         return false;
     }
+
+    template <class... Ts>
+    static bool print(std::ostream& os, const std::tuple<Ts...>& data, char sep)
+    {
+        return TuplePrinter<decltype(data), sizeof...(Ts)>::print(os, data, sep);
+    }
 };
 
 template <class T>
-struct data_printer<T, std::enable_if_t<is_iterable<T>::value, void>>
+struct DataPrinter<T, std::enable_if_t<is_iterable<T>::value, void>>
 {
-    static bool print(fmt::ostream& os, const T& data, char sep)
+    static bool print(std::ostream& os, const T& data, char sep)
     {
-        uint32_t i = 0;
         bool printed = false;
         for (const auto& v : data)
         {
+            bool printed_prev = printed;
             if (printed)
                 os << sep;
             printed = print_data(os, v, sep);
-            ++i;
+            if (!printed && printed_prev)
+                fmt::unputc(os);
         }
-        if (i > 0 && !printed)
-            os.unputc(sep);
         return true;
     }
 };
 
 template <class T>
-constexpr bool print_data(fmt::ostream& os, const T& data, char sep)
+constexpr bool print_data(std::ostream& os, const T& data, char sep)
 {
-    return data_printer<T>::print(os, data, sep);
+    return DataPrinter<T>::print(os, data, sep);
 }
 
 /**/
 
 template <class T, class... Ts>
-constexpr bool print_data(fmt::ostream& os, const T& data, const Ts& ... rest)
+constexpr bool print_data(std::ostream& os, const T& data, const Ts& ... rest)
 {
     constexpr char sep = ',';
     bool printed = print_data(os, data, sep);
@@ -250,14 +274,14 @@ constexpr bool print_data(fmt::ostream& os, const T& data, const Ts& ... rest)
             os << sep;
         printed_rest = print_data(os, rest...);
         if (!printed_rest && printed)
-            os.unputc(sep);
+            fmt::unputc(os);
     }
     return printed || printed_rest;
 }
 
 /**/
 
-inline void print_common_data(fmt::ostream& os, drakvuf_trap_info_t* info)
+inline void print_common_data(std::ostream& os, drakvuf_trap_info_t* info)
 {
     if (info)
     {
@@ -279,12 +303,12 @@ inline void print_common_data(fmt::ostream& os, drakvuf_trap_info_t* info)
 template<class... Args>
 void print(const char* plugin_name, drakvuf_t drakvuf, drakvuf_trap_info_t* info, const Args& ... args)
 {
-    fmt::out << plugin_name << ' ';
+    fmt::cout << plugin_name << ' ';
 
     bool printed = false;
     if (info)
     {
-        print_common_data(fmt::out, info);
+        print_common_data(fmt::cout, info);
         printed = true;
     }
 
@@ -292,13 +316,13 @@ void print(const char* plugin_name, drakvuf_t drakvuf, drakvuf_trap_info_t* info
     {
         constexpr char sep = ',';
         if (printed)
-            fmt::out << sep;
-        if (!print_data(fmt::out, args...))
-            fmt::out.unputc(sep);
+            fmt::cout << sep;
+        if (!print_data(fmt::cout, args...))
+            fmt::unputc(fmt::cout);
     }
 
-    fmt::out << "\n";
-    fmt::out.flush();
+    fmt::cout << "\n";
+    fmt::cout.flush();
 }
 
 } // namespace kvfmt

--- a/src/plugins/output_format/kvfmt.h
+++ b/src/plugins/output_format/kvfmt.h
@@ -107,7 +107,7 @@
 
 #include "common.h"
 
-#include <type_traits_helpers.h>
+#include "plugins/type_traits_helpers.h"
 
 namespace kvfmt
 {

--- a/src/plugins/output_format/kvfmt.h
+++ b/src/plugins/output_format/kvfmt.h
@@ -102,12 +102,202 @@
 *                                                                         *
 ***************************************************************************/
 
-#ifndef PLUGINS_OUTPUT_FORMAT_H
-#define PLUGINS_OUTPUT_FORMAT_H
+#ifndef PLUGINS_OUTPUT_FORMAT_KVFMT_H
+#define PLUGINS_OUTPUT_FORMAT_KVFMT_H
 
-#include "output_format/csvfmt.h"
-#include "output_format/deffmt.h"
-#include "output_format/jsonfmt.h"
-#include "output_format/kvfmt.h"
+#include "common.h"
 
-#endif
+#include <type_traits_helpers.h>
+
+namespace kvfmt
+{
+
+template <class T>
+constexpr bool print_data(fmt::ostream& os, const T& data, char sep = 0);
+
+
+template <class T, class = void, class...>
+struct data_printer
+{
+
+    static bool print(fmt::ostream& os, const TimeVal& t, char)
+    {
+        os << t.tv_sec << ".";
+
+        auto c = os.fill('0');
+        auto w = os.width(6);
+        os << t.tv_usec << std::setfill(c) << std::setw(w);
+        return true;
+    }
+
+    template <class Tv = T>
+    static bool print(fmt::ostream& os, const fmt::Nval<Tv>& data, char)
+    {
+        os << data.value;
+        return true;
+    }
+
+    template <class Tv = T>
+    static bool print(fmt::ostream& os, const fmt::Xval<Tv>& data, char)
+    {
+        os << data.value;
+        return true;
+    }
+
+    template <class Tv = T>
+    static bool print(fmt::ostream& os, const fmt::Fval<Tv>& data, char)
+    {
+        auto ff = os.flags();
+        os << std::fixed << data.value;
+        os.flags(ff);
+        return true;
+    }
+
+    template <class Tv = T>
+    static bool print(fmt::ostream& os, const fmt::Rstr<Tv>& data, char)
+    {
+        os << data.value;
+        return true;
+    }
+
+    template <class Tv = T>
+    static bool print(fmt::ostream& os, const fmt::Qstr<Tv>& data, char)
+    {
+        os << '"' << data.value << '"';
+        return true;
+    }
+
+    template <class Tv = T>
+    static bool print(fmt::ostream& os, const std::function<bool(std::ostream&)>& printer, char)
+    {
+        std::ostringstream ss;
+        bool printed = printer(ss);
+        if (printed)
+            os << ss.str();
+        return printed;
+    }
+
+    template <class Tv = T>
+    static bool print(fmt::ostream& os, const std::optional<Tv>& data, char sep)
+    {
+        if (!data.has_value())
+            return false;
+
+        return print_data(os, data.value(), sep);
+    }
+
+    template <class Tk, class Tv>
+    static bool print(fmt::ostream& os, const std::pair<Tk, Tv>& data, char)
+    {
+        static_assert(
+            std::is_same_v<Tk, const char*> ||
+            std::is_same_v<std::decay_t<Tk>, std::string> ||
+            std::is_same_v<std::decay_t<Tk>, std::string_view>,
+            "Unsupported KV printer key type");
+
+        auto pos = os.tellp();
+        if (print_data(os, fmt::rstr(data.first), 0))
+        {
+            os << '=';
+            if (print_data(os, data.second, ';'))
+            {
+                return true;
+            }
+        }
+        os.seekp(pos);
+        return false;
+    }
+};
+
+template <class T>
+struct data_printer<T, std::enable_if_t<is_iterable<T>::value, void>>
+{
+    static bool print(fmt::ostream& os, const T& data, char sep)
+    {
+        uint32_t i = 0;
+        bool printed = false;
+        for (const auto& v : data) {
+            if (printed)
+                os << sep;
+            printed = print_data(os, v, sep);
+            ++i;
+        }
+        if (i > 0 && !printed)
+            os.unputc(sep);
+        return true;
+    }
+};
+
+template <class T>
+constexpr bool print_data(fmt::ostream& os, const T& data, char sep) {
+    return data_printer<T>::print(os, data, sep);
+}
+
+/**/
+
+template <class T, class... Ts>
+constexpr bool print_data(fmt::ostream& os, const T& data, const Ts&... rest) {
+    constexpr char sep = ',';
+    bool printed = print_data(os, data, sep);
+    bool printed_rest = false;
+
+    if constexpr (sizeof...(rest) > 0)
+    {
+        if (printed)
+            os << sep;
+        printed_rest = print_data(os, rest...);
+        if (!printed_rest && printed)
+            os.unputc(sep);
+    }
+    return printed || printed_rest;
+}
+
+/**/
+
+inline void print_common_data(fmt::ostream& os, drakvuf_trap_info_t* info)
+{
+    if (info)
+    {
+        std::optional<decltype(fmt::rstr(info->trap->name))> method;
+        if (info->trap->name)
+            method = fmt::rstr(info->trap->name);
+
+        print_data(os,
+            keyval("Time", TimeVal{UNPACK_TIMEVAL(info->timestamp)}),
+            keyval("PID", fmt::nval(info->attached_proc_data.pid)),
+            keyval("PPID", fmt::nval(info->attached_proc_data.ppid)),
+            keyval("TID", fmt::nval(info->attached_proc_data.tid)),
+            keyval("ProcessName", fmt::qstr(info->attached_proc_data.name)),
+            keyval("Method", method)
+        );
+    }
+}
+
+template<class... Args>
+void print(const char* plugin_name, drakvuf_t drakvuf, drakvuf_trap_info_t* info, const Args& ... args)
+{
+    fmt::out << plugin_name << ' ';
+
+    bool printed = false;
+    if (info)
+    {
+        print_common_data(fmt::out, info);
+        printed = true;
+    }
+
+    if constexpr (sizeof...(args) > 0)
+    {
+        constexpr char sep = ',';
+        if (printed)
+            fmt::out << sep;
+        if (!print_data(fmt::out, args...))
+            fmt::out.unputc(sep);
+    }
+
+    fmt::out << "\n";
+    fmt::out.flush();
+}
+
+} // namespace kvfmt
+
+#endif // PLUGINS_OUTPUT_FORMAT_KVFMT_H

--- a/src/plugins/output_format/kvfmt.h
+++ b/src/plugins/output_format/kvfmt.h
@@ -196,7 +196,7 @@ struct data_printer
             "Unsupported KV printer key type");
 
         auto pos = os.tellp();
-        if (print_data(os, fmt::rstr(data.first), 0))
+        if (print_data(os, fmt::Rstr(data.first), 0))
         {
             os << '=';
             if (print_data(os, data.second, ';'))
@@ -261,16 +261,16 @@ inline void print_common_data(fmt::ostream& os, drakvuf_trap_info_t* info)
 {
     if (info)
     {
-        std::optional<decltype(fmt::rstr(info->trap->name))> method;
+        std::optional<fmt::Rstr<decltype(info->trap->name)>> method;
         if (info->trap->name)
-            method = fmt::rstr(info->trap->name);
+            method = fmt::Rstr(info->trap->name);
 
         print_data(os,
                    keyval("Time", TimeVal{UNPACK_TIMEVAL(info->timestamp)}),
-                   keyval("PID", fmt::nval(info->attached_proc_data.pid)),
-                   keyval("PPID", fmt::nval(info->attached_proc_data.ppid)),
-                   keyval("TID", fmt::nval(info->attached_proc_data.tid)),
-                   keyval("ProcessName", fmt::qstr(info->attached_proc_data.name)),
+                   keyval("PID", fmt::Nval(info->attached_proc_data.pid)),
+                   keyval("PPID", fmt::Nval(info->attached_proc_data.ppid)),
+                   keyval("TID", fmt::Nval(info->attached_proc_data.tid)),
+                   keyval("ProcessName", fmt::Qstr(info->attached_proc_data.name)),
                    keyval("Method", method)
                   );
     }

--- a/src/plugins/output_format/ostream.cpp
+++ b/src/plugins/output_format/ostream.cpp
@@ -102,12 +102,11 @@
 *                                                                         *
 ***************************************************************************/
 
-#ifndef PLUGINS_OUTPUT_FORMAT_H
-#define PLUGINS_OUTPUT_FORMAT_H
+#include "ostream.h"
 
-#include "output_format/csvfmt.h"
-#include "output_format/deffmt.h"
-#include "output_format/jsonfmt.h"
-#include "output_format/kvfmt.h"
+namespace fmt
+{
 
-#endif
+ostream out;
+
+} // namespace fmt

--- a/src/plugins/output_format/ostream.cpp
+++ b/src/plugins/output_format/ostream.cpp
@@ -104,9 +104,33 @@
 
 #include "ostream.h"
 
+#include <sstream>
+
+#include <stdio.h>
+#include <unistd.h>
+
 namespace fmt
 {
 
-ostream out;
+class StrBuf : public std::stringbuf
+{
+protected:
+    int sync() final
+    {
+        // this is required because of printf() logging
+        fflush(stdout);
+
+        int size = pptr() - pbase();
+        if (write(STDOUT_FILENO, pbase(), size) == size)
+        {
+            seekpos(0);
+            return 0;
+        }
+        return -1;
+    }
+};
+
+static StrBuf outbuf;
+std::ostream cout(&outbuf);
 
 } // namespace fmt

--- a/src/plugins/output_format/ostream.h
+++ b/src/plugins/output_format/ostream.h
@@ -113,8 +113,9 @@
 
 #include <stdio.h>
 #include <unistd.h>
- 
-namespace fmt {
+
+namespace fmt
+{
 
 template<std::size_t SIZE, class CharT = char>
 class ArrayedStreamBuffer : public std::basic_streambuf<CharT>
@@ -123,7 +124,7 @@ public:
     using Base = std::basic_streambuf<CharT>;
     using int_type = typename Base::int_type;
     using char_type = typename Base::char_type;
- 
+
 public:
     ArrayedStreamBuffer() : buffer_{}
     {
@@ -132,7 +133,7 @@ public:
 
     void unputc(char_type ch)
     {
-        if(Base::pptr() > Base::pbase() && Base::pptr()[-1] == ch)
+        if (Base::pptr() > Base::pbase() && Base::pptr()[-1] == ch)
         {
             int sz = sizeof(ch);
             Base::pbump(-sz);

--- a/src/plugins/output_format/ostream.h
+++ b/src/plugins/output_format/ostream.h
@@ -106,77 +106,23 @@
 #define PLUGINS_OUTPUT_FORMAT_OSTREAM_H
 #pragma once
 
-#include <array>
-#include <ios>
 #include <iostream>
-#include <streambuf>
-
-#include <stdio.h>
-#include <unistd.h>
 
 namespace fmt
 {
 
-template<std::size_t SIZE, class CharT = char>
-class ArrayedStreamBuffer : public std::basic_streambuf<CharT>
+inline void unputc(std::ostream& os)
 {
-public:
-    using Base = std::basic_streambuf<CharT>;
-    using int_type = typename Base::int_type;
-    using char_type = typename Base::char_type;
+    constexpr int char_size = sizeof(std::ostream::char_type);
 
-public:
-    ArrayedStreamBuffer() : buffer_{}
+    size_t pos = os.tellp();
+    if (pos > char_size)
     {
-        Base::setp(buffer_.begin(), buffer_.end());
+        os.seekp(pos - char_size);
     }
+}
 
-    void unputc(char_type ch)
-    {
-        if (Base::pptr() > Base::pbase() && Base::pptr()[-1] == ch)
-        {
-            int sz = sizeof(ch);
-            Base::pbump(-sz);
-        }
-    }
-
-protected:
-    int sync() final
-    {
-        // this is required because of printf() logging
-        fflush(stdout);
-
-        int size = Base::pptr() - Base::pbase();
-        if (write(STDOUT_FILENO, Base::pbase(), size) == size)
-        {
-            Base::pbump(-size);
-            return 0;
-        }
-        return -1;
-    }
-
-private:
-    std::array<char_type, SIZE> buffer_;
-};
-
-class ostream: public std::ostream
-{
-public:
-    ostream(): std::ostream(&streambuf)
-    {
-        exceptions(std::ostream::failbit);
-    }
-
-    void unputc(char_type ch)
-    {
-        streambuf.unputc(ch);
-    }
-
-private:
-    ArrayedStreamBuffer<4096> streambuf;
-};
-
-extern ostream out;
+extern std::ostream cout;
 
 } // namespace fmt
 

--- a/src/plugins/type_traits_helpers.h
+++ b/src/plugins/type_traits_helpers.h
@@ -108,6 +108,11 @@
 
 #include <type_traits>
 
+template<class T>
+struct always_false: std::false_type {};
+
+/**/
+
 template <class T, class = void>
 struct has_begin_helper : std::false_type {};
 

--- a/src/plugins/type_traits_helpers.h
+++ b/src/plugins/type_traits_helpers.h
@@ -1,0 +1,144 @@
+/*********************IMPORTANT DRAKVUF LICENSE TERMS***********************
+ *                                                                         *
+ * DRAKVUF (C) 2014-2020 Tamas K Lengyel.                                  *
+ * Tamas K Lengyel is hereinafter referred to as the author.               *
+ * This program is free software; you may redistribute and/or modify it    *
+ * under the terms of the GNU General Public License as published by the   *
+ * Free Software Foundation; Version 2 ("GPL"), BUT ONLY WITH ALL OF THE   *
+ * CLARIFICATIONS AND EXCEPTIONS DESCRIBED HEREIN.  This guarantees your   *
+ * right to use, modify, and redistribute this software under certain      *
+ * conditions.  If you wish to embed DRAKVUF technology into proprietary   *
+ * software, alternative licenses can be aquired from the author.          *
+ *                                                                         *
+ * Note that the GPL places important restrictions on "derivative works",  *
+ * yet it does not provide a detailed definition of that term.  To avoid   *
+ * misunderstandings, we interpret that term as broadly as copyright law   *
+ * allows.  For example, we consider an application to constitute a        *
+ * derivative work for the purpose of this license if it does any of the   *
+ * following with any software or content covered by this license          *
+ * ("Covered Software"):                                                   *
+ *                                                                         *
+ * o Integrates source code from Covered Software.                         *
+ *                                                                         *
+ * o Reads or includes copyrighted data files.                             *
+ *                                                                         *
+ * o Is designed specifically to execute Covered Software and parse the    *
+ * results (as opposed to typical shell or execution-menu apps, which will *
+ * execute anything you tell them to).                                     *
+ *                                                                         *
+ * o Includes Covered Software in a proprietary executable installer.  The *
+ * installers produced by InstallShield are an example of this.  Including *
+ * DRAKVUF with other software in compressed or archival form does not     *
+ * trigger this provision, provided appropriate open source decompression  *
+ * or de-archiving software is widely available for no charge.  For the    *
+ * purposes of this license, an installer is considered to include Covered *
+ * Software even if it actually retrieves a copy of Covered Software from  *
+ * another source during runtime (such as by downloading it from the       *
+ * Internet).                                                              *
+ *                                                                         *
+ * o Links (statically or dynamically) to a library which does any of the  *
+ * above.                                                                  *
+ *                                                                         *
+ * o Executes a helper program, module, or script to do any of the above.  *
+ *                                                                         *
+ * This list is not exclusive, but is meant to clarify our interpretation  *
+ * of derived works with some common examples.  Other people may interpret *
+ * the plain GPL differently, so we consider this a special exception to   *
+ * the GPL that we apply to Covered Software.  Works which meet any of     *
+ * these conditions must conform to all of the terms of this license,      *
+ * particularly including the GPL Section 3 requirements of providing      *
+ * source code and allowing free redistribution of the work as a whole.    *
+ *                                                                         *
+ * Any redistribution of Covered Software, including any derived works,    *
+ * must obey and carry forward all of the terms of this license, including *
+ * obeying all GPL rules and restrictions.  For example, source code of    *
+ * the whole work must be provided and free redistribution must be         *
+ * allowed.  All GPL references to "this License", are to be treated as    *
+ * including the terms and conditions of this license text as well.        *
+ *                                                                         *
+ * Because this license imposes special exceptions to the GPL, Covered     *
+ * Work may not be combined (even as part of a larger work) with plain GPL *
+ * software.  The terms, conditions, and exceptions of this license must   *
+ * be included as well.  This license is incompatible with some other open *
+ * source licenses as well.  In some cases we can relicense portions of    *
+ * DRAKVUF or grant special permissions to use it in other open source     *
+ * software.  Please contact tamas.k.lengyel@gmail.com with any such       *
+ * requests.  Similarly, we don't incorporate incompatible open source     *
+ * software into Covered Software without special permission from the      *
+ * copyright holders.                                                      *
+ *                                                                         *
+ * If you have any questions about the licensing restrictions on using     *
+ * DRAKVUF in other works, are happy to help.  As mentioned above,         *
+ * alternative license can be requested from the author to integrate       *
+ * DRAKVUF into proprietary applications and appliances.  Please email     *
+ * tamas.k.lengyel@gmail.com for further information.                      *
+ *                                                                         *
+ * If you have received a written license agreement or contract for        *
+ * Covered Software stating terms other than these, you may choose to use  *
+ * and redistribute Covered Software under those terms instead of these.   *
+ *                                                                         *
+ * Source is provided to this software because we believe users have a     *
+ * right to know exactly what a program is going to do before they run it. *
+ * This also allows you to audit the software for security holes.          *
+ *                                                                         *
+ * Source code also allows you to port DRAKVUF to new platforms, fix bugs, *
+ * and add new features.  You are highly encouraged to submit your changes *
+ * on https://github.com/tklengyel/drakvuf, or by other methods.           *
+ * By sending these changes, it is understood (unless you specify          *
+ * otherwise) that you are offering unlimited, non-exclusive right to      *
+ * reuse, modify, and relicense the code.  DRAKVUF will always be          *
+ * available Open Source, but this is important because the inability to   *
+ * relicense code has caused devastating problems for other Free Software  *
+ * projects (such as KDE and NASM).                                        *
+ * To specify special license conditions of your contributions, just say   *
+ * so when you send them.                                                  *
+ *                                                                         *
+ * This program is distributed in the hope that it will be useful, but     *
+ * WITHOUT ANY WARRANTY; without even the implied warranty of              *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the DRAKVUF   *
+ * license file for more details (it's in a COPYING file included with     *
+ * DRAKVUF, and also available from                                        *
+ * https://github.com/tklengyel/drakvuf/COPYING)                           *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef DRAKVUF_PLUGINS_TYPE_TRAITS_HELPERS_H
+#define DRAKVUF_PLUGINS_TYPE_TRAITS_HELPERS_H
+#pragma once
+
+#include <type_traits>
+
+template <class T, class = void>
+struct has_begin_helper : std::false_type {};
+
+template <class T>
+struct has_begin_helper<T, std::void_t<decltype(std::begin(std::declval<T>()))>> : std::true_type {};
+
+template <class T, class = void>
+struct has_end_helper : std::false_type {};
+
+template <class T>
+struct has_end_helper<T, std::void_t<decltype(std::end(std::declval<T>()))>> : std::true_type {};
+
+
+template <class T, class = void>
+struct is_iterable_helper : std::false_type {};
+
+template <class T>
+struct is_iterable_helper<T, std::enable_if_t<has_begin_helper<T>::value && has_end_helper<T>::value, void>> : std::true_type {};
+
+template <class T>
+struct is_iterable : is_iterable_helper<T> {};
+
+/**/
+
+template <class T, class = void>
+struct is_printable_helper : std::false_type {};
+
+template <class T>
+struct is_printable_helper<T, std::void_t<decltype(std::declval<std::ostream>().operator<<(std::declval<T>()))>> : std::true_type {};
+
+template <class T>
+struct is_printable : is_printable_helper<T> {};
+
+#endif // DRAKVUF_PLUGINS_TYPE_TRAITS_HELPERS_H

--- a/src/plugins/type_traits_helpers.h
+++ b/src/plugins/type_traits_helpers.h
@@ -130,7 +130,7 @@ template <class T, class = void>
 struct is_iterable_helper : std::false_type {};
 
 template <class T>
-struct is_iterable_helper<T, std::enable_if_t<has_begin_helper<T>::value && has_end_helper<T>::value, void>> : std::true_type {};
+struct is_iterable_helper<T, std::enable_if_t<has_begin_helper<T>::value&& has_end_helper<T>::value, void>> : std::true_type {};
 
 template <class T>
 struct is_iterable : is_iterable_helper<T> {};


### PR DESCRIPTION
I have tried to unify various printers.
So it can print only 'fmt' defined types and types should be specified in print() explicitly.
