### PR TITLE
apimon: log DLL ImageBase and function RVAs when hooking

### DIFF
--- a/src/libusermode/userhook.cpp
+++ b/src/libusermode/userhook.cpp
@@ -353,7 +353,6 @@ static event_response_t internal_perform_hooking(drakvuf_t drakvuf, drakvuf_trap
                 if (vmi_translate_sym2v(lg.vmi, &ctx, target.target_name.c_str(), &exec_func) != VMI_SUCCESS)
                 {
                     target.state = HOOK_FAILED;
-                    target.offset = 0;
                     return VMI_EVENT_RESPONSE_NONE;
                 }
 
@@ -425,7 +424,7 @@ static event_response_t perform_hooking(drakvuf_t drakvuf, drakvuf_trap_info * i
         }
 
         for (auto& reg : plugin->plugins) {
-            reg.post_cb(drakvuf, (const dll_view_t*)dll_meta, (const std::vector<hook_target_view_t> *)&targets, reg.extra);
+            reg.post_cb(drakvuf, (const dll_view_t*)dll_meta, targets, reg.extra);
         }
     }
 

--- a/src/libusermode/userhook.hpp
+++ b/src/libusermode/userhook.hpp
@@ -164,7 +164,7 @@ struct hook_target_entry_t
     void* plugin;
 
     hook_target_entry_t(std::string target_name, callback_t callback, const std::vector < std::unique_ptr < ArgumentPrinter > > &argument_printers, void* plugin)
-        : type(HOOK_BY_NAME), target_name(target_name), callback(callback), argument_printers(argument_printers), state(HOOK_FIRST_TRY), plugin(plugin)
+        : type(HOOK_BY_NAME), target_name(target_name), offset(0), callback(callback), argument_printers(argument_printers), state(HOOK_FIRST_TRY), plugin(plugin)
     {}
 
     hook_target_entry_t(std::string target_name, addr_t offset, callback_t callback, const std::vector < std::unique_ptr < ArgumentPrinter > > &argument_printers, void* plugin)
@@ -205,7 +205,7 @@ struct dll_view_t
 };
 
 typedef void (*dll_pre_hook_cb)(drakvuf_t, const dll_view_t*, void*);
-typedef void (*dll_post_hook_cb)(drakvuf_t, const dll_view_t*, const std::vector<hook_target_view_t> *targets, void*);
+typedef void (*dll_post_hook_cb)(drakvuf_t, const dll_view_t*, const std::vector<hook_target_view_t> &targets, void*);
 
 struct usermode_cb_registration {
     dll_pre_hook_cb pre_cb;

--- a/src/libusermode/userhook.hpp
+++ b/src/libusermode/userhook.hpp
@@ -184,6 +184,16 @@ struct return_hook_target_entry_t
         pid(pid), plugin(plugin), argument_printers(argument_printers) {}
 };
 
+struct hook_target_view_t
+{
+    std::string target_name;
+    addr_t offset;
+    target_hook_state state;
+
+    hook_target_view_t(std::string target_name, addr_t offset, target_hook_state state)
+        : target_name(target_name), offset(offset), state(state) {}
+};
+
 struct dll_view_t
 {
     // relevant while loading
@@ -195,7 +205,7 @@ struct dll_view_t
 };
 
 typedef void (*dll_pre_hook_cb)(drakvuf_t, const dll_view_t*, void*);
-typedef void (*dll_post_hook_cb)(drakvuf_t, const dll_view_t*, void*);
+typedef void (*dll_post_hook_cb)(drakvuf_t, const dll_view_t*, const std::vector<hook_target_view_t> *targets, void*);
 
 struct usermode_cb_registration {
     dll_pre_hook_cb pre_cb;

--- a/src/plugins/apimon/apimon.cpp
+++ b/src/plugins/apimon/apimon.cpp
@@ -310,7 +310,7 @@ static event_response_t usermode_hook_cb(drakvuf_t drakvuf, drakvuf_trap_info* i
     return VMI_EVENT_RESPONSE_NONE;
 }
 
-static void print_addresses(drakvuf_t drakvuf, apimon *plugin, const dll_view_t *dll, const std::vector<hook_target_view_t> *targets)
+static void print_addresses(drakvuf_t drakvuf, apimon *plugin, const dll_view_t *dll, const std::vector<hook_target_view_t>& targets)
 {
     unicode_string_t* dll_name;
     json_object *j_root;
@@ -331,7 +331,7 @@ static void print_addresses(drakvuf_t drakvuf, apimon *plugin, const dll_view_t 
     j_root = json_object_new_object();
     j_rvas = json_object_new_object();
 
-    for (auto const& target : *targets)
+    for (auto const& target : targets)
     {
         if (target.state == HOOK_OK)
             json_object_object_add(j_rvas, target.target_name.c_str(), json_object_new_int(target.offset));
@@ -375,7 +375,7 @@ static void on_dll_discovered(drakvuf_t drakvuf, const dll_view_t* dll, void* ex
         vmi_free_unicode_str(dll_name);
 }
 
-static void on_dll_hooked(drakvuf_t drakvuf, const dll_view_t* dll, const std::vector<hook_target_view_t>* targets, void* extra)
+static void on_dll_hooked(drakvuf_t drakvuf, const dll_view_t* dll, const std::vector<hook_target_view_t>& targets, void* extra)
 {
     apimon* plugin = (apimon*)extra;
     print_addresses(drakvuf, plugin, dll, targets);

--- a/src/plugins/apimon/apimon.cpp
+++ b/src/plugins/apimon/apimon.cpp
@@ -181,6 +181,7 @@ static event_response_t usermode_return_hook_cb(drakvuf_t drakvuf, drakvuf_trap_
             escaped_pname = drakvuf_escape_str(info->proc_data.name);
             printf( "{"
                     "\"Plugin\": \"apimon\", "
+                    "\"Event\": \"api_called\", "
                     "\"TimeStamp\":" "\"" FORMAT_TIMEVAL "\", "
                     "\"ProcessName\": %s, "
                     "\"UserName\": \"%s\", "
@@ -309,6 +310,49 @@ static event_response_t usermode_hook_cb(drakvuf_t drakvuf, drakvuf_trap_info* i
     return VMI_EVENT_RESPONSE_NONE;
 }
 
+static void print_addresses(drakvuf_t drakvuf, apimon *plugin, const dll_view_t *dll, const std::vector<hook_target_view_t> *targets)
+{
+    unicode_string_t* dll_name;
+    json_object *j_root;
+    json_object *j_rvas;
+    vmi_pid_t pid;
+    vmi_lock_guard lg(drakvuf);
+
+    dll_name = drakvuf_read_unicode_va(lg.vmi, dll->mmvad.file_name_ptr, 0);
+
+    if (plugin->m_output_format != OUTPUT_JSON)
+        return;
+
+    if (!dll_name || !dll_name->contents)
+        goto out;
+
+    vmi_dtb_to_pid(lg.vmi, dll->dtb, &pid);
+
+    j_root = json_object_new_object();
+    j_rvas = json_object_new_object();
+
+    for (auto const& target : *targets)
+    {
+        if (target.state == HOOK_OK)
+            json_object_object_add(j_rvas, target.target_name.c_str(), json_object_new_int(target.offset));
+    }
+
+    json_object_object_add(j_root, "Plugin", json_object_new_string("apimon"));
+    json_object_object_add(j_root, "Event", json_object_new_string("dll_loaded"));
+    json_object_object_add(j_root, "Rva", j_rvas);
+    json_object_object_add(j_root, "DllBase", json_object_new_string_fmt("0x%lx", dll->real_dll_base));
+    json_object_object_add(j_root, "DllName", json_object_new_string((const char *)dll_name->contents));
+    json_object_object_add(j_root, "PID", json_object_new_int(pid));
+
+    printf("%s\n", json_object_to_json_string(j_root));
+
+    json_object_put(j_root);
+
+out:
+    if (dll_name)
+        vmi_free_unicode_str(dll_name);
+}
+
 static void on_dll_discovered(drakvuf_t drakvuf, const dll_view_t* dll, void* extra)
 {
     apimon* plugin = (apimon*)extra;
@@ -331,8 +375,10 @@ static void on_dll_discovered(drakvuf_t drakvuf, const dll_view_t* dll, void* ex
         vmi_free_unicode_str(dll_name);
 }
 
-static void on_dll_hooked(drakvuf_t drakvuf, const dll_view_t* dll, void* extra)
+static void on_dll_hooked(drakvuf_t drakvuf, const dll_view_t* dll, const std::vector<hook_target_view_t>* targets, void* extra)
 {
+    apimon* plugin = (apimon*)extra;
+    print_addresses(drakvuf, plugin, dll, targets);
     PRINT_DEBUG("[APIMON] DLL hooked - done\n");
 }
 

--- a/src/plugins/memdump/userhook.cpp
+++ b/src/plugins/memdump/userhook.cpp
@@ -170,7 +170,7 @@ static void on_dll_discovered(drakvuf_t drakvuf, const dll_view_t* dll, void* ex
     drakvuf_release_vmi(drakvuf);
 }
 
-static void on_dll_hooked(drakvuf_t drakvuf, const dll_view_t* dll, void* extra)
+static void on_dll_hooked(drakvuf_t drakvuf, const dll_view_t* dll, const std::vector<hook_target_view_t>* targets, void* extra)
 {
     PRINT_DEBUG("[MEMDUMP] DLL hooked - done\n");
 }

--- a/src/plugins/memdump/userhook.cpp
+++ b/src/plugins/memdump/userhook.cpp
@@ -170,7 +170,7 @@ static void on_dll_discovered(drakvuf_t drakvuf, const dll_view_t* dll, void* ex
     drakvuf_release_vmi(drakvuf);
 }
 
-static void on_dll_hooked(drakvuf_t drakvuf, const dll_view_t* dll, const std::vector<hook_target_view_t>* targets, void* extra)
+static void on_dll_hooked(drakvuf_t drakvuf, const dll_view_t* dll, const std::vector<hook_target_view_t>& targets, void* extra)
 {
     PRINT_DEBUG("[MEMDUMP] DLL hooked - done\n");
 }


### PR DESCRIPTION
Introduce new kind of apimon log line when `OUTPUT_JSON` is used:

```json
{
  "Plugin": "apimon",
  "Event": "dll_loaded",
  "Rva": {
    "SetupDiGetClassDevsA": 39104,
    "SetupDiGetClassDevsW": 20292,
    "SetupDiGetDeviceRegistryPropertyA": 417636,
    "SetupDiGetDeviceRegistryPropertyW": 23640,
    "SetupDiBuildDriverInfoList": 71040,
    "IsUserAdmin": 720196
  },
  "DllBase": "0x7fefdf70000",
  "DllName": "\\Windows\\System32\\setupapi.dll",
  "PID": 1424
}
```

this gives a lot of hints about where the DLLs are in particular processes.