### PR TITLE
libusermode: stop print addresses of string arguments

### DIFF
--- a/src/libusermode/printers/printers.cpp
+++ b/src/libusermode/printers/printers.cpp
@@ -108,7 +108,7 @@
 #include <libvmi/libvmi.h>
 #include <libdrakvuf/libdrakvuf.h>
 
-ArgumentPrinter::ArgumentPrinter(std::string arg_name) : name(arg_name)
+ArgumentPrinter::ArgumentPrinter(std::string arg_name, bool print_no_addr) : name(arg_name), print_no_addr(print_no_addr)
 {
     // intentionally empty
 }
@@ -134,7 +134,10 @@ std::string StringPrinterInterface::print(drakvuf_t drakvuf, drakvuf_trap_info* 
     std::string str = getBuffer(vmi, &ctx);
     drakvuf_release_vmi(drakvuf);
     std::stringstream stream;
-    stream << name << "=0x" << std::hex << argument << ":\"" << str << "\"";
+    stream << name << "=";
+    if (!print_no_addr)
+        stream << "0x" << std::hex << argument << ":";
+    stream << "\"" << str << "\"";
     return stream.str();
 }
 
@@ -183,7 +186,10 @@ std::string UnicodePrinter::print(drakvuf_t drakvuf, drakvuf_trap_info* info, ui
     }
     drakvuf_release_vmi(drakvuf);
     std::stringstream stream;
-    stream << name << "=0x" << std::hex << argument << ":\"" << str << "\"";
+    stream << name << "=";
+    if (!print_no_addr)
+        stream << "0x" << std::hex << argument << ":";
+    stream << "\"" << str << "\"";
     return stream.str();
 }
 
@@ -253,8 +259,8 @@ std::string GuidPrinter::print(drakvuf_t drakvuf, drakvuf_trap_info* info, uint6
     return name + "=" + std::string(stream);
 }
 
-BitMaskPrinter::BitMaskPrinter(std::string arg_name, std::map < uint64_t, std::string > dict)
-    : ArgumentPrinter(arg_name)
+BitMaskPrinter::BitMaskPrinter(std::string arg_name, bool print_no_addr, std::map < uint64_t, std::string > dict)
+    : ArgumentPrinter(arg_name, print_no_addr)
     , dict(dict)
 {
     // intentionally empty

--- a/src/libusermode/printers/printers.hpp
+++ b/src/libusermode/printers/printers.hpp
@@ -114,8 +114,9 @@ class ArgumentPrinter
 {
 protected:
     std::string name;
+    bool print_no_addr;
 public:
-    ArgumentPrinter(std::string arg_name);
+    ArgumentPrinter(std::string arg_name, bool print_no_addr);
 
     virtual std::string print(drakvuf_t drakvuf, drakvuf_trap_info* info, uint64_t argument) const;
     virtual ~ArgumentPrinter();
@@ -185,7 +186,7 @@ class BitMaskPrinter : public ArgumentPrinter
 {
     std::map < uint64_t, std::string > dict;
 public:
-    BitMaskPrinter(std::string arg_name, std::map < uint64_t, std::string > dict);
+    BitMaskPrinter(std::string arg_name, bool print_no_addr, std::map < uint64_t, std::string > dict);
     std::string print(drakvuf_t drakvuf, drakvuf_trap_info* info, uint64_t argument) const;
 };
 

--- a/src/libusermode/userhook.cpp
+++ b/src/libusermode/userhook.cpp
@@ -884,19 +884,19 @@ bool drakvuf_request_usermode_hook(drakvuf_t drakvuf, const dll_view_t* dll, con
     return true;
 }
 
-void drakvuf_load_dll_hook_config(drakvuf_t drakvuf, const char* dll_hooks_list_path, std::vector<plugin_target_config_entry_t>* wanted_hooks)
+void drakvuf_load_dll_hook_config(drakvuf_t drakvuf, const char* dll_hooks_list_path, const bool print_no_addr, std::vector<plugin_target_config_entry_t>* wanted_hooks)
 {
     if (!dll_hooks_list_path)
     {
         // if the DLL hook list was not provided, we provide some simple defaults
         std::vector< std::unique_ptr < ArgumentPrinter > > arg_vec1;
-        arg_vec1.push_back(std::unique_ptr < ArgumentPrinter>(new ArgumentPrinter("wVersionRequired")));
-        arg_vec1.push_back(std::unique_ptr < ArgumentPrinter>(new ArgumentPrinter("lpWSAData")));
+        arg_vec1.push_back(std::unique_ptr < ArgumentPrinter>(new ArgumentPrinter("wVersionRequired", print_no_addr)));
+        arg_vec1.push_back(std::unique_ptr < ArgumentPrinter>(new ArgumentPrinter("lpWSAData", print_no_addr)));
         wanted_hooks->emplace_back("ws2_32.dll", "WSAStartup", "log+stack", std::move(arg_vec1));
 
         std::vector< std::unique_ptr < ArgumentPrinter > > arg_vec2;
-        arg_vec2.push_back(std::unique_ptr < ArgumentPrinter>(new ArgumentPrinter("ExitCode")));
-        arg_vec2.push_back(std::unique_ptr < ArgumentPrinter>(new ArgumentPrinter("Unknown")));
+        arg_vec2.push_back(std::unique_ptr < ArgumentPrinter>(new ArgumentPrinter("ExitCode", print_no_addr)));
+        arg_vec2.push_back(std::unique_ptr < ArgumentPrinter>(new ArgumentPrinter("Unknown", print_no_addr)));
         wanted_hooks->emplace_back("ntdll.dll", "RtlExitUserProcess", "log+stack", std::move(arg_vec2));
         return;
     }
@@ -981,31 +981,31 @@ void drakvuf_load_dll_hook_config(drakvuf_t drakvuf, const char* dll_hooks_list_
 
             if (arg_type == "lpcstr" || arg_type == "lpctstr")
             {
-                e.argument_printers.push_back(std::unique_ptr< ArgumentPrinter>(new AsciiPrinter(arg_name)));
+                e.argument_printers.push_back(std::unique_ptr< ArgumentPrinter>(new AsciiPrinter(arg_name, print_no_addr)));
             }
             else if (arg_type == "lpcwstr" || arg_type == "lpwstr" || arg_type == "bstr")
             {
-                e.argument_printers.push_back(std::unique_ptr< ArgumentPrinter>(new WideStringPrinter(arg_name)));
+                e.argument_printers.push_back(std::unique_ptr< ArgumentPrinter>(new WideStringPrinter(arg_name, print_no_addr)));
             }
             else if (arg_type == "punicode_string")
             {
-                e.argument_printers.push_back(std::unique_ptr< ArgumentPrinter>(new UnicodePrinter(arg_name)));
+                e.argument_printers.push_back(std::unique_ptr< ArgumentPrinter>(new UnicodePrinter(arg_name, print_no_addr)));
             }
             else if (arg_type == "pulong")
             {
-                e.argument_printers.push_back(std::unique_ptr< ArgumentPrinter>(new UlongPrinter(arg_name)));
+                e.argument_printers.push_back(std::unique_ptr< ArgumentPrinter>(new UlongPrinter(arg_name, print_no_addr)));
             }
             else if (arg_type == "lpvoid*")
             {
-                e.argument_printers.push_back(std::unique_ptr< ArgumentPrinter>(new PointerToPointerPrinter(arg_name)));
+                e.argument_printers.push_back(std::unique_ptr< ArgumentPrinter>(new PointerToPointerPrinter(arg_name, print_no_addr)));
             }
             else if (arg_type == "refclsid" || arg_type == "refiid")
             {
-                e.argument_printers.push_back(std::unique_ptr< ArgumentPrinter>(new GuidPrinter(arg_name)));
+                e.argument_printers.push_back(std::unique_ptr< ArgumentPrinter>(new GuidPrinter(arg_name, print_no_addr)));
             }
             else
             {
-                e.argument_printers.push_back(std::unique_ptr< ArgumentPrinter>(new ArgumentPrinter(arg_name)));
+                e.argument_printers.push_back(std::unique_ptr< ArgumentPrinter>(new ArgumentPrinter(arg_name, print_no_addr)));
             }
 
             ++arg_idx;

--- a/src/libusermode/userhook.hpp
+++ b/src/libusermode/userhook.hpp
@@ -225,6 +225,6 @@ typedef enum usermode_reg_status {
 
 usermode_reg_status_t drakvuf_register_usermode_callback(drakvuf_t drakvuf, usermode_cb_registration* reg);
 bool drakvuf_request_usermode_hook(drakvuf_t drakvuf, const dll_view_t* dll, const plugin_target_config_entry_t* target, callback_t callback, void* extra);
-void drakvuf_load_dll_hook_config(drakvuf_t drakvuf, const char* dll_hooks_list_path, std::vector<plugin_target_config_entry_t>* wanted_hooks);
+void drakvuf_load_dll_hook_config(drakvuf_t drakvuf, const char* dll_hooks_list_path, const bool print_no_addr, std::vector<plugin_target_config_entry_t>* wanted_hooks);
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -230,12 +230,16 @@ static void print_usage()
 #ifdef ENABLE_PLUGIN_MEMDUMP
             "\t --memdump-dir <directory>\n"
             "\t                           Where to store memory dumps\n"
-            "\t --dll-hooks-list <file>\n"
-            "\t                           List of DLL functions to be hooked (see wiki)\n"
             "\t --json-clr <path to json>\n"
             "\t                           The JSON profile for clr.dll\n"
             "\t --json-mscorwks <path to json>\n"
             "\t                           The JSON profile for mscorewks.dll\n"
+#endif
+#if defined(ENABLE_PLUGIN_MEMDUMP) || defined(ENABLE_PLUGIN_APIMON)
+            "\t --dll-hooks-list <file>\n"
+            "\t                           List of DLL functions to be hooked (see wiki)\n"
+            "\t --userhook-no-addr\n"
+            "\t                           List of DLL functions to be hooked (see wiki)\n"
 #endif
 #ifdef ENABLE_PLUGIN_PROCDUMP
             "\t --procdump-dir <directory>\n"
@@ -309,6 +313,7 @@ int main(int argc, char** argv)
         opt_json_clr,
         opt_json_mscorwks,
         opt_disable_sysret,
+        opt_userhook_no_addr,
     };
     const option long_opts[] =
     {
@@ -337,6 +342,7 @@ int main(int argc, char** argv)
         {"json-mscorwks", required_argument, NULL, opt_json_mscorwks},
         {"syscall-hooks-list", required_argument, NULL, 'S'},
         {"disable-sysret", no_argument, NULL, opt_disable_sysret},
+        {"userhook-no-addr", no_argument, NULL, opt_userhook_no_addr},
         {"fast-singlestep", no_argument, NULL, 'F'},
         {NULL, 0, NULL, 0}
     };
@@ -488,6 +494,9 @@ int main(int argc, char** argv)
                 break;
             case opt_json_mpr:
                 options.mpr_profile = optarg;
+                break;
+            case opt_userhook_no_addr:
+                options.userhook_no_addr = true;
                 break;
 #ifdef ENABLE_PLUGIN_WMIMON
             case opt_json_ole32:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -239,7 +239,7 @@ static void print_usage()
             "\t --dll-hooks-list <file>\n"
             "\t                           List of DLL functions to be hooked (see wiki)\n"
             "\t --userhook-no-addr\n"
-            "\t                           List of DLL functions to be hooked (see wiki)\n"
+            "\t                           Stop printing addresses of string arguments in apimon and memdump\n"
 #endif
 #ifdef ENABLE_PLUGIN_PROCDUMP
             "\t --procdump-dir <directory>\n"

--- a/src/plugins/apimon/apimon.cpp
+++ b/src/plugins/apimon/apimon.cpp
@@ -337,7 +337,7 @@ apimon::apimon(drakvuf_t drakvuf, const apimon_config* c, output_format_t output
 {
     try
     {
-        drakvuf_load_dll_hook_config(drakvuf, c->dll_hooks_list, &this->wanted_hooks);
+        drakvuf_load_dll_hook_config(drakvuf, c->dll_hooks_list, c->print_no_addr, &this->wanted_hooks);
     }
     catch (int e)
     {

--- a/src/plugins/apimon/apimon.h
+++ b/src/plugins/apimon/apimon.h
@@ -116,6 +116,7 @@
 struct apimon_config
 {
     const char* dll_hooks_list;
+    const bool print_no_addr;
 };
 
 class apimon: public pluginex

--- a/src/plugins/memdump/memdump.h
+++ b/src/plugins/memdump/memdump.h
@@ -119,6 +119,7 @@ struct memdump_config
     const char* dll_hooks_list;
     const char* clr_profile;
     const char* mscorwks_profile;
+    const bool print_no_addr;
 };
 
 class memdump: public pluginex

--- a/src/plugins/memdump/userhook.cpp
+++ b/src/plugins/memdump/userhook.cpp
@@ -179,7 +179,7 @@ void memdump::userhook_init(drakvuf_t drakvuf, const memdump_config* c, output_f
 {
     try
     {
-        drakvuf_load_dll_hook_config(drakvuf, c->dll_hooks_list, &this->wanted_hooks);
+        drakvuf_load_dll_hook_config(drakvuf, c->dll_hooks_list, c->print_no_addr, &this->wanted_hooks);
     }
     catch (int e)
     {

--- a/src/plugins/plugins.cpp
+++ b/src/plugins/plugins.cpp
@@ -328,7 +328,7 @@ int drakvuf_plugins::start(const drakvuf_plugin_t plugin_id,
                         .dll_hooks_list = options->dll_hooks_list,
                         .clr_profile = options->clr_profile,
                         .mscorwks_profile = options->mscorwks_profile,
-                        .print_no_addr = options->userhook_no_addr
+                        .print_no_addr = options->userhook_no_addr,
                     };
                     this->plugins[plugin_id] = new memdump(this->drakvuf, &config, this->output);
                     break;

--- a/src/plugins/plugins.cpp
+++ b/src/plugins/plugins.cpp
@@ -327,7 +327,8 @@ int drakvuf_plugins::start(const drakvuf_plugin_t plugin_id,
                         .memdump_dir = options->memdump_dir,
                         .dll_hooks_list = options->dll_hooks_list,
                         .clr_profile = options->clr_profile,
-                        .mscorwks_profile = options->mscorwks_profile
+                        .mscorwks_profile = options->mscorwks_profile,
+                        .print_no_addr = options->userhook_no_addr
                     };
                     this->plugins[plugin_id] = new memdump(this->drakvuf, &config, this->output);
                     break;
@@ -338,7 +339,8 @@ int drakvuf_plugins::start(const drakvuf_plugin_t plugin_id,
                 {
                     apimon_config config =
                     {
-                        .dll_hooks_list = options->dll_hooks_list
+                        .dll_hooks_list = options->dll_hooks_list,
+                        .print_no_addr = options->userhook_no_addr
                     };
                     this->plugins[plugin_id] = new apimon(this->drakvuf, &config, this->output);
                     break;

--- a/src/plugins/plugins.h
+++ b/src/plugins/plugins.h
@@ -134,6 +134,7 @@ struct plugins_options
     const char* combase_profile;        // PLUGIN_WMIMON
     const char* memdump_dir;            // PLUGIN_MEMDUMP
     const char* dll_hooks_list;         // PLUGIN_MEMDUMP, PLUGIN_APIMON
+    bool userhook_no_addr;              // PLUGIN_MEMDUMP, PLUGIN_APIMON
     const char* procdump_dir;           // PLUGIN_PROCDUMP
     bool compress_procdumps = false;    // PLUGIN_PROCDUMP
     const char* clr_profile;            // PLUGIN_MEMDUMP


### PR DESCRIPTION
This unifies the output of libusermode with other plugins where we print only values but no addresses