### PR TITLE
regmon: Use memcpy instead of reinterpret_cast

### DIFF
--- a/src/plugins/regmon/regmon.cpp
+++ b/src/plugins/regmon/regmon.cpp
@@ -305,7 +305,8 @@ static unicode_string_t* get_data_as_string( drakvuf_t drakvuf, drakvuf_trap_inf
         ctx.addr = data_addr;
         for (size_t i = 0 ; i < data_bytes.size() ; i += 2)
         {
-            uint16_t value_word = *(reinterpret_cast<uint16_t*>(&data_bytes[i]));
+            uint16_t value_word;
+            memcpy(&value_word, &data_bytes[i], sizeof(value_word));
 
             if (value_word == 0)
             {
@@ -321,7 +322,8 @@ static unicode_string_t* get_data_as_string( drakvuf_t drakvuf, drakvuf_trap_inf
 
             if (data_bytes.size() - i >= 4)
             {
-                uint32_t value_dword = *(reinterpret_cast<uint32_t*>(&data_bytes[i]));
+                uint32_t value_dword;
+                memcpy(&value_dword, &data_bytes[i], sizeof(value_dword));
                 if ((value_dword == 0) && ((i + 4) >= data_bytes.size()))
                     break;
             }


### PR DESCRIPTION
Casting pointers with reinterpret_cast in some cases might violate
alignment requirements. Use memcpy to fix this issue.