### PR TITLE
ipt: xen_helper: implement methods to support vmtrace IPT

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -413,6 +413,13 @@ AC_ARG_WITH([stdlib],
 AS_IF([test "x$with_stdlib" != "xsystem"],
   [CXXFLAGS="$CXXFLAGS -stdlib=$with_stdlib"])
 
+AC_ARG_ENABLE([ipt],
+  [AS_HELP_STRING([--enable-ipt],
+    [Enable Intel Processor Trace support (special Xen version required) @<:@no@:>@])],
+  [enable_ipt="$enableval"],
+  [enable_ipt="no"])
+AM_CONDITIONAL([ENABLE_IPT], [test x$enable_ipt = xyes])
+
 #####################################################
 # AUTOHARDEN START
 # We want to check for compiler flag support, but there is no way to make

--- a/src/xen_helper/Makefile.am
+++ b/src/xen_helper/Makefile.am
@@ -134,5 +134,9 @@ if SANITIZE
 #AM_LDFLAGS += $(SANITIZE_LDFLAGS)
 endif
 
+if ENABLE_IPT
+AM_CFLAGS += $(HARDEN_CFLAGS) -DENABLE_IPT
+endif
+
 noinst_LTLIBRARIES= libxenhelper.la
 libxenhelper_la_SOURCES= $(h_sources) $(c_sources)

--- a/src/xen_helper/xen_helper.c
+++ b/src/xen_helper/xen_helper.c
@@ -112,6 +112,8 @@
 #define XEN_ALTP2M_external 2
 #endif
 
+#define UNUSED(x) (void)(x)
+
 bool xen_init_interface(xen_interface_t** xen)
 {
 
@@ -151,6 +153,10 @@ bool xen_init_interface(xen_interface_t** xen)
     }
     (*xen)->evtchn_fd = xc_evtchn_fd((*xen)->evtchn);
 
+#ifdef ENABLE_IPT
+    (*xen)->fmem = xenforeignmemory_open(0, 0);
+#endif
+
     return 1;
 
 err:
@@ -172,6 +178,10 @@ void xen_free_interface(xen_interface_t* xen)
             xc_interface_close(xen->xc);
         if (xen->evtchn)
             xc_evtchn_close(xen->evtchn);
+#ifdef ENABLE_IPT
+        if (xen->fmem)
+            xenforeignmemory_close(xen->fmem);
+#endif
         g_free(xen);
     }
 }
@@ -322,3 +332,120 @@ bool xen_set_vcpu_ctx(xen_interface_t* xen, domid_t domID, int vcpu, vcpu_guest_
 {
     return xc_vcpu_setcontext(xen->xc, domID, vcpu, ctx) == 0;
 }
+
+#ifdef ENABLE_IPT
+int xen_enable_ipt(xen_interface_t* xen, domid_t domID, int vcpu, ipt_state_t* ipt_state)
+{
+    int rc = xc_vmtrace_pt_enable(xen->xc, domID, vcpu);
+
+    if (rc)
+    {
+        fprintf(stderr, "Failed to call xc_vmtrace_pt_enable\n");
+        return 0;
+    }
+
+    rc = xc_vmtrace_pt_get_offset(xen->xc, domID, vcpu, NULL, &ipt_state->size);
+
+    if (rc)
+    {
+        fprintf(stderr, "Failed to get trace buffer size\n");
+        return 0;
+    }
+
+    ipt_state->fres = xenforeignmemory_map_resource(
+                          xen->fmem, domID, XENMEM_resource_vmtrace_buf,
+                          /* vcpu: */ vcpu,
+                          /* frame: */ 0,
+                          /* num_frames: */ ipt_state->size >> XC_PAGE_SHIFT,
+                          (void**)&ipt_state->buf,
+                          PROT_READ, 0);
+
+    if (!ipt_state->buf)
+    {
+        fprintf(stderr, "Failed to map trace buffer\n");
+        return 0;
+    }
+
+    return 1;
+}
+
+int xen_get_ipt_offset(xen_interface_t* xen, domid_t domID, int vcpu, ipt_state_t* ipt_state)
+{
+    uint64_t offset;
+    int rc;
+
+    rc = xc_vmtrace_pt_get_offset(xen->xc, domID, vcpu, &offset, NULL);
+
+    if (rc == ENODATA)
+    {
+        fprintf(stderr, "xc_vmtrace_pt_get_offset returned ENODATA\n");
+        ipt_state->last_offset = ipt_state->offset;
+        return 1;
+    }
+    else if (rc)
+    {
+        fprintf(stderr, "Failed to call xc_vmtrace_pt_get_offset: %d\n", rc);
+        return 0;
+    }
+
+    ipt_state->last_offset = ipt_state->offset;
+    ipt_state->offset = offset;
+    return 1;
+}
+
+int xen_disable_ipt(xen_interface_t* xen, domid_t domID, int vcpu, ipt_state_t* ipt_state)
+{
+    int rc = xenforeignmemory_unmap_resource(xen->fmem, ipt_state->fres);
+
+    if (rc)
+    {
+        fprintf(stderr, "Failed to unmap resource\n");
+        return 0;
+    }
+
+    rc = xenforeignmemory_close(xen->fmem);
+
+    if (rc)
+    {
+        fprintf(stderr, "Failed to close fmem\n");
+        return 0;
+    }
+
+    rc = xc_vmtrace_pt_disable(xen->xc, domID, vcpu);
+
+    if (rc)
+    {
+        fprintf(stderr, "Failed to call xc_vmtrace_pt_disable\n");
+        return 0;
+    }
+
+    return 1;
+}
+#else
+int xen_enable_ipt(xen_interface_t* xen, domid_t domID, int vcpu, ipt_state_t* ipt_state)
+{
+    UNUSED(xen);
+    UNUSED(domID);
+    UNUSED(vcpu);
+    UNUSED(ipt_state);
+    return 0;
+}
+
+int xen_get_ipt_offset(xen_interface_t* xen, domid_t domID, int vcpu, ipt_state_t* ipt_state)
+{
+    UNUSED(xen);
+    UNUSED(domID);
+    UNUSED(vcpu);
+    UNUSED(ipt_state);
+    return 0;
+}
+
+int xen_disable_ipt(xen_interface_t* xen, domid_t domID, int vcpu, ipt_state_t* ipt_state)
+{
+    UNUSED(xen);
+    UNUSED(domID);
+    UNUSED(vcpu);
+    UNUSED(ipt_state);
+    return 0;
+}
+#endif

--- a/src/xen_helper/xen_helper.c
+++ b/src/xen_helper/xen_helper.c
@@ -178,10 +178,8 @@ void xen_free_interface(xen_interface_t* xen)
             xc_interface_close(xen->xc);
         if (xen->evtchn)
             xc_evtchn_close(xen->evtchn);
-#ifdef ENABLE_IPT
         if (xen->fmem)
             xenforeignmemory_close(xen->fmem);
-#endif
         g_free(xen);
     }
 }

--- a/src/xen_helper/xen_helper.h
+++ b/src/xen_helper/xen_helper.h
@@ -111,6 +111,7 @@
 
 #include <libxl_utils.h>
 #include <xenctrl.h>
+#include <xenforeignmemory.h>
 
 typedef struct xen_interface
 {
@@ -120,7 +121,20 @@ typedef struct xen_interface
     xentoollog_logger* xl_logger;
     xc_evtchn *evtchn;             // the Xen event channel
     int evtchn_fd;                 // its FD
+
+    xenforeignmemory_handle *fmem;
 } xen_interface_t;
+
+typedef struct ipt_state
+{
+    uint8_t *buf;
+    uint64_t size;
+
+    uint64_t offset;
+    uint64_t last_offset;
+
+    xenforeignmemory_resource_handle *fres;
+} ipt_state_t;
 
 /* FUNCTIONS */
 
@@ -139,4 +153,8 @@ bool xen_enable_altp2m(xen_interface_t* xen, domid_t domID);
 int xen_version(void);
 bool xen_get_vcpu_ctx(xen_interface_t *xen, domid_t domID, int vcpu, vcpu_guest_context_any_t *regs);
 bool xen_set_vcpu_ctx(xen_interface_t *xen, domid_t domID, int vcpu, vcpu_guest_context_any_t *regs);
+
+int xen_enable_ipt(xen_interface_t* xen, domid_t domID, int vcpu, ipt_state_t* ipt_state);
+int xen_get_ipt_offset(xen_interface_t* xen, domid_t domID, int vcpu, ipt_state_t* ipt_state);
+int xen_disable_ipt(xen_interface_t* xen, domid_t domID, int vcpu, ipt_state_t* ipt_state);
 #endif


### PR DESCRIPTION
Can be enabled conditionally with `./configure --enable-ipt`, special Xen version required: https://github.com/icedevml/xen/commits/ipt-patch-v7d

Once vmtrace IPT is upstreamed, it could be compiled-in by default.