### PR TITLE
memdump: Fix double free

### DIFF
--- a/src/plugins/memdump/memdump.cpp
+++ b/src/plugins/memdump/memdump.cpp
@@ -290,7 +290,6 @@ bool dump_memory_region(
         goto done;
 
     display_file = (const char*)file;
-    g_free((gpointer)chk_str);
 
     if (rename(tmp_file_path, file_path) != 0)
         goto done;


### PR DESCRIPTION
From the `g_checksum_get_string ()` docs:

> The returned string is owned by the checksum and should not be modified or freed.

Fix the double-free introduced by 52e93e5841f1590007f8f6b895fc5743f1009557