### PR TITLE
injector: don't accept kernel address as return address in trap frame

### DIFF
--- a/src/libinjector/win_injector.c
+++ b/src/libinjector/win_injector.c
@@ -741,6 +741,12 @@ static event_response_t wait_for_target_process_cb(drakvuf_t drakvuf, drakvuf_tr
             goto done;
         }
 
+        if (bp_addr & VMI_BIT_MASK(47, 63))
+        {
+            PRINT_DEBUG("Trap frame contains return address 0x%lx which is inside kernel, retry\n", bp_addr);
+            goto done;
+        }
+
         if (setup_int3_trap(injector, info, bp_addr))
         {
             PRINT_DEBUG("Got return address 0x%lx from trapframe and it's now trapped!\n",


### PR DESCRIPTION
resolve #940