### PR TITLE
libinjector: fix x64 stack alignment (#1086)

### DIFF
--- a/src/libinjector/injector_stack.c
+++ b/src/libinjector/injector_stack.c
@@ -328,16 +328,9 @@ static bool setup_stack_64(vmi_instance_t vmi, x86_registers_t* regs, struct arg
          * > The stack will always be maintained 16-byte aligned, except within the prolog
          * > (for example, after the return address is pushed), and except where indicated
          * > in Function Types for a certain class of frame functions.
-         *
-         * So place one extra argument to achieve alignment just before CALL instruction.
          */
-        if (nb_args % 2)
-        {
+        if (((addr - nb_args*0x8 - 0x8) & 0xf) != 8)
             addr -= 0x8;
-            ctx.addr = addr;
-            if (VMI_FAILURE == vmi_write_64(vmi, &ctx, &nul64))
-                goto err;
-        }
 
         // http://www.codemachine.com/presentations/GES2010.TRoy.Slides.pdf
         //


### PR DESCRIPTION
The error affects libinjector, procdump, memdump and filedelete plugins.

More about stack alignment:
* [x64 stack usage](https://docs.microsoft.com/en-us/cpp/build/stack-usage?view=msvc-160#stack-allocation)
* [In-depth: Windows x64 ABI: Stack frames](https://www.gamasutra.com/view/news/178446/Indepth_Windows_x64_ABI_Stack_frames.php)
* [About the x64 stack Alignment](https://community.intel.com/t5/Intel-ISA-Extensions/About-the-x64-stack-Alignment/td-p/881085)
* [what is "stack alignment"?](https://stackoverflow.com/a/672482)