### PR TITLE
Refactor win_get_process_name : ImageFileName length varies

### DIFF
--- a/src/libdrakvuf/win-processes.c
+++ b/src/libdrakvuf/win-processes.c
@@ -331,7 +331,9 @@ char* win_get_process_name(drakvuf_t drakvuf, addr_t eprocess_base, bool fullpat
             while (tokens && tokens[index+1] != NULL)
                 index++;
 
-            name = g_strdup(tokens[index]);
+            if (tokens)
+                name = g_strdup(tokens[index]);
+
             g_strfreev(tokens);
         }
 

--- a/src/libdrakvuf/win-processes.c
+++ b/src/libdrakvuf/win-processes.c
@@ -326,13 +326,16 @@ char* win_get_process_name(drakvuf_t drakvuf, addr_t eprocess_base, bool fullpat
         // relying on it would sometimes yield incomplete process name.
         if ( !fullpath )
         {
-            g_free(name);
             char** tokens = g_strsplit(name, "\\", -1);
             int index = 0;
 
-            while (tokens[index])
-                name = tokens[index++];
-            name = g_strdup(tokens[index]);
+            if (tokens && tokens[index])
+            {
+                g_free(name);
+                while (tokens[index])
+                    name = tokens[index++];
+                name = g_strdup(name);
+            }
 
             g_strfreev(tokens);
         }


### PR DESCRIPTION
`win_get_process_name` uses two different approaches to yield the process name, one of which is not reliable when it comes to lengthy process names `ImageFileName` as it is a char array limited to `0x0F` (number varies between kernel versions/builds), thus if the process name is longer it may return incomplete name. To solve this, I used string splitting on the full path and took the last token which points to the process name. 

The `vmi_read_str_va` is kept in the return as fallback option in case the other method fails.