### PR TITLE
procmon: fix uninitialized members (from coverity)

### DIFF
--- a/src/plugins/procmon/procmon.cpp
+++ b/src/plugins/procmon/procmon.cpp
@@ -133,7 +133,7 @@ struct open_process_result_t: public call_result_t<T>
 template<typename T>
 struct open_thread_result_t: public call_result_t<T>
 {
-    open_thread_result_t(T* src) : call_result_t<T>(src), thread_handle_addr(), desired_access(), object_attributes_addr(), client_id{} {}
+    open_thread_result_t(T* src) : call_result_t<T>(src), thread_handle_addr(), desired_access(), object_attributes_addr(), client_id(), unique_thread() {}
 
     addr_t thread_handle_addr;
     uint32_t desired_access;
@@ -145,7 +145,7 @@ struct open_thread_result_t: public call_result_t<T>
 template<typename T>
 struct process_creation_result_t: public call_result_t<T>
 {
-    process_creation_result_t(T* src) : call_result_t<T>(src), new_process_handle_addr(), user_process_parameters_addr() {}
+    process_creation_result_t(T* src) : call_result_t<T>(src), new_process_handle_addr(), new_thread_handle_addr(), user_process_parameters_addr() {}
 
     addr_t new_process_handle_addr;
     addr_t new_thread_handle_addr;

--- a/src/plugins/procmon/procmon.cpp
+++ b/src/plugins/procmon/procmon.cpp
@@ -349,6 +349,7 @@ static event_response_t create_user_process_hook(
 
     data->set_result_call_params(info, drakvuf_get_current_thread(drakvuf, info));
     data->new_process_handle_addr = process_handle_addr;
+    data->new_thread_handle_addr = thread_handle_addr;
     data->user_process_parameters_addr = user_process_parameters_addr;
     return VMI_EVENT_RESPONSE_NONE;
 }


### PR DESCRIPTION
Fix Coverity issues from #969 