### PR TITLE
Small libuserhooks refactor. Make it a proper singleton.

### DIFF
--- a/src/libusermode/running.cpp
+++ b/src/libusermode/running.cpp
@@ -492,8 +492,5 @@ void drakvuf_request_userhook_on_running_process(
     callback_t cb,
     void* extra)
 {
-    if (!instance || !instance->initialized)
-        throw -1;
-
-    instance->request_userhook_on_running_process(drakvuf, target_process, dll_name, func_name, cb, extra);
+    userhook::get_instance(drakvuf).request_userhook_on_running_process(drakvuf, target_process, dll_name, func_name, cb, extra);
 }

--- a/src/libusermode/uh-private.hpp
+++ b/src/libusermode/uh-private.hpp
@@ -165,14 +165,13 @@ struct copy_on_write_result_t : public call_result_t
 class userhook : public pluginex
 {
 public:
+    userhook(userhook const&) = delete;
+
     std::array<size_t, __OFFSET_MAX> offsets;
 
     std::vector<usermode_cb_registration> plugins;
     // map dtb -> list of hooked dlls
     std::map<addr_t, std::vector<dll_t>> loaded_dlls;
-
-    userhook(drakvuf_t drakvuf);
-    ~userhook();
 
     static userhook& get_instance(drakvuf_t drakvuf)
     {
@@ -184,8 +183,10 @@ public:
     void register_plugin(drakvuf_t drakvuf, usermode_cb_registration reg);
     void request_usermode_hook(drakvuf_t drakvuf, const dll_view_t* dll, const plugin_target_config_entry_t* target, callback_t callback, void* extra);
     void request_userhook_on_running_process(drakvuf_t drakvuf, addr_t target_process, const std::string& dll_name, const std::string& func_name, callback_t cb, void* extra);
-};
 
-extern userhook* instance;
+private:
+    userhook(drakvuf_t drakvuf); // Force get_instance().
+    ~userhook();
+};
 
 #endif

--- a/src/libusermode/uh-private.hpp
+++ b/src/libusermode/uh-private.hpp
@@ -165,20 +165,21 @@ struct copy_on_write_result_t : public call_result_t
 class userhook : public pluginex
 {
 public:
-    int initialized;
     std::array<size_t, __OFFSET_MAX> offsets;
 
     std::vector<usermode_cb_registration> plugins;
     // map dtb -> list of hooked dlls
     std::map<addr_t, std::vector<dll_t>> loaded_dlls;
 
-    userhook(drakvuf_t drakvuf) : pluginex(drakvuf, OUTPUT_DEFAULT), initialized(0)
-    {
-        drakvuf_get_kernel_struct_members_array_rva(drakvuf, offset_names, __OFFSET_MAX, offsets.data());
-    }
+    userhook(drakvuf_t drakvuf);
     ~userhook();
 
-    usermode_reg_status_t init(drakvuf_t drakvuf);
+    static userhook& get_instance(drakvuf_t drakvuf) {
+        static userhook instance(drakvuf);
+        return instance; 
+    }
+
+    static bool is_supported(drakvuf_t drakvuf);
     void register_plugin(drakvuf_t drakvuf, usermode_cb_registration reg);
     void request_usermode_hook(drakvuf_t drakvuf, const dll_view_t* dll, const plugin_target_config_entry_t* target, callback_t callback, void* extra);
     void request_userhook_on_running_process(drakvuf_t drakvuf, addr_t target_process, const std::string& dll_name, const std::string& func_name, callback_t cb, void* extra);

--- a/src/libusermode/uh-private.hpp
+++ b/src/libusermode/uh-private.hpp
@@ -174,9 +174,10 @@ public:
     userhook(drakvuf_t drakvuf);
     ~userhook();
 
-    static userhook& get_instance(drakvuf_t drakvuf) {
+    static userhook& get_instance(drakvuf_t drakvuf)
+    {
         static userhook instance(drakvuf);
-        return instance; 
+        return instance;
     }
 
     static bool is_supported(drakvuf_t drakvuf);

--- a/src/libusermode/userhook.cpp
+++ b/src/libusermode/userhook.cpp
@@ -766,7 +766,8 @@ void userhook::register_plugin(drakvuf_t drakvuf, usermode_cb_registration reg)
 
 bool userhook::is_supported(drakvuf_t drakvuf)
 {
-    { // Lock vmi.
+    {
+        // Lock vmi.
         vmi_lock_guard vmi(drakvuf);
         win_build_info_t build;
         if (vmi_get_windows_build_info(vmi.vmi, &build) &&

--- a/src/libusermode/userhook.cpp
+++ b/src/libusermode/userhook.cpp
@@ -815,7 +815,7 @@ userhook::~userhook()
             {
                 if (target.state == HOOK_OK)
                 {
-                    delete target.trap;
+                    wrap_delete(target.trap);
                 }
             }
         }

--- a/src/libusermode/userhook.cpp
+++ b/src/libusermode/userhook.cpp
@@ -132,9 +132,6 @@
 #include "uh-private.hpp"
 
 
-userhook* instance = nullptr;
-
-
 static void wrap_delete(drakvuf_trap_t* trap)
 {
     g_slice_free(drakvuf_trap_t, trap);
@@ -751,46 +748,6 @@ static event_response_t copy_on_write_handler(drakvuf_t drakvuf, drakvuf_trap_in
     return VMI_EVENT_RESPONSE_NONE;
 }
 
-usermode_reg_status_t userhook::init(drakvuf_t drakvuf)
-{
-    {
-        vmi_lock_guard vmi(drakvuf);
-        win_build_info_t build;
-        if (vmi_get_windows_build_info(vmi.vmi, &build) &&
-            VMI_OS_WINDOWS_10 == build.version &&
-            15063 >= build.buildnumber)
-        {
-            return USERMODE_OS_UNSUPPORTED;
-        }
-    }
-
-    page_mode_t pm = drakvuf_get_page_mode(drakvuf);
-
-    if (pm != VMI_PM_IA32E)
-    {
-        PRINT_DEBUG("[USERHOOK] Usermode hooking is not yet supported on this architecture/bitness.\n");
-        return USERMODE_ARCH_UNSUPPORTED;
-    }
-
-    if (this->initialized)
-    {
-        PRINT_DEBUG("[USERHOOK] Attempted double initialization.\n");
-        return USERMODE_REGISTER_ERROR;
-    }
-
-    breakpoint_in_system_process_searcher bp;
-    if (!register_trap(nullptr, protect_virtual_memory_hook_cb, bp.for_syscall_name("NtProtectVirtualMemory")) ||
-        !register_trap(nullptr, map_view_of_section_hook_cb, bp.for_syscall_name("NtMapViewOfSection")) ||
-        !register_trap(nullptr, system_service_handler_hook_cb, bp.for_syscall_name("KiSystemServiceHandler")) ||
-        !register_trap(nullptr, terminate_process_hook_cb, bp.for_syscall_name("NtTerminateProcess")) ||
-        !register_trap(nullptr, copy_on_write_handler, bp.for_syscall_name("MiCopyOnWrite")))
-    {
-        return USERMODE_REGISTER_ERROR;
-    }
-
-    this->initialized = true;
-    return USERMODE_REGISTER_SUCCESS;
-}
 
 void userhook::request_usermode_hook(drakvuf_t drakvuf, const dll_view_t* dll, const plugin_target_config_entry_t* target, callback_t callback, void* extra)
 {
@@ -805,6 +762,46 @@ void userhook::request_usermode_hook(drakvuf_t drakvuf, const dll_view_t* dll, c
 void userhook::register_plugin(drakvuf_t drakvuf, usermode_cb_registration reg)
 {
     this->plugins.push_back(reg);
+}
+
+bool userhook::is_supported(drakvuf_t drakvuf)
+{
+    { // Lock vmi.
+        vmi_lock_guard vmi(drakvuf);
+        win_build_info_t build;
+        if (vmi_get_windows_build_info(vmi.vmi, &build) &&
+            VMI_OS_WINDOWS_10 == build.version &&
+            15063 >= build.buildnumber)
+        {
+            PRINT_DEBUG("[USERHOOK] Usermode hooking is not yet supported on this operating system.\n");
+            return false;
+        }
+    } // Unlock vmi.
+
+    page_mode_t pm = drakvuf_get_page_mode(drakvuf);
+    if (pm != VMI_PM_IA32E)
+    {
+        PRINT_DEBUG("[USERHOOK] Usermode hooking is not yet supported on this architecture/bitness.\n");
+        return false;
+    }
+
+    return true;
+}
+
+userhook::userhook(drakvuf_t drakvuf): pluginex(drakvuf, OUTPUT_DEFAULT)
+{
+    if (!is_supported(drakvuf))
+        throw -1;
+
+    drakvuf_get_kernel_struct_members_array_rva(drakvuf, offset_names, __OFFSET_MAX, offsets.data());
+
+    breakpoint_in_system_process_searcher bp;
+    if (!register_trap(nullptr, protect_virtual_memory_hook_cb, bp.for_syscall_name("NtProtectVirtualMemory")) ||
+        !register_trap(nullptr, map_view_of_section_hook_cb, bp.for_syscall_name("NtMapViewOfSection")) ||
+        !register_trap(nullptr, system_service_handler_hook_cb, bp.for_syscall_name("KiSystemServiceHandler")) ||
+        !register_trap(nullptr, terminate_process_hook_cb, bp.for_syscall_name("NtTerminateProcess")) ||
+        !register_trap(nullptr, copy_on_write_handler, bp.for_syscall_name("MiCopyOnWrite")))
+        throw -1;
 }
 
 userhook::~userhook()
@@ -824,35 +821,14 @@ userhook::~userhook()
     }
 }
 
-usermode_reg_status_t drakvuf_register_usermode_callback(drakvuf_t drakvuf, usermode_cb_registration* reg)
+void drakvuf_register_usermode_callback(drakvuf_t drakvuf, usermode_cb_registration* reg)
 {
-    usermode_reg_status_t ret = USERMODE_REGISTER_ERROR;
-
-    if (!instance)
-    {
-        instance = new userhook(drakvuf);
-    }
-
-    if (!instance->initialized)
-    {
-        ret = instance->init(drakvuf);
-
-        if (ret != USERMODE_REGISTER_SUCCESS)
-            return ret;
-    }
-
-    instance->register_plugin(drakvuf, *reg);
-    return USERMODE_REGISTER_SUCCESS;
+    userhook::get_instance(drakvuf).register_plugin(drakvuf, *reg);
 }
 
 bool drakvuf_request_usermode_hook(drakvuf_t drakvuf, const dll_view_t* dll, const plugin_target_config_entry_t* target, callback_t callback, void* extra)
 {
-    if (!instance || !instance->initialized)
-    {
-        return false;
-    }
-
-    instance->request_usermode_hook(drakvuf, dll, target, callback, extra);
+    userhook::get_instance(drakvuf).request_usermode_hook(drakvuf, dll, target, callback, extra);
     return true;
 }
 
@@ -1007,4 +983,9 @@ void drakvuf_load_dll_hook_config(drakvuf_t drakvuf, const char* dll_hooks_list_
             ++arg_idx;
         }
     }
+}
+
+bool drakvuf_are_userhooks_supported(drakvuf_t drakvuf)
+{
+    return userhook::is_supported(drakvuf);
 }

--- a/src/libusermode/userhook.hpp
+++ b/src/libusermode/userhook.hpp
@@ -240,15 +240,8 @@ struct usermode_cb_registration
     void* extra;
 };
 
-typedef enum usermode_reg_status
-{
-    USERMODE_REGISTER_ERROR,
-    USERMODE_REGISTER_SUCCESS,
-    USERMODE_ARCH_UNSUPPORTED,
-    USERMODE_OS_UNSUPPORTED,
-} usermode_reg_status_t;
-
-usermode_reg_status_t drakvuf_register_usermode_callback(drakvuf_t drakvuf, usermode_cb_registration* reg);
+bool drakvuf_are_userhooks_supported(drakvuf_t drakvuf);
+void drakvuf_register_usermode_callback(drakvuf_t drakvuf, usermode_cb_registration* reg);
 bool drakvuf_request_usermode_hook(drakvuf_t drakvuf, const dll_view_t* dll, const plugin_target_config_entry_t* target, callback_t callback, void* extra);
 void drakvuf_load_dll_hook_config(drakvuf_t drakvuf, const char* dll_hooks_list_path, const bool print_no_addr, std::vector<plugin_target_config_entry_t>* wanted_hooks);
 

--- a/src/plugins/apimon/apimon.cpp
+++ b/src/plugins/apimon/apimon.cpp
@@ -337,7 +337,8 @@ static void on_dll_hooked(drakvuf_t drakvuf, const dll_view_t* dll, const std::v
 apimon::apimon(drakvuf_t drakvuf, const apimon_config* c, output_format_t output)
     : pluginex(drakvuf, output)
 {
-    if (!drakvuf_are_userhooks_supported(drakvuf)) {
+    if (!drakvuf_are_userhooks_supported(drakvuf))
+    {
         PRINT_DEBUG("[APIMON] Usermode hooking not supported.\n");
         return;
     }

--- a/src/plugins/apimon/apimon.cpp
+++ b/src/plugins/apimon/apimon.cpp
@@ -337,6 +337,11 @@ static void on_dll_hooked(drakvuf_t drakvuf, const dll_view_t* dll, const std::v
 apimon::apimon(drakvuf_t drakvuf, const apimon_config* c, output_format_t output)
     : pluginex(drakvuf, output)
 {
+    if (!drakvuf_are_userhooks_supported(drakvuf)) {
+        PRINT_DEBUG("[APIMON] Usermode hooking not supported.\n");
+        return;
+    }
+
     try
     {
         drakvuf_load_dll_hook_config(drakvuf, c->dll_hooks_list, c->print_no_addr, &this->wanted_hooks);
@@ -368,22 +373,7 @@ apimon::apimon(drakvuf_t drakvuf, const apimon_config* c, output_format_t output
         .post_cb = on_dll_hooked,
         .extra = (void*)this
     };
-
-    usermode_reg_status_t status = drakvuf_register_usermode_callback(drakvuf, &reg);
-
-    switch (status)
-    {
-        case USERMODE_REGISTER_SUCCESS:
-            // success, nothing to do
-            break;
-        case USERMODE_ARCH_UNSUPPORTED:
-        case USERMODE_OS_UNSUPPORTED:
-            PRINT_DEBUG("[APIMON] Usermode hooking is not supported on this architecture/bitness/os version, these features will be disabled\n");
-            break;
-        default:
-            PRINT_DEBUG("[APIMON] Failed to subscribe to libusermode\n");
-            throw -1;
-    }
+    drakvuf_register_usermode_callback(drakvuf, &reg);
 }
 
 apimon::~apimon()

--- a/src/plugins/memdump/userhook.cpp
+++ b/src/plugins/memdump/userhook.cpp
@@ -177,6 +177,11 @@ static void on_dll_hooked(drakvuf_t drakvuf, const dll_view_t* dll, const std::v
 
 void memdump::userhook_init(drakvuf_t drakvuf, const memdump_config* c, output_format_t output)
 {
+    if (!drakvuf_are_userhooks_supported(drakvuf)) {
+        PRINT_DEBUG("[MEMDUMP] Usermode hooking not supported. Some features will be disabled.\n");
+        return;
+    }
+
     try
     {
         drakvuf_load_dll_hook_config(drakvuf, c->dll_hooks_list, c->print_no_addr, &this->wanted_hooks);
@@ -208,19 +213,7 @@ void memdump::userhook_init(drakvuf_t drakvuf, const memdump_config* c, output_f
         .post_cb = on_dll_hooked,
         .extra = (void*)this
     };
-
-    usermode_reg_status_t status = drakvuf_register_usermode_callback(drakvuf, &reg);
-
-    if (status == USERMODE_ARCH_UNSUPPORTED ||
-        status == USERMODE_OS_UNSUPPORTED)
-    {
-        PRINT_DEBUG("[MEMDUMP] Usermode hooking is not supported on this architecture/bitness/os version, these features will be disabled\n");
-    }
-    else if (status != USERMODE_REGISTER_SUCCESS)
-    {
-        PRINT_DEBUG("[MEMDUMP] Failed to subscribe to libusermode\n");
-        throw -1;
-    }
+    drakvuf_register_usermode_callback(drakvuf, &reg);
 }
 
 void memdump::setup_dotnet_hooks(drakvuf_t drakvuf, const char* dll_name, const char* profile)

--- a/src/plugins/memdump/userhook.cpp
+++ b/src/plugins/memdump/userhook.cpp
@@ -177,7 +177,8 @@ static void on_dll_hooked(drakvuf_t drakvuf, const dll_view_t* dll, const std::v
 
 void memdump::userhook_init(drakvuf_t drakvuf, const memdump_config* c, output_format_t output)
 {
-    if (!drakvuf_are_userhooks_supported(drakvuf)) {
+    if (!drakvuf_are_userhooks_supported(drakvuf))
+    {
         PRINT_DEBUG("[MEMDUMP] Usermode hooking not supported. Some features will be disabled.\n");
         return;
     }

--- a/src/plugins/rpcmon/rpcmon.cpp
+++ b/src/plugins/rpcmon/rpcmon.cpp
@@ -380,7 +380,8 @@ static void on_dll_hooked(drakvuf_t drakvuf, const dll_view_t* dll, const std::v
 rpcmon::rpcmon(drakvuf_t drakvuf, output_format_t output)
     : pluginex(drakvuf, output)
 {
-    if (!drakvuf_are_userhooks_supported(drakvuf)) {
+    if (!drakvuf_are_userhooks_supported(drakvuf))
+    {
         PRINT_DEBUG("[RPCMON] Usermode hooking not supported.\n");
         return;
     }

--- a/src/plugins/rpcmon/rpcmon.cpp
+++ b/src/plugins/rpcmon/rpcmon.cpp
@@ -380,6 +380,10 @@ static void on_dll_hooked(drakvuf_t drakvuf, const dll_view_t* dll, const std::v
 rpcmon::rpcmon(drakvuf_t drakvuf, output_format_t output)
     : pluginex(drakvuf, output)
 {
+    if (!drakvuf_are_userhooks_supported(drakvuf)) {
+        PRINT_DEBUG("[RPCMON] Usermode hooking not supported.\n");
+        return;
+    }
     std::vector< std::unique_ptr < ArgumentPrinter > > arg_vec;
 
     const auto log = HookActions::empty().set_log();
@@ -409,22 +413,7 @@ rpcmon::rpcmon(drakvuf_t drakvuf, output_format_t output)
         .post_cb = on_dll_hooked,
         .extra = (void*)this
     };
-
-    usermode_reg_status_t status = drakvuf_register_usermode_callback(drakvuf, &reg);
-
-    switch (status)
-    {
-        case USERMODE_REGISTER_SUCCESS:
-            // success, nothing to do
-            break;
-        case USERMODE_ARCH_UNSUPPORTED:
-        case USERMODE_OS_UNSUPPORTED:
-            PRINT_DEBUG("[RPCMON] Usermode hooking is not supported on this architecture/bitness/os version, these features will be disabled\n");
-            break;
-        default:
-            PRINT_DEBUG("[RPCMON] Failed to subscribe to libusermode\n");
-            throw -1;
-    }
+    drakvuf_register_usermode_callback(drakvuf, &reg);
 }
 
 rpcmon::~rpcmon()


### PR DESCRIPTION
This is just a very small refactor of libuserhook. This pr. should fix memory leak issues observed in #1060 