### PR TITLE
procmon: fix logical error

### DIFF
--- a/src/plugins/procmon/winnt.cpp
+++ b/src/plugins/procmon/winnt.cpp
@@ -127,7 +127,7 @@ std::string stringify_protection_attributes(uint32_t attributes, char sep)
         if (num > 1)
             result.append(1, sep);
 
-        switch (attributes)
+        switch (attr)
         {
             case PAGE_NOACCESS:
                 result.append("PAGE_NOACCESS");


### PR DESCRIPTION
The error was introduced in d158bf532867075037785eaf72d1657e1450b314

Split #975 