### PR TITLE
Enable optional debug output for drakvuf-bundle

### DIFF
--- a/package/Dockerfile-final
+++ b/package/Dockerfile-final
@@ -4,7 +4,7 @@ COPY . /build
 RUN export INSTALL_PATH="/build/usr" && \
     cd /build/libvmi && \
     autoreconf -vif && \
-    ./configure --prefix=$INSTALL_PATH --disable-kvm --disable-file --disable-bareflank --disable-safety-checks && \
+    ./configure --prefix=$INSTALL_PATH --disable-kvm --disable-file --disable-bareflank --disable-safety-checks --enable-vmi-debug && \
     make -j$(nproc) && \
     make install && \
     ldconfig
@@ -17,7 +17,7 @@ RUN export INSTALL_PATH="/build/usr" && \
     export LDFLAGS="-L$INSTALL_PATH/lib" && \
     export CFLAGS="-I$INSTALL_PATH/include" && \
     autoreconf -vif && \
-    ./configure --prefix=$INSTALL_PATH && \
+    ./configure --prefix=$INSTALL_PATH --enable-debug && \
     make -j$(nproc) && \
     make install
 


### PR DESCRIPTION
The debug printouts will not show by default but would have to be enabled with:
* `LIBVMI_DEBUG=1` for LibVMI
* `-v` switch for DRAKVUF

this would make it much easier to diagnose some bugs.