### PR TITLE
Unify return callback checks

### DIFF
--- a/src/libdrakvuf/libdrakvuf.h
+++ b/src/libdrakvuf/libdrakvuf.h
@@ -472,6 +472,22 @@ bool drakvuf_get_current_thread_id(drakvuf_t drakvuf,
                                    drakvuf_trap_info_t* info,
                                    uint32_t* thread_id) NOEXCEPT;
 
+/*
+ * To catch the moment of exiting the currently executing function,
+ * we put a breakpoint on the instruction located at the function's
+ * return address.
+ *
+ * Such a breakpoint can also be triggered on exit from another function
+ * call (called in another thread or even a process), or on exit from a
+ * recursive call.
+ *
+ * This function checks that the callback was triggered on exit from the
+ * function call we need.
+ */
+bool drakvuf_check_return_context(drakvuf_t drakvuf, drakvuf_trap_info_t* info,
+                                  vmi_pid_t target_pid, uint32_t target_tid,
+                                  addr_t target_rsp) NOEXCEPT;
+
 addr_t drakvuf_exportksym_to_va(drakvuf_t drakvuf,
                                 const vmi_pid_t pid, const char* proc_name,
                                 const char* mod_name, addr_t rva) NOEXCEPT;

--- a/src/libdrakvuf/linux.c
+++ b/src/libdrakvuf/linux.c
@@ -153,6 +153,13 @@ addr_t linux_get_function_argument(drakvuf_t drakvuf, drakvuf_trap_info_t* info,
     return ret;
 }
 
+bool linux_check_return_context(drakvuf_trap_info_t* info, vmi_pid_t pid, uint32_t tid, addr_t rsp)
+{
+    return (info->proc_data.pid == pid)
+           && (info->proc_data.tid == tid)
+           && (!rsp || info->regs->rip == rsp);
+}
+
 static bool find_kernbase(drakvuf_t drakvuf)
 {
     if ( VMI_FAILURE == vmi_translate_ksym2v(drakvuf->vmi, "_text", &drakvuf->kernbase) )
@@ -184,6 +191,7 @@ bool set_os_linux(drakvuf_t drakvuf)
     drakvuf->osi.exportsym_to_va = linux_eprocess_sym2va;
     drakvuf->osi.export_lib_address = get_lib_address;
     drakvuf->osi.get_function_argument = linux_get_function_argument;
+    drakvuf->osi.check_return_context = linux_check_return_context;
 
     return 1;
 }

--- a/src/libdrakvuf/linux.h
+++ b/src/libdrakvuf/linux.h
@@ -134,4 +134,6 @@ bool linux_find_eprocess_and_pid(drakvuf_t drakvuf, vmi_pid_t find_pid, char* co
 
 addr_t linux_get_function_argument(drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t argument_number);
 
+bool linux_check_return_context(drakvuf_trap_info_t* info, vmi_pid_t pid, uint32_t tid, addr_t rsp);
+
 #endif

--- a/src/libdrakvuf/os.c
+++ b/src/libdrakvuf/os.c
@@ -540,3 +540,11 @@ addr_t drakvuf_get_wow_peb(drakvuf_t drakvuf, access_context_t* ctx, addr_t epro
 
     return 0;
 }
+
+bool drakvuf_check_return_context(drakvuf_t drakvuf, drakvuf_trap_info_t* info, vmi_pid_t pid, uint32_t tid, addr_t rsp)
+{
+    if ( drakvuf->osi.check_return_context )
+        return drakvuf->osi.check_return_context(info, pid, tid, rsp);
+
+    return false;
+}

--- a/src/libdrakvuf/os.h
+++ b/src/libdrakvuf/os.h
@@ -256,6 +256,9 @@ typedef struct os_interface
     addr_t (*get_wow_peb)
     (drakvuf_t drakvuf, access_context_t* ctx, addr_t eprocess);
 
+    bool (*check_return_context)
+    (drakvuf_trap_info_t* info, vmi_pid_t pid, uint32_t tid, addr_t rsp);
+
 } os_interface_t;
 
 bool set_os_windows(drakvuf_t drakvuf);

--- a/src/libdrakvuf/win.c
+++ b/src/libdrakvuf/win.c
@@ -436,6 +436,13 @@ bool fill_wow_offsets( drakvuf_t drakvuf, size_t size, const char* names [][2] )
     return 1 ;
 }
 
+bool win_check_return_context(drakvuf_trap_info_t* info, vmi_pid_t pid, uint32_t tid, addr_t rsp)
+{
+    return (info->attached_proc_data.pid == pid)
+           && (info->attached_proc_data.tid == tid)
+           && (!rsp || info->regs->rsp > rsp);
+}
+
 bool set_os_windows(drakvuf_t drakvuf)
 {
 
@@ -510,6 +517,7 @@ bool set_os_windows(drakvuf_t drakvuf)
     drakvuf->osi.get_user_stack32 = win_get_user_stack32;
     drakvuf->osi.get_user_stack64 = win_get_user_stack64;
     drakvuf->osi.get_wow_peb = win_get_wow_peb;
+    drakvuf->osi.check_return_context = win_check_return_context;
 
     return true;
 }

--- a/src/libdrakvuf/win.h
+++ b/src/libdrakvuf/win.h
@@ -194,4 +194,6 @@ bool win_get_wow_context(drakvuf_t drakvuf, addr_t ethread, addr_t* wow_ctx);
 bool win_get_user_stack32(drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t* stack_ptr, addr_t* frame_ptr);
 bool win_get_user_stack64(drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t* stack_ptr);
 
+bool win_check_return_context(drakvuf_trap_info_t* info, vmi_pid_t pid, uint32_t tid, addr_t rsp);
+
 #endif

--- a/src/libusermode/userhook.hpp
+++ b/src/libusermode/userhook.hpp
@@ -200,14 +200,18 @@ struct hook_target_entry_t
 struct return_hook_target_entry_t
 {
     vmi_pid_t pid;
+    uint32_t tid;
+    addr_t rsp;
+
     drakvuf_trap_t* trap;
     std::string clsid;
     void* plugin;
     std::vector < uint64_t > arguments;
     const std::vector < std::unique_ptr < ArgumentPrinter > >& argument_printers;
 
-    return_hook_target_entry_t(vmi_pid_t pid, std::string clsid, void* plugin, const std::vector < std::unique_ptr < ArgumentPrinter > >& argument_printers) :
-        pid(pid), trap(nullptr), clsid(clsid), plugin(plugin), argument_printers(argument_printers) {}
+    return_hook_target_entry_t(vmi_pid_t pid, uint32_t tid, addr_t rsp,
+                               std::string clsid, void* plugin, const std::vector < std::unique_ptr < ArgumentPrinter > >& argument_printers) :
+        pid(pid), tid(tid), rsp(rsp), trap(nullptr), clsid(clsid), plugin(plugin), argument_printers(argument_printers) {}
 };
 
 struct hook_target_view_t

--- a/src/plugins/apimon/apimon.cpp
+++ b/src/plugins/apimon/apimon.cpp
@@ -127,8 +127,7 @@ static event_response_t usermode_return_hook_cb(drakvuf_t drakvuf, drakvuf_trap_
 {
     return_hook_target_entry_t* ret_target = (return_hook_target_entry_t*)info->trap->data;
 
-    // TODO check thread_id and cr3?
-    if (info->proc_data.pid != ret_target->pid)
+    if (!drakvuf_check_return_context(drakvuf, info, ret_target->pid, ret_target->tid, ret_target->rsp))
         return VMI_EVENT_RESPONSE_NONE;
 
     auto plugin = (apimon*)ret_target->plugin;
@@ -178,7 +177,7 @@ static event_response_t usermode_hook_cb(drakvuf_t drakvuf, drakvuf_trap_info* i
 {
     hook_target_entry_t* target = (hook_target_entry_t*)info->trap->data;
 
-    if (target->pid != info->proc_data.pid)
+    if (target->pid != info->attached_proc_data.pid)
         return VMI_EVENT_RESPONSE_NONE;
 
     vmi_lock_guard lg(drakvuf);
@@ -207,7 +206,9 @@ static event_response_t usermode_hook_cb(drakvuf_t drakvuf, drakvuf_trap_info* i
         return VMI_EVENT_RESPONSE_NONE;
     }
 
-    return_hook_target_entry_t* ret_target = new (std::nothrow) return_hook_target_entry_t(target->pid, target->clsid, target->plugin, target->argument_printers);
+    return_hook_target_entry_t* ret_target = new (std::nothrow) return_hook_target_entry_t(
+        info->attached_proc_data.pid, info->attached_proc_data.tid, info->regs->rsp,
+        target->clsid, target->plugin, target->argument_printers);
 
     if (!ret_target)
     {

--- a/src/plugins/filedelete/filedelete.cpp
+++ b/src/plugins/filedelete/filedelete.cpp
@@ -620,7 +620,7 @@ event_response_t memcpy_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
     wrapper_t* injector = (wrapper_t*)info->trap->data;
     filedelete* f = injector->f;
 
-    if (info->attached_proc_data.pid != injector->target_pid || info->attached_proc_data.tid != injector->target_tid)
+    if (!drakvuf_check_return_context(drakvuf, info, injector->target_pid, injector->target_tid, 0))
         return VMI_EVENT_RESPONSE_NONE;
 
     auto response = 0;
@@ -670,7 +670,7 @@ event_response_t unmapview_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 {
     wrapper_t* injector = (wrapper_t*)info->trap->data;
 
-    if (info->attached_proc_data.pid != injector->target_pid || info->attached_proc_data.tid != injector->target_tid)
+    if (!drakvuf_check_return_context(drakvuf, info, injector->target_pid, injector->target_tid, 0))
         return VMI_EVENT_RESPONSE_NONE;
 
     vmi_lock_guard vmi(drakvuf);
@@ -689,10 +689,10 @@ event_response_t mapview_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 
     auto response = 0;
 
-    vmi_instance_t vmi = drakvuf_lock_and_get_vmi(drakvuf);
+    if (!drakvuf_check_return_context(drakvuf, info, injector->target_pid, injector->target_tid, 0))
+        return VMI_EVENT_RESPONSE_NONE;
 
-    if (info->attached_proc_data.pid != injector->target_pid || info->attached_proc_data.tid != injector->target_tid)
-        goto done;
+    vmi_instance_t vmi = drakvuf_lock_and_get_vmi(drakvuf);
 
     if (info->regs->rax)
     {
@@ -763,10 +763,10 @@ event_response_t injected_createsection_cb(drakvuf_t drakvuf, drakvuf_trap_info_
 
     auto response = 0;
 
-    vmi_instance_t vmi = drakvuf_lock_and_get_vmi(drakvuf);
+    if (!drakvuf_check_return_context(drakvuf, info, injector->target_pid, injector->target_tid, 0))
+        return VMI_EVENT_RESPONSE_NONE;
 
-    if (info->attached_proc_data.pid != injector->target_pid || info->attached_proc_data.tid != injector->target_tid)
-        goto done;
+    vmi_instance_t vmi = drakvuf_lock_and_get_vmi(drakvuf);
 
     if (info->regs->rax)
     {
@@ -817,10 +817,10 @@ event_response_t exallocatepool_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 
     auto response = 0;
 
-    vmi_instance_t vmi = drakvuf_lock_and_get_vmi(drakvuf);
+    if (!drakvuf_check_return_context(drakvuf, info, injector->target_pid, injector->target_tid, 0))
+        return VMI_EVENT_RESPONSE_NONE;
 
-    if (info->attached_proc_data.pid != injector->target_pid || info->attached_proc_data.tid != injector->target_tid)
-        goto done;
+    vmi_instance_t vmi = drakvuf_lock_and_get_vmi(drakvuf);
 
     if (info->regs->rax)
     {
@@ -862,7 +862,7 @@ event_response_t queryvolumeinfo_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info
 
     auto response = 0;
 
-    if (info->attached_proc_data.pid != injector->target_pid || info->attached_proc_data.tid != injector->target_tid)
+    if (!drakvuf_check_return_context(drakvuf, info, injector->target_pid, injector->target_tid, 0))
         return VMI_EVENT_RESPONSE_NONE;
 
     vmi_instance_t vmi = drakvuf_lock_and_get_vmi(drakvuf);
@@ -930,8 +930,8 @@ event_response_t queryinfo_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 
     auto response = VMI_EVENT_RESPONSE_NONE;
 
-    if (info->attached_proc_data.pid != injector->target_pid || info->attached_proc_data.tid != injector->target_tid)
-        return response;
+    if (!drakvuf_check_return_context(drakvuf, info, injector->target_pid, injector->target_tid, 0))
+        return VMI_EVENT_RESPONSE_NONE;
 
     vmi_instance_t vmi = drakvuf_lock_and_get_vmi(drakvuf);
 
@@ -1102,10 +1102,7 @@ static event_response_t createfile_ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t
 
     auto w = (struct createfile_ret_info*)info->trap->data;
 
-    if (info->attached_proc_data.pid != w->pid || info->attached_proc_data.tid != w->tid)
-        return VMI_EVENT_RESPONSE_NONE;
-
-    if (w->rsp && info->regs->rsp <= w->rsp)
+    if (!drakvuf_check_return_context(drakvuf, info, w->pid, w->tid, w->rsp))
         return VMI_EVENT_RESPONSE_NONE;
 
     // Return if NtCreateFile/NtOpenFile failed

--- a/src/plugins/filetracer/linux.cpp
+++ b/src/plugins/filetracer/linux.cpp
@@ -409,10 +409,7 @@ static event_response_t open_file_ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t*
     struct linux_wrapper* lw = (struct linux_wrapper*)info->trap->data;
     addr_t file_struct = 0;
 
-    if (info->proc_data.pid != lw->pid || info->proc_data.tid != lw->tid)
-        return VMI_EVENT_RESPONSE_NONE;
-
-    if (lw->rsp && info->regs->rip != lw->rsp)
+    if (!drakvuf_check_return_context(drakvuf, info, lw->pid, lw->tid, lw->rsp))
         return VMI_EVENT_RESPONSE_NONE;
 
     file_struct = info->regs->rax;

--- a/src/plugins/memdump/userhook.cpp
+++ b/src/plugins/memdump/userhook.cpp
@@ -135,8 +135,7 @@ static event_response_t usermode_hook_cb(drakvuf_t drakvuf, drakvuf_trap_info* i
 {
     hook_target_entry_t* target = (hook_target_entry_t*)info->trap->data;
 
-    // TODO check thread_id and cr3?
-    if (target->pid != info->proc_data.pid)
+    if (target->pid != info->attached_proc_data.pid)
         return VMI_EVENT_RESPONSE_NONE;
 
     if (target->target_name == "AssemblyNative::LoadImage")

--- a/src/plugins/plugins_ex.h
+++ b/src/plugins/plugins_ex.h
@@ -336,33 +336,26 @@ struct breakpoint_by_pid_searcher
 struct call_result_t
 {
     call_result_t()
-        : target_cr3(), target_thread(), target_rsp()
+        : target_pid(), target_tid(), target_rsp()
     {}
 
     virtual ~call_result_t()
     {};
 
-    void set_result_call_params(const drakvuf_trap_info_t* info, addr_t thread)
+    void set_result_call_params(const drakvuf_trap_info_t* info)
     {
-        target_thread = thread;
-        target_cr3 = info->regs->cr3;
+        target_pid = info->attached_proc_data.pid;
+        target_tid = info->attached_proc_data.tid;
         target_rsp = info->regs->rsp;
     }
 
-    bool verify_result_call_params(const drakvuf_trap_info_t* info, addr_t thread)
+    bool verify_result_call_params(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
     {
-        if (info->regs->cr3 != target_cr3 ||
-            !thread || thread != target_thread ||
-            info->regs->rsp <= target_rsp)
-        {
-            return false;
-        }
-
-        return true;
+        return drakvuf_check_return_context(drakvuf, info, target_pid, target_tid, target_rsp);
     }
 
-    reg_t target_cr3;
-    addr_t target_thread;
+    vmi_pid_t target_pid;
+    uint32_t target_tid;
     addr_t target_rsp;
 };
 

--- a/src/plugins/procdump/procdump.cpp
+++ b/src/plugins/procdump/procdump.cpp
@@ -549,11 +549,8 @@ static event_response_t rtlcopymemory_cb(drakvuf_t drakvuf,
 
     auto ctx = static_cast<struct procdump_ctx*>(info->trap->data);
 
-    if (info->attached_proc_data.pid != ctx->pid ||
-        info->attached_proc_data.tid != ctx->tid)
-    {
+    if (!drakvuf_check_return_context(drakvuf, info, ctx->pid, ctx->tid, 0))
         return VMI_EVENT_RESPONSE_NONE;
-    }
 
     // Restore stack pointer
     // This is crucial because lots of injections could exhaust the kernel stack
@@ -588,11 +585,8 @@ static event_response_t exallocatepool_cb(drakvuf_t drakvuf,
 
     auto ctx = static_cast<struct procdump_ctx*>(info->trap->data);
 
-    if (info->attached_proc_data.pid != ctx->pid ||
-        info->attached_proc_data.tid != ctx->tid)
-    {
+    if (!drakvuf_check_return_context(drakvuf, info, ctx->pid, ctx->tid, 0))
         return VMI_EVENT_RESPONSE_NONE;
-    }
 
     // Restore stack pointer
     // This is crucial because lots of injections could exhaust the kernel stack

--- a/src/plugins/procmon/procmon.cpp
+++ b/src/plugins/procmon/procmon.cpp
@@ -288,7 +288,7 @@ static event_response_t process_creation_return_hook(drakvuf_t drakvuf, drakvuf_
     auto plugin = get_trap_plugin<procmon>(info);
     auto params = get_trap_params<process_creation_result_t>(info);
 
-    if (!params->verify_result_call_params(info, drakvuf_get_current_thread(drakvuf, info)))
+    if (!params->verify_result_call_params(drakvuf, info))
         return VMI_EVENT_RESPONSE_NONE;
 
     addr_t user_process_parameters_addr = params->user_process_parameters_addr;
@@ -333,7 +333,7 @@ static event_response_t process_create_ex_return_hook(drakvuf_t drakvuf, drakvuf
     auto plugin = get_trap_plugin<procmon>(info);
     auto params = get_trap_params<process_create_ex_result_t>(info);
 
-    if (!params->verify_result_call_params(info, drakvuf_get_current_thread(drakvuf, info)))
+    if (!params->verify_result_call_params(drakvuf, info))
         return VMI_EVENT_RESPONSE_NONE;
 
     addr_t process_handle_addr = params->process_handle_addr;
@@ -388,7 +388,7 @@ static event_response_t create_user_process_hook(
                     breakpoint_by_pid_searcher());
 
     auto params = get_trap_params<process_creation_result_t>(trap);
-    params->set_result_call_params(info, drakvuf_get_current_thread(drakvuf, info));
+    params->set_result_call_params(info);
     params->new_process_handle_addr = process_handle_addr;
     params->new_thread_handle_addr = thread_handle_addr;
     params->user_process_parameters_addr = user_process_parameters_addr;
@@ -415,7 +415,7 @@ static event_response_t create_process_ex_hook(
 
     auto params = get_trap_params<process_create_ex_result_t>(trap);
 
-    params->set_result_call_params(info, drakvuf_get_current_thread(drakvuf, info));
+    params->set_result_call_params(info);
     params->process_handle_addr = process_handle_addr;
     params->desired_access = desired_access;
     params->object_attributes_addr = object_attributes_addr;
@@ -491,7 +491,7 @@ static event_response_t open_process_return_hook_cb(drakvuf_t drakvuf, drakvuf_t
     auto plugin = get_trap_plugin<procmon>(info);
     auto params = get_trap_params<open_process_result_t>(info);
 
-    if (!params->verify_result_call_params(info, drakvuf_get_current_thread(drakvuf, info)))
+    if (!params->verify_result_call_params(drakvuf, info))
         return VMI_EVENT_RESPONSE_NONE;
 
     access_context_t ctx =
@@ -540,7 +540,7 @@ static event_response_t open_process_hook_cb(drakvuf_t drakvuf, drakvuf_trap_inf
 
     auto params = get_trap_params<open_process_result_t>(trap);
 
-    params->set_result_call_params(info, drakvuf_get_current_thread(drakvuf, info));
+    params->set_result_call_params(info);
 
     // PHANDLE ProcessHandle
     params->process_handle_addr = drakvuf_get_function_argument(drakvuf, info, 1);
@@ -572,7 +572,7 @@ static event_response_t open_thread_return_hook_cb(drakvuf_t drakvuf, drakvuf_tr
     auto plugin = get_trap_plugin<procmon>(info);
     auto params = get_trap_params<open_thread_result_t>(info);
 
-    if (!params->verify_result_call_params(info, drakvuf_get_current_thread(drakvuf, info)))
+    if (!params->verify_result_call_params(drakvuf, info))
         return VMI_EVENT_RESPONSE_NONE;
 
     access_context_t ctx =
@@ -621,7 +621,7 @@ static event_response_t open_thread_hook_cb(drakvuf_t drakvuf, drakvuf_trap_info
 
     auto params = get_trap_params<open_thread_result_t>(trap);
 
-    params->set_result_call_params(info, drakvuf_get_current_thread(drakvuf, info));
+    params->set_result_call_params(info);
 
     // PHANDLE ProcessHandle
     params->thread_handle_addr = drakvuf_get_function_argument(drakvuf, info, 1);

--- a/src/plugins/syscalls/linux.cpp
+++ b/src/plugins/syscalls/linux.cpp
@@ -206,8 +206,8 @@ static event_response_t linux_ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* inf
 {
     struct wrapper* w = (struct wrapper*)info->trap->data;
 
-    if ( w->tid != info->proc_data.tid )
-        return 0;
+    if (!drakvuf_check_return_context(drakvuf, info, w->pid, w->tid, 0))
+        return VMI_EVENT_RESPONSE_NONE;
 
     syscalls* s = w->s;
 
@@ -269,6 +269,7 @@ static event_response_t linux_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
     struct wrapper* wr = g_slice_new0(struct wrapper);
     wr->s = s;
     wr->num = nr;
+    wr->pid = info->proc_data.pid;
     wr->tid = info->proc_data.tid;
 
     drakvuf_trap_t* ret_trap = g_slice_new0(drakvuf_trap_t);

--- a/src/plugins/syscalls/private.h
+++ b/src/plugins/syscalls/private.h
@@ -459,6 +459,7 @@ struct wrapper
     const char* type;
     struct wrapper* w;
     uint16_t num;
+    vmi_pid_t pid;
     addr_t tid;
     addr_t stack_fingerprint;
 };

--- a/src/plugins/wmimon/wmimon.cpp
+++ b/src/plugins/wmimon/wmimon.cpp
@@ -371,7 +371,7 @@ event_response_t ExecMethod_return_handler(drakvuf_t drakvuf, drakvuf_trap_info_
         return VMI_EVENT_RESPONSE_NONE;
     }
 
-    if (!data->verify_result_call_params(info, drakvuf_get_current_thread(drakvuf, info)))
+    if (!data->verify_result_call_params(drakvuf, info))
         return VMI_EVENT_RESPONSE_NONE;
 
     plugin->destroy_trap(drakvuf, info->trap);
@@ -438,7 +438,7 @@ event_response_t ExecMethod_handler(drakvuf_t drakvuf, drakvuf_trap_info_t* info
         return VMI_EVENT_RESPONSE_NONE;
     }
 
-    params->set_result_call_params(info, drakvuf_get_current_thread(drakvuf, info));
+    params->set_result_call_params(info);
     params->m_object = drakvuf_get_function_argument(drakvuf, info, 2);
     params->m_method = drakvuf_get_function_argument(drakvuf, info, 3);
     params->m_vtable = drakvuf_get_function_argument(drakvuf, info, 6);
@@ -457,7 +457,7 @@ event_response_t GetObject_return_handler(drakvuf_t drakvuf, drakvuf_trap_info_t
         return VMI_EVENT_RESPONSE_NONE;
     }
 
-    if (!data->verify_result_call_params(info, drakvuf_get_current_thread(drakvuf, info)))
+    if (!data->verify_result_call_params(drakvuf, info))
         return VMI_EVENT_RESPONSE_NONE;
 
     plugin->destroy_trap(drakvuf, info->trap);
@@ -513,7 +513,7 @@ event_response_t GetObject_handler(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
         return VMI_EVENT_RESPONSE_NONE;
     }
 
-    params->set_result_call_params(info, drakvuf_get_current_thread(drakvuf, info));
+    params->set_result_call_params(info);
     params->m_object = drakvuf_get_function_argument(drakvuf, info, 2);
     params->m_vtable = drakvuf_get_function_argument(drakvuf, info, 5);
 
@@ -531,7 +531,7 @@ event_response_t ExecQuery_return_handler(drakvuf_t drakvuf, drakvuf_trap_info_t
         return VMI_EVENT_RESPONSE_NONE;
     }
 
-    if (!data->verify_result_call_params(info, drakvuf_get_current_thread(drakvuf, info)))
+    if (!data->verify_result_call_params(drakvuf, info))
         return VMI_EVENT_RESPONSE_NONE;
 
     plugin->destroy_trap(drakvuf, info->trap);
@@ -587,7 +587,7 @@ event_response_t ExecQuery_handler(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
         return VMI_EVENT_RESPONSE_NONE;
     }
 
-    params->set_result_call_params(info, drakvuf_get_current_thread(drakvuf, info));
+    params->set_result_call_params(info);
     params->m_command = drakvuf_get_function_argument(drakvuf, info, 3);
     params->m_vtable = drakvuf_get_function_argument(drakvuf, info, 6);
 
@@ -605,7 +605,7 @@ event_response_t ConnectServer_return_handler(drakvuf_t drakvuf, drakvuf_trap_in
         return VMI_EVENT_RESPONSE_NONE;
     }
 
-    if (!data->verify_result_call_params(info, drakvuf_get_current_thread(drakvuf, info)))
+    if (!data->verify_result_call_params(drakvuf, info))
         return VMI_EVENT_RESPONSE_NONE;
 
     plugin->destroy_trap(drakvuf, info->trap);
@@ -676,7 +676,7 @@ event_response_t ConnectServer_handler(drakvuf_t drakvuf, drakvuf_trap_info_t* i
         return VMI_EVENT_RESPONSE_NONE;
     }
 
-    params->set_result_call_params(info, drakvuf_get_current_thread(drakvuf, info));
+    params->set_result_call_params(info);
     params->m_resource = drakvuf_get_function_argument(drakvuf, info, 2);
     params->m_vtable = drakvuf_get_function_argument(drakvuf, info, 9);
 
@@ -695,7 +695,7 @@ event_response_t CoCreateInstanse_return_handler(drakvuf_t drakvuf, drakvuf_trap
         return VMI_EVENT_RESPONSE_NONE;
     }
 
-    if (!data->verify_result_call_params(info, drakvuf_get_current_thread(drakvuf, info)) || FAILED(info->regs->rax))
+    if (!data->verify_result_call_params(drakvuf, info) || FAILED(info->regs->rax))
         return VMI_EVENT_RESPONSE_NONE;
 
     plugin->destroy_trap(drakvuf, info->trap);
@@ -765,7 +765,7 @@ event_response_t CoCreateInstanse_handler(drakvuf_t drakvuf, drakvuf_trap_info_t
         return VMI_EVENT_RESPONSE_NONE;
     }
 
-    params->set_result_call_params(info, drakvuf_get_current_thread(drakvuf, info));
+    params->set_result_call_params(info);
     params->CLSID = drakvuf_get_function_argument(drakvuf, info, 1);
     params->IID = drakvuf_get_function_argument(drakvuf, info, 4);
     params->m_vtable = drakvuf_get_function_argument(drakvuf, info, 5);


### PR DESCRIPTION
This attempt is not ideal, but it takes a step towards unifying the checks that the breakpoint was triggered at the exit from the call we need.