### PR TITLE
ipt: implement CATCHALL_BREAKPOINT trap type

### DIFF
--- a/src/libdrakvuf/drakvuf.c
+++ b/src/libdrakvuf/drakvuf.c
@@ -349,6 +349,15 @@ bool inject_trap_reg(drakvuf_t drakvuf, drakvuf_trap_t* trap)
     return 0;
 }
 
+bool inject_trap_catchall_breakpoint(drakvuf_t drakvuf, drakvuf_trap_t* trap)
+{
+    if ( !drakvuf->catchall_breakpoint )
+        return 0;
+
+    drakvuf->catchall_breakpoint = g_slist_prepend(drakvuf->catchall_breakpoint, trap);
+    return 1;
+};
+
 bool inject_trap_debug(drakvuf_t drakvuf, drakvuf_trap_t* trap)
 {
     if ( !drakvuf->debug && !control_debug_trap(drakvuf, 1) )
@@ -399,6 +408,9 @@ bool drakvuf_add_trap(drakvuf_t drakvuf, drakvuf_trap_t* trap)
             break;
         case CPUID:
             ret = inject_trap_cpuid(drakvuf, trap);
+            break;
+        case CATCHALL_BREAKPOINT:
+            ret = inject_trap_catchall_breakpoint(drakvuf, trap);
             break;
         case __INVALID_TRAP_TYPE: /* fall-through */
         default:

--- a/src/libdrakvuf/libdrakvuf.h
+++ b/src/libdrakvuf/libdrakvuf.h
@@ -158,7 +158,8 @@ typedef enum trap_type
     MEMACCESS,
     REGISTER,
     DEBUG,
-    CPUID
+    CPUID,
+    CATCHALL_BREAKPOINT
 } trap_type_t;
 
 typedef enum memaccess_type

--- a/src/libdrakvuf/private.h
+++ b/src/libdrakvuf/private.h
@@ -238,7 +238,7 @@ struct drakvuf
     GHashTable* memaccess_lookup_trap; // key: trap pointer
     // val: struct memaccess
 
-    GSList* cr0, *cr3, *cr4, *debug, *cpuid;
+    GSList* cr0, *cr3, *cr4, *debug, *cpuid, *catchall_breakpoint;
 
     GSList* event_fd_info;     // the list of registered event FDs
     struct pollfd* event_fds;  // auto-generated pollfd for poll()
@@ -333,6 +333,7 @@ bool inject_trap_breakpoint(drakvuf_t drakvuf, drakvuf_trap_t* trap);
 bool inject_trap_reg(drakvuf_t drakvuf, drakvuf_trap_t* trap);
 bool inject_trap_debug(drakvuf_t drakvuf, drakvuf_trap_t* trap);
 bool inject_trap_cpuid(drakvuf_t drakvuf, drakvuf_trap_t* trap);
+bool inject_trap_catchall_breakpoint(drakvuf_t drakvuf, drakvuf_trap_t* trap);
 
 event_response_t post_mem_cb(vmi_instance_t vmi, vmi_event_t* event);
 event_response_t pre_mem_cb(vmi_instance_t vmi, vmi_event_t* event);

--- a/src/libdrakvuf/vmi.c
+++ b/src/libdrakvuf/vmi.c
@@ -619,12 +619,16 @@ event_response_t int3_cb(vmi_instance_t vmi, vmi_event_t* event)
     trap_info.attached_proc_data.tid       = attached_proc_data.tid;
 
     drakvuf->in_callback = 1;
-    GSList* loop = s->traps;
-    while (loop)
+    GSList* lists[2] = {drakvuf->catchall_breakpoint, s->traps};
+    for (int i = 0; i < 2; i++)
     {
-        trap_info.trap = (drakvuf_trap_t*)loop->data;
-        rsp |= trap_info.trap->cb(drakvuf, &trap_info);
-        loop = loop->next;
+        GSList* loop = lists[i];
+        while (loop)
+        {
+            trap_info.trap = (drakvuf_trap_t*)loop->data;
+            rsp |= trap_info.trap->cb(drakvuf, &trap_info);
+            loop = loop->next;
+        }
     }
     drakvuf->in_callback = 0;
 
@@ -1005,6 +1009,8 @@ void remove_trap(drakvuf_t drakvuf,
             if ( !drakvuf->cpuid )
                 control_cpuid_trap(drakvuf, 0);
             break;
+        case CATCHALL_BREAKPOINT:
+            drakvuf->catchall_breakpoint = g_slist_remove(drakvuf->catchall_breakpoint, trap);
         case __INVALID_TRAP_TYPE: /* fall-through */
         default:
             break;
@@ -1698,6 +1704,8 @@ void close_vmi(drakvuf_t drakvuf)
         g_slist_free(drakvuf->cpuid);
     if (drakvuf->cr3)
         g_slist_free(drakvuf->cr3);
+    if (drakvuf->catchall_breakpoint)
+        g_slist_free(drakvuf->catchall_breakpoint);
     if (drakvuf->memaccess_lookup_gfn)
         g_hash_table_destroy(drakvuf->memaccess_lookup_gfn);
     if (drakvuf->memaccess_lookup_trap)

--- a/src/libdrakvuf/vmi.c
+++ b/src/libdrakvuf/vmi.c
@@ -620,7 +620,9 @@ event_response_t int3_cb(vmi_instance_t vmi, vmi_event_t* event)
 
     drakvuf->in_callback = 1;
     GSList* lists[2] = {drakvuf->catchall_breakpoint, s->traps};
-    for (int i = 0; i < 2; i++)
+    // catchall breakpoint will not be fired
+    // if there are no "normal" subscribers for this trap
+    for (int i = 0; s->traps && i < 2; i++)
     {
         GSList* loop = lists[i];
         while (loop)


### PR DESCRIPTION
Because for the IPT we need to inject a special PTWRITE packet whenever a DRAKVUF breakpoint is hit, the IPT plugin needs to have ability to subscribe to all breakpoints. It doesn't need any special insight about what other plugins do, but it needs such kind of event to properly synchronize the IPT logs.

This might look weird but I hope reasonable.