### PR TITLE
Added set to store unique hashes of dumped memory regions

### DIFF
--- a/src/plugins/memdump/memdump.cpp
+++ b/src/plugins/memdump/memdump.cpp
@@ -277,6 +277,11 @@ bool dump_memory_region(
     fclose(fp);
 
     chk_str = g_checksum_get_string(checksum);
+    if (plugin->dumped_hashes.find(chk_str) != plugin->dumped_hashes.end()) {
+        // We have already dumped this memory region.
+        goto done;
+    }
+    plugin->dumped_hashes.insert(chk_str);
 
     // The file name format for the memory dump file is:
     // <dump base address>_<contents hash>

--- a/src/plugins/memdump/memdump.cpp
+++ b/src/plugins/memdump/memdump.cpp
@@ -196,6 +196,7 @@ bool dump_memory_region(
     size_t num_pages;
 
     GChecksum* checksum = nullptr;
+    std::string dump_hash;
 
     size_t tmp_len_bytes = len_bytes;
 
@@ -277,11 +278,12 @@ bool dump_memory_region(
     fclose(fp);
 
     chk_str = g_checksum_get_string(checksum);
-    if (plugin->dumped_hashes.find(chk_str) != plugin->dumped_hashes.end()) {
+    dump_hash.assign(chk_str);
+    if (plugin->dumped_hashes.find(dump_hash) != plugin->dumped_hashes.end()) {
         // We have already dumped this memory region.
         goto done;
     }
-    plugin->dumped_hashes.insert(chk_str);
+    plugin->dumped_hashes.insert(dump_hash);
 
     // The file name format for the memory dump file is:
     // <dump base address>_<contents hash>

--- a/src/plugins/memdump/memdump.h
+++ b/src/plugins/memdump/memdump.h
@@ -106,6 +106,7 @@
 #define MEMDUMP_H
 
 #include <vector>
+#include <unordered_set>
 #include <memory>
 
 #include <glib.h>
@@ -133,6 +134,7 @@ public:
     size_t kthread_process_rva;
 
     std::vector<plugin_target_config_entry_t> wanted_hooks;
+    std::unordered_set<std::string> dumped_hashes;
 
     memdump(drakvuf_t drakvuf, const memdump_config* config, output_format_t output);
     ~memdump();

--- a/src/plugins/memdump/memdump.h
+++ b/src/plugins/memdump/memdump.h
@@ -106,7 +106,6 @@
 #define MEMDUMP_H
 
 #include <vector>
-#include <unordered_set>
 #include <memory>
 
 #include <glib.h>
@@ -134,7 +133,6 @@ public:
     size_t kthread_process_rva;
 
     std::vector<plugin_target_config_entry_t> wanted_hooks;
-    std::unordered_set<std::string> dumped_hashes;
 
     memdump(drakvuf_t drakvuf, const memdump_config* config, output_format_t output);
     ~memdump();


### PR DESCRIPTION
We are dumping the same memory regions in memdump plugin.  I've added a set in which I store hashes of already dumped memory regions and before dumping region I just check if it is already in the set. Analysis of 30k samples proved that this very basic check reduces the storage by 18%.