### PR TITLE
OUTPUT_JSON: print Xval as actual hex string, not as a number

### DIFF
--- a/src/plugins/output_format/jsonfmt.h
+++ b/src/plugins/output_format/jsonfmt.h
@@ -142,7 +142,7 @@ public:
     template <class Tv = T>
     static bool print(std::ostream& os, const fmt::Xval<Tv>& data, char)
     {
-        os << data.value;
+        os << "\"0x" << std::hex << data.value << "\"" << std::dec;
         return true;
     }
 


### PR DESCRIPTION
Xval in JSON format should be represented as `"0x1234"`, not as a decimal. It's absolutely hard to manually read virtual addresses in decimal etc.