### PR TITLE
libuserhook, syscalls: fix possible segmentation fault

### DIFF
--- a/src/libusermode/uh-private.hpp
+++ b/src/libusermode/uh-private.hpp
@@ -206,6 +206,8 @@ struct copy_on_write_result_t : public call_result_t
 class userhook : public pluginex
 {
 public:
+    drakvuf_t m_drakvuf = nullptr;
+
     userhook(userhook const&) = delete;
 
     std::array<size_t, __OFFSET_MAX> offsets;

--- a/src/libusermode/userhook.cpp
+++ b/src/libusermode/userhook.cpp
@@ -805,7 +805,7 @@ bool userhook::is_supported(drakvuf_t drakvuf)
     return true;
 }
 
-userhook::userhook(drakvuf_t drakvuf): pluginex(drakvuf, OUTPUT_DEFAULT)
+userhook::userhook(drakvuf_t drakvuf): pluginex(drakvuf, OUTPUT_DEFAULT), m_drakvuf(drakvuf)
 {
     if (!is_supported(drakvuf))
         throw -1;
@@ -831,7 +831,7 @@ userhook::~userhook()
             {
                 if (target.state == HOOK_OK)
                 {
-                    wrap_delete(target.trap);
+                    drakvuf_remove_trap(m_drakvuf, target.trap, wrap_delete);
                 }
             }
         }

--- a/src/plugins/syscalls/linux.cpp
+++ b/src/plugins/syscalls/linux.cpp
@@ -216,7 +216,7 @@ static event_response_t linux_ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* inf
     print_syscall(s, drakvuf, VMI_OS_LINUX, false, info, w->num, std::string(info->trap->breakpoint.module), sc, args, info->regs->rax, nullptr);
 
     drakvuf_remove_trap(drakvuf, info->trap, (drakvuf_trap_free_t)free_trap);
-    s->traps = g_slist_remove(s->traps, info->trap);
+    s->ret_traps = g_slist_remove(s->ret_traps, info->trap);
 
     return 0;
 }
@@ -260,7 +260,7 @@ static event_response_t linux_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 
     print_syscall(s, drakvuf, VMI_OS_LINUX, true, info, nr, std::string(info->trap->breakpoint.module), sc, args, 0, NULL);
 
-    if ( s->disable_sysret )
+    if ( s->disable_sysret || s->is_stopping() )
         return 0;
 
     addr_t ret_addr = drakvuf_get_function_return_address(drakvuf, info);
@@ -283,7 +283,7 @@ static event_response_t linux_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
     ret_trap->ttl = UNLIMITED_TTL;
 
     if ( drakvuf_add_trap(drakvuf, ret_trap) )
-        s->traps = g_slist_prepend(s->traps, ret_trap);
+        s->ret_traps = g_slist_prepend(s->ret_traps, ret_trap);
     else
     {
         g_slice_free(drakvuf_trap_t, ret_trap);

--- a/src/plugins/syscalls/linux.cpp
+++ b/src/plugins/syscalls/linux.cpp
@@ -216,7 +216,7 @@ static event_response_t linux_ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* inf
     print_syscall(s, drakvuf, VMI_OS_LINUX, false, info, w->num, std::string(info->trap->breakpoint.module), sc, args, info->regs->rax, nullptr);
 
     drakvuf_remove_trap(drakvuf, info->trap, (drakvuf_trap_free_t)free_trap);
-    s->ret_traps = g_slist_remove(s->ret_traps, info->trap);
+    s->traps = g_slist_remove(s->traps, info->trap);
 
     return 0;
 }
@@ -260,7 +260,7 @@ static event_response_t linux_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 
     print_syscall(s, drakvuf, VMI_OS_LINUX, true, info, nr, std::string(info->trap->breakpoint.module), sc, args, 0, NULL);
 
-    if ( s->disable_sysret || s->is_stopping() )
+    if ( s->disable_sysret )
         return 0;
 
     addr_t ret_addr = drakvuf_get_function_return_address(drakvuf, info);
@@ -283,7 +283,7 @@ static event_response_t linux_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
     ret_trap->ttl = UNLIMITED_TTL;
 
     if ( drakvuf_add_trap(drakvuf, ret_trap) )
-        s->ret_traps = g_slist_prepend(s->ret_traps, ret_trap);
+        s->traps = g_slist_prepend(s->traps, ret_trap);
     else
     {
         g_slice_free(drakvuf_trap_t, ret_trap);

--- a/src/plugins/syscalls/linux.cpp
+++ b/src/plugins/syscalls/linux.cpp
@@ -203,20 +203,20 @@ static std::vector<uint64_t> linux_build_argbuf(vmi_instance_t vmi,
 
 static event_response_t linux_ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 {
-    //Loads a pointer to the plugin, which is responsible for the trap
-    auto s = get_trap_plugin<syscalls>(info);
+    struct wrapper* w = (struct wrapper*)info->trap->data;
 
-    //get_trap_params reinterprets the pointer of info->trap->data as a pointer to duplicate_result_t
-    auto w = get_trap_params<wrapper_t>(info);
-
-    //Verifies that the params we got above (preset by the previous trap) match the trap_information this cb got called with.
-    if (!w->verify_result_call_params(drakvuf, info))
+    if (!drakvuf_check_return_context(drakvuf, info, w->pid, w->tid, 0))
         return VMI_EVENT_RESPONSE_NONE;
+
+    syscalls* s = w->s;
 
     const syscall_t* sc = w->num < NUM_SYSCALLS_LINUX ? linuxsc::linux_syscalls[w->num] : NULL;
 
     std::vector<uint64_t> args;
     print_syscall(s, drakvuf, VMI_OS_LINUX, false, info, w->num, std::string(info->trap->breakpoint.module), sc, args, info->regs->rax, nullptr);
+
+    drakvuf_remove_trap(drakvuf, info->trap, (drakvuf_trap_free_t)free_trap);
+    s->traps = g_slist_remove(s->traps, info->trap);
 
     return 0;
 }
@@ -224,8 +224,8 @@ static event_response_t linux_ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* inf
 static event_response_t linux_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 {
     auto vmi = vmi_lock_guard(drakvuf);
-    //Loads a pointer to the plugin, which is responsible for the trap
-    auto s = get_trap_plugin<syscalls>(info);
+    struct wrapper* w = (struct wrapper*)info->trap->data;
+    syscalls* s = w->s;
 
     const syscall_t* sc = NULL;
     addr_t pt_regs = 0;
@@ -263,30 +263,32 @@ static event_response_t linux_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
     if ( s->disable_sysret )
         return 0;
 
-    auto trap = s->register_trap<wrapper_t>(
-            info,
-            linux_ret_cb,
-            breakpoint_by_dtb_searcher());
-    if (!trap)
-    {
-        PRINT_DEBUG("Failed to trap syscall return\n");
-        return 0;
-    }
-    trap->breakpoint.module = "linux";
+    addr_t ret_addr = drakvuf_get_function_return_address(drakvuf, info);
 
-    //After the trap got constructed, enrich its details already with some information we already (and just) know here (at this point).
-
-    //wrapper extends from call_result_t which extends from plugin_params
-    //get_trap_params reinterprets the pointer of trap->data as a pointer to wrapper
-    //Load the information that is saved by hitting the first trap.
-    //With params we can preset the params that the newly risen second breakpoint will receive.
-    auto wr = get_trap_params<wrapper_t>(trap);
-
-    //Save the address of the target thread, address of the rsp (this was the rip-address, which we used for construction) and the value of the CR3 register to the params.
-    wr->set_result_call_params(info);
-
-    //enrich the params of the new/next trap. This information is used later.
+    struct wrapper* wr = g_slice_new0(struct wrapper);
+    wr->s = s;
     wr->num = nr;
+    wr->pid = info->proc_data.pid;
+    wr->tid = info->proc_data.tid;
+
+    drakvuf_trap_t* ret_trap = g_slice_new0(drakvuf_trap_t);
+    ret_trap->breakpoint.lookup_type = LOOKUP_DTB;
+    ret_trap->breakpoint.dtb = info->regs->cr3;
+    ret_trap->breakpoint.addr_type = ADDR_VA;
+    ret_trap->breakpoint.addr = ret_addr;
+    ret_trap->breakpoint.module = "linux";
+    ret_trap->type = BREAKPOINT;
+    ret_trap->cb = linux_ret_cb;
+    ret_trap->data = wr;
+    ret_trap->ttl = UNLIMITED_TTL;
+
+    if ( drakvuf_add_trap(drakvuf, ret_trap) )
+        s->traps = g_slist_prepend(s->traps, ret_trap);
+    else
+    {
+        g_slice_free(drakvuf_trap_t, ret_trap);
+        g_slice_free(struct wrapper, w);
+    }
 
     return 0;
 }
@@ -311,15 +313,27 @@ void setup_linux(drakvuf_t drakvuf, syscalls* s)
 
     addr_t kaslr = s->kernel_base - _text;
 
-    breakpoint_in_system_process_searcher bp;
-    auto trap = s->register_trap(
-            nullptr,
-            linux_cb,
-            bp.for_linux(0, syscall64 + kaslr));
-    if (!trap)
+    drakvuf_trap_t* trap = g_slice_new0(drakvuf_trap_t);
+    struct wrapper* w = g_slice_new0(struct wrapper);
+
+    w->s = s;
+
+    trap->breakpoint.lookup_type = LOOKUP_PID;
+    trap->breakpoint.pid = 0;
+    trap->breakpoint.addr_type = ADDR_VA;
+    trap->breakpoint.addr = syscall64 + kaslr;
+    trap->breakpoint.module = "linux";
+    trap->type = BREAKPOINT;
+    trap->cb = linux_cb;
+    trap->data = w;
+    trap->ttl = drakvuf_get_limited_traps_ttl(drakvuf);
+    trap->ah_cb = nullptr;
+
+    if ( drakvuf_add_trap(drakvuf, trap) )
+        s->traps = g_slist_prepend(s->traps, trap);
+    else
     {
-        PRINT_DEBUG("Failed to trap syscall");
+        free_trap(trap);
         throw -1;
     }
-    trap->breakpoint.module = "linux";
 }

--- a/src/plugins/syscalls/private.h
+++ b/src/plugins/syscalls/private.h
@@ -455,17 +455,14 @@ typedef struct
     const arg_t* args;
 } syscall_t;
 
-struct wrapper;
-struct wrapper
+struct wrapper_t : public call_result_t
 {
-    syscalls* s;
+    wrapper_t() : call_result_t()
+    {}
+
     const syscall_t* sc;
     const char* type;
-    struct wrapper* w;
     uint16_t num;
-    vmi_pid_t pid;
-    addr_t tid;
-    addr_t stack_fingerprint;
 };
 
 #define SYSCALL(_name, _ret, _num_args, ...)                     \
@@ -482,6 +479,5 @@ void print_syscall(syscalls* s, drakvuf_t drakvuf, os_t os,
     int nr, std::string module, const syscall_t* sc,
     const std::vector<uint64_t>& args,
     uint64_t ret, const char* extra_info);
-void free_trap(gpointer p);
 
 #endif // commoncsproto_h

--- a/src/plugins/syscalls/private.h
+++ b/src/plugins/syscalls/private.h
@@ -480,4 +480,19 @@ void print_syscall(syscalls* s, drakvuf_t drakvuf, os_t os,
     const std::vector<uint64_t>& args,
     uint64_t ret, const char* extra_info);
 
+// NOTE Non "pluginex" support for linux
+struct wrapper;
+struct wrapper
+{
+    syscalls* s;
+    const syscall_t* sc;
+    const char* type;
+    struct wrapper* w;
+    uint16_t num;
+    vmi_pid_t pid;
+    addr_t tid;
+    addr_t stack_fingerprint;
+};
+void free_trap(gpointer p);
+
 #endif // commoncsproto_h

--- a/src/plugins/syscalls/syscalls.cpp
+++ b/src/plugins/syscalls/syscalls.cpp
@@ -253,7 +253,8 @@ void free_trap(gpointer p)
 }
 
 syscalls::syscalls(drakvuf_t drakvuf, const syscalls_config* c, output_format_t output)
-    : traps(NULL)
+    : m_drakvuf(drakvuf)
+    , traps(NULL)
     , filter(NULL)
     , win32k_json(NULL)
     , format{output}
@@ -287,7 +288,7 @@ syscalls::~syscalls()
     GSList* loop = this->traps;
     while (loop)
     {
-        free_trap(loop->data);
+        drakvuf_remove_trap(m_drakvuf, (drakvuf_trap_t*)loop->data, (drakvuf_trap_free_t)free_trap);
         loop = loop->next;
     }
 

--- a/src/plugins/syscalls/syscalls.cpp
+++ b/src/plugins/syscalls/syscalls.cpp
@@ -286,10 +286,20 @@ syscalls::syscalls(drakvuf_t drakvuf, const syscalls_config* c, output_format_t 
 
 syscalls::~syscalls()
 {
-    // NOTE Hack for Linux (part 2)
-    if ( this->os != VMI_OS_WINDOWS )
+    if (this->traps || this->ret_traps ||
+        this->os != VMI_OS_WINDOWS) // NOTE Hack for Linux (part 2)
     {
+        // This means that there was no time to wait for plug-in stop
+        // so remove all data here.
+        // Or this is a Linux system.
         GSList* loop = this->traps;
+        while (loop)
+        {
+            free_trap(loop->data);
+            loop = loop->next;
+        }
+
+        loop = this->ret_traps;
         while (loop)
         {
             free_trap(loop->data);

--- a/src/plugins/syscalls/syscalls.cpp
+++ b/src/plugins/syscalls/syscalls.cpp
@@ -286,6 +286,17 @@ syscalls::syscalls(drakvuf_t drakvuf, const syscalls_config* c, output_format_t 
 
 syscalls::~syscalls()
 {
+    // NOTE Hack for Linux (part 2)
+    if ( this->os != VMI_OS_WINDOWS )
+    {
+        GSList* loop = this->traps;
+        while (loop)
+        {
+            free_trap(loop->data);
+            loop = loop->next;
+        }
+    }
+
     if ( this->filter )
         g_hash_table_destroy(this->filter);
 
@@ -296,6 +307,10 @@ syscalls::~syscalls()
 bool syscalls::stop()
 {
     m_is_stopping = true;
+
+    // NOTE Hack for Linux (part 1)
+    if ( this->os != VMI_OS_WINDOWS )
+        return true;
 
     if (this->ret_traps)
         return false;

--- a/src/plugins/syscalls/syscalls.h
+++ b/src/plugins/syscalls/syscalls.h
@@ -122,6 +122,7 @@ class syscalls: public plugin
 public:
     drakvuf_t m_drakvuf;
     GSList* traps;
+    GSList* ret_traps;
     GHashTable* filter;
     json_object* win32k_json;
 
@@ -142,6 +143,7 @@ public:
 
     syscalls(drakvuf_t drakvuf, const syscalls_config* config, output_format_t output);
     ~syscalls();
+    bool stop();
 };
 
 #endif

--- a/src/plugins/syscalls/syscalls.h
+++ b/src/plugins/syscalls/syscalls.h
@@ -120,6 +120,7 @@ struct syscalls_config
 class syscalls: public pluginex
 {
 public:
+    GSList* traps; // NOTE Non "pluginex" support for linux
     GHashTable* filter;
     json_object* win32k_json;
 

--- a/src/plugins/syscalls/syscalls.h
+++ b/src/plugins/syscalls/syscalls.h
@@ -120,6 +120,7 @@ struct syscalls_config
 class syscalls: public plugin
 {
 public:
+    drakvuf_t m_drakvuf;
     GSList* traps;
     GHashTable* filter;
     json_object* win32k_json;

--- a/src/plugins/syscalls/syscalls.h
+++ b/src/plugins/syscalls/syscalls.h
@@ -106,7 +106,7 @@
 #define SYSCALLS_H
 
 #include <glib.h>
-#include "plugins/plugins.h"
+#include "plugins/plugins_ex.h"
 #include "plugins/private.h"
 #include "plugins/output_format.h"
 
@@ -117,12 +117,9 @@ struct syscalls_config
     bool disable_sysret;
 };
 
-class syscalls: public plugin
+class syscalls: public pluginex
 {
 public:
-    drakvuf_t m_drakvuf;
-    GSList* traps;
-    GSList* ret_traps;
     GHashTable* filter;
     json_object* win32k_json;
 
@@ -143,7 +140,6 @@ public:
 
     syscalls(drakvuf_t drakvuf, const syscalls_config* config, output_format_t output);
     ~syscalls();
-    bool stop();
 };
 
 #endif

--- a/src/plugins/syscalls/win.cpp
+++ b/src/plugins/syscalls/win.cpp
@@ -118,18 +118,15 @@
 
 static event_response_t ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 {
-    struct wrapper* wr = (struct wrapper*)info->trap->data;
+    //Loads a pointer to the plugin, which is responsible for the trap
+    auto s = get_trap_plugin<syscalls>(info);
 
-    /*
-     * Multiple syscalls might hit the same return address so make sure we are
-     * handling the correct thread's return here.
-     */
-    if (!drakvuf_check_return_context(drakvuf, info, wr->pid, wr->tid, wr->stack_fingerprint - 1))
+    //get_trap_params reinterprets the pointer of info->trap->data as a pointer to duplicate_result_t
+    auto wr = get_trap_params<wrapper_t>(info);
+
+    //Verifies that the params we got above (preset by the previous trap) match the trap_information this cb got called with.
+    if (!wr->verify_result_call_params(drakvuf, info))
         return VMI_EVENT_RESPONSE_NONE;
-
-    struct wrapper* w = (struct wrapper*)wr->w;
-    const syscall_t* sc = w->sc;
-    syscalls* s = w->s;
 
     char exit_status_buf[NTSTATUS_MAX_FORMAT_STR_SIZE] = {0};
     const char* exit_status_str = ntstatus_to_string(ntstatus_t(info->regs->rax));
@@ -137,10 +134,12 @@ static event_response_t ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
         exit_status_str = ntstatus_format_string(ntstatus_t(info->regs->rax), exit_status_buf, sizeof(exit_status_buf));
 
     std::vector<uint64_t> args;
-    print_syscall(s, drakvuf, VMI_OS_WINDOWS, false, info, w->num, std::string(info->trap->breakpoint.module), sc, args, info->regs->rax, exit_status_str);
+    print_syscall(s, drakvuf, VMI_OS_WINDOWS, false, info, wr->num, std::string(info->trap->breakpoint.module), wr->sc, args, info->regs->rax, exit_status_str);
 
-    drakvuf_remove_trap(drakvuf, info->trap, (drakvuf_trap_free_t)free_trap);
-    s->ret_traps = g_slist_remove(s->ret_traps, info->trap);
+    //Destroys this return trap, because it is specific for the RIP and not usable anymore. This was the trap being called when the physical address got computed.
+    //Deletes this trap from the list of existing traps traps
+    //Additionally removes the trap and frees the memory
+    s->destroy_trap(info->trap);
 
     return 0;
 }
@@ -148,9 +147,13 @@ static event_response_t ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 static event_response_t syscall_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 {
     auto vmi = vmi_lock_guard(drakvuf);
-    struct wrapper* w = (struct wrapper*)info->trap->data;
+
+    //Loads a pointer to the plugin, which is responsible for the trap
+    auto s = get_trap_plugin<syscalls>(info);
+
+    //get_trap_params reinterprets the pointer of info->trap->data as a pointer to duplicate_result_t
+    auto w = get_trap_params<wrapper_t>(info);
     const syscall_t* sc = w->sc;
-    syscalls* s = w->s;
 
     unsigned int nargs = sc ? sc->num_args : 0;
     std::vector<uint64_t> args(nargs);
@@ -211,44 +214,32 @@ static event_response_t syscall_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
     if ( !ret_addr )
         return 0;
 
-    drakvuf_trap_t* ret_trap = g_slice_new0(drakvuf_trap_t);
-    struct wrapper* wr = g_slice_new0(struct wrapper);
-
-    wr->pid = info->attached_proc_data.pid;
-    wr->tid = info->attached_proc_data.tid;
-    wr->w = w;
-    if ( 4 == s->reg_size )
+    auto trap = s->register_trap<wrapper_t>(
+            info,
+            ret_cb,
+            breakpoint_by_dtb_searcher());
+    if (!trap)
     {
-        // For 32-bit Windows, the calling convention of the syscall api is _stdcall, which means the callee to clear the stack space.
-        // So when the function returns, the value of the stack pointer should be the current rsp add the size of the parameters and
-        // the size of the return address (4 bytes)
-        wr->stack_fingerprint = info->regs->rsp + 4 * nargs + 4;
+        PRINT_DEBUG("Failed to trap syscall return %hu\n", w->num);
+        return 0;
     }
-    else
-    {
-        // For 64-bit windows calling convention, the stack pointer remains unchanged before and after the function call.
-        // So when the function returns, the value of the stack pointer should be the current rsp add the size of the return address (8 bytes)
-        // See : https://docs.microsoft.com/en-us/cpp/build/x64-software-conventions?view=vs-2019
-        wr->stack_fingerprint = info->regs->rsp + 8;
-    }
+    trap->breakpoint.module = w->type;
 
-    ret_trap->breakpoint.lookup_type = LOOKUP_DTB;
-    ret_trap->breakpoint.addr_type = ADDR_VA;
-    ret_trap->breakpoint.addr = ret_addr;
-    ret_trap->breakpoint.dtb = info->regs->cr3;
-    ret_trap->breakpoint.module = w->type;
-    ret_trap->type = BREAKPOINT;
-    ret_trap->cb = ret_cb;
-    ret_trap->data = (void*)wr;
-    ret_trap->ttl = UNLIMITED_TTL;
+    //After the trap got constructed, enrich its details already with some information we already (and just) know here (at this point).
 
-    if ( drakvuf_add_trap(drakvuf, ret_trap) )
-        s->ret_traps = g_slist_prepend(s->ret_traps, ret_trap);
-    else
-    {
-        g_slice_free(drakvuf_trap_t, ret_trap);
-        g_slice_free(struct wrapper, wr);
-    }
+    //wrapper extends from call_result_t which extends from plugin_params
+    //get_trap_params reinterprets the pointer of trap->data as a pointer to wrapper
+    //Load the information that is saved by hitting the first trap.
+    //With params we can preset the params that the newly risen second breakpoint will receive.
+    auto wr = get_trap_params<wrapper_t>(trap);
+
+    //Save the address of the target thread, address of the rsp (this was the rip-address, which we used for construction) and the value of the CR3 register to the params.
+    wr->set_result_call_params(info);
+
+    //enrich the params of the new/next trap. This information is used later.
+    wr->num = w->num;
+    wr->type = w->type;
+    wr->sc = w->sc;
 
     return 0;
 }
@@ -338,32 +329,29 @@ static bool trap_syscall_table_entries(drakvuf_t drakvuf, vmi_instance_t vmi, sy
             continue;
         }
 
-        struct wrapper* w = g_slice_new0(struct wrapper);
-        drakvuf_trap_t* trap = g_slice_new0(drakvuf_trap_t);
+        breakpoint_by_dtb_searcher bp;
+        auto trap = s->register_trap<wrapper_t>(
+                nullptr,
+                syscall_cb,
+                bp.for_virt_addr(syscall_va).for_dtb(cr3));
+        if (!trap)
+        {
+            PRINT_DEBUG("Failed to trap syscall %lu @ 0x%lx\n", syscall_num, syscall_va);
+            continue;
+        }
 
+        //After the trap got constructed, enrich its details already with some information we already (and just) know here (at this point).
+
+        //wrapper extends from call_result_t which extends from plugin_params
+        //get_trap_params reinterprets the pointer of trap->data as a pointer to wrapper
+        //Load the information that is saved by hitting the first trap.
+        //With params we can preset the params that the newly risen second breakpoint will receive.
+        auto w = get_trap_params<wrapper_t>(trap);
+
+        //enrich the params of the new/next trap. This information is used later.
         w->num = syscall_num;
-        w->s = s;
         w->type = ntos ? "nt" : "win32k";
         w->sc = definition;
-
-        trap->breakpoint.lookup_type = LOOKUP_DTB;
-        trap->breakpoint.dtb = cr3;
-        trap->breakpoint.addr_type = ADDR_VA;
-        trap->breakpoint.addr = syscall_va;
-        trap->type = BREAKPOINT;
-        trap->cb = syscall_cb;
-        trap->data = w;
-        trap->ttl = drakvuf_get_limited_traps_ttl(drakvuf);
-        trap->ah_cb = nullptr;
-
-        if ( drakvuf_add_trap(drakvuf, trap) )
-            s->traps = g_slist_prepend(s->traps, trap);
-        else
-        {
-            PRINT_DEBUG("Failed to trap syscall %lu @ 0x%lx\n", syscall_num, trap->breakpoint.addr);
-            g_slice_free(struct wrapper, trap->data);
-            g_slice_free(drakvuf_trap_t, trap);
-        }
     }
 
     error = 0;

--- a/src/plugins/syscalls/win.cpp
+++ b/src/plugins/syscalls/win.cpp
@@ -140,7 +140,7 @@ static event_response_t ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
     print_syscall(s, drakvuf, VMI_OS_WINDOWS, false, info, w->num, std::string(info->trap->breakpoint.module), sc, args, info->regs->rax, exit_status_str);
 
     drakvuf_remove_trap(drakvuf, info->trap, (drakvuf_trap_free_t)free_trap);
-    s->traps = g_slist_remove(s->traps, info->trap);
+    s->ret_traps = g_slist_remove(s->ret_traps, info->trap);
 
     return 0;
 }
@@ -204,7 +204,7 @@ static event_response_t syscall_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
     print_syscall(s, drakvuf, VMI_OS_WINDOWS, true, info, w->num, std::string(w->type), sc, args, 0, NULL);
     vmi.lock();
 
-    if ( s->disable_sysret )
+    if ( s->disable_sysret || s->is_stopping() )
         return 0;
 
     addr_t ret_addr = drakvuf_get_function_return_address(drakvuf, info);
@@ -243,7 +243,7 @@ static event_response_t syscall_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
     ret_trap->ttl = UNLIMITED_TTL;
 
     if ( drakvuf_add_trap(drakvuf, ret_trap) )
-        s->traps = g_slist_prepend(s->traps, ret_trap);
+        s->ret_traps = g_slist_prepend(s->ret_traps, ret_trap);
     else
     {
         g_slice_free(drakvuf_trap_t, ret_trap);


### PR DESCRIPTION
I have noticed occasional segmentation faults while traversing `int3` hooks due to jump into null page. The relative code is:
```c

        GSList* loop = lists[i];
        while (loop)
        {
            trap_info.trap = (drakvuf_trap_t*)loop->data;
            rsp |= trap_info.trap->cb(drakvuf, &trap_info);
            loop = loop->next;
        }
```

In GDB I get context:
```gdb
(gdb) i r
rax            0xb06aef0        184987376
rbx            0x0      0
rcx            0x7ffeb589a870   140731944118384
rdx            0xb05f560        184939872
rsi            0x7ffeb589a918   140731944118552
rdi            0x1040e20        17042976
rbp            0x7ffeb589a9f0   0x7ffeb589a9f0
rsp            0x7ffeb589a8c0   0x7ffeb589a8c0
r8             0x6      6
r9             0x0      0
r10            0xb066fc0        184971200
r11            0x0      0
r12            0x1040e20        17042976
r13            0x1      1
r14            0xb050150        184877392
r15            0x7ffeb589a918   140731944118552
rip            0x4292c0 0x4292c0 <int3_cb+384>
eflags         0x10206  [ PF IF RF ]
cs             0xe033   57395
ss             0xe02b   57387
ds             0x0      0
es             0x0      0
fs             0x0      0
gs             0x0      0
(gdb) p /x *(drakvuf_trap_info_t*)0x7ffeb589a918
$3 = {timestamp = 0x5c0137c4da0d0, vcpu = 0x1, altp2m_idx = 0x0, proc_data = {name = 0xb0629e0, pid = 0x770, ppid = 0x514, base_addr = 0xfffffa80039b3b30, userid = 0x1, tid = 0xa58}, attached_proc_data = {
    name = 0xb0674e0, pid = 0x770, ppid = 0x514, base_addr = 0xfffffa80039b3b30, userid = 0x1, tid = 0xa58}, trap_pa = 0x5f2291d9, regs = 0x7ffeb589aa98, trap = 0xb06aef0, event_uid = 0x6196, {cpuid = 0x0, 
    debug = 0x0}}
(gdb) printf "%s\n", 0xb0629e0
\Device\HarddiskVolume2\Program Files\Microsoft Office\Office14\POWERPNT.EXE
(gdb) printf "%s\n", 0xb0674e0
\Device\HarddiskVolume2\Program Files\Microsoft Office\Office14\POWERPNT.EXE
(gdb) p /x *(drakvuf_trap_t*)0xb06aef0
$4 = {type = 0xb066070, id = 0x1015010, cb = 0x18, data = 0x206d6172676f7250, {name = 0xb069f20, _name = 0xb069f20}, {breakpoint = {lookup_type = 0x12, {pid = 0x12, proc = 0x12, dtb = 0x12}, 
      module = 0x78652e6570796b53, addr_type = 0x790065, {rva = 0x31, addr = 0x31, symbol = 0x31}}, memaccess = {gfn = 0x12, access = 0x12, type = 0x0}, reg = 0x12}, ttl = 0xb060c00, last_ttl_rst = 0x0, 
  ah_cb = 0x0}
```

One could notice that `drakvuf_trap_t` is trashed. I believe that this is a sort of use-after-free error. Though I failed to catch the error after building with sanitizers.

After digging into the code I have found two suspicious places. I have noticed with additional debug messages and checks that at least `libusermode` and `syscalls` plug-ins remove traps still in a list.

I propose to use common `drakvuf_remove_trap` instead of manually free the memory.