### PR TITLE
argument printers: escape non-printable characters in strings

### DIFF
--- a/src/libusermode/printers/printers.cpp
+++ b/src/libusermode/printers/printers.cpp
@@ -108,7 +108,7 @@
 #include <libvmi/libvmi.h>
 #include <libdrakvuf/libdrakvuf.h>
 
-std::string escape_str(const std::string &s)
+std::string escape_str(const std::string& s)
 {
     char const* const hexdig = "0123456789ABCDEF";
     std::stringstream os;

--- a/src/libusermode/printers/printers.cpp
+++ b/src/libusermode/printers/printers.cpp
@@ -108,6 +108,31 @@
 #include <libvmi/libvmi.h>
 #include <libdrakvuf/libdrakvuf.h>
 
+std::string escape_str(const std::string &s)
+{
+    char const* const hexdig = "0123456789ABCDEF";
+    std::stringstream os;
+
+    for (char c : s)
+    {
+        switch (c)
+        {
+        case '\\': os << "\\\\"; break;
+        case '\t': os << "\\t";  break;
+        case '\r': os << "\\r";  break;
+        case '\n': os << "\\n";  break;
+        default:
+            if (c < ' ' || c > '~')
+                os << "\\x" << hexdig[c >> 4] << hexdig[c & 0xF];
+            else
+                os << c;
+            break;
+        }
+    }
+
+    return os.str();
+}
+
 ArgumentPrinter::ArgumentPrinter(std::string arg_name, bool print_no_addr) : name(arg_name), print_no_addr(print_no_addr)
 {
     // intentionally empty
@@ -142,7 +167,7 @@ std::string StringPrinterInterface::print(drakvuf_t drakvuf, drakvuf_trap_info* 
     stream << name << "=";
     if (!print_no_addr)
         stream << "0x" << std::hex << argument << ":";
-    stream << "\"" << str << "\"";
+    stream << "\"" << escape_str(str) << "\"";
     return stream.str();
 }
 
@@ -194,7 +219,7 @@ std::string UnicodePrinter::print(drakvuf_t drakvuf, drakvuf_trap_info* info, ui
     stream << name << "=";
     if (!print_no_addr)
         stream << "0x" << std::hex << argument << ":";
-    stream << "\"" << str << "\"";
+    stream << "\"" << escape_str(str) << "\"";
     return stream.str();
 }
 

--- a/src/libusermode/printers/printers.cpp
+++ b/src/libusermode/printers/printers.cpp
@@ -117,16 +117,24 @@ std::string escape_str(const std::string &s)
     {
         switch (c)
         {
-        case '\\': os << "\\\\"; break;
-        case '\t': os << "\\t";  break;
-        case '\r': os << "\\r";  break;
-        case '\n': os << "\\n";  break;
-        default:
-            if (c < ' ' || c > '~')
-                os << "\\x" << hexdig[c >> 4] << hexdig[c & 0xF];
-            else
-                os << c;
-            break;
+            case '\\':
+                os << "\\\\";
+                break;
+            case '\t':
+                os << "\\t";
+                break;
+            case '\r':
+                os << "\\r";
+                break;
+            case '\n':
+                os << "\\n";
+                break;
+            default:
+                if (c < ' ' || c > '~')
+                    os << "\\x" << hexdig[c >> 4] << hexdig[c & 0xF];
+                else
+                    os << c;
+                break;
         }
     }
 


### PR DESCRIPTION
Sometimes `apimon` encounters an invalid string or just a byte buffer. When it tries to print it as ASCII/Unicode string, invalid characters might appear in JSON. Here we try to escape all non-printable characters with backslash sequences, to avoid producing binary output out of DRAKVUF.

/cc @BonusPlay @chivay @kscieslinski 

/cc @skvl (you might be affected by this change)

related https://github.com/CERT-Polska/drakvuf-sandbox/issues/270