### PR TITLE
libusermode,apimon,memdump: print CLSID from dll hook list

### DIFF
--- a/src/libusermode/uh-private.hpp
+++ b/src/libusermode/uh-private.hpp
@@ -159,7 +159,7 @@ public:
 
     usermode_reg_status_t init(drakvuf_t drakvuf);
     void register_plugin(drakvuf_t drakvuf, usermode_cb_registration reg);
-    void request_usermode_hook(drakvuf_t drakvuf, const dll_view_t* dll, target_hook_type, const char* func_name, addr_t offset, callback_t callback, const std::vector< std::unique_ptr < ArgumentPrinter > > &argument_printers, void* extra);
+    void request_usermode_hook(drakvuf_t drakvuf, const dll_view_t* dll, const plugin_target_config_entry_t* target, callback_t callback, void* extra);
 };
 
 extern userhook* instance;

--- a/src/libusermode/userhook.hpp
+++ b/src/libusermode/userhook.hpp
@@ -126,6 +126,7 @@ struct plugin_target_config_entry_t
     std::string dll_name;
     target_hook_type type;
     std::string function_name;
+    std::string clsid;
     addr_t offset;
     std::string log_strategy;
     std::vector< std::unique_ptr< ArgumentPrinter > > argument_printers;
@@ -156,6 +157,7 @@ struct hook_target_entry_t
     vmi_pid_t pid;
     target_hook_type type;
     std::string target_name;
+    std::string clsid;
     addr_t offset;
     callback_t callback;
     const std::vector < std::unique_ptr < ArgumentPrinter > > &argument_printers;
@@ -163,12 +165,12 @@ struct hook_target_entry_t
     drakvuf_trap_t* trap;
     void* plugin;
 
-    hook_target_entry_t(std::string target_name, callback_t callback, const std::vector < std::unique_ptr < ArgumentPrinter > > &argument_printers, void* plugin)
-        : type(HOOK_BY_NAME), target_name(target_name), offset(0), callback(callback), argument_printers(argument_printers), state(HOOK_FIRST_TRY), plugin(plugin)
+    hook_target_entry_t(std::string target_name, std::string clsid, callback_t callback, const std::vector < std::unique_ptr < ArgumentPrinter > > &argument_printers, void* plugin)
+        : type(HOOK_BY_NAME), target_name(target_name), clsid(clsid), offset(0), callback(callback), argument_printers(argument_printers), state(HOOK_FIRST_TRY), plugin(plugin)
     {}
 
-    hook_target_entry_t(std::string target_name, addr_t offset, callback_t callback, const std::vector < std::unique_ptr < ArgumentPrinter > > &argument_printers, void* plugin)
-        : type(HOOK_BY_OFFSET), target_name(target_name), offset(offset), callback(callback), argument_printers(argument_printers), state(HOOK_FIRST_TRY), plugin(plugin)
+    hook_target_entry_t(std::string target_name, std::string clsid, addr_t offset, callback_t callback, const std::vector < std::unique_ptr < ArgumentPrinter > > &argument_printers, void* plugin)
+        : type(HOOK_BY_OFFSET), target_name(target_name), clsid(clsid), offset(offset), callback(callback), argument_printers(argument_printers), state(HOOK_FIRST_TRY), plugin(plugin)
     {}
 };
 
@@ -176,12 +178,13 @@ struct return_hook_target_entry_t
 {
     vmi_pid_t pid;
     drakvuf_trap_t* trap;
+    std::string clsid;
     void* plugin;
     std::vector < uint64_t > arguments;
     const std::vector < std::unique_ptr < ArgumentPrinter > > &argument_printers;
 
-    return_hook_target_entry_t(vmi_pid_t pid, void* plugin, const std::vector < std::unique_ptr < ArgumentPrinter > > &argument_printers) :
-        pid(pid), plugin(plugin), argument_printers(argument_printers) {}
+    return_hook_target_entry_t(vmi_pid_t pid, std::string clsid, void* plugin, const std::vector < std::unique_ptr < ArgumentPrinter > > &argument_printers) :
+        pid(pid), clsid(clsid), plugin(plugin), argument_printers(argument_printers) {}
 };
 
 struct hook_target_view_t
@@ -221,7 +224,7 @@ typedef enum usermode_reg_status {
 } usermode_reg_status_t;
 
 usermode_reg_status_t drakvuf_register_usermode_callback(drakvuf_t drakvuf, usermode_cb_registration* reg);
-bool drakvuf_request_usermode_hook(drakvuf_t drakvuf, const dll_view_t* dll, target_hook_type type, const char* func_name, addr_t offset, callback_t callback, const std::vector< std::unique_ptr< ArgumentPrinter > > &argument_printers, void* extra);
+bool drakvuf_request_usermode_hook(drakvuf_t drakvuf, const dll_view_t* dll, const plugin_target_config_entry_t* target, callback_t callback, void* extra);
 void drakvuf_load_dll_hook_config(drakvuf_t drakvuf, const char* dll_hooks_list_path, std::vector<plugin_target_config_entry_t>* wanted_hooks);
 
 #endif

--- a/src/plugins/memdump/userhook.cpp
+++ b/src/plugins/memdump/userhook.cpp
@@ -159,7 +159,7 @@ static void on_dll_discovered(drakvuf_t drakvuf, const dll_view_t* dll, void* ex
         {
             if (strstr((const char*)dll_name->contents, wanted_hook.dll_name.c_str()) != 0)
             {
-                drakvuf_request_usermode_hook(drakvuf, dll, wanted_hook.type, wanted_hook.function_name.c_str(), wanted_hook.offset, usermode_hook_cb, std::vector < std::unique_ptr< ArgumentPrinter > >(), plugin);
+                drakvuf_request_usermode_hook(drakvuf, dll, &wanted_hook, usermode_hook_cb, plugin);
             }
         }
     }


### PR DESCRIPTION
This allows to provide a CLSID in dll hooks list which is used as meta information to link multiple events in output e.g.:
```
System32\taskschd.dll,ITaskService::GetFolder,clsid,0F87369F-A4E5-4CFC-BD3E-73E6154572DD,20520,log,this:lpvoid,path:bstr,ppFolder:lpvoid*
```