### PR TITLE
fix: add target_rsp checks into filedelete plugin

### DIFF
--- a/src/plugins/filedelete/filedelete2_helpers.cpp
+++ b/src/plugins/filedelete/filedelete2_helpers.cpp
@@ -162,6 +162,9 @@ void free_resources(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
     info->regs->r14 = injector->saved_regs.r14;
     info->regs->r15 = injector->saved_regs.r15;
 
+    info->regs->rip = injector->saved_regs.rip;
+    info->regs->rsp = injector->saved_regs.rsp;
+
     drakvuf_remove_trap(drakvuf, injector->bp, (drakvuf_trap_free_t)free);
     g_free(injector->buffer);
     g_free(injector);

--- a/src/plugins/filedelete/private.h
+++ b/src/plugins/filedelete/private.h
@@ -198,6 +198,8 @@ struct wrapper_t
 
     vmi_pid_t target_pid;
     uint32_t target_tid;
+    addr_t target_rsp;
+
     addr_t eprocess_base;
 
     x86_registers_t saved_regs;


### PR DESCRIPTION
 * add target_rsp checks on exit from injected calls
 * replace manual lock management by RAII
 * restore RIP and PSP registers after injection