### PR TITLE
kvfmt: fix format for quoted strings

### DIFF
--- a/src/plugins/output_format/kvfmt.h
+++ b/src/plugins/output_format/kvfmt.h
@@ -188,9 +188,6 @@ struct DataPrinter
     template <class Tv = T>
     static bool print(std::ostream& os, const fmt::Qstr<Tv>& data, char)
     {
-        if (data.value.empty())
-            return false;
-
         os << '"' << data.value << '"';
         return true;
     }


### PR DESCRIPTION
The key value pair with empty quoted string should be printed.

The error was introduced in c2d8bbe8bfdcb6a5014e7a6cbf31088cd2b7b008

Split #975 