### PR TITLE
Context based view fixes

### DIFF
--- a/src/libdrakvuf/drakvuf.c
+++ b/src/libdrakvuf/drakvuf.c
@@ -379,7 +379,7 @@ bool inject_trap_reg(drakvuf_t drakvuf, drakvuf_trap_t* trap)
 {
     if (CR3 == trap->reg)
     {
-        if ( !drakvuf->cr3 && !control_cr3_trap(drakvuf, 1) )
+        if ( !drakvuf->cr3 && !drakvuf->enable_cr3_based_interception && !control_cr3_trap(drakvuf, 1) )
             return 0;
 
         drakvuf->cr3 = g_slist_prepend(drakvuf->cr3, trap);
@@ -439,7 +439,7 @@ bool drakvuf_add_trap(drakvuf_t drakvuf, drakvuf_trap_t* trap)
             ret = inject_trap_breakpoint(drakvuf, trap);
             break;
         case MEMACCESS:
-            ret = inject_trap_mem(drakvuf, trap, 0, drakvuf->altp2m_idx);
+            ret = inject_trap_mem(drakvuf, trap, 0);
             break;
         case REGISTER:
             ret = inject_trap_reg(drakvuf, trap);

--- a/src/libdrakvuf/private.h
+++ b/src/libdrakvuf/private.h
@@ -360,6 +360,7 @@ bool inject_trap_cpuid(drakvuf_t drakvuf, drakvuf_trap_t* trap);
 bool inject_trap_catchall_breakpoint(drakvuf_t drakvuf, drakvuf_trap_t* trap);
 
 event_response_t post_mem_cb(vmi_instance_t vmi, vmi_event_t* event);
+event_response_t post_mem_idrx_cb(vmi_instance_t vmi, vmi_event_t* event);
 event_response_t pre_mem_cb(vmi_instance_t vmi, vmi_event_t* event);
 event_response_t int3_cb(vmi_instance_t vmi, vmi_event_t* event);
 event_response_t cr3_cb(vmi_instance_t vmi, vmi_event_t* event);

--- a/src/libdrakvuf/vmi.h
+++ b/src/libdrakvuf/vmi.h
@@ -134,7 +134,7 @@ bool inject_trap(drakvuf_t drakvuf,
     vmi_pid_t pid);
 bool inject_trap_mem(drakvuf_t drakvuf,
     drakvuf_trap_t* trap,
-    bool guard2, uint16_t view);
+    bool guard2);
 bool inject_trap_pa(drakvuf_t drakvuf,
     drakvuf_trap_t* trap,
     addr_t pa);


### PR DESCRIPTION
For idrx guard3 and guard4 we shouldn't be using inject_trap_mem because there the assumption is that it can share space with traps requested by plugins. But the idrx view is only for internal use, so we reduce the complexity of the code by special casing handling of the idrx W trap.

Fixes #1195 