### PR TITLE
Build Debian packages using GitHub Actions

### DIFF
--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -53,6 +53,9 @@ jobs:
         uses: actions/download-artifact@v1
         with:
           name: release-url
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
       - name: Generate variables
         id: gen_vars
         run: |
@@ -69,15 +72,12 @@ jobs:
           XEN_COMMIT=$(git ls-tree HEAD xen | cut -f3 '-d ' | cut -f1 -d$'\t')
           echo "Xen commit: $XEN_COMMIT"
           echo "::set-output name=xen_commit::${XEN_COMMIT}"
-      - uses: actions/checkout@v2
-        with:
-          submodules: recursive
       - name: Cache Xen intermediate
         uses: actions/cache@v2
         with:
           path: |
             package/cache
-          key: ${{ matrix.container }}-${{ steps.gen_vars.outputs.xen_commit }}
+          key: xen-${{ matrix.container }}-${{ steps.gen_vars.outputs.xen_commit }}
       - name: Build package
         id: build_drakvuf_deb
         run: |

--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -1,5 +1,7 @@
-name: deb
+name: Build package
 on:
+  push:
+    branches: [ master ]
   pull_request:
     branches: [ master ]
 jobs:
@@ -14,6 +16,7 @@ jobs:
     - name: Create a Release
       uses: actions/create-release@v1
       id: create_release
+      if: ${{ github.event_name == 'push' }}
       env:
         GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
       with:
@@ -21,12 +24,15 @@ jobs:
         release_name: DRAKVUF ${{ steps.gen_vars.outputs.cur_datetime }} ${{ steps.gen_vars.outputs.short_sha }}
         owner: tklengyel
         repo: drakvuf-builds
+        commitish: master
         draft: false
         prerelease: false
     - name: Store release URL as file
+      if: ${{ github.event_name == 'push' }}
       run: |
         echo "${{ steps.create_release.outputs.upload_url }}" > release-url.txt
     - name: Upload release URL artifact
+      if: ${{ github.event_name == 'push' }}
       uses: actions/upload-artifact@v1
       with:
         name: release-url
@@ -43,6 +49,7 @@ jobs:
           - "ubuntu:focal"
     steps:
       - name: Fetch release URL
+        if: ${{ github.event_name == 'push' }}
         uses: actions/download-artifact@v1
         with:
           name: release-url
@@ -53,10 +60,12 @@ jobs:
           DISTRIBUTION=$(echo ${{ matrix.container }} | cut -f2 '-d:')
           ARTIFACT_PREFIX="${SYSTEM_ID}_${DISTRIBUTION}"
           echo "Artifact prefix: $ARTIFACT_PREFIX"
-          RELEASE_URL=$(cat release-url/release-url.txt)
-          echo "Release URL: $RELEASE_URL"
+          if [ -f release-url/release-url.txt ] ; then
+            RELEASE_URL=$(cat release-url/release-url.txt)
+            echo "Release URL: $RELEASE_URL"
+            echo "::set-output name=release_url::${RELEASE_URL}"
+          fi
           echo "::set-output name=artifact_prefix::${ARTIFACT_PREFIX}"
-          echo "::set-output name=release_url::${RELEASE_URL}"
       - uses: actions/checkout@v2
         with:
           submodules: recursive
@@ -69,6 +78,7 @@ jobs:
           echo "::set-output name=drakvuf_deb_path::${DRAKVUF_DEB_PATH}"
           echo "::set-output name=drakvuf_deb_name::${{ steps.gen_vars.outputs.artifact_prefix }}_${DRAKVUF_DEB_NAME}"
       - name: Upload release asset
+        if: ${{ github.event_name == 'push' }}
         uses: actions/upload-release-asset@v1.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}

--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -1,0 +1,79 @@
+name: deb
+on:
+  pull_request:
+    branches: [ master ]
+jobs:
+  release:
+    runs-on: ubuntu-18.04
+    steps:
+    - name: Generate variables
+      id: gen_vars
+      run: |
+        echo "::set-output name=short_sha::$(echo ${GITHUB_SHA} | cut -c1-8)"
+        echo "::set-output name=cur_datetime::$(date '+%Y-%m-%d %H:%M:%S')"
+    - name: Create a Release
+      uses: actions/create-release@v1
+      id: create_release
+      env:
+        GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+      with:
+        tag_name: build-${{ github.sha }}
+        release_name: DRAKVUF ${{ steps.gen_vars.outputs.cur_datetime }} ${{ steps.gen_vars.outputs.short_sha }}
+        owner: tklengyel
+        repo: drakvuf-builds
+        draft: false
+        prerelease: false
+    - name: Store release URL as file
+      run: |
+        echo "${{ steps.create_release.outputs.upload_url }}" > release-url.txt
+    - name: Upload release URL artifact
+      uses: actions/upload-artifact@v1
+      with:
+        name: release-url
+        path: release-url.txt
+  deb:
+    needs: [release]
+    runs-on: ubuntu-18.04
+    strategy:
+      fail-fast: false
+      matrix:
+        container:
+          - "debian:buster"
+          - "ubuntu:bionic"
+          - "ubuntu:focal"
+    steps:
+      - name: Fetch release URL
+        uses: actions/download-artifact@v1
+        with:
+          name: release-url
+      - name: Generate variables
+        id: gen_vars
+        run: |
+          SYSTEM_ID=$(echo ${{ matrix.container }} | cut -f1 '-d:')
+          DISTRIBUTION=$(echo ${{ matrix.container }} | cut -f2 '-d:')
+          ARTIFACT_PREFIX="${SYSTEM_ID}_${DISTRIBUTION}"
+          echo "Artifact prefix: $ARTIFACT_PREFIX"
+          RELEASE_URL=$(cat release-url/release-url.txt)
+          echo "Release URL: $RELEASE_URL"
+          echo "::set-output name=artifact_prefix::${ARTIFACT_PREFIX}"
+          echo "::set-output name=release_url::${RELEASE_URL}"
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Build package
+        id: build_drakvuf_deb
+        run: |
+          sh package/build.sh ${{ matrix.container }}
+          DRAKVUF_DEB_PATH=$(find package/out/*.deb | head -n1)
+          DRAKVUF_DEB_NAME=$(basename "$DRAKVUF_DEB_PATH")
+          echo "::set-output name=drakvuf_deb_path::${DRAKVUF_DEB_PATH}"
+          echo "::set-output name=drakvuf_deb_name::${{ steps.gen_vars.outputs.artifact_prefix }}_${DRAKVUF_DEB_NAME}"
+      - name: Upload release asset
+        uses: actions/upload-release-asset@v1.0.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        with:
+          upload_url: ${{ steps.gen_vars.outputs.release_url }}
+          asset_path: ${{ steps.build_drakvuf_deb.outputs.drakvuf_deb_path }}
+          asset_name: ${{ steps.build_drakvuf_deb.outputs.drakvuf_deb_name }}
+          asset_content_type: application/vnd.debian.binary-package

--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -67,6 +67,7 @@ jobs:
           fi
           echo "::set-output name=artifact_prefix::${ARTIFACT_PREFIX}"
           XEN_COMMIT=$(git ls-tree HEAD xen | cut -f3 '-d ' | cut -f1 -d$'\t')
+          echo "Xen commit: $XEN_COMMIT"
           echo "::set-output name=xen_commit::${XEN_COMMIT}"
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -66,9 +66,17 @@ jobs:
             echo "::set-output name=release_url::${RELEASE_URL}"
           fi
           echo "::set-output name=artifact_prefix::${ARTIFACT_PREFIX}"
+          XEN_COMMIT=$(git ls-tree HEAD xen | cut -f3 '-d ' | cut -f1 -d$'\t')
+          echo "::set-output name=xen_commit::${XEN_COMMIT}"
       - uses: actions/checkout@v2
         with:
           submodules: recursive
+      - name: Cache Xen intermediate
+        uses: actions/cache@v2
+        with:
+          path: |
+            package/cache
+          key: ${{ matrix.container }}-${{ steps.gen_vars.outputs.xen_commit }}
       - name: Build package
         id: build_drakvuf_deb
         run: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,32 +54,6 @@ jobs:
     include:
 
 #
-# Build binary packages and push them as releases on drakvuf-builds
-#
-    - stage: package
-      if: branch = master
-      env:
-        - TEST="package build"
-      script:
-        - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then exit 0; fi'
-        - git submodule update --init libvmi xen dwarf2json
-        - travis_wait 60 sh package/build.sh;
-      cache:
-        directories:
-          - package/cache
-      before_deploy:
-        - git config --local user.name "drakvuf-builds"
-        - git config --local user.email "drakvuf-builds@tklsoftware.com"
-        - export TRAVIS_TAG=${TRAVIS_TAG:-$(date +'%Y%m%d%H%M%S')-$(git log --format=%h -1)}
-        - git tag $TRAVIS_TAG
-      deploy:
-        provider: releases
-        edge: true
-        repo: tklengyel/drakvuf-builds
-        file:
-          - package/out/**/*
-
-#
 # Coverity
 #
     - stage: cloudscan


### PR DESCRIPTION
Switch from Travis to GitHub Action, it builds much much faster and we could also build for 3 distros in parallel.

* When somebody makes a pull request, a dry run of package build is executed (release creation and asset upload steps are skipped).
* When the PR is pushed to master, actual release is created and assets are uploaded.