### PR TITLE
filedelete: fix handle leak

### DIFF
--- a/src/plugins/filedelete/filedelete.h
+++ b/src/plugins/filedelete/filedelete.h
@@ -169,6 +169,7 @@ public:
     addr_t queryvolumeinfo_va = 0;
     addr_t queryinfo_va = 0;
     addr_t createsection_va = 0;
+    addr_t close_handle_va = 0;
     addr_t mapview_va = 0;
     addr_t unmapview_va = 0;
     addr_t readfile_va = 0;

--- a/src/plugins/filedelete/filedelete2_helpers.cpp
+++ b/src/plugins/filedelete/filedelete2_helpers.cpp
@@ -211,6 +211,24 @@ bool inject_memcpy(drakvuf_t drakvuf, drakvuf_trap_info_t* info, vmi_instance_t 
     return true;
 }
 
+bool inject_close_handle(drakvuf_t drakvuf, drakvuf_trap_info_t* info, vmi_instance_t vmi, wrapper_t* injector)
+{
+    // Remove stack arguments and home space from previous injection
+    info->regs->rsp = injector->saved_regs.rsp;
+
+    struct argument args[1] = {};
+
+    init_int_argument(&args[0], injector->section_handle);
+
+    if (!setup_stack_locked(drakvuf, vmi, info->regs, args, 1))
+        return false;
+
+    info->regs->rip = injector->f->close_handle_va;
+    injector->bp->cb = close_handle_cb;
+
+    return true;
+}
+
 bool inject_unmapview(drakvuf_t drakvuf, drakvuf_trap_info_t* info, vmi_instance_t vmi, wrapper_t* injector)
 {
     // Remove stack arguments and home space from previous injection

--- a/src/plugins/filedelete/private.h
+++ b/src/plugins/filedelete/private.h
@@ -293,6 +293,7 @@ event_response_t exallocatepool_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 event_response_t queryvolumeinfo_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
 event_response_t queryinfo_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
 event_response_t injected_createsection_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
+event_response_t close_handle_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
 event_response_t mapview_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
 event_response_t unmapview_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
 event_response_t memcpy_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
@@ -306,6 +307,7 @@ bool inject_waitobject(drakvuf_t drakvuf, drakvuf_trap_info_t* info, vmi_instanc
 bool inject_queryvolumeinfo(drakvuf_t drakvuf, drakvuf_trap_info_t* info, vmi_instance_t vmi, wrapper_t* injector);
 bool inject_queryinfo(drakvuf_t drakvuf, drakvuf_trap_info_t* info, vmi_instance_t vmi, wrapper_t* injector);
 bool inject_createsection(drakvuf_t drakvuf, drakvuf_trap_info_t* info, vmi_instance_t vmi, wrapper_t* injector);
+bool inject_close_handle(drakvuf_t drakvuf, drakvuf_trap_info_t* info, vmi_instance_t vmi, wrapper_t* injector);
 bool inject_mapview(drakvuf_t drakvuf, drakvuf_trap_info_t* info, vmi_instance_t vmi, wrapper_t* injector);
 bool inject_unmapview(drakvuf_t drakvuf, drakvuf_trap_info_t* info, vmi_instance_t vmi, wrapper_t* injector);
 bool inject_memcpy(drakvuf_t drakvuf, drakvuf_trap_info_t* info, vmi_instance_t vmi, wrapper_t* injector);


### PR DESCRIPTION
Because of the error the Windows fails to delete the file.