### PR TITLE
Make fast singlestep optional

### DIFF
--- a/src/drakvuf.cpp
+++ b/src/drakvuf.cpp
@@ -168,10 +168,11 @@ drakvuf_c::drakvuf_c(const char* domain,
                      bool verbose,
                      bool leave_paused,
                      bool libvmi_conf,
-                     addr_t kpgd)
+                     addr_t kpgd,
+                     bool fast_singlestep)
     : leave_paused{ leave_paused }
 {
-    if (!drakvuf_init(&drakvuf, domain, json_kernel_path, json_wow_path, verbose, libvmi_conf, kpgd))
+    if (!drakvuf_init(&drakvuf, domain, json_kernel_path, json_wow_path, verbose, libvmi_conf, kpgd, fast_singlestep))
     {
         drakvuf_close(drakvuf, leave_paused);
         throw std::runtime_error("drakvuf_init() failed");

--- a/src/drakvuf.h
+++ b/src/drakvuf.h
@@ -152,7 +152,8 @@ public:
               bool verbose,
               bool leave_paused,
               bool libvmi_conf,
-              addr_t kpgd);
+              addr_t kpgd,
+              bool fast_singlestep);
     ~drakvuf_c();
 
     int is_initialized();

--- a/src/injector.c
+++ b/src/injector.c
@@ -296,7 +296,7 @@ int main(int argc, char** argv)
     sigaction(SIGINT, &act, NULL);
     sigaction(SIGALRM, &act, NULL);
 
-    if (!drakvuf_init(&drakvuf, domain, json_kernel_path, NULL, verbose, libvmi_conf, kpgd))
+    if (!drakvuf_init(&drakvuf, domain, json_kernel_path, NULL, verbose, libvmi_conf, kpgd, false))
     {
         fprintf(stderr, "Failed to initialize on domain %s\n", domain);
         return 1;

--- a/src/libdrakvuf/drakvuf.c
+++ b/src/libdrakvuf/drakvuf.c
@@ -156,7 +156,7 @@ void drakvuf_close(drakvuf_t drakvuf, const bool pause)
     g_free(drakvuf);
 }
 
-bool drakvuf_init(drakvuf_t* drakvuf, const char* domain, const char* json_kernel_path, const char* json_wow_path, bool _verbose, bool libvmi_conf, addr_t kpgd)
+bool drakvuf_init(drakvuf_t* drakvuf, const char* domain, const char* json_kernel_path, const char* json_wow_path, bool _verbose, bool libvmi_conf, addr_t kpgd, bool fast_singlestep)
 {
 
     if ( !domain || !json_kernel_path )
@@ -196,7 +196,7 @@ bool drakvuf_init(drakvuf_t* drakvuf, const char* domain, const char* json_kerne
 
     drakvuf_pause(*drakvuf);
 
-    if (!init_vmi(*drakvuf, libvmi_conf))
+    if (!init_vmi(*drakvuf, libvmi_conf, fast_singlestep))
         goto err;
 
     switch ((*drakvuf)->os)

--- a/src/libdrakvuf/libdrakvuf.h
+++ b/src/libdrakvuf/libdrakvuf.h
@@ -361,7 +361,8 @@ bool drakvuf_init (drakvuf_t* drakvuf,
                    const char* json_wow_profile,
                    const bool verbose,
                    const bool libvmi_conf,
-                   const addr_t kpgd) NOEXCEPT;
+                   const addr_t kpgd,
+                   const bool fast_singlestep) NOEXCEPT;
 void drakvuf_close (drakvuf_t drakvuf, const bool pause) NOEXCEPT;
 bool drakvuf_add_trap(drakvuf_t drakvuf,
                       drakvuf_trap_t* trap) NOEXCEPT;

--- a/src/libdrakvuf/vmi.h
+++ b/src/libdrakvuf/vmi.h
@@ -119,7 +119,7 @@
       g_hash_table_iter_init(&i, table); \
       while(g_hash_table_iter_next(&i,(void**)&key,(void**)&val))
 
-bool init_vmi(drakvuf_t drakvuf, bool libvmi_conf);
+bool init_vmi(drakvuf_t drakvuf, bool libvmi_conf, bool fast_singlestep);
 void close_vmi(drakvuf_t drakvuf);
 
 event_response_t trap_guard(vmi_instance_t vmi, vmi_event_t* event);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -171,6 +171,7 @@ static void print_usage()
             "\t -x <plugin>               Don't activate the specified plugin\n"
             "\t -a <plugin>               Activate the specified plugin\n"
             "\t -p                        Leave domain paused after DRAKVUF exits\n"
+            "\t -F                        Enable fast singlestepping (requires Xen 4.14+)\n"
 #ifdef ENABLE_DOPPELGANGING
             "\t -B <path>                 The host path of the windows binary to inject (requires -m doppelganging)\n"
             "\t -P <target>               The guest path of the clean guest process to use as a cover (requires -m doppelganging)\n"
@@ -269,6 +270,7 @@ int main(int argc, char** argv)
     bool verbose = false;
     bool leave_paused = false;
     bool libvmi_conf = false;
+    bool fast_singlestep = false;
     addr_t kpgd = 0;
     plugins_options options = {};
     bool disabled_all = false; // Used to disable all plugin once
@@ -335,9 +337,10 @@ int main(int argc, char** argv)
         {"json-mscorwks", required_argument, NULL, opt_json_mscorwks},
         {"syscall-hooks-list", required_argument, NULL, 'S'},
         {"disable-sysret", no_argument, NULL, opt_disable_sysret},
+        {"fast-singlestep", no_argument, NULL, 'F'},
         {NULL, 0, NULL, 0}
     };
-    const char* opts = "r:d:i:I:e:m:t:D:o:vx:a:f:spT:S:Mc:nblgj:k:w:W:h";
+    const char* opts = "r:d:i:I:e:m:t:D:o:vx:a:f:spT:S:Mc:nblgj:k:w:W:hF";
 
     while ((c = getopt_long (argc, argv, opts, long_opts, &long_index)) != -1)
         switch (c)
@@ -456,6 +459,9 @@ int main(int argc, char** argv)
             case 'l':
                 libvmi_conf = true;
                 break;
+            case 'F':
+                fast_singlestep = true;
+                break;
             case 'k':
                 kpgd = strtoull(optarg, NULL, 0);
                 break;
@@ -549,7 +555,7 @@ int main(int argc, char** argv)
 
     try
     {
-        drakvuf = new drakvuf_c(domain, json_kernel_path, json_wow_path, output, verbose, leave_paused, libvmi_conf, kpgd);
+        drakvuf = new drakvuf_c(domain, json_kernel_path, json_wow_path, output, verbose, leave_paused, libvmi_conf, kpgd, fast_singlestep);
     }
     catch (const std::exception& e)
     {

--- a/src/proc_stat.cpp
+++ b/src/proc_stat.cpp
@@ -174,7 +174,7 @@ int main(int argc, char** argv)
 
 
     /* initialize the Drakvuf library */
-    if (!drakvuf_init(&drakvuf, domain, profile, NULL, false, false, 0))
+    if (!drakvuf_init(&drakvuf, domain, profile, NULL, false, false, 0, false))
     {
         printf("Failed to initialize Drakvuf\n");
         goto done;

--- a/src/repl.cpp
+++ b/src/repl.cpp
@@ -190,7 +190,7 @@ int main(int argc, char** argv)
     sigaction(SIGINT, &act, NULL);
     sigaction(SIGALRM, &act, NULL);
 
-    if (!drakvuf_init(&drakvuf, domain, json_kernel_path, NULL, verbose, libvmi_conf, kpgd))
+    if (!drakvuf_init(&drakvuf, domain, json_kernel_path, NULL, verbose, libvmi_conf, kpgd, false))
     {
         fprintf(stderr, "Failed to initialize on domain %s\n", domain);
         return 1;


### PR DESCRIPTION
While using the new fast singlestep feature from Xen 4.14 a bug has been popping up. When a previous run of DRAKVUF was stopped while fast singlestep was set but before the MTF trap occured, the fast singlestep setting remains in effect either though MTF itself gets disabled. Next time when a new run of DRAKVUF is started and the first event that triggers is an EPT event, the corresponding `post_mem_cb` is skipped since the fast singlestep setting is still set in Xen. There is currently no way to remove the fast singlestep setting. This is only an issue when multiple runs of DRAKVUF are done, with a single run this is not an issue so we keep the option available to use it. However, while the issue is fixed upstream we don't set it as the default.