### PR TITLE
fix: target_rsp checks in procmon plugin

### DIFF
--- a/src/plugins/procdump/private.h
+++ b/src/plugins/procdump/private.h
@@ -126,6 +126,7 @@ struct procdump_ctx
     vmi_pid_t pid;
     vmi_pid_t ppid;
     uint32_t tid;
+    addr_t target_rsp;
     string name;
     procdump* plugin;
     drakvuf_trap_t* bp;


### PR DESCRIPTION
* add target_rsp checks on exit from injected calls
* extract inject_copy_memory function
* fix some memory skipping in case of injection error