### PR TITLE
Proper catching of plugin start fall-through

### DIFF
--- a/src/plugins/Makefile.am
+++ b/src/plugins/Makefile.am
@@ -313,8 +313,7 @@ endif
 
 if !DEBUG
 AM_CXXFLAGS += -Wno-c99-designator -Wno-reorder-init-list
-AM_CXXFLAGS += -Wno-unknown-warning-option -Wimplicit-fallthrough=n \
-               -Werror=implicit-fallthrough
+AM_CXXFLAGS += -Wno-unknown-warning-option
 else
 AM_CXXFLAGS += -DDRAKVUF_DEBUG -Werror -Wall -Wextra -g -ggdb3
 AM_CXXFLAGS += -ferror-limit=0
@@ -323,8 +322,7 @@ AM_CXXFLAGS += -Wno-c99-designator -Wno-reorder-init-list
 AM_CXXFLAGS += -Wcast-qual -Wcast-align -Wstrict-aliasing \
                -Wpointer-arith -Winit-self -Wshadow \
                -Wredundant-decls -Wfloat-equal -Wundef \
-               -Wvla -Wformat -Wformat-security \
-               -Wimplicit-fallthrough=n
+               -Wvla -Wformat -Wformat-security
 # Note that -pg is incompatible with HARDENING
 if !HARDENING
 AM_CXXFLAGS += -pg

--- a/src/plugins/plugins.cpp
+++ b/src/plugins/plugins.cpp
@@ -393,7 +393,11 @@ int drakvuf_plugins::start(const drakvuf_plugin_t plugin_id,
                     break;
                 }
 #endif
-                case __DRAKVUF_PLUGIN_LIST_MAX: /* fall-through */
+                case __DRAKVUF_PLUGIN_LIST_MAX:
+                    /* Should never reach here */
+                    fprintf(stderr, "Plugin start falls-through to default switch case!\n");
+                    throw -1;
+
                 default:
                     break;
             }


### PR DESCRIPTION
There is no such option as `-Wimplicit-fallthrough=n` and `-Wextra` already enables `-Wimplicit-fallthrough=3`. It evidently didn't catch the previous error. Adding a more explicit `throw -1` in case the default switch case is reached.