### PR TITLE
Fix KV-format of RunningProcess messages

### DIFF
--- a/src/plugins/output_format/csvfmt.h
+++ b/src/plugins/output_format/csvfmt.h
@@ -329,6 +329,16 @@ void print(const char* plugin_name, drakvuf_t drakvuf, drakvuf_trap_info_t* info
     fmt::cout.flush();
 }
 
+inline void print_running_process(const char* plugin_name, drakvuf_t drakvuf, gint64 timestamp, proc_data_t const& proc_data)
+{
+    print(plugin_name, drakvuf, nullptr,
+          keyval("Time", TimeVal{UNPACK_TIMEVAL(timestamp)}),
+          keyval("PID", fmt::Nval(proc_data.pid)),
+          keyval("PPID", fmt::Nval(proc_data.ppid)),
+          keyval("RunningProcess", fmt::Qstr(proc_data.name))
+         );
+}
+
 } // namespace csvfmt
 
 #endif // PLUGINS_OUTPUT_FORMAT_CSVFMT_H

--- a/src/plugins/output_format/deffmt.h
+++ b/src/plugins/output_format/deffmt.h
@@ -347,6 +347,16 @@ void print(const char* plugin_name, drakvuf_t drakvuf, drakvuf_trap_info_t* info
     fmt::cout.flush();
 }
 
+inline void print_running_process(const char* plugin_name, drakvuf_t drakvuf, gint64 timestamp, proc_data_t const& proc_data)
+{
+    print(plugin_name, drakvuf, nullptr,
+          keyval("TIME", TimeVal{UNPACK_TIMEVAL(timestamp)}),
+          keyval("PID", fmt::Nval(proc_data.pid)),
+          keyval("PPID", fmt::Nval(proc_data.ppid)),
+          keyval("RunningProcess", fmt::Qstr(proc_data.name))
+         );
+}
+
 } // namespace deffmt
 
 #endif // PLUGINS_OUTPUT_FORMAT_DEFFMT_H

--- a/src/plugins/output_format/jsonfmt.h
+++ b/src/plugins/output_format/jsonfmt.h
@@ -439,6 +439,16 @@ void print(const char* plugin_name, drakvuf_t drakvuf, drakvuf_trap_info_t* info
     fmt::cout.flush();
 }
 
+inline void print_running_process(const char* plugin_name, drakvuf_t drakvuf, gint64 timestamp, proc_data_t const& proc_data)
+{
+    print(plugin_name, drakvuf, nullptr,
+          keyval("TimeStamp", TimeVal{UNPACK_TIMEVAL(timestamp)}),
+          keyval("PID", fmt::Nval(proc_data.pid)),
+          keyval("PPID", fmt::Nval(proc_data.ppid)),
+          keyval("RunningProcess", fmt::Qstr(proc_data.name))
+         );
+}
+
 } // namespace jsonfmt
 
 #endif // PLUGINS_OUTPUT_FORMAT_JSONFMT_H

--- a/src/plugins/output_format/kvfmt.h
+++ b/src/plugins/output_format/kvfmt.h
@@ -348,6 +348,16 @@ void print(const char* plugin_name, drakvuf_t drakvuf, drakvuf_trap_info_t* info
     fmt::cout.flush();
 }
 
+inline void print_running_process(const char* plugin_name, drakvuf_t drakvuf, gint64 timestamp, proc_data_t const& proc_data)
+{
+    print(plugin_name, drakvuf, nullptr,
+          keyval("Time", TimeVal{UNPACK_TIMEVAL(timestamp)}),
+          keyval("PID", fmt::Nval(proc_data.pid)),
+          keyval("PPID", fmt::Nval(proc_data.ppid)),
+          keyval("RunningProcess", fmt::Qstr(proc_data.name))
+         );
+}
+
 } // namespace kvfmt
 
 #endif // PLUGINS_OUTPUT_FORMAT_KVFMT_H

--- a/src/plugins/output_format/xfmt.h
+++ b/src/plugins/output_format/xfmt.h
@@ -128,6 +128,25 @@ void print(output_format_t format, const char* plugin_name, drakvuf_t drakvuf, d
     }
 }
 
+inline void print_running_process(output_format_t format, const char* plugin_name, drakvuf_t drakvuf, gint64 timestamp, proc_data_t const& proc_data)
+{
+    switch (format)
+    {
+        case OUTPUT_CSV:
+            csvfmt::print_running_process(plugin_name, drakvuf, timestamp, proc_data);
+            break;
+        case OUTPUT_KV:
+            kvfmt::print_running_process(plugin_name, drakvuf, timestamp, proc_data);
+            break;
+        case OUTPUT_JSON:
+            jsonfmt::print_running_process(plugin_name, drakvuf, timestamp, proc_data);
+            break;
+        case OUTPUT_DEFAULT:
+            deffmt::print_running_process(plugin_name, drakvuf, timestamp, proc_data);
+            break;
+    }
+}
+
 } // namespace fmt
 
 #endif // PLUGINS_OUTPUT_FORMAT_XFMT_H

--- a/src/plugins/procmon/procmon.cpp
+++ b/src/plugins/procmon/procmon.cpp
@@ -738,14 +738,7 @@ static void process_visitor(drakvuf_t drakvuf, addr_t process, void* visitor_ctx
 
     gint64 t = g_get_real_time();
 
-    fmt::print(ctx->format, "procmon", drakvuf, nullptr,
-               keyval("TimeStamp", TimeVal{UNPACK_TIMEVAL(t)}),
-               keyval("PID", fmt::Nval(data.pid)),
-               keyval("PPID", fmt::Nval(data.ppid)),
-               keyval("TID", fmt::Nval(data.tid)),
-               keyval("Method", fmt::Qstr("null")),
-               keyval("RunningProcess", fmt::Qstr(data.name))
-              );
+    fmt::print_running_process(ctx->format, "procmon", drakvuf, t, data);
 
     g_free(const_cast<char*>(data.name));
 }


### PR DESCRIPTION
In all plugins KV format uses "Time" field for timestamp.