### PR TITLE
ipt: implement event counter

### DIFF
--- a/src/libdrakvuf/libdrakvuf.h
+++ b/src/libdrakvuf/libdrakvuf.h
@@ -193,6 +193,7 @@ typedef struct drakvuf_trap_info
     addr_t trap_pa;
     x86_registers_t* regs;
     drakvuf_trap_t* trap;
+    uint64_t event_uid; /* Unique sequential event identifier */
     union
     {
         const cpuid_event_t* cpuid; /* For CPUID traps */

--- a/src/libdrakvuf/private.h
+++ b/src/libdrakvuf/private.h
@@ -252,6 +252,8 @@ struct drakvuf
     fd_info_t fd_info_lookup;  // auto-generated for fast drakvuf_loop lookups
     int poll_rc;
 
+    uint64_t event_counter;    // incremental unique trap event ID
+
     ipt_state_t ipt_state[MAX_DRAKVUF_VCPU];
 };
 

--- a/src/libdrakvuf/vmi.c
+++ b/src/libdrakvuf/vmi.c
@@ -405,6 +405,9 @@ event_response_t pre_mem_cb(vmi_instance_t vmi, vmi_event_t* event)
     trap_info.attached_proc_data.userid    = attached_proc_data.userid;
     trap_info.attached_proc_data.tid       = attached_proc_data.tid;
 
+    if (s->traps)
+        trap_info.event_uid = ++drakvuf->event_counter;
+
     GSList* loop = s->traps;
     drakvuf->in_callback = 1;
     while (loop)
@@ -617,6 +620,9 @@ event_response_t int3_cb(vmi_instance_t vmi, vmi_event_t* event)
     trap_info.attached_proc_data.ppid      = attached_proc_data.ppid;
     trap_info.attached_proc_data.userid    = attached_proc_data.userid;
     trap_info.attached_proc_data.tid       = attached_proc_data.tid;
+
+    if (s->traps)
+        trap_info.event_uid = ++drakvuf->event_counter;
 
     drakvuf->in_callback = 1;
     GSList* lists[2] = {drakvuf->catchall_breakpoint, s->traps};

--- a/src/plugins/output_format/jsonfmt.h
+++ b/src/plugins/output_format/jsonfmt.h
@@ -419,7 +419,8 @@ inline auto get_common_data(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
                keyval("UserName", fmt::Qstr(USERIDSTR(drakvuf))),
                keyval("UserId", fmt::Nval(info->proc_data.userid)),
                keyval("ProcessName", fmt::Qstr(proc_data->name)),
-               keyval("Method", method)
+               keyval("Method", method),
+               keyval("EventUID", fmt::Xval(info->event_uid))
            );
 }
 


### PR DESCRIPTION
Assign an unique sequential ID to each trap occurrence. This number will be both printed in DRAKVUF's output (implemented by this PR) and injected into IPT logs in appropriate place (further PR will implement it). This will be used to synchronize DRAKVUF with Intel Processor Trace.