### PR TITLE
Fix windows syscalls error: capture unreliable return values

### DIFF
--- a/src/plugins/syscalls/private.h
+++ b/src/plugins/syscalls/private.h
@@ -449,6 +449,7 @@ struct wrapper
     struct wrapper *w;
     uint16_t num;
     addr_t tid;
+    addr_t stack_fingerprint;
 };
 
 #define SYSCALL(_name, _ret, _num_args, ...)                     \

--- a/src/plugins/syscalls/win.cpp
+++ b/src/plugins/syscalls/win.cpp
@@ -122,7 +122,7 @@ static event_response_t ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
      * Multiple syscalls might hit the same return address so make sure we are
      * handling the correct thread's return here.
      */
-    if ( info->proc_data.tid != wr->tid )
+    if ( info->proc_data.tid != wr->tid || wr->stack_fingerprint != info->regs->rsp)
         return 0;
 
     struct wrapper *w = (struct wrapper *)wr->w;
@@ -225,6 +225,15 @@ static event_response_t syscall_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 
     wr->tid = info->proc_data.tid;
     wr->w = w;
+    if ( 4 == s->reg_size )
+    {
+        wr->stack_fingerprint = info->regs->rsp + 4 /*return address*/ + 4 * nargs;
+    }
+    else
+    {
+        wr->stack_fingerprint = info->regs->rsp + 8 /*return address*/;
+    }
+    
 
     ret_trap->breakpoint.lookup_type = LOOKUP_DTB;
     ret_trap->breakpoint.addr_type = ADDR_VA;

--- a/src/plugins/syscalls/win.cpp
+++ b/src/plugins/syscalls/win.cpp
@@ -230,19 +230,15 @@ static event_response_t syscall_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
         // For 32-bit Windows, the calling convention of the syscall api is _stdcall, which means the callee to clear the stack space.
         // So when the function returns, the value of the stack pointer should be the current rsp add the size of the parameters and
         // the size of the return address (4 bytes)
-        // See : https://docs.microsoft.com/en-us/cpp/cpp/stdcall?view=vs-2019
         wr->stack_fingerprint = info->regs->rsp + 4 * nargs + 4;
     }
     else
     {
-        // For 64-bit windows calling convention, the stack pointer remains unchanged before and after the function call. Caller's prolog
-        // code has already allocated space for all the register and stack parameters required by callee at the bottom of the stack, and 
-        // caller's epilog code will deallocate the fixed stack allocation. So when the function returns, the value of the stack pointer
-        // should be the current rsp add the size of the return address (8 bytes)
+        // For 64-bit windows calling convention, the stack pointer remains unchanged before and after the function call.
+        // So when the function returns, the value of the stack pointer should be the current rsp add the size of the return address (8 bytes)
         // See : https://docs.microsoft.com/en-us/cpp/build/x64-software-conventions?view=vs-2019
         wr->stack_fingerprint = info->regs->rsp + 8;
     }
-    
 
     ret_trap->breakpoint.lookup_type = LOOKUP_DTB;
     ret_trap->breakpoint.addr_type = ADDR_VA;


### PR DESCRIPTION
The logic of the current code cannot obtain the correct return value in some cases. For example:  Use the parameter **-S** (syscalls filter) to set a monitor on **NtFunctionA** . When this monitored function called, it will trigger **syscall_cb** and get the return address from the stack pointed to by the **rsp** register, and add a trap at that address. But this **NtFunctionA** will call other functions which will reach the same return address of this **NtFunctionA.** Based on the logical of the current code, it will remove this return trap. And we will see the return value of another function. So, just use the **tid** is not enough, i use the **rsp** value to resolve this problem for windows system calls. I don't know if this completely solved the problem, Sorry.

Because I am not familiar with Linux, I don’t know if there will be same problem on Linux.