### PR TITLE
Refactor plugins_ex class

### DIFF
--- a/src/drakvuf.cpp
+++ b/src/drakvuf.cpp
@@ -188,10 +188,10 @@ drakvuf_c::~drakvuf_c()
 
     g_free(injector_to_be_freed);
 
+    delete plugins;
+
     if (drakvuf)
         drakvuf_close(drakvuf, leave_paused);
-
-    delete plugins;
 }
 
 void drakvuf_c::interrupt(int signal)

--- a/src/libusermode/uh-private.hpp
+++ b/src/libusermode/uh-private.hpp
@@ -124,20 +124,18 @@ struct dll_t
     addr_t pf_max_addr;
 };
 
-template<typename T>
-struct map_view_of_section_result_t : public call_result_t<T>
+struct map_view_of_section_result_t : public call_result_t
 {
-    map_view_of_section_result_t(T* src) : call_result_t<T>(src), section_handle(), process_handle(), base_address_ptr() {}
+    map_view_of_section_result_t() : call_result_t(), section_handle(), process_handle(), base_address_ptr() {}
 
     uint64_t section_handle;
     uint64_t process_handle;
     addr_t base_address_ptr;
 };
 
-template<typename T>
-struct copy_on_write_result_t : public call_result_t<T>
+struct copy_on_write_result_t : public call_result_t
 {
-    copy_on_write_result_t(T* src) : call_result_t<T>(src), vaddr(), pte(), old_cow_pa() {}
+    copy_on_write_result_t() : call_result_t(), vaddr(), pte(), old_cow_pa() {}
 
     addr_t vaddr;
     addr_t pte;

--- a/src/plugins/envmon/envmon.cpp
+++ b/src/plugins/envmon/envmon.cpp
@@ -190,8 +190,6 @@ static const std::map<uint64_t, std::string> define_dos_device_flags
 static event_response_t trap_SspipGetUserName_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 {
     auto p = get_trap_plugin<envmon>(info);
-    if (!p)
-        return VMI_EVENT_RESPONSE_NONE;
 
     addr_t ex_name_fmt = drakvuf_get_function_argument(drakvuf, info, 1);
 
@@ -210,8 +208,6 @@ static event_response_t trap_SspipGetUserName_cb(drakvuf_t drakvuf, drakvuf_trap
 static event_response_t trap_DefineDosDeviceW_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 {
     auto p = get_trap_plugin<envmon>(info);
-    if (!p)
-        return VMI_EVENT_RESPONSE_NONE;
 
     const auto flags = print::FieldToString(define_dos_device_flags, std::bitset<64>(drakvuf_get_function_argument(drakvuf, info, 1)));
     addr_t device_name_va = drakvuf_get_function_argument(drakvuf, info, 2);
@@ -254,8 +250,6 @@ static event_response_t trap_DefineDosDeviceW_cb(drakvuf_t drakvuf, drakvuf_trap
 static event_response_t trap_GetComputerNameW_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 {
     auto p = get_trap_plugin<envmon>(info);
-    if (!p)
-        return VMI_EVENT_RESPONSE_NONE;
 
     fmt::print(p->m_output_format, "envmon", drakvuf, info);
     return VMI_EVENT_RESPONSE_NONE;
@@ -264,8 +258,6 @@ static event_response_t trap_GetComputerNameW_cb(drakvuf_t drakvuf, drakvuf_trap
 static event_response_t trap_IsNativeVhdBoot_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 {
     auto p = get_trap_plugin<envmon>(info);
-    if (!p)
-        return VMI_EVENT_RESPONSE_NONE;
 
     fmt::print(p->m_output_format, "envmon", drakvuf, info);
     return VMI_EVENT_RESPONSE_NONE;
@@ -274,8 +266,6 @@ static event_response_t trap_IsNativeVhdBoot_cb(drakvuf_t drakvuf, drakvuf_trap_
 static event_response_t trap_GetComputerNameExW_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 {
     auto p = get_trap_plugin<envmon>(info);
-    if (!p)
-        return VMI_EVENT_RESPONSE_NONE;
 
     // COMPUTER_NAME_FORMAT NameType
     addr_t name_type = drakvuf_get_function_argument(drakvuf, info, 1);
@@ -294,8 +284,6 @@ static event_response_t trap_GetComputerNameExW_cb(drakvuf_t drakvuf, drakvuf_tr
 static event_response_t trap_GetAdaptersAddresses_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 {
     auto p = get_trap_plugin<envmon>(info);
-    if (!p)
-        return VMI_EVENT_RESPONSE_NONE;
 
     const auto family = print::FieldToString(family_name_formats, drakvuf_get_function_argument(drakvuf, info, 1));
     const auto flags  = print::FieldToString(flags_name_formats, std::bitset<64>(drakvuf_get_function_argument(drakvuf, info, 2)));
@@ -323,8 +311,6 @@ static event_response_t trap_GetAdaptersAddresses_cb(drakvuf_t drakvuf, drakvuf_
 static event_response_t trap_WNetGetProviderNameW_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 {
     auto p = get_trap_plugin<envmon>(info);
-    if (!p)
-        return VMI_EVENT_RESPONSE_NONE;
 
     const auto net_type = drakvuf_get_function_argument(drakvuf, info, 1);
     fmt::print(p->m_output_format, "envmon", drakvuf, info,
@@ -410,7 +396,7 @@ envmon::envmon(drakvuf_t drakvuf, const envmon_config* c, output_format_t output
     PRINT_DEBUG("envmon attempt to setup a trap for \"sspicli.dll\"\n");
     {
         breakpoint_in_dll_module_searcher bp(sspicli_profile, "sspicli.dll");
-        if (!register_trap(drakvuf, nullptr, this, trap_SspipGetUserName_cb, bp.for_syscall_name("SspipGetUserName")))
+        if (!register_trap(nullptr, trap_SspipGetUserName_cb, bp.for_syscall_name("SspipGetUserName")))
             throw -1;
     }
     json_object_put(sspicli_profile);
@@ -425,14 +411,13 @@ envmon::envmon(drakvuf_t drakvuf, const envmon_config* c, output_format_t output
     PRINT_DEBUG("envmon attempt to setup a trap for \"kernelbase.dll\"\n");
     {
         breakpoint_in_dll_module_searcher bp(kernelbase_profile, "kernelbase.dll");
-        if (!register_trap(drakvuf, nullptr, this, trap_GetComputerNameExW_cb, bp.for_syscall_name("GetComputerNameExW")))
+        if (!register_trap(nullptr, trap_GetComputerNameExW_cb, bp.for_syscall_name("GetComputerNameExW")))
             throw -1;
-
     }
 
     {
         breakpoint_in_dll_module_searcher bp(kernelbase_profile, "kernelbase.dll");
-        if (!register_trap(drakvuf, nullptr, this, trap_DefineDosDeviceW_cb, bp.for_syscall_name("DefineDosDeviceW")))
+        if (!register_trap(nullptr, trap_DefineDosDeviceW_cb, bp.for_syscall_name("DefineDosDeviceW")))
             throw -1;
     }
     json_object_put(kernelbase_profile);
@@ -447,7 +432,7 @@ envmon::envmon(drakvuf_t drakvuf, const envmon_config* c, output_format_t output
     PRINT_DEBUG("envmon attempt to setup a trap for \"kernel32.dll\"\n");
     {
         breakpoint_in_dll_module_searcher bp(kernel32_profile, "kernel32.dll");
-        if (!register_trap(drakvuf, nullptr, this, trap_GetComputerNameW_cb, bp.for_syscall_name("GetComputerNameW")))
+        if (!register_trap(nullptr, trap_GetComputerNameW_cb, bp.for_syscall_name("GetComputerNameW")))
             throw -1;
     }
 
@@ -455,7 +440,7 @@ envmon::envmon(drakvuf_t drakvuf, const envmon_config* c, output_format_t output
     {
         PRINT_DEBUG("envmon attempt to setup a trap for \"kernel32.dll\"\n");
         breakpoint_in_dll_module_searcher bp(kernel32_profile, "kernel32.dll");
-        if (!register_trap(drakvuf, nullptr, this, trap_IsNativeVhdBoot_cb, bp.for_syscall_name("IsNativeVhdBoot")))
+        if (!register_trap(nullptr, trap_IsNativeVhdBoot_cb, bp.for_syscall_name("IsNativeVhdBoot")))
             throw -1;
     }
     json_object_put(kernel32_profile);
@@ -473,7 +458,7 @@ envmon::envmon(drakvuf_t drakvuf, const envmon_config* c, output_format_t output
         {
             PRINT_DEBUG("envmon attempt to setup a trap for \"kernel32.dll\"\n");
             breakpoint_in_dll_module_searcher bp(wow_kernel32_profile, "kernel32.dll", true);
-            if (!register_trap(drakvuf, nullptr, this, trap_IsNativeVhdBoot_cb, bp.for_syscall_name("IsNativeVhdBoot")))
+            if (!register_trap(nullptr, trap_IsNativeVhdBoot_cb, bp.for_syscall_name("IsNativeVhdBoot")))
                 throw -1;
         }
         json_object_put(wow_kernel32_profile);
@@ -489,7 +474,7 @@ envmon::envmon(drakvuf_t drakvuf, const envmon_config* c, output_format_t output
     PRINT_DEBUG("envmon attempt to setup a trap for \"iphlpapi.dll\"\n");
     {
         breakpoint_in_dll_module_searcher bp(iphlpapi_profile, "iphlpapi.dll");
-        if (!register_trap(drakvuf, nullptr, this, trap_GetAdaptersAddresses_cb, bp.for_syscall_name("GetAdaptersAddresses")))
+        if (!register_trap(nullptr, trap_GetAdaptersAddresses_cb, bp.for_syscall_name("GetAdaptersAddresses")))
             throw -1;
 
     }
@@ -505,7 +490,7 @@ envmon::envmon(drakvuf_t drakvuf, const envmon_config* c, output_format_t output
     PRINT_DEBUG("envmon attempt to setup a trap for \"mpr.dll\"\n");
     {
         breakpoint_in_dll_module_searcher bp(mpr_profile, "mpr.dll");
-        if (!register_trap(drakvuf, nullptr, this, trap_WNetGetProviderNameW_cb, bp.for_syscall_name("WNetGetProviderNameW")))
+        if (!register_trap(nullptr, trap_WNetGetProviderNameW_cb, bp.for_syscall_name("WNetGetProviderNameW")))
             throw -1;
     }
 

--- a/src/plugins/librarymon/librarymon.cpp
+++ b/src/plugins/librarymon/librarymon.cpp
@@ -117,8 +117,6 @@ static event_response_t load_library_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* 
         return VMI_EVENT_RESPONSE_NONE;
 
     auto mon = get_trap_plugin<librarymon>(info);
-    if (!mon)
-        return VMI_EVENT_RESPONSE_NONE;
 
     unicode_string_t path { 0, 0, 0 };
     unicode_string_t name { 0, 0, 0 };
@@ -159,11 +157,11 @@ librarymon::librarymon(drakvuf_t drakvuf, const librarymon_config* c, output_for
     PRINT_DEBUG("Librarymon attempt to setup a trap for \"LdrLoadDll\"\n");
 
     breakpoint_in_dll_module_searcher bp(ntdll_profile, "ntdll.dll");
-    if (!register_trap(drakvuf, nullptr, this, load_library_cb, bp.for_syscall_name("LdrLoadDll")))
+    if (!register_trap(nullptr, load_library_cb, bp.for_syscall_name("LdrLoadDll")))
         throw -1;
 
     PRINT_DEBUG("Librarymon attempt to setup a trap for \"LdrGetDllHandle\"\n");
-    if (!register_trap(drakvuf, nullptr, this, load_library_cb, bp.for_syscall_name("LdrGetDllHandle")))
+    if (!register_trap(nullptr, load_library_cb, bp.for_syscall_name("LdrGetDllHandle")))
         throw -1;
 
 

--- a/src/plugins/plugins_ex.cpp
+++ b/src/plugins/plugins_ex.cpp
@@ -102,7 +102,6 @@
 *                                                                         *
 ***************************************************************************/
 
-#include <stdexcept>
 #include <libdrakvuf/libdrakvuf.h>
 #include "plugins_ex.h"
 
@@ -122,39 +121,3 @@ std::string FieldToString(const std::map<uint64_t, std::string>& maps, uint64_t 
 
 // Errors
 char ERROR_MSG_ADDING_TRAP[] = "Failed to add a trap";
-
-pluginex::pluginex(drakvuf_t drakvuf, output_format_t output)
-    : m_output_format(output)
-    , m_params()
-{
-}
-
-pluginex::~pluginex()
-{
-    g_slist_free_full(m_params, reinterpret_cast<void (*)(void*)>(destroy_plugin_params));
-}
-
-void pluginex::attach_plugin_params(drakvuf_trap_t* data)
-{
-    m_params = g_slist_append(m_params, data);
-}
-
-drakvuf_trap_t* pluginex::detach_plugin_params(drakvuf_trap_t* data)
-{
-    m_params = g_slist_remove(m_params, data);
-    return data;
-}
-
-void pluginex::destroy_plugin_params(drakvuf_trap_t* trap)
-{
-    if (trap && trap->data)
-        delete reinterpret_cast<plugin_params<pluginex>*>(trap->data);
-
-    delete trap;
-}
-
-void pluginex::destroy_trap(drakvuf_t drakvuf, drakvuf_trap_t* trap)
-{
-    m_params = g_slist_remove(m_params, trap);
-    drakvuf_remove_trap(drakvuf, trap, destroy_plugin_params);
-}

--- a/src/plugins/procdump/procdump.cpp
+++ b/src/plugins/procdump/procdump.cpp
@@ -705,8 +705,6 @@ static bool dump_mmvad(drakvuf_t drakvuf, mmvad_info_t* mmvad,
 static bool prepare_mdmp_header(drakvuf_t drakvuf, drakvuf_trap_info_t* info, procdump_ctx* ctx)
 {
     auto plugin = get_trap_plugin<procdump>(info);
-    if (!plugin)
-        return false;
 
     uint32_t time_stamp = g_get_real_time() / G_USEC_PER_SEC;
 
@@ -863,10 +861,6 @@ static event_response_t terminate_process_cb(drakvuf_t drakvuf,
         return VMI_EVENT_RESPONSE_NONE;
 
     auto plugin = get_trap_plugin<procdump>(info);
-    if (!plugin)
-    {
-        return VMI_EVENT_RESPONSE_NONE;
-    }
 
     // The callback could be called if other thread invokes NtTerminateProcess
     // or as a return path from injected function.
@@ -1029,12 +1023,8 @@ procdump::procdump(drakvuf_t drakvuf, const procdump_config* config,
     __cpuid(0x80000001, r0, amd_extended_cpu_features, r1, r2);
 
     breakpoint_in_system_process_searcher bp;
-    if (!register_trap<procdump>(
-            drakvuf, nullptr, this, terminate_process_cb,
-            bp.for_syscall_name("NtTerminateProcess")))
-    {
+    if (!register_trap(nullptr, terminate_process_cb, bp.for_syscall_name("NtTerminateProcess")))
         throw -1;
-    }
 }
 
 procdump::~procdump()

--- a/src/plugins/wmimon/wmimon.cpp
+++ b/src/plugins/wmimon/wmimon.cpp
@@ -269,38 +269,34 @@ struct search_breakpoint_by_addr
     const wmimon* m_plugin;
 };
 
-template <typename T>
-struct CoCreateInstanse : public call_result_t<T>
+struct CoCreateInstanse : public call_result_t
 {
-    CoCreateInstanse(T* src) : call_result_t<T>(src), CLSID(), IID(), m_vtable() {}
+    CoCreateInstanse() : call_result_t(), CLSID(), IID(), m_vtable() {}
 
     addr_t CLSID;
     addr_t IID;
     addr_t m_vtable;
 };
 
-template <typename T>
-struct ConnectServerParams : public call_result_t<T>
+struct ConnectServerParams : public call_result_t
 {
-    ConnectServerParams(T* src) : call_result_t<T>(src), m_resource(), m_vtable() {}
+    ConnectServerParams() : call_result_t(), m_resource(), m_vtable() {}
 
     addr_t m_resource;
     addr_t m_vtable;
 };
 
-template <typename T>
-struct ExecQueryParams : public call_result_t<T>
+struct ExecQueryParams : public call_result_t
 {
-    ExecQueryParams(T* src) : call_result_t<T>(src), m_command(), m_vtable() {}
+    ExecQueryParams() : call_result_t(), m_command(), m_vtable() {}
 
     addr_t m_command;
     addr_t m_vtable;
 };
 
-template <typename T>
-struct ExecMethodParams : public call_result_t<T>
+struct ExecMethodParams : public call_result_t
 {
-    ExecMethodParams(T* src) : call_result_t<T>(src), m_object(), m_method(), m_vtable() {}
+    ExecMethodParams() : call_result_t(), m_object(), m_method(), m_vtable() {}
 
     addr_t m_object;
     addr_t m_method;
@@ -366,8 +362,8 @@ private:
 
 event_response_t ExecMethod_return_handler(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 {
-    auto data = get_trap_params<wmimon, ExecMethodParams<wmimon>>(info);
-    auto plugin = get_trap_plugin<wmimon, ExecMethodParams<wmimon>>(info);
+    auto data = get_trap_params<wmimon, ExecMethodParams>(info);
+    auto plugin = get_trap_plugin<wmimon, ExecMethodParams>(info);
     if (!plugin || !data)
     {
         PRINT_DEBUG("[WMIMon] ExecMethodReturn invalid trap params\n");
@@ -427,17 +423,15 @@ event_response_t ExecMethod_handler(drakvuf_t drakvuf, drakvuf_trap_info_t* info
         return VMI_EVENT_RESPONSE_NONE;
     }
 
-    auto trap = plugin->register_trap<wmimon, ExecMethodParams<wmimon>>(
-                    drakvuf,
+    auto trap = plugin->register_trap<ExecMethodParams>(
                     info,
-                    plugin,
                     ExecMethod_return_handler,
                     breakpoint_by_dtb_searcher());
 
     if (!trap)
         return VMI_EVENT_RESPONSE_NONE;
 
-    auto params = get_trap_params<wmimon, ExecMethodParams<wmimon>>(trap);
+    auto params = get_trap_params<wmimon, ExecMethodParams>(trap);
     if (!params)
     {
         plugin->destroy_trap(drakvuf, trap);
@@ -454,8 +448,8 @@ event_response_t ExecMethod_handler(drakvuf_t drakvuf, drakvuf_trap_info_t* info
 
 event_response_t GetObject_return_handler(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 {
-    auto data = get_trap_params<wmimon, ExecMethodParams<wmimon>>(info);
-    auto plugin = get_trap_plugin<wmimon, ExecMethodParams<wmimon>>(info);
+    auto data = get_trap_params<wmimon, ExecMethodParams>(info);
+    auto plugin = get_trap_plugin<wmimon, ExecMethodParams>(info);
     if (!plugin || !data)
     {
         PRINT_DEBUG("[WMIMon] GetObjectReturn invalid trap params\n");
@@ -504,17 +498,15 @@ event_response_t GetObject_handler(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
         return VMI_EVENT_RESPONSE_NONE;
     }
 
-    auto trap = plugin->register_trap<wmimon, ExecMethodParams<wmimon>>(
-                    drakvuf,
+    auto trap = plugin->register_trap<ExecMethodParams>(
                     info,
-                    plugin,
                     GetObject_return_handler,
                     breakpoint_by_dtb_searcher());
 
     if (!trap)
         return VMI_EVENT_RESPONSE_NONE;
 
-    auto params = get_trap_params<wmimon, ExecMethodParams<wmimon>>(trap);
+    auto params = get_trap_params<wmimon, ExecMethodParams>(trap);
     if (!params)
     {
         plugin->destroy_trap(drakvuf, trap);
@@ -530,8 +522,8 @@ event_response_t GetObject_handler(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 
 event_response_t ExecQuery_return_handler(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 {
-    auto data = get_trap_params<wmimon, ExecQueryParams<wmimon>>(info);
-    auto plugin = get_trap_plugin<wmimon, ExecQueryParams<wmimon>>(info);
+    auto data = get_trap_params<wmimon, ExecQueryParams>(info);
+    auto plugin = get_trap_plugin<wmimon, ExecQueryParams>(info);
     if (!plugin || !data)
     {
         PRINT_DEBUG("[WMIMon] ExecQueryReturn invalid trap params\n");
@@ -580,17 +572,15 @@ event_response_t ExecQuery_handler(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
         return VMI_EVENT_RESPONSE_NONE;
     }
 
-    auto trap = plugin->register_trap<wmimon, ExecQueryParams<wmimon>>(
-                    drakvuf,
+    auto trap = plugin->register_trap<ExecQueryParams>(
                     info,
-                    plugin,
                     ExecQuery_return_handler,
                     breakpoint_by_dtb_searcher());
 
     if (!trap)
         return VMI_EVENT_RESPONSE_NONE;
 
-    auto params = get_trap_params<wmimon, ExecQueryParams<wmimon>>(trap);
+    auto params = get_trap_params<wmimon, ExecQueryParams>(trap);
     if (!params)
     {
         plugin->destroy_trap(drakvuf, trap);
@@ -606,8 +596,8 @@ event_response_t ExecQuery_handler(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 
 event_response_t ConnectServer_return_handler(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 {
-    auto data = get_trap_params<wmimon, ConnectServerParams<wmimon>>(info);
-    auto plugin = get_trap_plugin<wmimon, ConnectServerParams<wmimon>>(info);
+    auto data = get_trap_params<wmimon, ConnectServerParams>(info);
+    auto plugin = get_trap_plugin<wmimon, ConnectServerParams>(info);
     if (!plugin || !data)
     {
         PRINT_DEBUG("[WMIMon] ConnectServerReturn invalid trap params\n");
@@ -648,14 +638,9 @@ event_response_t ConnectServer_return_handler(drakvuf_t drakvuf, drakvuf_trap_in
         vtable vt(drakvuf, info, data->m_vtable, 26);
 
         search_breakpoint_by_addr bp(plugin, vt[20]);
-        plugin->register_trap<wmimon>(drakvuf, info, plugin, ExecQuery_handler,
-                                      bp, "ExecQuery");
-
-        plugin->register_trap<wmimon>(drakvuf, info, plugin, GetObject_handler,
-                                      bp.set_addr(vt[6]), "GetObject");
-
-        plugin->register_trap<wmimon>(drakvuf, info, plugin, ExecMethod_handler,
-                                      bp.set_addr(vt[24]), "ExecMethod");
+        plugin->register_trap(info, ExecQuery_handler, bp, "ExecQuery");
+        plugin->register_trap(info, GetObject_handler, bp.set_addr(vt[6]), "GetObject");
+        plugin->register_trap(info, ExecMethod_handler, bp.set_addr(vt[24]), "ExecMethod");
     }
     catch (const std::exception& e)
     {
@@ -676,17 +661,15 @@ event_response_t ConnectServer_handler(drakvuf_t drakvuf, drakvuf_trap_info_t* i
         return VMI_EVENT_RESPONSE_NONE;
     }
 
-    auto trap = plugin->register_trap<wmimon, ConnectServerParams<wmimon>>(
-                    drakvuf,
+    auto trap = plugin->register_trap<ConnectServerParams>(
                     info,
-                    plugin,
                     ConnectServer_return_handler,
                     breakpoint_by_dtb_searcher());
 
     if (!trap)
         return VMI_EVENT_RESPONSE_NONE;
 
-    auto params = get_trap_params<wmimon, ConnectServerParams<wmimon>>(trap);
+    auto params = get_trap_params<wmimon, ConnectServerParams>(trap);
     if (!params)
     {
         plugin->destroy_trap(drakvuf, trap);
@@ -703,8 +686,8 @@ event_response_t ConnectServer_handler(drakvuf_t drakvuf, drakvuf_trap_info_t* i
 
 event_response_t CoCreateInstanse_return_handler(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 {
-    auto data = get_trap_params<wmimon, CoCreateInstanse<wmimon>>(info);
-    auto plugin = get_trap_plugin<wmimon, CoCreateInstanse<wmimon>>(info);
+    auto data = get_trap_params<wmimon, CoCreateInstanse>(info);
+    auto plugin = get_trap_plugin<wmimon, CoCreateInstanse>(info);
     if (!plugin || !data)
     {
         PRINT_DEBUG("[WMIMon] CoCreateInstanse_return invalid trap params!\n");
@@ -721,8 +704,7 @@ event_response_t CoCreateInstanse_return_handler(drakvuf_t drakvuf, drakvuf_trap
     {
         vtable vt(drakvuf, info, data->m_vtable, 4);
 
-        plugin->register_trap<wmimon>(drakvuf, info, plugin, ConnectServer_handler,
-                                      search_breakpoint_by_addr(plugin, vt[3]), "ConnectServer");
+        plugin->register_trap(info, ConnectServer_handler, search_breakpoint_by_addr(plugin, vt[3]), "ConnectServer");
     }
     catch (const std::exception& e)
     {
@@ -771,16 +753,12 @@ event_response_t CoCreateInstanse_handler(drakvuf_t drakvuf, drakvuf_trap_info_t
             return VMI_EVENT_RESPONSE_NONE;
     }
 
-    auto trap = plugin->register_trap<wmimon, CoCreateInstanse<wmimon>>(drakvuf,
-                info,
-                plugin,
-                CoCreateInstanse_return_handler,
-                breakpoint_by_dtb_searcher());
+    auto trap = plugin->register_trap<CoCreateInstanse>(info, CoCreateInstanse_return_handler, breakpoint_by_dtb_searcher());
 
     if (!trap)
         return VMI_EVENT_RESPONSE_NONE;
 
-    auto params = get_trap_params<wmimon, CoCreateInstanse<wmimon>>(trap);
+    auto params = get_trap_params<wmimon, CoCreateInstanse>(trap);
     if (!params)
     {
         plugin->destroy_trap(drakvuf, trap);
@@ -843,7 +821,7 @@ wmimon::wmimon(drakvuf_t drakvuf, const wmimon_config* c, output_format_t output
 
     PRINT_DEBUG("[WMIMon] attempt to setup a trap for \"%s::CoCreateInstance\"\n", dll_name);
     breakpoint_in_dll_module_searcher bp(profile, dll_name);
-    if (!register_trap<wmimon>(drakvuf, nullptr, this, CoCreateInstanse_handler, bp.for_syscall_name("CoCreateInstance")))
+    if (!register_trap(nullptr, CoCreateInstanse_handler, bp.for_syscall_name("CoCreateInstance")))
         throw -1;
 
     // if (c->wow_ole32_profile)


### PR DESCRIPTION
 - remove allocators, as noone used them
 - remove a lot of templates from hook params
 - separate `get_trap_params` and `get_trap_plugin`
 - use `std::unique_ptr` with custom deleter for traps
 - minimal changes to old API

Currently WIP as this is 1st commit where "it builds", now it needs extended testing.