### PR TITLE
libusermode: refactor log strategies

### DIFF
--- a/src/libusermode/userhook.hpp
+++ b/src/libusermode/userhook.hpp
@@ -121,10 +121,27 @@ enum target_hook_type
     HOOK_BY_OFFSET
 };
 
-enum class LogStrategy
+struct HookActions
 {
-    LOG,
-    LOG_AND_STACK,
+    bool log;
+    bool stack;
+
+    HookActions() : log{false}, stack{false} {}
+
+    static HookActions empty()
+    {
+        return HookActions{};
+    }
+    HookActions& set_log()
+    {
+        this->log = true;
+        return *this;
+    }
+    HookActions& set_stack()
+    {
+        this->stack = true;
+        return *this;
+    }
 };
 
 struct plugin_target_config_entry_t
@@ -134,19 +151,19 @@ struct plugin_target_config_entry_t
     std::string function_name;
     std::string clsid;
     addr_t offset;
-    LogStrategy log_strategy;
+    HookActions actions;
     std::vector< std::unique_ptr< ArgumentPrinter > > argument_printers;
 
     plugin_target_config_entry_t()
-        : dll_name(), function_name(), offset(), log_strategy(), argument_printers()
+        : dll_name(), function_name(), offset(), actions(), argument_printers()
     {}
 
-    plugin_target_config_entry_t(std::string&& dll_name, std::string&& function_name, addr_t offset, LogStrategy log_strategy, std::vector< std::unique_ptr< ArgumentPrinter > >&& argument_printers)
-        : dll_name(std::move(dll_name)), type(HOOK_BY_OFFSET), function_name(std::move(function_name)), offset(offset), log_strategy(log_strategy), argument_printers(std::move(argument_printers))
+    plugin_target_config_entry_t(std::string&& dll_name, std::string&& function_name, addr_t offset, HookActions hook_actions, std::vector< std::unique_ptr< ArgumentPrinter > >&& argument_printers)
+        : dll_name(std::move(dll_name)), type(HOOK_BY_OFFSET), function_name(std::move(function_name)), offset(offset), actions(hook_actions), argument_printers(std::move(argument_printers))
     {}
 
-    plugin_target_config_entry_t(std::string&& dll_name, std::string&& function_name, LogStrategy log_strategy, std::vector< std::unique_ptr< ArgumentPrinter > >&& argument_printers)
-        : dll_name(std::move(dll_name)), type(HOOK_BY_NAME), function_name(std::move(function_name)), offset(), log_strategy(log_strategy), argument_printers(std::move(argument_printers))
+    plugin_target_config_entry_t(std::string&& dll_name, std::string&& function_name, HookActions hook_actions, std::vector< std::unique_ptr< ArgumentPrinter > >&& argument_printers)
+        : dll_name(std::move(dll_name)), type(HOOK_BY_NAME), function_name(std::move(function_name)), offset(), actions(hook_actions), argument_printers(std::move(argument_printers))
     {}
 };
 

--- a/src/libusermode/userhook.hpp
+++ b/src/libusermode/userhook.hpp
@@ -121,6 +121,12 @@ enum target_hook_type
     HOOK_BY_OFFSET
 };
 
+enum class LogStrategy
+{
+    LOG,
+    LOG_AND_STACK,
+};
+
 struct plugin_target_config_entry_t
 {
     std::string dll_name;
@@ -128,19 +134,19 @@ struct plugin_target_config_entry_t
     std::string function_name;
     std::string clsid;
     addr_t offset;
-    std::string log_strategy;
+    LogStrategy log_strategy;
     std::vector< std::unique_ptr< ArgumentPrinter > > argument_printers;
 
     plugin_target_config_entry_t()
         : dll_name(), function_name(), offset(), log_strategy(), argument_printers()
     {}
 
-    plugin_target_config_entry_t(std::string&& dll_name, std::string&& function_name, addr_t offset, std::string&& log_strategy, std::vector< std::unique_ptr< ArgumentPrinter > >&& argument_printers)
-        : dll_name(std::move(dll_name)), type(HOOK_BY_OFFSET), function_name(std::move(function_name)), offset(offset), log_strategy(std::move(log_strategy)), argument_printers(std::move(argument_printers))
+    plugin_target_config_entry_t(std::string&& dll_name, std::string&& function_name, addr_t offset, LogStrategy log_strategy, std::vector< std::unique_ptr< ArgumentPrinter > >&& argument_printers)
+        : dll_name(std::move(dll_name)), type(HOOK_BY_OFFSET), function_name(std::move(function_name)), offset(offset), log_strategy(log_strategy), argument_printers(std::move(argument_printers))
     {}
 
-    plugin_target_config_entry_t(std::string&& dll_name, std::string&& function_name, std::string&& log_strategy, std::vector< std::unique_ptr< ArgumentPrinter > >&& argument_printers)
-        : dll_name(std::move(dll_name)), type(HOOK_BY_NAME), function_name(std::move(function_name)), offset(), log_strategy(std::move(log_strategy)), argument_printers(std::move(argument_printers))
+    plugin_target_config_entry_t(std::string&& dll_name, std::string&& function_name, LogStrategy log_strategy, std::vector< std::unique_ptr< ArgumentPrinter > >&& argument_printers)
+        : dll_name(std::move(dll_name)), type(HOOK_BY_NAME), function_name(std::move(function_name)), offset(), log_strategy(log_strategy), argument_printers(std::move(argument_printers))
     {}
 };
 

--- a/src/plugins/apimon/apimon.cpp
+++ b/src/plugins/apimon/apimon.cpp
@@ -347,16 +347,6 @@ apimon::apimon(drakvuf_t drakvuf, const apimon_config* c, output_format_t output
         throw -1;
     }
 
-    auto it = std::begin(this->wanted_hooks);
-
-    while (it != std::end(this->wanted_hooks))
-    {
-        if ((*it).log_strategy != "log" && (*it).log_strategy != "log+stack")
-            it = this->wanted_hooks.erase(it);
-        else
-            ++it;
-    }
-
     if (this->wanted_hooks.empty())
     {
         // don't load this plugin if there is nothing to do

--- a/src/plugins/apimon/apimon.cpp
+++ b/src/plugins/apimon/apimon.cpp
@@ -347,6 +347,15 @@ apimon::apimon(drakvuf_t drakvuf, const apimon_config* c, output_format_t output
         throw -1;
     }
 
+    auto& hooks = this->wanted_hooks;
+    auto noLog = [](const auto& entry)
+    {
+        return !entry.actions.log;
+    };
+    hooks.erase(
+        std::remove_if(std::begin(hooks), std::end(hooks), noLog),
+        std::end(hooks));
+
     if (this->wanted_hooks.empty())
     {
         // don't load this plugin if there is nothing to do

--- a/src/plugins/memdump/userhook.cpp
+++ b/src/plugins/memdump/userhook.cpp
@@ -191,7 +191,7 @@ void memdump::userhook_init(drakvuf_t drakvuf, const memdump_config* c, output_f
 
     while (it != std::end(this->wanted_hooks))
     {
-        if ((*it).log_strategy != "stack" && (*it).log_strategy != "log+stack")
+        if ((*it).log_strategy != LogStrategy::LOG_AND_STACK)
             it = this->wanted_hooks.erase(it);
         else
             ++it;
@@ -248,7 +248,7 @@ void memdump::setup_dotnet_hooks(drakvuf_t drakvuf, const char* dll_name, const 
     entry.dll_name = dll_name;
     entry.type = HOOK_BY_OFFSET;
     entry.offset = func_rva;
-    entry.log_strategy = "log+stack";
+    entry.log_strategy = LogStrategy::LOG_AND_STACK;
     this->wanted_hooks.push_back(std::move(entry));
 }
 

--- a/src/plugins/memdump/userhook.cpp
+++ b/src/plugins/memdump/userhook.cpp
@@ -187,15 +187,14 @@ void memdump::userhook_init(drakvuf_t drakvuf, const memdump_config* c, output_f
         throw -1;
     }
 
-    auto it = std::begin(this->wanted_hooks);
-
-    while (it != std::end(this->wanted_hooks))
+    auto& hooks = this->wanted_hooks;
+    auto noStack = [](const auto& entry)
     {
-        if ((*it).log_strategy != LogStrategy::LOG_AND_STACK)
-            it = this->wanted_hooks.erase(it);
-        else
-            ++it;
-    }
+        return !entry.actions.stack;
+    };
+    hooks.erase(
+        std::remove_if(std::begin(hooks), std::end(hooks), noStack),
+        std::end(hooks));
 
     if (this->wanted_hooks.empty())
     {
@@ -248,7 +247,7 @@ void memdump::setup_dotnet_hooks(drakvuf_t drakvuf, const char* dll_name, const 
     entry.dll_name = dll_name;
     entry.type = HOOK_BY_OFFSET;
     entry.offset = func_rva;
-    entry.log_strategy = LogStrategy::LOG_AND_STACK;
+    entry.actions = HookActions::empty().set_log().set_stack();
     this->wanted_hooks.push_back(std::move(entry));
 }
 

--- a/src/plugins/rpcmon/rpcmon.cpp
+++ b/src/plugins/rpcmon/rpcmon.cpp
@@ -382,25 +382,26 @@ rpcmon::rpcmon(drakvuf_t drakvuf, output_format_t output)
 {
     std::vector< std::unique_ptr < ArgumentPrinter > > arg_vec;
 
+    const auto log = HookActions::empty().set_log();
     arg_vec.push_back(std::unique_ptr < ArgumentPrinter>(new ArgumentPrinter("pStubDescriptor", false)));
     arg_vec.push_back(std::unique_ptr < ArgumentPrinter>(new ArgumentPrinter("pFormat", false)));
-    wanted_hooks.emplace_back("rpcrt4.dll", "NdrAsyncClientCall", LogStrategy::LOG, std::move(arg_vec));
+    wanted_hooks.emplace_back("rpcrt4.dll", "NdrAsyncClientCall", log, std::move(arg_vec));
 
     arg_vec.push_back(std::unique_ptr < ArgumentPrinter>(new ArgumentPrinter("pStubDescriptor", false)));
     arg_vec.push_back(std::unique_ptr < ArgumentPrinter>(new ArgumentPrinter("pFormat", false)));
-    wanted_hooks.emplace_back("rpcrt4.dll", "NdrAsyncClientCall2", LogStrategy::LOG, std::move(arg_vec));
+    wanted_hooks.emplace_back("rpcrt4.dll", "NdrAsyncClientCall2", log, std::move(arg_vec));
 
     arg_vec.push_back(std::unique_ptr < ArgumentPrinter>(new ArgumentPrinter("pStubDescriptor", false)));
     arg_vec.push_back(std::unique_ptr < ArgumentPrinter>(new ArgumentPrinter("pFormat", false)));
-    wanted_hooks.emplace_back("rpcrt4.dll", "NdrClientCall", LogStrategy::LOG, std::move(arg_vec));
+    wanted_hooks.emplace_back("rpcrt4.dll", "NdrClientCall", log, std::move(arg_vec));
 
     arg_vec.push_back(std::unique_ptr < ArgumentPrinter>(new ArgumentPrinter("pStubDescriptor", false)));
     arg_vec.push_back(std::unique_ptr < ArgumentPrinter>(new ArgumentPrinter("pFormat", false)));
-    wanted_hooks.emplace_back("rpcrt4.dll", "NdrClientCall2", LogStrategy::LOG, std::move(arg_vec));
+    wanted_hooks.emplace_back("rpcrt4.dll", "NdrClientCall2", log, std::move(arg_vec));
 
     arg_vec.push_back(std::unique_ptr < ArgumentPrinter>(new ArgumentPrinter("pStubDescriptor", false)));
     arg_vec.push_back(std::unique_ptr < ArgumentPrinter>(new ArgumentPrinter("pFormat", false)));
-    wanted_hooks.emplace_back("rpcrt4.dll", "NdrClientCall4", LogStrategy::LOG, std::move(arg_vec));
+    wanted_hooks.emplace_back("rpcrt4.dll", "NdrClientCall4", log, std::move(arg_vec));
 
     usermode_cb_registration reg =
     {

--- a/src/plugins/rpcmon/rpcmon.cpp
+++ b/src/plugins/rpcmon/rpcmon.cpp
@@ -384,23 +384,23 @@ rpcmon::rpcmon(drakvuf_t drakvuf, output_format_t output)
 
     arg_vec.push_back(std::unique_ptr < ArgumentPrinter>(new ArgumentPrinter("pStubDescriptor", false)));
     arg_vec.push_back(std::unique_ptr < ArgumentPrinter>(new ArgumentPrinter("pFormat", false)));
-    wanted_hooks.emplace_back("rpcrt4.dll", "NdrAsyncClientCall", "log", std::move(arg_vec));
+    wanted_hooks.emplace_back("rpcrt4.dll", "NdrAsyncClientCall", LogStrategy::LOG, std::move(arg_vec));
 
     arg_vec.push_back(std::unique_ptr < ArgumentPrinter>(new ArgumentPrinter("pStubDescriptor", false)));
     arg_vec.push_back(std::unique_ptr < ArgumentPrinter>(new ArgumentPrinter("pFormat", false)));
-    wanted_hooks.emplace_back("rpcrt4.dll", "NdrAsyncClientCall2", "log", std::move(arg_vec));
+    wanted_hooks.emplace_back("rpcrt4.dll", "NdrAsyncClientCall2", LogStrategy::LOG, std::move(arg_vec));
 
     arg_vec.push_back(std::unique_ptr < ArgumentPrinter>(new ArgumentPrinter("pStubDescriptor", false)));
     arg_vec.push_back(std::unique_ptr < ArgumentPrinter>(new ArgumentPrinter("pFormat", false)));
-    wanted_hooks.emplace_back("rpcrt4.dll", "NdrClientCall", "log", std::move(arg_vec));
+    wanted_hooks.emplace_back("rpcrt4.dll", "NdrClientCall", LogStrategy::LOG, std::move(arg_vec));
 
     arg_vec.push_back(std::unique_ptr < ArgumentPrinter>(new ArgumentPrinter("pStubDescriptor", false)));
     arg_vec.push_back(std::unique_ptr < ArgumentPrinter>(new ArgumentPrinter("pFormat", false)));
-    wanted_hooks.emplace_back("rpcrt4.dll", "NdrClientCall2", "log", std::move(arg_vec));
+    wanted_hooks.emplace_back("rpcrt4.dll", "NdrClientCall2", LogStrategy::LOG, std::move(arg_vec));
 
     arg_vec.push_back(std::unique_ptr < ArgumentPrinter>(new ArgumentPrinter("pStubDescriptor", false)));
     arg_vec.push_back(std::unique_ptr < ArgumentPrinter>(new ArgumentPrinter("pFormat", false)));
-    wanted_hooks.emplace_back("rpcrt4.dll", "NdrClientCall4", "log", std::move(arg_vec));
+    wanted_hooks.emplace_back("rpcrt4.dll", "NdrClientCall4", LogStrategy::LOG, std::move(arg_vec));
 
     usermode_cb_registration reg =
     {


### PR DESCRIPTION
In current implementation, log strategy is implemented as a std::string.
Using an enum is both faster and less error-prone.

Additionaly, remove the concept of "stack" strategy as it has no sense
(doing work, without any benefit to the user).