### PR TITLE
procdump: fix endless loop for Windows 10

### DIFF
--- a/src/plugins/procdump/procdump.cpp
+++ b/src/plugins/procdump/procdump.cpp
@@ -321,6 +321,8 @@ static enum rtlcopy_status dump_with_rtlcopymemory(drakvuf_t drakvuf,
             ctx->writer->append(zeros, VMI_PS_4KB);
 
         vad->second.idx += ptes_to_dump;
+        skip = max_contigious_range(prototype_ptes, total_number_of_ptes,
+                                    vad->second.idx, ptes_to_dump, ctx->POOL_SIZE_IN_PAGES);
 
         if (0 == ptes_to_dump)
         {


### PR DESCRIPTION
The error has been introduced in bd35d25f1cd95270588417d99d05220775451c17.
The `skip` variable is useless here but makes static checkers happy. The
main purpose here is changing the value of `ptes_to_dump`.