### PR TITLE
libusermode: Add missing include to printers

### DIFF
--- a/src/libusermode/printers/printers.cpp
+++ b/src/libusermode/printers/printers.cpp
@@ -105,6 +105,7 @@
 #include "printers.hpp"
 #include <array>
 #include <string>
+#include <sstream>
 #include <iomanip>
 #include <libvmi/libvmi.h>
 #include <libdrakvuf/libdrakvuf.h>


### PR DESCRIPTION
Compilation may fail depending on the version of C++ standard library:
```
printers/printers.cpp:116:23: error: implicit instantiation of undefined template 'std::__1::basic_stringstream<char, std::__1::
char_traits<char>, std::__1::allocator<char>>'
    std::stringstream os;
                      ^
/snap/zig/3072/lib/libcxx/include/iosfwd:139:32: note: template is declared here
    class _LIBCPP_TEMPLATE_VIS basic_stringstream;
                               ^
printers/printers.cpp:159:23: error: implicit instantiation of undefined template 'std::__1::basic_stringstream<char, std::__1::
char_traits<char>, std::__1::allocator<char>>'
    std::stringstream stream;
                      ^
/snap/zig/3072/lib/libcxx/include/iosfwd:139:32: note: template is declared here
    class _LIBCPP_TEMPLATE_VIS basic_stringstream;
                               ^
```