### PR TITLE
Fix missing Xen toolstack in drakvuf-bundle

### DIFF
--- a/package/Dockerfile-xen
+++ b/package/Dockerfile-xen
@@ -27,5 +27,4 @@ RUN cd /build-xen && \
     make -j$(nproc) install-xen && \
     make -j$(nproc) install-tools && \
     mv /build-xen/dist/install /dist-xen && \
-    rm -rf /build-xen && \
-    find /dist-xen
+    rm -rf /build-xen

--- a/package/Dockerfile-xen
+++ b/package/Dockerfile-xen
@@ -21,9 +21,11 @@ RUN cd /build-xen && \
     echo CONFIG_MEM_SHARING=y >> xen/.config && \
     make -C xen olddefconfig && \
     echo "Running Xen's make dist..." && \
-    make -j$(nproc) dist && \
+    make -j$(nproc) dist-xen && \
+    make -j$(nproc) dist-tools && \
     echo "Install Xen..." && \
     make -j$(nproc) install-xen && \
     make -j$(nproc) install-tools && \
     mv /build-xen/dist/install /dist-xen && \
-    rm -rf /build-xen
+    rm -rf /build-xen && \
+    find /dist-xen


### PR DESCRIPTION
Semantics of `make dist` has changed, now it doesn't build the whole toolstack and the `drakvuf-bundle` is broken since some time. It doesn't contain the required Xen toolstack binaries.