### PR TITLE
Check for wow64 in breakpoint searchers

### DIFF
--- a/src/plugins/plugins_ex.h
+++ b/src/plugins/plugins_ex.h
@@ -325,9 +325,10 @@ struct breakpoint_by_dtb_searcher
                 .addr = info->regs->rsp,
             };
 
-            addr_t ret_addr;
+            addr_t ret_addr = 0;
             vmi_instance_t vmi = drakvuf_lock_and_get_vmi(drakvuf);
-            status_t status = vmi_read_addr(vmi, &ctx, &ret_addr);
+            size_t ptr_width = drakvuf_is_wow64(drakvuf, info) ? 4 : 8;
+            status_t status = vmi_read(vmi, &ctx, ptr_width, &ret_addr, nullptr);
             drakvuf_release_vmi(drakvuf);
 
             if (status != VMI_SUCCESS)
@@ -361,9 +362,10 @@ struct breakpoint_by_pid_searcher
                 .addr = info->regs->rsp,
             };
 
-            addr_t ret_addr;
+            addr_t ret_addr = 0;
             vmi_instance_t vmi = drakvuf_lock_and_get_vmi(drakvuf);
-            status_t status = vmi_read_addr(vmi, &ctx, &ret_addr);
+            size_t ptr_width = drakvuf_is_wow64(drakvuf, info) ? 4 : 8;
+            status_t status = vmi_read_addr(vmi, &ctx, ptr_width, &ret_addr, nullptr);
             drakvuf_release_vmi(drakvuf);
 
             if (status != VMI_SUCCESS)

--- a/src/plugins/plugins_ex.h
+++ b/src/plugins/plugins_ex.h
@@ -365,7 +365,7 @@ struct breakpoint_by_pid_searcher
             addr_t ret_addr = 0;
             vmi_instance_t vmi = drakvuf_lock_and_get_vmi(drakvuf);
             size_t ptr_width = drakvuf_is_wow64(drakvuf, info) ? 4 : 8;
-            status_t status = vmi_read_addr(vmi, &ctx, ptr_width, &ret_addr, nullptr);
+            status_t status = vmi_read(vmi, &ctx, ptr_width, &ret_addr, nullptr);
             drakvuf_release_vmi(drakvuf);
 
             if (status != VMI_SUCCESS)


### PR DESCRIPTION
Note: I'm not so sure if this is correct fix as I'm not to familiar with this part of code.

When trying to add a usermode hook on return from function I've encountered an error in `register_trap`. It turned out that when running 32 bit sample, the `breakpoint_by_dtb_searcher` was reading 8 bytes from stack instead of expected 4 bytes (pointer width for 32 bit applications). Same issue occurs in `breakpoint_by_pid_searcher`.

