### PR TITLE
libuserhook on_dll_discovered logic refactored

### DIFF
--- a/src/libusermode/userhook.cpp
+++ b/src/libusermode/userhook.cpp
@@ -138,6 +138,18 @@ static void wrap_delete(drakvuf_trap_t* trap)
     g_slice_free(drakvuf_trap_t, trap);
 }
 
+static std::string drakvuf_read_unicode(drakvuf_t drakvuf, addr_t addr)
+{
+    std::string str;
+    auto vmi = vmi_lock_guard(drakvuf);
+    unicode_string_t* us = drakvuf_read_unicode_va(vmi, addr, 0);
+    if (us && us->contents)
+        str.assign(reinterpret_cast<const char*>(us->contents));
+    if (us)
+        vmi_free_unicode_str(us);
+    return str;
+}
+
 /**
  * Check if this thread is currently in process of loading a DLL.
  * If so, return a pointer to the associated metadata.
@@ -202,9 +214,14 @@ static dll_t* create_dll_meta(drakvuf_t drakvuf, drakvuf_trap_info* info, userho
         .v.is_hooked = false
     };
 
-    for (auto& reg : plugin->plugins)
+    std::string dll_name = drakvuf_read_unicode(drakvuf, dll_meta.v.mmvad.file_name_ptr);
+
+    if (!dll_name.empty())
     {
-        reg.pre_cb(drakvuf, (const dll_view_t*)&dll_meta, reg.extra);
+        for (auto& reg : plugin->plugins)
+        {
+            reg.pre_cb(drakvuf, dll_name, (const dll_view_t*)&dll_meta, reg.extra);
+        }
     }
 
     if (dll_meta.targets.empty())
@@ -991,7 +1008,7 @@ plugin_target_config_entry_t parse_entry(
 }
 
 
-void drakvuf_load_dll_hook_config(drakvuf_t drakvuf, const char* dll_hooks_list_path, const bool print_no_addr, std::vector<plugin_target_config_entry_t>* wanted_hooks)
+void drakvuf_load_dll_hook_config(drakvuf_t drakvuf, const char* dll_hooks_list_path, bool print_no_addr, const hook_filter_t& hook_filter, wanted_hooks_t& wanted_hooks)
 {
     PrinterConfig config{};
     config.print_no_addr = print_no_addr;
@@ -1003,12 +1020,15 @@ void drakvuf_load_dll_hook_config(drakvuf_t drakvuf, const char* dll_hooks_list_
         std::vector<std::unique_ptr<ArgumentPrinter>> arg_vec1;
         arg_vec1.push_back(std::make_unique<ArgumentPrinter>("wVersionRequired", config));
         arg_vec1.push_back(std::make_unique<ArgumentPrinter>("lpWSAData", config));
-        wanted_hooks->emplace_back("ws2_32.dll", "WSAStartup", log_and_stack, std::move(arg_vec1));
+        plugin_target_config_entry_t e1("ws2_32.dll", "WSAStartup", log_and_stack, std::move(arg_vec1));
 
         std::vector<std::unique_ptr<ArgumentPrinter>> arg_vec2;
         arg_vec2.push_back(std::make_unique<ArgumentPrinter>("ExitCode", config));
         arg_vec2.push_back(std::make_unique<ArgumentPrinter>("Unknown", config));
-        wanted_hooks->emplace_back("ntdll.dll", "RtlExitUserProcess", log_and_stack, std::move(arg_vec2));
+        plugin_target_config_entry_t e2("ntdll.dll", "RtlExitUserProcess", log_and_stack, std::move(arg_vec2));
+
+        if (!hook_filter(e1)) wanted_hooks.add_hook(std::move(e1));
+        if (!hook_filter(e2)) wanted_hooks.add_hook(std::move(e2));
         return;
     }
 
@@ -1028,7 +1048,8 @@ void drakvuf_load_dll_hook_config(drakvuf_t drakvuf, const char* dll_hooks_list_
         try
         {
             std::stringstream ss(line);
-            wanted_hooks->push_back(parse_entry(ss, config));
+            auto e = parse_entry(ss, config);
+            if (!hook_filter(e)) wanted_hooks.add_hook(std::move(e));
         }
         catch (const std::runtime_error& exc)
         {

--- a/src/libusermode/userhook.hpp
+++ b/src/libusermode/userhook.hpp
@@ -107,7 +107,9 @@
 
 #include <string>
 #include <vector>
+#include <map>
 #include <memory>
+#include <functional>
 
 #include <glib.h>
 #include "plugins/private.h"
@@ -235,7 +237,7 @@ struct dll_view_t
     bool is_hooked;
 };
 
-typedef void (*dll_pre_hook_cb)(drakvuf_t, const dll_view_t*, void*);
+typedef void (*dll_pre_hook_cb)(drakvuf_t, const std::string&, const dll_view_t*, void*);
 typedef void (*dll_post_hook_cb)(drakvuf_t, const dll_view_t*, const std::vector<hook_target_view_t>& targets, void*);
 
 struct usermode_cb_registration
@@ -244,6 +246,43 @@ struct usermode_cb_registration
     dll_post_hook_cb post_cb;
     void* extra;
 };
+
+class wanted_hooks_t
+{
+public:
+    void add_hook(plugin_target_config_entry_t&& e)
+    {
+        hooks[e.dll_name].emplace_back(std::move(e));
+    }
+
+    template<typename... Args>
+    void add_hook(Args&& ... args)
+    {
+        auto e = plugin_target_config_entry_t(std::forward<Args>(args)...);
+        add_hook(std::move(e));
+    }
+
+    bool empty() const noexcept
+    {
+        return hooks.empty();
+    }
+
+    void visit_hooks_for(const std::string& dll_name, std::function<void(const plugin_target_config_entry_t&)>&& visitor) const
+    {
+        for (const auto& [pattern, wanted_hooks] : hooks)
+        {
+            if (dll_name.find(pattern) != std::string::npos)
+            {
+                std::for_each(std::begin(wanted_hooks), std::end(wanted_hooks), visitor);
+            }
+        }
+    }
+
+private:
+    std::map<std::string, std::vector<plugin_target_config_entry_t>> hooks;
+};
+
+using hook_filter_t = std::function<bool(const plugin_target_config_entry_t&)>;
 
 /**
  * Userhooks are not supported on some windows versions yet, therefore
@@ -256,7 +295,7 @@ struct usermode_cb_registration
 bool drakvuf_are_userhooks_supported(drakvuf_t drakvuf);
 void drakvuf_register_usermode_callback(drakvuf_t drakvuf, usermode_cb_registration* reg);
 bool drakvuf_request_usermode_hook(drakvuf_t drakvuf, const dll_view_t* dll, const plugin_target_config_entry_t* target, callback_t callback, void* extra);
-void drakvuf_load_dll_hook_config(drakvuf_t drakvuf, const char* dll_hooks_list_path, const bool print_no_addr, std::vector<plugin_target_config_entry_t>* wanted_hooks);
+void drakvuf_load_dll_hook_config(drakvuf_t drakvuf, const char* dll_hooks_list_path, const bool print_no_addr, const hook_filter_t& hook_filter, wanted_hooks_t& wanted_hooks);
 
 
 /**

--- a/src/plugins/apimon/apimon.h
+++ b/src/plugins/apimon/apimon.h
@@ -122,7 +122,7 @@ struct apimon_config
 class apimon: public pluginex
 {
 public:
-    std::vector<plugin_target_config_entry_t> wanted_hooks;
+    wanted_hooks_t wanted_hooks;
 
     apimon(drakvuf_t drakvuf, const apimon_config* config, output_format_t output);
     ~apimon();

--- a/src/plugins/memdump/memdump.h
+++ b/src/plugins/memdump/memdump.h
@@ -134,7 +134,7 @@ public:
     size_t wow64context_eip_rva;
     size_t wow64context_eax_rva;
 
-    std::vector<plugin_target_config_entry_t> wanted_hooks;
+    wanted_hooks_t wanted_hooks;
 
     memdump(drakvuf_t drakvuf, const memdump_config* config, output_format_t output);
     ~memdump();

--- a/src/plugins/rpcmon/rpcmon.h
+++ b/src/plugins/rpcmon/rpcmon.h
@@ -105,9 +105,6 @@
 #ifndef RPCMON_H
 #define RPCMON_H
 
-#include <vector>
-#include <memory>
-
 #include <glib.h>
 #include <libusermode/userhook.hpp>
 #include "plugins/private.h"
@@ -116,7 +113,7 @@
 class rpcmon: public pluginex
 {
 public:
-    std::vector<plugin_target_config_entry_t> wanted_hooks;
+    wanted_hooks_t wanted_hooks;
 
     rpcmon(drakvuf_t drakvuf, output_format_t output);
     ~rpcmon();


### PR DESCRIPTION
 * Filter dll hook rules while config loading
 * Load wanted hooks into structure optimized for on_dll_discovered logic (search on dll names only)
 * Remove code duplication in libusermode clients (dll_name calculation and memory management)
 * Replace C strstr call by C++ string::find