### PR TITLE
injector: optionally wait until injected process terminates

### DIFF
--- a/src/drakvuf.cpp
+++ b/src/drakvuf.cpp
@@ -244,6 +244,7 @@ injector_status_t drakvuf_c::inject_cmd(vmi_pid_t injection_pid,
                                  true,
                                  &injector_to_be_freed,
                                  global_search,
+                                 false,
                                  args_count,
                                  args);
 

--- a/src/injector.c
+++ b/src/injector.c
@@ -146,6 +146,7 @@ static inline void print_help(void)
             "\t [-P] <target>             The guest path of the clean guest process to use as a cover (requires -m doppelganging)\n"
             "\t -I <injection thread>     The ThreadID in the process to hijack for injection (requires -i) (LINUX: Injects to TGID Thread if ThreadID not specified)\n"
             "\t -c <current_working_dir>  The current working directory for injected executable\n"
+            "\t -w                        Inject process and wait untill it terminates (requires -m createproc)\n"
 #ifdef DRAKVUF_DEBUG
             "\t -v                        Turn on verbose (debug) output\n"
 #endif
@@ -168,6 +169,7 @@ int main(int argc, char** argv)
     injection_method_t injection_method = INJECT_METHOD_CREATEPROC;
     bool verbose = 0;
     bool libvmi_conf = false;
+    bool wait_for_exit = false;
     const char* args[10] = {};
     int args_count = 0;
     addr_t kpgd = 0;
@@ -182,7 +184,7 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    while ((c = getopt (argc, argv, "r:d:i:I:e:m:B:P:f:k:vlgo:")) != -1)
+    while ((c = getopt (argc, argv, "r:d:i:I:e:m:B:P:f:k:vlgo:w")) != -1)
         switch (c)
         {
             case 'r':
@@ -258,6 +260,9 @@ int main(int argc, char** argv)
                 if (!strncmp(optarg, "json", 4))
                     output = OUTPUT_JSON;
                 break;
+            case 'w':
+                wait_for_exit = true;
+                break;
             default:
                 fprintf(stderr, "Unrecognized option: %c\n", c);
                 return rc;
@@ -322,6 +327,7 @@ int main(int argc, char** argv)
                                false,
                                NULL,
                                injection_global_search,
+                               wait_for_exit,
                                args_count,
                                args);
 

--- a/src/libinjector/injector.c
+++ b/src/libinjector/injector.c
@@ -118,6 +118,7 @@ injector_status_t injector_start_app(
     bool break_loop_on_detection,
     injector_t* injector_to_be_freed,
     bool global_search,
+    bool wait_for_exit,
     int args_count,
     const char* args[])
 {
@@ -134,7 +135,8 @@ injector_status_t injector_start_app(
                                          target_process,
                                          break_loop_on_detection,
                                          injector_to_be_freed,
-                                         global_search);
+                                         global_search,
+                                         wait_for_exit);
     }
     else if (drakvuf_get_os_type(drakvuf) == VMI_OS_LINUX)
     {

--- a/src/libinjector/libinjector.h
+++ b/src/libinjector/libinjector.h
@@ -216,6 +216,7 @@ injector_status_t injector_start_app(drakvuf_t drakvuf,
                                      bool break_loop_on_detection,
                                      injector_t* injector_to_be_freed,
                                      bool global_search, // out: iff break_loop_on_detection is set
+                                     bool wait_for_exit,
                                      int args_count,
                                      const char* args[]) NOEXCEPT;
 

--- a/src/libinjector/private.h
+++ b/src/libinjector/private.h
@@ -148,7 +148,8 @@ injector_status_t injector_start_app_on_win(drakvuf_t drakvuf,
         const char* target_process,
         bool break_loop_on_detection,
         injector_t* injector_to_be_freed,
-        bool global_search);
+        bool global_search,
+        bool wait_for_exit);
 
 static inline void copy_gprs(registers_t* dst, registers_t* src)
 {


### PR DESCRIPTION
Add `-w` command line switch in `injector` which blocks until the termination of injected program is observed. Program's exit code is captured and `injector` returns error if it's non-zero.

![2020-10-24-00-01-55](https://user-images.githubusercontent.com/6976513/97057916-b028ca00-158c-11eb-84ff-b68525b79332.gif)
