### PR TITLE
Add infrastructure to stop plugins

### DIFF
--- a/src/drakvuf.cpp
+++ b/src/drakvuf.cpp
@@ -166,7 +166,7 @@ int drakvuf_c::stop_plugins(const bool* plugin_list)
     bool failed = false;
     bool pending = false;
 
-    for (int i = 0; i < __DRAKVUF_PLUGIN_LIST_MAX; i++)
+    for (int i = 0; i < __DRAKVUF_PLUGIN_LIST_MAX && !failed && !pending; i++)
     {
         if (plugin_list[i])
         {
@@ -197,9 +197,16 @@ static bool is_stopped(drakvuf_t drakvuf, void* data)
     auto d = (struct stop_plugins_data*)data;
     auto rc = drakvuf_is_interrupted(drakvuf);
     if (SIGDRAKVUFTIMEOUT == rc)
-        return rc;
+    {
+        PRINT_DEBUG("[STOP] Timeout\n");
+        return true;
+    }
     else
-        return rc && !d->_drakvuf_c->stop_plugins(d->plugin_list);
+    {
+        rc = rc || !d->_drakvuf_c->stop_plugins(d->plugin_list);
+        PRINT_DEBUG("[STOP] Check plugins %d\n", rc);
+        return rc == 0;
+    }
 }
 
 void drakvuf_c::plugin_stop_loop(int timeout, const bool* plugin_list)

--- a/src/drakvuf.cpp
+++ b/src/drakvuf.cpp
@@ -173,6 +173,23 @@ int drakvuf_c::stop_plugins(const bool* plugin_list)
         }
     }
 
+    bool is_stopped;
+    do
+    {
+        // TODO Use `drakvuf_loop(is_stopped)
+        loop(1);
+
+        is_stopped = true;
+
+        for (int i = 0; i < __DRAKVUF_PLUGIN_LIST_MAX; i++)
+        {
+            if (plugin_list[i])
+            {
+                is_stopped &= plugins->is_stopped(static_cast<drakvuf_plugin_t>(i));
+            }
+        }
+    } while(!is_stopped);
+
     return 1;
 }
 

--- a/src/drakvuf.cpp
+++ b/src/drakvuf.cpp
@@ -188,7 +188,7 @@ int drakvuf_c::stop_plugins(const bool* plugin_list)
                 is_stopped &= plugins->is_stopped(static_cast<drakvuf_plugin_t>(i));
             }
         }
-    } while(!is_stopped);
+    } while (!is_stopped);
 
     return 1;
 }

--- a/src/drakvuf.cpp
+++ b/src/drakvuf.cpp
@@ -161,6 +161,21 @@ int drakvuf_c::start_plugins(const bool* plugin_list, const plugins_options* opt
     return 1;
 }
 
+int drakvuf_c::stop_plugins(const bool* plugin_list)
+{
+    for (int i = 0; i < __DRAKVUF_PLUGIN_LIST_MAX; i++)
+    {
+        if (plugin_list[i])
+        {
+            int rc = plugins->stop(static_cast<drakvuf_plugin_t>(i));
+            if (rc < 0)
+                return rc;
+        }
+    }
+
+    return 1;
+}
+
 drakvuf_c::drakvuf_c(const char* domain,
                      const char* json_kernel_path,
                      const char* json_wow_path,

--- a/src/drakvuf.h
+++ b/src/drakvuf.h
@@ -178,7 +178,7 @@ public:
     void terminate(vmi_pid_t injection_pid, uint32_t injection_tid, vmi_pid_t pid, int termination_timeout, std::shared_ptr<const std::unordered_map<vmi_pid_t, bool>> terminated_processes);
     int start_plugins(const bool* plugin_list, const plugins_options* options);
     int stop_plugins(const bool* plugin_list);
-    void wait_stopped(const bool* plugin_list);
+    void plugin_stop_loop(const bool* plugin_list);
 };
 
 #endif

--- a/src/drakvuf.h
+++ b/src/drakvuf.h
@@ -178,7 +178,7 @@ public:
     void terminate(vmi_pid_t injection_pid, uint32_t injection_tid, vmi_pid_t pid, int termination_timeout, std::shared_ptr<const std::unordered_map<vmi_pid_t, bool>> terminated_processes);
     int start_plugins(const bool* plugin_list, const plugins_options* options);
     int stop_plugins(const bool* plugin_list);
-    void plugin_stop_loop(const bool* plugin_list);
+    void plugin_stop_loop(int timeout, const bool* plugin_list);
 };
 
 #endif

--- a/src/drakvuf.h
+++ b/src/drakvuf.h
@@ -177,6 +177,7 @@ public:
                                  vmi_pid_t* injected_pid);
     void terminate(vmi_pid_t injection_pid, uint32_t injection_tid, vmi_pid_t pid, int termination_timeout, std::shared_ptr<const std::unordered_map<vmi_pid_t, bool>> terminated_processes);
     int start_plugins(const bool* plugin_list, const plugins_options* options);
+    int stop_plugins(const bool* plugin_list);
 };
 
 #endif

--- a/src/drakvuf.h
+++ b/src/drakvuf.h
@@ -178,6 +178,7 @@ public:
     void terminate(vmi_pid_t injection_pid, uint32_t injection_tid, vmi_pid_t pid, int termination_timeout, std::shared_ptr<const std::unordered_map<vmi_pid_t, bool>> terminated_processes);
     int start_plugins(const bool* plugin_list, const plugins_options* options);
     int stop_plugins(const bool* plugin_list);
+    void wait_stopped(const bool* plugin_list);
 };
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -637,6 +637,15 @@ int main(int argc, char** argv)
             break;
     }
 
+    PRINT_DEBUG("Beginning stop plugins\n");
+
+    bool plugin_stop_list[] = {[0 ... __DRAKVUF_PLUGIN_LIST_MAX-1] = 0};
+    plugin_stop_list[PLUGIN_BSODMON] = 1;
+    if (drakvuf->stop_plugins(plugin_stop_list) < 0)
+        return drakvuf_exit_code_t::FAIL;
+
+    PRINT_DEBUG("Finished stop plugins\n");
+
     if (terminate && injected_pid)
         drakvuf->terminate(injection_pid, injection_thread, injected_pid, termination_timeout, terminated_processes);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -637,16 +637,6 @@ int main(int argc, char** argv)
             break;
     }
 
-    PRINT_DEBUG("Beginning stop plugins\n");
-
-    bool plugin_stop_list[] = {[0 ... __DRAKVUF_PLUGIN_LIST_MAX-1] = 0};
-    plugin_stop_list[PLUGIN_BSODMON] = 1;
-    plugin_stop_list[PLUGIN_FILEDELETE] = 1;
-    if (drakvuf->stop_plugins(plugin_stop_list) < 0)
-        return drakvuf_exit_code_t::FAIL;
-
-    PRINT_DEBUG("Finished stop plugins\n");
-
     if (terminate && injected_pid)
         drakvuf->terminate(injection_pid, injection_thread, injected_pid, termination_timeout, terminated_processes);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -641,6 +641,7 @@ int main(int argc, char** argv)
 
     bool plugin_stop_list[] = {[0 ... __DRAKVUF_PLUGIN_LIST_MAX-1] = 0};
     plugin_stop_list[PLUGIN_BSODMON] = 1;
+    plugin_stop_list[PLUGIN_FILEDELETE] = 1;
     if (drakvuf->stop_plugins(plugin_stop_list) < 0)
         return drakvuf_exit_code_t::FAIL;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -131,13 +131,6 @@ static inline void disable_plugin(char* optarg, bool* plugin_list)
             plugin_list[i] = false;
 }
 
-static inline void stop_plugin(char* optarg, bool* plugin_list)
-{
-    for (int i=0; i<__DRAKVUF_PLUGIN_LIST_MAX; i++)
-        if (!strcmp(optarg, drakvuf_plugin_names[i]))
-            plugin_list[i] = true;
-}
-
 static inline void disable_all_plugins(bool* plugin_list)
 {
     for (int i = 0; i < __DRAKVUF_PLUGIN_LIST_MAX; i++)
@@ -180,7 +173,6 @@ static void print_usage()
             "\t -t <timeout>              Timeout (in seconds)\n"
             "\t -o <format>               Output format (default, csv, kv, or json)\n"
             "\t -x <plugin>               Don't activate the specified plugin\n"
-            "\t --stop <plugin>           Stop the specified plugin before termination loop\n"
             "\t --wait-stop-plugins <timeout>\n"
             "\t                           Wait for plugins to stop before termination loop\n"
             "\t -a <plugin>               Activate the specified plugin\n"
@@ -284,8 +276,6 @@ int main(int argc, char** argv)
     struct sigaction act;
     output_format_t output = OUTPUT_DEFAULT;
     bool plugin_list[] = {[0 ... __DRAKVUF_PLUGIN_LIST_MAX-1] = 1};
-    bool stop_plugin_list[] = {[0 ... __DRAKVUF_PLUGIN_LIST_MAX-1] = 0};
-    bool is_stop_plugin = false;
     int wait_stop_plugins = 0;
     bool verbose = false;
     bool leave_paused = false;
@@ -335,7 +325,6 @@ int main(int argc, char** argv)
         opt_userhook_no_addr,
         opt_terminate,
         opt_termination_timeout,
-        opt_stop_plugin,
         opt_wait_stop_plugins,
     };
     const option long_opts[] =
@@ -369,7 +358,6 @@ int main(int argc, char** argv)
         {"disable-sysret", no_argument, NULL, opt_disable_sysret},
         {"userhook-no-addr", no_argument, NULL, opt_userhook_no_addr},
         {"fast-singlestep", no_argument, NULL, 'F'},
-        {"stop", required_argument, NULL, opt_stop_plugin},
         {"wait-stop-plugins", required_argument, NULL, opt_wait_stop_plugins},
         {NULL, 0, NULL, 0}
     };
@@ -453,10 +441,6 @@ int main(int argc, char** argv)
                 break;
             case 'x':
                 disable_plugin(optarg, plugin_list);
-                break;
-            case opt_stop_plugin:
-                stop_plugin(optarg, stop_plugin_list);
-                is_stop_plugin = true;
                 break;
             case opt_wait_stop_plugins:
                 wait_stop_plugins = atoi(optarg);
@@ -661,25 +645,22 @@ int main(int argc, char** argv)
             break;
     }
 
+    PRINT_DEBUG("Beginning stop plugins\n");
+
     bool plugins_pending = false;
-    if (is_stop_plugin)
-    {
-        PRINT_DEBUG("Beginning stop plugins\n");
+    int rc = drakvuf->stop_plugins(plugin_list);
+    if (rc < 0)
+        return drakvuf_exit_code_t::FAIL;
+    else if (rc > 0)
+        plugins_pending = true;
 
-        int rc = drakvuf->stop_plugins(stop_plugin_list);
-        if (rc < 0)
-            return drakvuf_exit_code_t::FAIL;
-        else if (rc > 0)
-            plugins_pending = true;
+    PRINT_DEBUG("Finished stop plugins\n");
 
-        PRINT_DEBUG("Finished stop plugins\n");
-    }
-
-    if (is_stop_plugin && plugins_pending && wait_stop_plugins)
+    if (plugins_pending && wait_stop_plugins)
     {
         PRINT_DEBUG("Beginning wait stop plugins\n");
 
-        drakvuf->plugin_stop_loop(wait_stop_plugins, stop_plugin_list);
+        drakvuf->plugin_stop_loop(wait_stop_plugins, plugin_list);
 
         PRINT_DEBUG("Finished wait stop plugins\n");
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -674,7 +674,7 @@ int main(int argc, char** argv)
     {
         PRINT_DEBUG("Beginning wait stop plugins\n");
 
-        drakvuf->wait_stopped(stop_plugin_list);
+        drakvuf->plugin_stop_loop(stop_plugin_list);
 
         PRINT_DEBUG("Finished wait stop plugins\n");
     }

--- a/src/plugins/bsodmon/bsodmon.cpp
+++ b/src/plugins/bsodmon/bsodmon.cpp
@@ -171,9 +171,5 @@ bsodmon::~bsodmon()
 void bsodmon::stop()
 {
     drakvuf_remove_trap(drakvuf, &trap, nullptr);
-}
-
-bool bsodmon::is_stopped()
-{
-    return true;
+    _stopped = true;
 }

--- a/src/plugins/bsodmon/bsodmon.cpp
+++ b/src/plugins/bsodmon/bsodmon.cpp
@@ -166,10 +166,13 @@ bsodmon::bsodmon(drakvuf_t drakvuf, bool _abort_on_bsod, output_format_t output)
 
 bsodmon::~bsodmon()
 {
+    if (!m_is_stopping)
+        stop();
 }
 
-void bsodmon::stop()
+bool bsodmon::stop()
 {
     drakvuf_remove_trap(drakvuf, &trap, nullptr);
-    _stopped = true;
+    m_is_stopping = true;
+    return true;
 }

--- a/src/plugins/bsodmon/bsodmon.cpp
+++ b/src/plugins/bsodmon/bsodmon.cpp
@@ -153,7 +153,8 @@ static event_response_t hook_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 }
 
 bsodmon::bsodmon(drakvuf_t drakvuf, bool _abort_on_bsod, output_format_t output)
-    : format{output}
+    : drakvuf{drakvuf}
+    , format{output}
     , abort_on_bsod{_abort_on_bsod}
 {
     init_bugcheck_map( this, drakvuf );
@@ -161,4 +162,9 @@ bsodmon::bsodmon(drakvuf_t drakvuf, bool _abort_on_bsod, output_format_t output)
     trap.cb   = hook_cb;
     if ( !drakvuf_get_kernel_symbol_rva( drakvuf, "KeBugCheck2", &trap.breakpoint.rva) ) throw -1;
     if ( ! drakvuf_add_trap( drakvuf, &trap ) ) throw -1;
+}
+
+bsodmon::~bsodmon()
+{
+    drakvuf_remove_trap(drakvuf, &trap, nullptr);
 }

--- a/src/plugins/bsodmon/bsodmon.cpp
+++ b/src/plugins/bsodmon/bsodmon.cpp
@@ -166,5 +166,14 @@ bsodmon::bsodmon(drakvuf_t drakvuf, bool _abort_on_bsod, output_format_t output)
 
 bsodmon::~bsodmon()
 {
+}
+
+void bsodmon::stop()
+{
     drakvuf_remove_trap(drakvuf, &trap, nullptr);
+}
+
+bool bsodmon::is_stopped()
+{
+    return true;
 }

--- a/src/plugins/bsodmon/bsodmon.h
+++ b/src/plugins/bsodmon/bsodmon.h
@@ -121,7 +121,7 @@ public:
     bsodmon(drakvuf_t drakvuf, bool abort_on_bsod, output_format_t output);
     ~bsodmon();
 
-    void stop();
+    bool stop();
 
 private:
     drakvuf_trap_t trap =

--- a/src/plugins/bsodmon/bsodmon.h
+++ b/src/plugins/bsodmon/bsodmon.h
@@ -121,6 +121,9 @@ public:
     bsodmon(drakvuf_t drakvuf, bool abort_on_bsod, output_format_t output);
     ~bsodmon();
 
+    void stop();
+    bool is_stopped();
+
 private:
     drakvuf_trap_t trap =
     {

--- a/src/plugins/bsodmon/bsodmon.h
+++ b/src/plugins/bsodmon/bsodmon.h
@@ -122,7 +122,6 @@ public:
     ~bsodmon();
 
     void stop();
-    bool is_stopped();
 
 private:
     drakvuf_trap_t trap =

--- a/src/plugins/bsodmon/bsodmon.h
+++ b/src/plugins/bsodmon/bsodmon.h
@@ -113,11 +113,13 @@
 class bsodmon : public plugin
 {
 public:
+    drakvuf_t drakvuf;
     const output_format_t format;
     std::map<int, const char*> bugcheck_map;
     bool abort_on_bsod;
 
     bsodmon(drakvuf_t drakvuf, bool abort_on_bsod, output_format_t output);
+    ~bsodmon();
 
 private:
     drakvuf_trap_t trap =

--- a/src/plugins/filedelete/filedelete.cpp
+++ b/src/plugins/filedelete/filedelete.cpp
@@ -1373,7 +1373,8 @@ static addr_t get_function_va(drakvuf_t drakvuf, const char* lib, const char* fu
 }
 
 filedelete::filedelete(drakvuf_t drakvuf, const filedelete_config* c, output_format_t output)
-    : offsets(new size_t[__OFFSET_MAX])
+    : drakvuf(drakvuf)
+    , offsets(new size_t[__OFFSET_MAX])
     , dump_folder(c->dump_folder)
     , pm(drakvuf_get_page_mode(drakvuf))
     , format(output)
@@ -1431,4 +1432,15 @@ filedelete::filedelete(drakvuf_t drakvuf, const filedelete_config* c, output_for
 filedelete::~filedelete()
 {
     delete[] offsets;
+}
+
+void filedelete::stop()
+{
+    for (unsigned long i = 0; i < sizeof(traps)/sizeof(traps[0]); ++i)
+        drakvuf_remove_trap(drakvuf, &traps[i], nullptr);
+}
+
+bool filedelete::is_stopped()
+{
+    return closing_handles.empty();
 }

--- a/src/plugins/filedelete/filedelete.cpp
+++ b/src/plugins/filedelete/filedelete.cpp
@@ -1431,16 +1431,15 @@ filedelete::filedelete(drakvuf_t drakvuf, const filedelete_config* c, output_for
 
 filedelete::~filedelete()
 {
+    if (!m_is_stopping)
+        stop();
     delete[] offsets;
 }
 
-void filedelete::stop()
+bool filedelete::stop()
 {
     for (unsigned long i = 0; i < sizeof(traps)/sizeof(traps[0]); ++i)
         drakvuf_remove_trap(drakvuf, &traps[i], nullptr);
-}
-
-bool filedelete::is_stopped()
-{
+    m_is_stopping = true;
     return closing_handles.empty();
 }

--- a/src/plugins/filedelete/filedelete.h
+++ b/src/plugins/filedelete/filedelete.h
@@ -163,8 +163,7 @@ public:
     filedelete(drakvuf_t drakvuf, const filedelete_config* config, output_format_t output);
     ~filedelete();
 
-    void stop();
-    bool is_stopped();
+    bool stop();
 
     // For `filedelete2`
     addr_t queryvolumeinfo_va = 0;

--- a/src/plugins/filedelete/filedelete.h
+++ b/src/plugins/filedelete/filedelete.h
@@ -146,6 +146,7 @@ public:
             .data = (void*)this
         }
     };
+    drakvuf_t drakvuf = nullptr;
     size_t* offsets;
     size_t control_area_size = 0;
     size_t mmpte_size = 0;
@@ -161,6 +162,9 @@ public:
 
     filedelete(drakvuf_t drakvuf, const filedelete_config* config, output_format_t output);
     ~filedelete();
+
+    void stop();
+    bool is_stopped();
 
     // For `filedelete2`
     addr_t queryvolumeinfo_va = 0;

--- a/src/plugins/plugins.cpp
+++ b/src/plugins/plugins.cpp
@@ -398,9 +398,11 @@ int drakvuf_plugins::stop(const drakvuf_plugin_t plugin_id)
         if ( !this->plugins[plugin_id] || !drakvuf_plugin_os_support[plugin_id][this->os] )
             return 0;
 
+        bool is_stopped = false;
+
         try
         {
-            this->plugins[plugin_id]->stop();
+            is_stopped = this->plugins[plugin_id]->stop();
         }
         catch (int e)
         {
@@ -408,33 +410,17 @@ int drakvuf_plugins::stop(const drakvuf_plugin_t plugin_id)
             return -1;
         }
 
-        PRINT_DEBUG("Stopping plugin %s finished\n", drakvuf_plugin_names[plugin_id]);
-        return 1;
+        if (is_stopped)
+        {
+            PRINT_DEBUG("Stopping plugin %s finished\n", drakvuf_plugin_names[plugin_id]);
+            return 0;
+        }
+        else
+        {
+            PRINT_DEBUG("Stop plugin %s pending\n", drakvuf_plugin_names[plugin_id]);
+            return 1;
+        }
     }
 
     return 0;
-}
-
-bool drakvuf_plugins::is_stopped(const drakvuf_plugin_t plugin_id)
-{
-    if ( __DRAKVUF_PLUGIN_LIST_MAX != 0 &&
-         plugin_id < __DRAKVUF_PLUGIN_LIST_MAX )
-    {
-        PRINT_DEBUG("Check is plugin %s stopped\n", drakvuf_plugin_names[plugin_id]);
-
-        if ( !this->plugins[plugin_id] || !drakvuf_plugin_os_support[plugin_id][this->os] )
-            return true;
-
-        try
-        {
-            return this->plugins[plugin_id]->is_stopped();
-        }
-        catch (int e)
-        {
-            fprintf(stderr, "Check is plugin %s stopped failed!\n", drakvuf_plugin_names[plugin_id]);
-            return true;
-        }
-    }
-
-    return true;
 }

--- a/src/plugins/plugins.cpp
+++ b/src/plugins/plugins.cpp
@@ -400,7 +400,7 @@ int drakvuf_plugins::stop(const drakvuf_plugin_t plugin_id)
 
         try
         {
-            this->plugins[plugin_id].reset();
+            this->plugins[plugin_id]->stop();
         }
         catch (int e)
         {
@@ -413,4 +413,28 @@ int drakvuf_plugins::stop(const drakvuf_plugin_t plugin_id)
     }
 
     return 0;
+}
+
+bool drakvuf_plugins::is_stopped(const drakvuf_plugin_t plugin_id)
+{
+    if ( __DRAKVUF_PLUGIN_LIST_MAX != 0 &&
+         plugin_id < __DRAKVUF_PLUGIN_LIST_MAX )
+    {
+        PRINT_DEBUG("Check is plugin %s stopped\n", drakvuf_plugin_names[plugin_id]);
+
+        if ( !drakvuf_plugin_os_support[plugin_id][this->os] )
+            return true;
+
+        try
+        {
+            return this->plugins[plugin_id]->is_stopped();
+        }
+        catch (int e)
+        {
+            fprintf(stderr, "Check is plugin %s stopped failed!\n", drakvuf_plugin_names[plugin_id]);
+            return true;
+        }
+    }
+
+    return true;
 }

--- a/src/plugins/plugins.cpp
+++ b/src/plugins/plugins.cpp
@@ -387,3 +387,30 @@ int drakvuf_plugins::start(const drakvuf_plugin_t plugin_id,
 
     return 0;
 }
+
+int drakvuf_plugins::stop(const drakvuf_plugin_t plugin_id)
+{
+    if ( __DRAKVUF_PLUGIN_LIST_MAX != 0 &&
+         plugin_id < __DRAKVUF_PLUGIN_LIST_MAX )
+    {
+        PRINT_DEBUG("Stopping plugin %s\n", drakvuf_plugin_names[plugin_id]);
+
+        if ( !drakvuf_plugin_os_support[plugin_id][this->os] )
+            return 0;
+
+        try
+        {
+            this->plugins[plugin_id].reset();
+        }
+        catch (int e)
+        {
+            fprintf(stderr, "Plugin %s stop failed!\n", drakvuf_plugin_names[plugin_id]);
+            return -1;
+        }
+
+        PRINT_DEBUG("Stopping plugin %s finished\n", drakvuf_plugin_names[plugin_id]);
+        return 1;
+    }
+
+    return 0;
+}

--- a/src/plugins/plugins.cpp
+++ b/src/plugins/plugins.cpp
@@ -395,7 +395,7 @@ int drakvuf_plugins::stop(const drakvuf_plugin_t plugin_id)
     {
         PRINT_DEBUG("Stopping plugin %s\n", drakvuf_plugin_names[plugin_id]);
 
-        if ( !drakvuf_plugin_os_support[plugin_id][this->os] )
+        if ( !this->plugins[plugin_id] || !drakvuf_plugin_os_support[plugin_id][this->os] )
             return 0;
 
         try
@@ -422,7 +422,7 @@ bool drakvuf_plugins::is_stopped(const drakvuf_plugin_t plugin_id)
     {
         PRINT_DEBUG("Check is plugin %s stopped\n", drakvuf_plugin_names[plugin_id]);
 
-        if ( !drakvuf_plugin_os_support[plugin_id][this->os] )
+        if ( !this->plugins[plugin_id] || !drakvuf_plugin_os_support[plugin_id][this->os] )
             return true;
 
         try

--- a/src/plugins/plugins.h
+++ b/src/plugins/plugins.h
@@ -242,11 +242,18 @@ class plugin
 public:
     virtual ~plugin() = default;
 
-    virtual void stop() {}
+    virtual void stop()
+    {
+        _stopped = true;
+    }
+
     virtual bool is_stopped()
     {
-        return true;
+        return _stopped;
     }
+
+protected:
+    bool _stopped = false;
 };
 
 class drakvuf_plugins

--- a/src/plugins/plugins.h
+++ b/src/plugins/plugins.h
@@ -242,18 +242,19 @@ class plugin
 public:
     virtual ~plugin() = default;
 
-    virtual void stop()
+    virtual bool stop()
     {
-        _stopped = true;
+        m_is_stopping = true;
+        return true;
     }
 
-    virtual bool is_stopped()
+    virtual bool is_stopping()
     {
-        return _stopped;
+        return m_is_stopping;
     }
 
 protected:
-    bool _stopped = false;
+    bool m_is_stopping = false;
 };
 
 class drakvuf_plugins

--- a/src/plugins/plugins.h
+++ b/src/plugins/plugins.h
@@ -241,6 +241,9 @@ class plugin
 {
 public:
     virtual ~plugin() = default;
+
+    virtual void stop() {}
+    virtual bool is_stopped() { return true; }
 };
 
 class drakvuf_plugins
@@ -255,6 +258,7 @@ public:
     drakvuf_plugins(drakvuf_t drakvuf, output_format_t output, os_t os);
     int start(drakvuf_plugin_t plugin, const plugins_options* config);
     int stop(drakvuf_plugin_t plugin);
+    bool is_stopped(drakvuf_plugin_t plugin);
 };
 
 /***************************************************************************/

--- a/src/plugins/plugins.h
+++ b/src/plugins/plugins.h
@@ -254,6 +254,7 @@ private:
 public:
     drakvuf_plugins(drakvuf_t drakvuf, output_format_t output, os_t os);
     int start(drakvuf_plugin_t plugin, const plugins_options* config);
+    int stop(drakvuf_plugin_t plugin);
 };
 
 /***************************************************************************/

--- a/src/plugins/plugins.h
+++ b/src/plugins/plugins.h
@@ -243,7 +243,10 @@ public:
     virtual ~plugin() = default;
 
     virtual void stop() {}
-    virtual bool is_stopped() { return true; }
+    virtual bool is_stopped()
+    {
+        return true;
+    }
 };
 
 class drakvuf_plugins

--- a/src/plugins/plugins_ex.h
+++ b/src/plugins/plugins_ex.h
@@ -370,11 +370,7 @@ public:
     {
         while (!traps.empty())
             destroy_trap(traps.front());
-    }
-
-    virtual bool is_stopped()
-    {
-        return true;
+        _stopped = true;
     }
 
     // Params property is optional

--- a/src/plugins/plugins_ex.h
+++ b/src/plugins/plugins_ex.h
@@ -372,7 +372,10 @@ public:
             destroy_trap(traps.front());
     }
 
-    virtual bool is_stopped() { return true; }
+    virtual bool is_stopped()
+    {
+        return true;
+    }
 
     // Params property is optional
     template<typename Params = void, typename IB>

--- a/src/plugins/plugins_ex.h
+++ b/src/plugins/plugins_ex.h
@@ -363,9 +363,16 @@ public:
 
     virtual ~pluginex()
     {
-        for (auto& trap : traps)
-            delete_trap(trap);
+        stop();
     };
+
+    virtual void stop()
+    {
+        while (!traps.empty())
+            destroy_trap(traps.front());
+    }
+
+    virtual bool is_stopped() { return true; }
 
     // Params property is optional
     template<typename Params = void, typename IB>

--- a/src/plugins/plugins_ex.h
+++ b/src/plugins/plugins_ex.h
@@ -366,11 +366,17 @@ public:
         stop();
     };
 
-    virtual void stop()
+    virtual bool stop()
+    {
+        destroy_all_traps();
+        m_is_stopping = true;
+        return true;
+    }
+
+    virtual void destroy_all_traps()
     {
         while (!traps.empty())
             destroy_trap(traps.front());
-        _stopped = true;
     }
 
     // Params property is optional

--- a/src/plugins/procdump/procdump.cpp
+++ b/src/plugins/procdump/procdump.cpp
@@ -1044,3 +1044,8 @@ procdump::~procdump()
 
     g_slist_free(this->traps);
 }
+
+bool procdump::is_stopped()
+{
+    return terminating.empty();
+}

--- a/src/plugins/procdump/procdump.cpp
+++ b/src/plugins/procdump/procdump.cpp
@@ -867,6 +867,8 @@ static event_response_t terminate_process_cb(drakvuf_t drakvuf,
             // TODO Check if this line could be reached (look "detach" function)
             plugin->terminating.erase(info->attached_proc_data.pid);
             plugin->terminated_processes->insert_or_assign(info->attached_proc_data.pid, true);
+            if (plugin->terminating.empty() && plugin->is_stopping())
+                drakvuf_interrupt(drakvuf, 1);
         }
 
         return VMI_EVENT_RESPONSE_NONE;
@@ -1045,7 +1047,9 @@ procdump::~procdump()
     g_slist_free(this->traps);
 }
 
-bool procdump::is_stopped()
+bool procdump::stop()
 {
+    destroy_all_traps();
+    m_is_stopping = true;
     return terminating.empty();
 }

--- a/src/plugins/procdump/procdump.h
+++ b/src/plugins/procdump/procdump.h
@@ -159,6 +159,8 @@ public:
 
     procdump(drakvuf_t drakvuf, const procdump_config* config, output_format_t output);
     ~procdump();
+
+    bool is_stopped();
 };
 
 #endif

--- a/src/plugins/procdump/procdump.h
+++ b/src/plugins/procdump/procdump.h
@@ -139,6 +139,7 @@ public:
     std::shared_ptr<std::unordered_map<vmi_pid_t, bool>> terminated_processes;
     std::string const procdump_dir;
     bool const use_compression;
+    // FIXME Base class `pluginex` contains member `traps`
     GSList* traps;
     uint64_t procdumps_count;
     pool_map_t pools;
@@ -160,7 +161,7 @@ public:
     procdump(drakvuf_t drakvuf, const procdump_config* config, output_format_t output);
     ~procdump();
 
-    bool is_stopped();
+    bool stop();
 };
 
 #endif


### PR DESCRIPTION
This is an on-going work to add infrastructure to stop and destroy plug-ins.

For example this would allow to stop all plug-ins except procdump before starting termination loop. Thus termination loop would become more clean and simple.