### PR TITLE
drakvuf-bundle: fix bug in xen.cfg

### DIFF
--- a/package/extra/etc/default/grub.d/xen.cfg
+++ b/package/extra/etc/default/grub.d/xen.cfg
@@ -15,8 +15,10 @@ echo "Using DRAKVUF-optimized settings for Xen"
 # DRAK_DOM0_CPU=2
 # DRAK_DOM0_RAM=2048
 
-if ! command -v drak-find-xen-defaults &> /dev/null
+if command -v drak-find-xen-defaults >/dev/null
 then
+    echo Detected that drakvuf-bundle is installed.
+else
     echo "\e[31mWARNING!\e[0m Looks like DRAKVUF bundle is not installed."
     echo "\e[31mWARNING!\e[0m Xen will be not configured to work with DRAKVUF"
     exit 0


### PR DESCRIPTION
Turns out that scripts in `/etc/default/grub.d` are running inside `/bin/dash` which works differently than bash o_O

Fix bug that was causing `update-grub` always saying that drakvuf-bundle is not installed.