### PR TITLE
Refactor output format printers

### DIFF
--- a/src/plugins/output_format/deffmt.h
+++ b/src/plugins/output_format/deffmt.h
@@ -141,11 +141,9 @@ struct DataPrinter
 
     static bool print(std::ostream& os, const TimeVal& t, char)
     {
-        os << t.tv_sec << ".";
-
-        auto c = os.fill('0');
-        auto w = os.width(6);
-        os << t.tv_usec << std::setfill(c) << std::setw(w);
+        auto restore_flags = fmt::RestoreFlags(os);
+        os << t.tv_sec << '.' << std::setfill('0')
+           << std::setw(6) << t.tv_usec;
         return true;
     }
 
@@ -159,19 +157,17 @@ struct DataPrinter
     template <class Tv = T>
     static bool print(std::ostream& os, const fmt::Xval<Tv>& data, char)
     {
-        auto ff = os.flags();
+        auto restore_flags = fmt::RestoreFlags(os);
         auto base = data.withbase ? "0x" : "";
         os << base << std::uppercase << std::hex << data.value;
-        os.flags(ff);
         return true;
     }
 
     template <class Tv = T>
     static bool print(std::ostream& os, const fmt::Fval<Tv>& data, char)
     {
-        auto ff = os.flags();
+        auto restore_flags = fmt::RestoreFlags(os);
         os << std::fixed << data.value;
-        os.flags(ff);
         return true;
     }
 
@@ -192,20 +188,17 @@ struct DataPrinter
     template <class Tv = T>
     static bool print(std::ostream& os, const std::function<bool(std::ostream&)>& printer, char)
     {
-        std::ostringstream ss;
-        bool printed = printer(ss);
-        if (printed)
-            os << ss.str();
+        auto pos = os.tellp();
+        bool printed = printer(os);
+        if (!printed)
+            os.seekp(pos);
         return printed;
     }
 
     template <class Tv = T>
     static bool print(std::ostream& os, const std::optional<Tv>& data, char sep)
     {
-        if (!data.has_value())
-            return false;
-
-        return print_data(os, data.value(), sep);
+        return data.has_value() && print_data(os, data.value(), sep);
     }
 
     template <class Tk, class Tv>
@@ -343,8 +336,7 @@ void print(const char* plugin_name, drakvuf_t drakvuf, drakvuf_trap_info_t* info
             fmt::unputc(fmt::cout);
     }
 
-    fmt::cout << "\n";
-    fmt::cout.flush();
+    fmt::cout << std::endl;
 }
 
 inline void print_running_process(const char* plugin_name, drakvuf_t drakvuf, gint64 timestamp, proc_data_t const& proc_data)

--- a/src/plugins/output_format/jsonfmt.h
+++ b/src/plugins/output_format/jsonfmt.h
@@ -122,12 +122,10 @@ class DataPrinter
 public:
     static bool print(std::ostream& os, const TimeVal& t, char)
     {
+        auto restore_flags = fmt::RestoreFlags(os);
         os << '"';
-        os << t.tv_sec << ".";
-
-        auto c = os.fill('0');
-        auto w = os.width(6);
-        os << t.tv_usec << std::setfill(c) << std::setw(w);
+        os << t.tv_sec << '.' << std::setfill('0')
+           << std::setw(6) << t.tv_usec;
         os << '"';
         return true;
     }
@@ -142,16 +140,16 @@ public:
     template <class Tv = T>
     static bool print(std::ostream& os, const fmt::Xval<Tv>& data, char)
     {
-        os << "\"0x" << std::hex << data.value << "\"" << std::dec;
+        auto restore_flags = fmt::RestoreFlags(os);
+        os << "\"0x" << std::hex << data.value << "\"";
         return true;
     }
 
     template <class Tv = T>
     static bool print(std::ostream& os, const fmt::Fval<Tv>& data, char)
     {
-        auto ff = os.flags();
+        auto restore_flags = fmt::RestoreFlags(os);
         os << std::fixed << data.value;
-        os.flags(ff);
         return true;
     }
 
@@ -174,10 +172,10 @@ public:
     template <class Tv = T>
     static bool print(std::ostream& os, const std::function<bool(std::ostream&)>& printer, char)
     {
-        std::ostringstream ss;
-        bool printed = printer(ss);
-        if (printed)
-            os << ss.str();
+        auto pos = os.tellp();
+        bool printed = printer(os);
+        if (!printed)
+            os.seekp(pos);
         return printed;
     }
 
@@ -435,8 +433,7 @@ void print(const char* plugin_name, drakvuf_t drakvuf, drakvuf_trap_info_t* info
     else
         print_data(fmt::cout, sep, plugin, args...);
 
-    fmt::cout << "\n";
-    fmt::cout.flush();
+    fmt::cout << std::endl;
 }
 
 inline void print_running_process(const char* plugin_name, drakvuf_t drakvuf, gint64 timestamp, proc_data_t const& proc_data)

--- a/src/plugins/output_format/kvfmt.h
+++ b/src/plugins/output_format/kvfmt.h
@@ -141,11 +141,9 @@ struct DataPrinter
 
     static bool print(std::ostream& os, const TimeVal& t, char)
     {
-        os << t.tv_sec << ".";
-
-        auto c = os.fill('0');
-        auto w = os.width(6);
-        os << t.tv_usec << std::setfill(c) << std::setw(w);
+        auto restore_flags = fmt::RestoreFlags(os);
+        os << t.tv_sec << '.' << std::setfill('0')
+           << std::setw(6) << t.tv_usec;
         return true;
     }
 
@@ -159,19 +157,17 @@ struct DataPrinter
     template <class Tv = T>
     static bool print(std::ostream& os, const fmt::Xval<Tv>& data, char)
     {
-        auto ff = os.flags();
+        auto restore_flags = fmt::RestoreFlags(os);
         auto base = data.withbase ? "0x" : "";
         os << base << std::uppercase << std::hex << data.value;
-        os.flags(ff);
         return true;
     }
 
     template <class Tv = T>
     static bool print(std::ostream& os, const fmt::Fval<Tv>& data, char)
     {
-        auto ff = os.flags();
+        auto restore_flags = fmt::RestoreFlags(os);
         os << std::fixed << data.value;
-        os.flags(ff);
         return true;
     }
 
@@ -195,20 +191,17 @@ struct DataPrinter
     template <class Tv = T>
     static bool print(std::ostream& os, const std::function<bool(std::ostream&)>& printer, char)
     {
-        std::ostringstream ss;
-        bool printed = printer(ss);
-        if (printed)
-            os << ss.str();
+        auto pos = os.tellp();
+        bool printed = printer(os);
+        if (!printed)
+            os.seekp(pos);
         return printed;
     }
 
     template <class Tv = T>
     static bool print(std::ostream& os, const std::optional<Tv>& data, char sep)
     {
-        if (!data.has_value())
-            return false;
-
-        return print_data(os, data.value(), sep);
+        return data.has_value() && print_data(os, data.value(), sep);
     }
 
     template <class Tk, class Tv>
@@ -344,8 +337,7 @@ void print(const char* plugin_name, drakvuf_t drakvuf, drakvuf_trap_info_t* info
             fmt::unputc(fmt::cout);
     }
 
-    fmt::cout << "\n";
-    fmt::cout.flush();
+    fmt::cout << std::endl;
 }
 
 inline void print_running_process(const char* plugin_name, drakvuf_t drakvuf, gint64 timestamp, proc_data_t const& proc_data)

--- a/src/plugins/output_format/ostream.h
+++ b/src/plugins/output_format/ostream.h
@@ -122,6 +122,20 @@ inline void unputc(std::ostream& os)
     }
 }
 
+class RestoreFlags
+{
+private:
+    std::ios_base& ios;
+    std::ios_base::fmtflags const flags;
+
+public:
+    explicit RestoreFlags(std::ios_base& ios) : ios{ios}, flags{ios.flags()} {}
+    ~RestoreFlags()
+    {
+        ios.flags(flags);
+    }
+};
+
 extern std::ostream cout;
 
 } // namespace fmt


### PR DESCRIPTION
- Add RAII class RestoreFlags for undoing changes in stream format flags
- Replace manual "0x" printing by std::showbase.
- Rework time_val printers
- Replase printing of "\n" + flush() by std::endl.