### PR TITLE
Remove swab.patch for Debian build

### DIFF
--- a/package/Dockerfile-xen
+++ b/package/Dockerfile-xen
@@ -5,7 +5,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV USER root
 
 COPY package/depends.sh /tmp/depends.sh
-COPY package/swab.patch /tmp/swab.patch
 
 # build depends
 RUN mkdir -p /log && \

--- a/package/depends.sh
+++ b/package/depends.sh
@@ -30,11 +30,6 @@ apt-get --quiet --yes build-dep xen
 apt-get autoremove -y
 apt-get clean
 
-if [ "$SYSTEM" = "Debian" ]
-then
-    patch /usr/include/linux/swab.h /tmp/swab.patch
-fi
-
 rm -rf /var/lib/apt/lists* /tmp/* /var/tmp/*
 
 rm /usr/bin/gcc /usr/bin/g++

--- a/package/swab.patch
+++ b/package/swab.patch
@@ -1,8 +1,0 @@
-138c138
-< #if BITS_PER_LONG == 64
----
-> #if __BITS_PER_LONG == 64
-140c140
-< #else /* BITS_PER_LONG == 32 */
----
-> #else /* __BITS_PER_LONG == 32 */


### PR DESCRIPTION
Linux headers are now fixed in Debian, no need to apply `swab.patch`