### PR TITLE
Fixing typo in vmi_slat_change

### DIFF
--- a/src/libdrakvuf/vmi.c
+++ b/src/libdrakvuf/vmi.c
@@ -1116,7 +1116,7 @@ bool inject_trap_pa(drakvuf_t drakvuf,
             goto err_exit;
         }
         if (VMI_FAILURE == vmi_slat_change_gfn(
-                drakvuf->vmi, drakvuf->altp2m_idx, remapped_gfn->r, drakvuf->sink_page_gfn))
+                drakvuf->vmi, drakvuf->altp2m_idr, remapped_gfn->r, drakvuf->sink_page_gfn))
         {
             PRINT_DEBUG("%s: Failed to change gfn on view %u\n", __FUNCTION__, drakvuf->altp2m_idr);
             goto err_exit;


### PR DESCRIPTION
Reading through the code I came across a typo in the activation of remapped GFNs

the second part of the activation, it is changing **REMAPPED_GFN->R to SINK_PAGE_GFN** on `drakvuf->altp2m_idx`
`vmi_slat_change_gfn( drakvuf->vmi, drakvuf->altp2m_idx, remapped_gfn->r, drakvuf->sink_page_gfn)`

and as I can see when the slat change was previously made through XEN API  instead of VMI , it was **drakvuf->altp2m_idr** not **idx** as I expected
```
 xc_altp2m_change_gfn(drakvuf->xen->xc, drakvuf->domID,
                             drakvuf->altp2m_idr, remapped_gfn->r, drakvuf->zero_page_gfn);
```