### PR TITLE
Intel PT plugin v2

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,7 +39,31 @@ jobs:
       run: |
         # Install packages
         sudo apt-get update -q
-        sudo apt-get install -y clang-10 autoconf-archive flex bison libjson-c-dev libxen-dev
+        sudo apt-get install -y clang-10 autoconf-archive flex bison libjson-c-dev
+    - name: Get Xen version
+      id: get-xen-hash
+      run: |
+        echo ::set-output name=XEN_HASH::$(git submodule | grep xen | awk '{ print $1 }')
+    - name: Cache Xen debball
+      id: cache-xen
+      uses: actions/cache@v2
+      with:
+        path: xen/dist
+        key: ${{ steps.get-xen-hash.outputs.XEN_HASH }}
+    - name: Create Xen debball
+      if: steps.cache-xen.outputs.cache-hit != 'true'
+      run: |
+        sudo apt-get install -y wget git bcc bin86 gawk bridge-utils iproute2 libcurl4-openssl-dev bzip2 libpci-dev build-essential make gcc clang libc6-dev libc6-dev-i386 linux-libc-dev zlib1g-dev libncurses5-dev patch libvncserver-dev libssl-dev libsdl-dev iasl libbz2-dev e2fslibs-dev git-core uuid-dev ocaml libx11-dev bison flex ocaml-findlib xz-utils gettext libyajl-dev libpixman-1-dev libaio-dev libfdt-dev cabextract libglib2.0-dev autoconf automake libtool libjson-c-dev libfuse-dev liblzma-dev autoconf-archive kpartx python3-dev python3-pip golang python-dev libsystemd-dev
+        git submodule update --init xen
+        cd xen
+        ./configure --enable-githttp --disable-pvshim
+        make -j4 debball
+        cd ..
+    - name: Install Xen debball
+      run: |
+        sudo dpkg -i xen/dist/xen-*.deb
+    - name: Compile and install LibVMI
+      run: |
         # Compile & install LibVMI
         git submodule update --init libvmi
         cd libvmi
@@ -49,11 +73,10 @@ jobs:
         sudo make install
         sudo ldconfig
         cd ..
-
-    - run: |
+    - name: Compile and install DRAKVUF
+      run: |
         autoreconf -vif
         ./configure
         make
-
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -18,7 +18,29 @@ jobs:
         run: |
           sudo apt-get update -q
           sudo apt-get remove -y clang
-          sudo apt-get install -y clang-10 autoconf-archive flex bison libjson-c-dev libxen-dev
+          sudo apt-get install -y clang-10 autoconf-archive flex bison libjson-c-dev
+      - name: Get Xen version
+        id: get-xen-hash
+        run: |
+          echo ::set-output name=XEN_HASH::$(git submodule | grep xen | awk '{ print $1 }')
+      - name: Cache Xen debball
+        id: cache-xen
+        uses: actions/cache@v2
+        with:
+          path: xen/dist
+          key: ${{ steps.get-xen-hash.outputs.XEN_HASH }}
+      - name: Create Xen debball
+        if: steps.cache-xen.outputs.cache-hit != 'true'
+        run: |
+          sudo apt-get install -y wget git bcc bin86 gawk bridge-utils iproute2 libcurl4-openssl-dev bzip2 libpci-dev build-essential make gcc clang libc6-dev libc6-dev-i386 linux-libc-dev zlib1g-dev libncurses5-dev patch libvncserver-dev libssl-dev libsdl-dev iasl libbz2-dev e2fslibs-dev git-core uuid-dev ocaml libx11-dev bison flex ocaml-findlib xz-utils gettext libyajl-dev libpixman-1-dev libaio-dev libfdt-dev cabextract libglib2.0-dev autoconf automake libtool libjson-c-dev libfuse-dev liblzma-dev autoconf-archive kpartx python3-dev python3-pip golang python-dev libsystemd-dev
+          git submodule update --init xen
+          cd xen
+          ./configure --enable-githttp --disable-pvshim
+          make -j4 debball
+          cd ..
+      - name: Install Xen debball
+        run: |
+          sudo dpkg -i xen/dist/xen-*.deb
       - name: Install LibVMI
         run: |
           git submodule update --init libvmi

--- a/.github/workflows/container-compile.yml
+++ b/.github/workflows/container-compile.yml
@@ -19,12 +19,38 @@ jobs:
     - name: Install dependencies
       run: |
         apt-get update -q
-        apt-get install -y autoconf-archive flex bison libjson-c-dev libxen-dev clang build-essential git libtool autotools-dev libglib2.0-dev
+        apt-get install -y autoconf-archive flex bison libjson-c-dev clang build-essential git libtool autotools-dev libglib2.0-dev libyajl-dev
         apt-get clean
 
     - uses: actions/checkout@v2
       with:
         fetch-depth: 2
+
+    - name: Get Xen version
+      id: get-xen-hash
+      run: |
+        echo ::set-output name=XEN_HASH::$(git submodule | grep xen | awk '{ print $1 }')
+
+    - name: Cache Xen debball
+      id: cache-xen
+      uses: actions/cache@v2
+      with:
+        path: xen/dist
+        key: ${{ steps.get-xen-hash.outputs.XEN_HASH }}
+
+    - name: Create Xen debball
+      if: steps.cache-xen.outputs.cache-hit != 'true'
+      run: |
+        apt-get install -y wget git bcc bin86 gawk bridge-utils iproute2 libcurl4-openssl-dev bzip2 libpci-dev build-essential make gcc clang libc6-dev libc6-dev-i386 linux-libc-dev zlib1g-dev libncurses5-dev patch libvncserver-dev libssl-dev libsdl-dev iasl libbz2-dev e2fslibs-dev git-core uuid-dev ocaml libx11-dev bison flex ocaml-findlib xz-utils gettext libpixman-1-dev libaio-dev libfdt-dev cabextract libglib2.0-dev autoconf automake libtool libjson-c-dev libfuse-dev liblzma-dev autoconf-archive kpartx python3-dev python3-pip golang python-dev libsystemd-dev
+        git submodule update --init xen
+        cd xen
+        ./configure --enable-githttp --disable-pvshim
+        make -j4 debball
+        cd ..
+
+    - name: Install Xen debball
+      run: |
+        dpkg -i xen/dist/xen-*.deb
 
     - name: Install LibVMI
       run: |

--- a/.github/workflows/container-compile.yml
+++ b/.github/workflows/container-compile.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Get Xen version
       id: get-xen-hash
       run: |
-        echo ::set-output name=XEN_HASH::$(git submodule | grep xen | awk '{ print $1 }')
+        echo ::set-output name=XEN_HASH::${{ matrix.container }}_$(git submodule | grep xen | awk '{ print $1 }')
 
     - name: Cache Xen debball
       id: cache-xen

--- a/.github/workflows/scan-build.yml
+++ b/.github/workflows/scan-build.yml
@@ -11,11 +11,35 @@ jobs:
           - 'ubuntu-20.04'
     steps:
       - uses: actions/checkout@v2
-      - name: scan-build
+      - name: Install dependencies
         run: |
           # Install packages
           sudo apt-get update -q
-          sudo apt-get install -y clang-10 clang-tools-10 autoconf-archive flex bison libjson-c-dev libxen-dev
+          sudo apt-get install -y clang-10 clang-tools-10 autoconf-archive flex bison libjson-c-dev
+      - name: Get Xen version
+        id: get-xen-hash
+        run: |
+          echo ::set-output name=XEN_HASH::$(git submodule | grep xen | awk '{ print $1 }')
+      - name: Cache Xen debball
+        id: cache-xen
+        uses: actions/cache@v2
+        with:
+          path: xen/dist
+          key: ${{ steps.get-xen-hash.outputs.XEN_HASH }}
+      - name: Create Xen debball
+        if: steps.cache-xen.outputs.cache-hit != 'true'
+        run: |
+          sudo apt-get install -y wget git bcc bin86 gawk bridge-utils iproute2 libcurl4-openssl-dev bzip2 libpci-dev build-essential make gcc clang libc6-dev libc6-dev-i386 linux-libc-dev zlib1g-dev libncurses5-dev patch libvncserver-dev libssl-dev libsdl-dev iasl libbz2-dev e2fslibs-dev git-core uuid-dev ocaml libx11-dev bison flex ocaml-findlib xz-utils gettext libyajl-dev libpixman-1-dev libaio-dev libfdt-dev cabextract libglib2.0-dev autoconf automake libtool libjson-c-dev libfuse-dev liblzma-dev autoconf-archive kpartx python3-dev python3-pip golang python-dev libsystemd-dev
+          git submodule update --init xen
+          cd xen
+          ./configure --enable-githttp --disable-pvshim
+          make -j4 debball
+          cd ..
+      - name: Install Xen debball
+        run: |
+          sudo dpkg -i xen/dist/xen-*.deb
+      - name: Scan build
+        run: |
           # Set Exports
           export PATH=/usr/lib/llvm-10/bin:$PATH
           export CC=clang-10

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "xen"]
 	path = xen
-	url = https://github.com/tklengyel/xen
+	url = https://github.com/xen-project/xen
 	ignore = dirty
 [submodule "libvmi"]
 	path = libvmi

--- a/configure.ac
+++ b/configure.ac
@@ -438,6 +438,16 @@ if test x$plugin_exploitmon = xyes; then
   AC_DEFINE_UNQUOTED(ENABLE_PLUGIN_EXPLOITMON, 1, "")
 fi
 
+AC_ARG_ENABLE([plugin_ipt],
+  [AS_HELP_STRING([--disable-plugin-ipt],
+    [Enable processor trace plugin @<:@yes@:>@])],
+  [plugin_ipt="$enableval"],
+  [plugin_ipt="yes"])
+AM_CONDITIONAL([PLUGIN_IPT], [test x$plugin_ipt = xyes])
+if test x$plugin_ipt = xyes; then
+  AC_DEFINE_UNQUOTED(ENABLE_PLUGIN_IPT, 1, "")
+fi
+
 #####################################################
 
 AC_ARG_ENABLE([repl],
@@ -484,10 +494,10 @@ AS_IF([test "x$with_stdlib" != "xsystem"],
   [CXXFLAGS="$CXXFLAGS -stdlib=$with_stdlib"])
 
 AC_ARG_ENABLE([ipt],
-  [AS_HELP_STRING([--enable-ipt],
-    [Enable Intel Processor Trace support (special Xen version required) @<:@no@:>@])],
+  [AS_HELP_STRING([--disable-ipt],
+    [Enable Intel Processor Trace support (requires Xen 4.15) @<:@yes@:>@])],
   [enable_ipt="$enableval"],
-  [enable_ipt="no"])
+  [enable_ipt="yes"])
 AM_CONDITIONAL([ENABLE_IPT], [test x$enable_ipt = xyes])
 
 #####################################################
@@ -717,6 +727,7 @@ TLSMon:       $plugin_tlsmon
 Codemon:      $plugin_codemon
 Exploitmon:   $plugin_exploitmon
 LibHookTest:  $plugin_libhooktest
+IPT:          $plugin_ipt
 -------------------------------------------------------------------------------
 Deprecated Plugins
 WMIMon:       $plugin_wmimon

--- a/src/libdrakvuf/drakvuf.c
+++ b/src/libdrakvuf/drakvuf.c
@@ -928,10 +928,17 @@ static bool is_valid_vcpu(drakvuf_t drakvuf, unsigned int vcpu)
     return vcpu < MAX_DRAKVUF_VCPU && drakvuf->vcpus > vcpu;
 }
 
-bool drakvuf_enable_ipt(drakvuf_t drakvuf, unsigned int vcpu, uint8_t** buf, uint64_t* size)
+bool drakvuf_enable_ipt(drakvuf_t drakvuf, unsigned int vcpu, uint8_t** buf, uint64_t* size, uint64_t flags)
 {
     if ( !is_valid_vcpu(drakvuf, vcpu) )
         return false;
+
+    uint64_t rtit_flags = 0;
+    rtit_flags |= (flags & DRAKVUF_IPT_BRANCH_EN) ? RTIT_CTL_BRANCH_EN : 0;
+    rtit_flags |= (flags & DRAKVUF_IPT_TRACE_OS) ? RTIT_CTL_OS : 0;
+    rtit_flags |= (flags & DRAKVUF_IPT_TRACE_USR) ? RTIT_CTL_USR : 0;
+    rtit_flags |= (flags & DRAKVUF_IPT_DIS_RETC) ? RTIT_CTL_DIS_RETC : 0;
+    xen_set_ipt_option(drakvuf->xen, drakvuf->domID, vcpu, MSR_RTIT_CTL, rtit_flags);
 
     if ( !xen_enable_ipt(drakvuf->xen, drakvuf->domID, vcpu, &drakvuf->ipt_state[vcpu]) )
         return false;

--- a/src/libdrakvuf/libdrakvuf.h
+++ b/src/libdrakvuf/libdrakvuf.h
@@ -652,7 +652,12 @@ bool drakvuf_get_tid_from_handle(drakvuf_t drakvuf, drakvuf_trap_info_t* info, a
 
 bool drakvuf_set_vcpu_gprs(drakvuf_t drakvuf, unsigned int vcpu, registers_t* regs) NOEXCEPT;
 
-bool drakvuf_enable_ipt(drakvuf_t drakvuf, unsigned int vcpu, uint8_t** buf, uint64_t* size);
+#define DRAKVUF_IPT_BRANCH_EN (1 << 0)
+#define DRAKVUF_IPT_TRACE_OS  (1 << 1)
+#define DRAKVUF_IPT_TRACE_USR (1 << 2)
+#define DRAKVUF_IPT_DIS_RETC  (1 << 3)
+
+bool drakvuf_enable_ipt(drakvuf_t drakvuf, unsigned int vcpu, uint8_t** buf, uint64_t* size, uint64_t flags);
 bool drakvuf_get_ipt_offset(drakvuf_t drakvuf, unsigned int vcpu, uint64_t* offset, uint64_t* last_offset);
 bool drakvuf_disable_ipt(drakvuf_t drakvuf, unsigned int vcpu);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -307,6 +307,14 @@ static void print_usage()
         "\t --exploitmon-kernel2user-detect\n"
         "\t                           Detect kernel thread execution in user mode. This degrades performance.\n"
 #endif
+#ifdef ENABLE_PLUGIN_IPT
+        "\t --ipt-dir <directory>\n"
+        "\t                           Where to store data recorded with Intel Processor Trace\n"
+        "\t --ipt-trace-os\n"
+        "\t                           Enable IPT tracing in ring 0"
+        "\t --ipt-trace-user\n"
+        "\t                           Enable IPT tracing in ring > 0"
+#endif
         "\t -h, --help                Show this help\n"
     );
 }
@@ -398,6 +406,9 @@ int main(int argc, char** argv)
         opt_codemon_default_benign,
         opt_context_interception_processes,
         opt_exploitmon_kernel2user_detect,
+        opt_ipt_dir,
+        opt_ipt_trace_os,
+        opt_ipt_trace_user,
     };
     const option long_opts[] =
     {
@@ -448,9 +459,9 @@ int main(int argc, char** argv)
         {"context-based-interception", no_argument, NULL, 'C'},
         {"context-process", required_argument, NULL, opt_context_interception_processes},
         {"exploitmon-kernel2user-detect", no_argument, NULL, opt_exploitmon_kernel2user_detect},
-
-
-
+        {"ipt-dir", required_argument, NULL, opt_ipt_dir},
+        {"ipt-trace-os", no_argument, NULL, opt_ipt_trace_os},
+        {"ipt-trace-user", no_argument, NULL, opt_ipt_trace_user},
         {NULL, 0, NULL, 0}
     };
     const char* opts = "r:d:i:I:e:m:t:D:o:vx:a:f:spT:S:Mc:nblgj:k:w:W:hF:C";
@@ -703,6 +714,16 @@ int main(int argc, char** argv)
                 break;
             case opt_codemon_default_benign:
                 options.codemon_default_benign = true;
+#endif
+#ifdef ENABLE_PLUGIN_IPT
+            case opt_ipt_dir:
+                options.ipt_dir = optarg;
+                break;
+            case opt_ipt_trace_os:
+                options.ipt_trace_os = true;
+                break;
+            case opt_ipt_trace_user:
+                options.ipt_trace_user = true;
                 break;
 #endif
 #ifdef ENABLE_PLUGIN_EXPLOITMON

--- a/src/plugins/Makefile.am
+++ b/src/plugins/Makefile.am
@@ -293,6 +293,11 @@ sources += exploitmon/exploitmon.h
 sources += exploitmon/private.h
 endif
 
+if PLUGIN_IPT
+sources += ipt/ipt.cpp
+sources += ipt/ipt.h
+endif
+
 ###############################################################################
 sources += plugins.cpp plugins.h plugins_ex.cpp plugins_ex.h plugin_utils.cpp plugin_utils.h private.h type_traits_helpers.h filesystem.hpp hook_helpers.h
 sources += output_format.h output_format/common.h output_format/csvfmt.h output_format/deffmt.h output_format/jsonfmt.h output_format/kvfmt.h

--- a/src/plugins/plugins.cpp
+++ b/src/plugins/plugins.cpp
@@ -133,6 +133,7 @@
 #include "codemon/codemon.h"
 #include "libhooktest/libhooktest.h"
 #include "exploitmon/exploitmon.h"
+#include "ipt/ipt.h"
 
 drakvuf_plugins::drakvuf_plugins(const drakvuf_t _drakvuf, output_format_t _output, os_t _os)
     : drakvuf{ _drakvuf }, output{ _output }, os{ _os }
@@ -411,6 +412,19 @@ int drakvuf_plugins::start(const drakvuf_plugin_t plugin_id,
                         .enable_k2u = options->exploitmon_kernel2user_detect,
                     };
                     this->plugins[plugin_id] = std::make_unique<exploitmon>(this->drakvuf, &config, this->output);
+                    break;
+                }
+#endif
+#ifdef ENABLE_PLUGIN_IPT
+                case PLUGIN_IPT:
+                {
+                    ipt_config config =
+                    {
+                        .ipt_dir = options->ipt_dir,
+                        .trace_os = options->ipt_trace_os,
+                        .trace_user = options->ipt_trace_user,
+                    };
+                    this->plugins[plugin_id] = std::make_unique<ipt>(this->drakvuf, config, this->output);
                     break;
                 }
 #endif

--- a/src/plugins/plugins.h
+++ b/src/plugins/plugins.h
@@ -158,6 +158,9 @@ struct plugins_options
     bool codemon_analyse_system_dll_vad;    // PLUGIN_CODEMON
     bool codemon_default_benign;        // PLUGIN_CODEMON
     bool exploitmon_kernel2user_detect; // PLUGIN_EXPLOITMON
+    const char* ipt_dir;                // PLUGIN_IPT
+    bool ipt_trace_os;                  // PLUGIN_IPT
+    bool ipt_trace_user;                // PLUGIN_IPT
 };
 
 typedef enum drakvuf_plugin
@@ -191,6 +194,7 @@ typedef enum drakvuf_plugin
     PLUGIN_CODEMON,
     PLUGIN_LIBHOOKTEST,
     PLUGIN_EXPLOITMON,
+    PLUGIN_IPT,
     __DRAKVUF_PLUGIN_LIST_MAX
 } drakvuf_plugin_t;
 
@@ -225,6 +229,7 @@ static const char* drakvuf_plugin_names[] =
     [PLUGIN_CODEMON] = "codemon",
     [PLUGIN_LIBHOOKTEST] = "libhooktest",
     [PLUGIN_EXPLOITMON] = "exploitmon",
+    [PLUGIN_IPT] = "ipt",
 };
 
 static const bool drakvuf_plugin_os_support[__DRAKVUF_PLUGIN_LIST_MAX][VMI_OS_WINDOWS+1] =
@@ -258,6 +263,7 @@ static const bool drakvuf_plugin_os_support[__DRAKVUF_PLUGIN_LIST_MAX][VMI_OS_WI
     [PLUGIN_CODEMON]      = { [VMI_OS_WINDOWS] = 1, [VMI_OS_LINUX] = 0 },
     [PLUGIN_LIBHOOKTEST]  = { [VMI_OS_WINDOWS] = 1, [VMI_OS_LINUX] = 1 },
     [PLUGIN_EXPLOITMON]   = { [VMI_OS_WINDOWS] = 1, [VMI_OS_LINUX] = 0 },
+    [PLUGIN_IPT]          = { [VMI_OS_WINDOWS] = 1, [VMI_OS_LINUX] = 1 },
 };
 
 class plugin


### PR DESCRIPTION
This is a stripped-down version of the original IPT plugin. Most of the complex code has been
moved to hyperbee / codemon. This is just the core that controls tracing and dumps acquired
data to local files.

Plugin enhances acquired data streams with PTWRITE packets that contain information about
current CR3, thread ID and DRAKVUF event IDs.

Using the plugin is quite simple, user has to provide a directory to store the traces and pass flags
to enable tracing interesting code (`--ipt-trace-os` / `--ipt-trace-user`).

Since this functionality depends on Xen 4.15 which is currently in RC stage, plugin is disabled by default.

This changes require newer LibVMI version which includes `vmtrace_pos` in vCPU registers.
I'm not sure if we want to bump LibVMI at the same time as adding new plugin but I've included it nonetheless.