### PR TITLE
codemon: fix bug with memory dumps

### DIFF
--- a/src/plugins/codemon/codemon.cpp
+++ b/src/plugins/codemon/codemon.cpp
@@ -568,9 +568,6 @@ bool setup_dump_context(mmvad_info_t mmvad,
     ctx_memory_dump->translate_mechanism = VMI_TM_PROCESS_DTB;
     //The CR3 reg stores the address to the directory table base
     ctx_memory_dump->dtb = cr3;
-    //Required to be set to "null"
-    ctx_memory_dump->ksym = nullptr;
-    ctx_memory_dump->pid = 0;
 
     //Option to dump the whole VAD node instead of just a single page
     if (dump_vad)


### PR DESCRIPTION
At the moment codemon doesn't make any dumps because `setup_dump_context` is accessing the access_context_t union in a wrong way.

https://github.com/libvmi/libvmi/blob/582fc95d8c412148114e158c6f090e85f04f335d/libvmi/libvmi.h#L730-L735