### PR TITLE
Fix package build error in Travis

### DIFF
--- a/package/build.sh
+++ b/package/build.sh
@@ -19,7 +19,15 @@ mkdir -p package/log
 if [ ! -f "package/cache/xen-intermediate-$IMAGE-$XEN_HASH.tar.gz" ]
 then
     echo Building Xen intermediate $XEN_HASH...
-    docker build --build-arg "IMAGE=$IMAGE" -f package/Dockerfile-xen -t xen-intermediate . # 2>&1 >package/log/xen-build.log
+    DOCKER_CMD="docker build --build-arg 'IMAGE=$IMAGE' -f package/Dockerfile-xen -t xen-intermediate ."
+
+    if [ ! -z "$TRAVIS_JOB_ID" ]; then
+        # suppress Xen build logs when we are in CI
+        $DOCKER_CMD 2>&1 >package/log/xen-build.log
+    else
+        $DOCKER_CMD
+    fi
+
     if [ $? -ne 0 ]; then echo Xen intermediate image build failed, build log tail below ; tail -n 200 package/log/xen-build.log ; exit 1 ; fi
     echo Removing old Xen intermediate image...
     rm -f package/cache/xen-intermediate-*.tar.gz


### PR DESCRIPTION
I always forget to uncomment this:
```
# 2>&1 >package/log/xen-build.log
```

let's just make a special exception in the code for Travis