### PR TITLE
Procdump update

### DIFF
--- a/src/plugins/procdump/private.h
+++ b/src/plugins/procdump/private.h
@@ -115,6 +115,8 @@ struct vad_info
     uint64_t total_number_of_ptes;
     std::vector<uint64_t> prototype_ptes;
     uint32_t idx;                       // index in prototype_ptes
+    // Zero-fill missing DLLs in minidump to match the header.
+    bool zero_fill;
 };
 using vad_info_t = struct vad_info;
 using vads_t = std::map<addr_t, vad_info_t>;

--- a/src/plugins/procdump/private.h
+++ b/src/plugins/procdump/private.h
@@ -127,7 +127,9 @@ struct procdump_ctx
     string name;
     procdump* plugin;
     drakvuf_trap_t* bp;
+    drakvuf_trap_t* bp2;
     vads_t vads;
+    vads_t dlls;
     x86_registers_t saved_regs;
     uint64_t idx;
     addr_t pool;

--- a/src/plugins/procdump/private.h
+++ b/src/plugins/procdump/private.h
@@ -150,6 +150,10 @@ enum
     MMPTE_PROTOTYPE,
 };
 
+#define MM_SOFTWARE_PROTECTION_OFFSET 5
+#define MM_PROTOTYPE_PROTECTION_OFFSET 11
+
+#define MM_RWX_MASK           0x7
 #define MM_GUARD_PAGE         0x10
 
 // Assume that valid page is accessible
@@ -161,7 +165,7 @@ static bool IS_MMPTE_VALID(uint64_t mmpte)
 // Assume that MM_GUARD_PAGE shoulbe reset to page been accessible
 static bool IS_MMPTE_ACCESSIBLE(uint64_t protection)
 {
-    return (protection & 0x7) && !(protection & MM_GUARD_PAGE);
+    return (protection & MM_RWX_MASK) && !(protection & MM_GUARD_PAGE);
 }
 
 /*
@@ -180,21 +184,21 @@ static bool IS_MMPTE_TRANSITION(uint64_t mmpte)
 
 static bool IS_MMPTE_PROTOTYPE_ACCESSIBLE(uint64_t mmpte)
 {
-    auto is_accessible = IS_MMPTE_ACCESSIBLE((mmpte >> 11));
+    auto is_accessible = IS_MMPTE_ACCESSIBLE((mmpte >> MM_PROTOTYPE_PROTECTION_OFFSET));
     return VMI_GET_BIT(mmpte, 10) &&
            is_accessible;
 }
 
 static bool IS_MMPTE_TRANSITION_ACCESSIBLE(uint64_t mmpte)
 {
-    auto is_accessible = IS_MMPTE_ACCESSIBLE((mmpte >> 5));
+    auto is_accessible = IS_MMPTE_ACCESSIBLE((mmpte >> MM_SOFTWARE_PROTECTION_OFFSET));
     return VMI_GET_BIT(mmpte, 11) &&
            is_accessible;
 }
 
 static bool IS_MMPTE_SOFTWARE_ACCESSIBLE(uint64_t mmpte)
 {
-    auto is_accessible = IS_MMPTE_ACCESSIBLE((mmpte >> 5));
+    auto is_accessible = IS_MMPTE_ACCESSIBLE((mmpte >> MM_SOFTWARE_PROTECTION_OFFSET));
     return !IS_MMPTE_VALID(mmpte) &&
            !IS_MMPTE_PROTOTYPE(mmpte) &&
            !IS_MMPTE_TRANSITION(mmpte) &&

--- a/src/plugins/procdump/private.h
+++ b/src/plugins/procdump/private.h
@@ -135,7 +135,7 @@ struct procdump_ctx
     x86_registers_t saved_regs;
     uint64_t idx;
     addr_t pool;
-    const uint64_t POOL_SIZE_IN_PAGES = 0x100;
+    const uint64_t POOL_SIZE_IN_PAGES = 0x400;
     size_t size;
     size_t current_dump_size;
     string data_file_name;

--- a/src/plugins/procdump/procdump.cpp
+++ b/src/plugins/procdump/procdump.cpp
@@ -799,7 +799,7 @@ static event_response_t terminate_process_cb2(drakvuf_t drakvuf,
         return detach(drakvuf, info, ctx);
     else
     {
-        for (auto dll = ctx->dlls.begin(); dll != ctx->dlls.end();)
+        for (auto dll = ctx->dlls.begin(); dll != ctx->dlls.end(); ++dll)
         {
             auto vad = ctx->vads.find(dll->first);
             if (vad == ctx->vads.end() ||
@@ -810,8 +810,6 @@ static event_response_t terminate_process_cb2(drakvuf_t drakvuf,
                             dll->first, dll->second.total_number_of_ptes);
                 dll->second.zero_fill = true;
             }
-            else
-                ++dll;
         }
 
         ctx->vads.clear();

--- a/src/plugins/procdump/procdump.h
+++ b/src/plugins/procdump/procdump.h
@@ -143,6 +143,7 @@ public:
 
     addr_t malloc_va;
     addr_t memcpy_va;
+    addr_t clean_process_va;
 
     uint16_t win_build_number;
     uint16_t win_major;


### PR DESCRIPTION
* Fix parsing of prototype PTEs while traversing VAD. This fixes dumping memory-mapped files (at the time DLLs).
* Split dumping processes into two stages: stage 1 hooks NtTerminateProcess to dump all non-memory-mapped files regions and stage 2 hooks MmCleanProcessAddressSpace to dump memory-mapped files regions. This would allow to dump more information in the feature (at least I belive so).