### PR TITLE
xen_helper: Fix vmtrace interface

### DIFF
--- a/src/xen_helper/xen_helper.c
+++ b/src/xen_helper/xen_helper.c
@@ -382,13 +382,13 @@ bool xen_get_ipt_offset(xen_interface_t* xen, domid_t domID, unsigned int vcpu, 
 
     if (rc == ENODATA)
     {
-        fprintf(stderr, "xc_vmtrace_pt_get_offset returned ENODATA\n");
+        fprintf(stderr, "xc_vmtrace_output_position returned ENODATA\n");
         ipt_state->last_offset = ipt_state->offset;
         return true;
     }
     else if (rc)
     {
-        fprintf(stderr, "Failed to call xc_vmtrace_pt_get_offset: %d\n", rc);
+        fprintf(stderr, "xc_vmtrace_output_position failed: %d\n", rc);
         return false;
     }
 
@@ -421,7 +421,7 @@ bool xen_disable_ipt(xen_interface_t* xen, domid_t domID, unsigned int vcpu, ipt
 
     if (rc)
     {
-        fprintf(stderr, "Failed to close fmem\n");
+        fprintf(stderr, "Failed to close foreign memory\n");
         return false;
     }
 
@@ -429,7 +429,7 @@ bool xen_disable_ipt(xen_interface_t* xen, domid_t domID, unsigned int vcpu, ipt
 
     if (rc)
     {
-        fprintf(stderr, "Failed to call xc_vmtrace_pt_disable\n");
+        fprintf(stderr, "Failed to disable tracing\n");
         return false;
     }
 

--- a/src/xen_helper/xen_helper.c
+++ b/src/xen_helper/xen_helper.c
@@ -456,7 +456,7 @@ int xen_get_ipt_offset(xen_interface_t* xen, domid_t domID, unsigned int vcpu, i
     return 0;
 }
 
-int xen_get_ipt_option(xen_interface_t* xen, domid_t domID, unsigned int vcpu, uint64_t key, uint64_t value)
+int xen_set_ipt_option(xen_interface_t* xen, domid_t domID, unsigned int vcpu, uint64_t key, uint64_t value)
 {
     UNUSED(xen);
     UNUSED(domID);

--- a/src/xen_helper/xen_helper.h
+++ b/src/xen_helper/xen_helper.h
@@ -109,6 +109,7 @@
 #define XC_WANT_COMPAT_EVTCHN_API 1
 #define XC_WANT_COMPAT_MAP_FOREIGN_API 1
 
+#include <stdbool.h>
 #include <libxl_utils.h>
 #include <xenctrl.h>
 #include <xenforeignmemory.h>
@@ -154,9 +155,9 @@ int xen_version(void);
 bool xen_get_vcpu_ctx(xen_interface_t* xen, domid_t domID, unsigned int vcpu, vcpu_guest_context_any_t* regs);
 bool xen_set_vcpu_ctx(xen_interface_t* xen, domid_t domID, unsigned int vcpu, vcpu_guest_context_any_t* regs);
 
-int xen_enable_ipt(xen_interface_t* xen, domid_t domID, unsigned int vcpu, ipt_state_t* ipt_state);
-int xen_get_ipt_offset(xen_interface_t* xen, domid_t domID, unsigned int vcpu, ipt_state_t* ipt_state);
-int xen_set_ipt_option(xen_interface_t* xen, domid_t domID, unsigned int vcpu, uint64_t key, uint64_t value);
-int xen_get_ipt_option(xen_interface_t* xen, domid_t domID, unsigned int vcpu, uint64_t key, uint64_t* value);
-int xen_disable_ipt(xen_interface_t* xen, domid_t domID, unsigned int vcpu, ipt_state_t* ipt_state);
+bool xen_enable_ipt(xen_interface_t* xen, domid_t domID, unsigned int vcpu, ipt_state_t* ipt_state);
+bool xen_get_ipt_offset(xen_interface_t* xen, domid_t domID, unsigned int vcpu, ipt_state_t* ipt_state);
+bool xen_set_ipt_option(xen_interface_t* xen, domid_t domID, unsigned int vcpu, uint64_t key, uint64_t value);
+bool xen_get_ipt_option(xen_interface_t* xen, domid_t domID, unsigned int vcpu, uint64_t key, uint64_t* value);
+bool xen_disable_ipt(xen_interface_t* xen, domid_t domID, unsigned int vcpu, ipt_state_t* ipt_state);
 #endif

--- a/src/xen_helper/xen_helper.h
+++ b/src/xen_helper/xen_helper.h
@@ -156,5 +156,7 @@ bool xen_set_vcpu_ctx(xen_interface_t* xen, domid_t domID, unsigned int vcpu, vc
 
 int xen_enable_ipt(xen_interface_t* xen, domid_t domID, unsigned int vcpu, ipt_state_t* ipt_state);
 int xen_get_ipt_offset(xen_interface_t* xen, domid_t domID, unsigned int vcpu, ipt_state_t* ipt_state);
+int xen_set_ipt_option(xen_interface_t* xen, domid_t domID, unsigned int vcpu, uint64_t key, uint64_t value);
+int xen_get_ipt_option(xen_interface_t* xen, domid_t domID, unsigned int vcpu, uint64_t key, uint64_t* value);
 int xen_disable_ipt(xen_interface_t* xen, domid_t domID, unsigned int vcpu, ipt_state_t* ipt_state);
 #endif

--- a/src/xen_helper/xen_helper.h
+++ b/src/xen_helper/xen_helper.h
@@ -129,7 +129,7 @@ typedef struct xen_interface
 typedef struct ipt_state
 {
     uint8_t* buf;
-    uint64_t size;
+    size_t size;
 
     uint64_t offset;
     uint64_t last_offset;


### PR DESCRIPTION
- Reworked xen_helper to make it compile with the final interface that landed in Xen.
- Replaced `xc_vmtrace_enable` with `xc_vmtrace_reset_and_enable` to allow tracing VM multiple times.
- Added `xen_set/get_ipt_option` to control MSRs

I have some doubts about error codes returned by IPT-related functions. All of them return ints, however
the values are negated  - the convention is to return 0 in case of success and non-zero in case of failure.
Additionaly, @tklengyel said that he prefers returning bools instead, so I think that return values should also be changed.

CC @icedevml 