### PR TITLE
rpcmon: Intercept NdrClientCall3

### DIFF
--- a/src/plugins/rpcmon/rpcmon.cpp
+++ b/src/plugins/rpcmon/rpcmon.cpp
@@ -159,6 +159,62 @@ struct _MIDL_STUB_DESC
     addr_t RpcInterfaceInformation;
 } __attribute__((packed, aligned(4)));
 
+struct _MIDL_STUBLESS_PROXY_INFO
+{
+    addr_t pStubDesc;
+} __attribute__((packed, aligned(4)));
+
+struct rpc_info_t
+{
+    std::string InterfaceIdGuid;
+    std::string TransferSyntaxGuid;
+};
+
+static std::optional<rpc_info_t> parse_MIDL_STUB_DESC(drakvuf_t drakvuf, drakvuf_trap_info* info, addr_t arg)
+{
+    auto vmi = vmi_lock_guard(drakvuf);
+
+    size_t bytes_read = 0;
+    access_context_t ctx =
+    {
+        .translate_mechanism = VMI_TM_PROCESS_DTB,
+        .dtb = info->regs->cr3,
+        .addr = arg,
+    };
+
+    struct _MIDL_STUB_DESC stub_desc;
+    if (VMI_SUCCESS != vmi_read(vmi, &ctx, sizeof(stub_desc), &stub_desc, &bytes_read) || bytes_read != sizeof(stub_desc))
+        return {};
+
+    ctx.addr = stub_desc.RpcInterfaceInformation;
+    struct _RPC_CLIENT_INTERFACE rpc_iface;
+    if (VMI_SUCCESS != vmi_read(vmi, &ctx, sizeof(rpc_iface), &rpc_iface, &bytes_read) || bytes_read != sizeof(rpc_iface))
+        return {};
+
+    return {{rpc_iface.InterfaceId.SyntaxGuid.str(), rpc_iface.TransferSyntax.SyntaxGuid.str()}};
+}
+
+static std::optional<rpc_info_t> parse_MIDL_STUBLESS_PROXY_INFO(drakvuf_t drakvuf, drakvuf_trap_info* info, addr_t arg)
+{
+    struct _MIDL_STUBLESS_PROXY_INFO proxy;
+    {
+        auto vmi = vmi_lock_guard(drakvuf);
+
+        size_t bytes_read = 0;
+        access_context_t ctx =
+        {
+            .translate_mechanism = VMI_TM_PROCESS_DTB,
+            .dtb = info->regs->cr3,
+            .addr = arg,
+        };
+
+        if (VMI_SUCCESS != vmi_read(vmi, &ctx, sizeof(proxy), &proxy, &bytes_read) || bytes_read != sizeof(proxy))
+            return {};
+    }
+
+    return parse_MIDL_STUB_DESC(drakvuf, info, proxy.pStubDesc);
+}
+
 static event_response_t usermode_return_hook_cb(drakvuf_t drakvuf, drakvuf_trap_info* info)
 {
     return_hook_target_entry_t* ret_target = (return_hook_target_entry_t*)info->trap->data;
@@ -182,25 +238,19 @@ static event_response_t usermode_return_hook_cb(drakvuf_t drakvuf, drakvuf_trap_
 
             if (std::string("pStubDescriptor") == (*printer)->get_name())
             {
-                vmi_lock_guard vmi(drakvuf);
+                auto r = parse_MIDL_STUB_DESC(drakvuf, info, *arg);
+                if (!r) continue;
 
-                size_t bytes_read = 0;
-                access_context_t ctx;
-                ctx.translate_mechanism = VMI_TM_PROCESS_DTB;
-                ctx.dtb = info->regs->cr3;
-                ctx.addr = *arg;
+                fmt_extra.push_back(std::make_pair("InterfaceId", r->InterfaceIdGuid));
+                fmt_extra.push_back(std::make_pair("TransferSyntax", r->TransferSyntaxGuid));
+            }
+            else if (std::string("pStubProxy") == (*printer)->get_name())
+            {
+                auto r = parse_MIDL_STUBLESS_PROXY_INFO(drakvuf, info, *arg);
+                if (!r) continue;
 
-                struct _MIDL_STUB_DESC stub_desc;
-                if (VMI_SUCCESS != vmi_read(vmi, &ctx, sizeof(struct _MIDL_STUB_DESC), &stub_desc, &bytes_read) || bytes_read != sizeof(struct _MIDL_STUB_DESC))
-                    continue;
-
-                ctx.addr = stub_desc.RpcInterfaceInformation;
-                struct _RPC_CLIENT_INTERFACE rpc_iface;
-                if (VMI_SUCCESS != vmi_read(vmi, &ctx, sizeof(struct _RPC_CLIENT_INTERFACE), &rpc_iface, &bytes_read) || bytes_read != sizeof(struct _RPC_CLIENT_INTERFACE))
-                    continue;
-
-                fmt_extra.push_back(std::make_pair("InterfaceId", rpc_iface.InterfaceId.SyntaxGuid.str()));
-                fmt_extra.push_back(std::make_pair("TransferSyntax", rpc_iface.TransferSyntax.SyntaxGuid.str()));
+                fmt_extra.push_back(std::make_pair("InterfaceId", r->InterfaceIdGuid));
+                fmt_extra.push_back(std::make_pair("TransferSyntax", r->TransferSyntaxGuid));
             }
         }
     }
@@ -221,11 +271,11 @@ static event_response_t usermode_hook_cb(drakvuf_t drakvuf, drakvuf_trap_info* i
 {
     hook_target_entry_t* target = (hook_target_entry_t*)info->trap->data;
 
-    if (target->pid != info->proc_data.pid)
+    if (target->pid != info->attached_proc_data.pid)
         return VMI_EVENT_RESPONSE_NONE;
 
-    vmi_lock_guard lg(drakvuf);
-    vmi_v2pcache_flush(lg.vmi, info->regs->cr3);
+    auto vmi = vmi_lock_guard(drakvuf);
+    vmi_v2pcache_flush(vmi, info->regs->cr3);
 
     bool is_syswow = drakvuf_is_wow64(drakvuf, info);
 
@@ -240,9 +290,9 @@ static event_response_t usermode_hook_cb(drakvuf_t drakvuf, drakvuf_trap_info* i
     addr_t ret_addr = 0;
 
     if (is_syswow)
-        success = (vmi_read_32(lg.vmi, &ctx, (uint32_t*)&ret_addr) == VMI_SUCCESS);
+        success = (vmi_read_32(vmi, &ctx, (uint32_t*)&ret_addr) == VMI_SUCCESS);
     else
-        success = (vmi_read_64(lg.vmi, &ctx, &ret_addr) == VMI_SUCCESS);
+        success = (vmi_read_64(vmi, &ctx, &ret_addr) == VMI_SUCCESS);
 
     if (!success)
     {
@@ -275,7 +325,7 @@ static event_response_t usermode_hook_cb(drakvuf_t drakvuf, drakvuf_trap_info* i
 
     addr_t paddr;
 
-    if ( VMI_SUCCESS != vmi_pagetable_lookup(lg.vmi, info->regs->cr3, ret_addr, &paddr) )
+    if ( VMI_SUCCESS != vmi_pagetable_lookup(vmi, info->regs->cr3, ret_addr, &paddr) )
     {
         delete trap;
         delete ret_target;
@@ -352,8 +402,8 @@ static void on_dll_discovered(drakvuf_t drakvuf, const dll_view_t* dll, void* ex
 {
     rpcmon* plugin = (rpcmon*)extra;
 
-    vmi_lock_guard lg(drakvuf);
-    unicode_string_t* dll_name = drakvuf_read_unicode_va(lg.vmi, dll->mmvad.file_name_ptr, 0);
+    auto vmi = vmi_lock_guard(drakvuf);
+    unicode_string_t* dll_name = drakvuf_read_unicode_va(vmi, dll->mmvad.file_name_ptr, 0);
 
     if (dll_name && dll_name->contents)
     {
@@ -377,6 +427,21 @@ static void on_dll_hooked(drakvuf_t drakvuf, const dll_view_t* dll, const std::v
     PRINT_DEBUG("[RPCMON] DLL hooked - done\n");
 }
 
+static auto rpc_call_args()
+{
+    std::vector<std::unique_ptr<ArgumentPrinter>> args;
+    args.emplace_back(std::make_unique<ArgumentPrinter>("pStubDescriptor", false));
+    args.emplace_back(std::make_unique<ArgumentPrinter>("pFormat", false));
+    return args;
+}
+
+static auto rpc_call3_args()
+{
+    std::vector<std::unique_ptr<ArgumentPrinter>> args;
+    args.emplace_back(std::make_unique<ArgumentPrinter>("pStubProxy", false));
+    return args;
+}
+
 rpcmon::rpcmon(drakvuf_t drakvuf, output_format_t output)
     : pluginex(drakvuf, output)
 {
@@ -385,28 +450,14 @@ rpcmon::rpcmon(drakvuf_t drakvuf, output_format_t output)
         PRINT_DEBUG("[RPCMON] Usermode hooking not supported.\n");
         return;
     }
-    std::vector< std::unique_ptr < ArgumentPrinter > > arg_vec;
 
     const auto log = HookActions::empty().set_log();
-    arg_vec.push_back(std::unique_ptr < ArgumentPrinter>(new ArgumentPrinter("pStubDescriptor", false)));
-    arg_vec.push_back(std::unique_ptr < ArgumentPrinter>(new ArgumentPrinter("pFormat", false)));
-    wanted_hooks.emplace_back("rpcrt4.dll", "NdrAsyncClientCall", log, std::move(arg_vec));
-
-    arg_vec.push_back(std::unique_ptr < ArgumentPrinter>(new ArgumentPrinter("pStubDescriptor", false)));
-    arg_vec.push_back(std::unique_ptr < ArgumentPrinter>(new ArgumentPrinter("pFormat", false)));
-    wanted_hooks.emplace_back("rpcrt4.dll", "NdrAsyncClientCall2", log, std::move(arg_vec));
-
-    arg_vec.push_back(std::unique_ptr < ArgumentPrinter>(new ArgumentPrinter("pStubDescriptor", false)));
-    arg_vec.push_back(std::unique_ptr < ArgumentPrinter>(new ArgumentPrinter("pFormat", false)));
-    wanted_hooks.emplace_back("rpcrt4.dll", "NdrClientCall", log, std::move(arg_vec));
-
-    arg_vec.push_back(std::unique_ptr < ArgumentPrinter>(new ArgumentPrinter("pStubDescriptor", false)));
-    arg_vec.push_back(std::unique_ptr < ArgumentPrinter>(new ArgumentPrinter("pFormat", false)));
-    wanted_hooks.emplace_back("rpcrt4.dll", "NdrClientCall2", log, std::move(arg_vec));
-
-    arg_vec.push_back(std::unique_ptr < ArgumentPrinter>(new ArgumentPrinter("pStubDescriptor", false)));
-    arg_vec.push_back(std::unique_ptr < ArgumentPrinter>(new ArgumentPrinter("pFormat", false)));
-    wanted_hooks.emplace_back("rpcrt4.dll", "NdrClientCall4", log, std::move(arg_vec));
+    wanted_hooks.emplace_back("rpcrt4.dll", "NdrAsyncClientCall", log, rpc_call_args());
+    wanted_hooks.emplace_back("rpcrt4.dll", "NdrAsyncClientCall2", log, rpc_call_args());
+    wanted_hooks.emplace_back("rpcrt4.dll", "NdrClientCall", log, rpc_call_args());
+    wanted_hooks.emplace_back("rpcrt4.dll", "NdrClientCall2", log, rpc_call_args());
+    wanted_hooks.emplace_back("rpcrt4.dll", "NdrClientCall3", log, rpc_call3_args());
+    wanted_hooks.emplace_back("rpcrt4.dll", "NdrClientCall4", log, rpc_call_args());
 
     usermode_cb_registration reg =
     {


### PR DESCRIPTION
Intercept NdrClientCall3 and print InterfaceId and TransferSyntax extracted from it arguments.