### PR TITLE
drakvuf-bundle: default to sched=credit

### DIFF
--- a/package/extra/etc/default/grub.d/xen.cfg
+++ b/package/extra/etc/default/grub.d/xen.cfg
@@ -43,7 +43,7 @@ echo "You can edit these settings in /etc/default/grub.d/xen.cfg"
 
 # The following two are used to generate arguments for the hypervisor:
 #
-GRUB_CMDLINE_XEN_DEFAULT="dom0_mem=${DRAK_DOM0_RAM}M,max:${DRAK_DOM0_RAM}M dom0_max_vcpus=${DRAK_DOM0_CPU} dom0_vcpus_pin=1 force-ept=1 ept=pml=0 hap_1gb=0 hap_2mb=0 altp2m=1 smt=0"
+GRUB_CMDLINE_XEN_DEFAULT="dom0_mem=${DRAK_DOM0_RAM}M,max:${DRAK_DOM0_RAM}M dom0_max_vcpus=${DRAK_DOM0_CPU} dom0_vcpus_pin=1 force-ept=1 ept=pml=0 hap_1gb=0 hap_2mb=0 altp2m=1 smt=0 sched=credit"
 #GRUB_CMDLINE_XEN=""
 #
 # For example:


### PR DESCRIPTION
There are some scheduling issues with `sched=credit2` that are becoming especially visible when machine has many PCPUs. I've confirmed with Andrew Cooper that there were some reports about `credit2` recently.

I propose to default to `sched=credit` in drakvuf-bundle, which is a more stable choice.