### PR TITLE
Add the ability to access qemu monitor from drakvuf's core

### DIFF
--- a/src/libdrakvuf/drakvuf.c
+++ b/src/libdrakvuf/drakvuf.c
@@ -561,6 +561,11 @@ void drakvuf_force_resume (drakvuf_t drakvuf)
     xen_force_resume(drakvuf->xen, drakvuf->domID);
 }
 
+int drakvuf_send_qemu_monitor_command(drakvuf_t drakvuf, const char* in, char** out)
+{
+    return xen_send_qemu_monitor_command(drakvuf->xen, drakvuf->domID, in, out);
+}
+
 bool json_get_struct_members_array_rva(
     drakvuf_t drakvuf,
     json_object* json,

--- a/src/libdrakvuf/libdrakvuf.h
+++ b/src/libdrakvuf/libdrakvuf.h
@@ -386,6 +386,7 @@ bool drakvuf_init (drakvuf_t* drakvuf,
     uint64_t limited_traps_ttl) NOEXCEPT;
 bool drakvuf_init_os (drakvuf_t drakvuf) NOEXCEPT;
 void drakvuf_close (drakvuf_t drakvuf, const bool pause) NOEXCEPT;
+int drakvuf_send_qemu_monitor_command(drakvuf_t drakvuf, const char* in, char** out);
 bool drakvuf_add_trap(drakvuf_t drakvuf,
     drakvuf_trap_t* trap) NOEXCEPT;
 void drakvuf_remove_trap (drakvuf_t drakvuf,

--- a/src/xen_helper/xen_helper.h
+++ b/src/xen_helper/xen_helper.h
@@ -113,6 +113,7 @@
 #include <libxl_utils.h>
 #include <xenctrl.h>
 #include <xenforeignmemory.h>
+#include <libxl.h>
 
 #define MSR_RTIT_CTL 0x00000570
 #define RTIT_CTL_OS        (1 <<  2)
@@ -156,6 +157,7 @@ uint64_t xen_get_maxmemkb(xen_interface_t* xen, domid_t domID);
 bool xen_pause(xen_interface_t* xen, domid_t domID);
 void xen_resume(xen_interface_t* xen, domid_t domID);
 void xen_force_resume(xen_interface_t* xen, domid_t domID);
+int xen_send_qemu_monitor_command(xen_interface_t* xen, domid_t domID, const char* command_line, char** output);
 bool xen_enable_altp2m(xen_interface_t* xen, domid_t domID);
 int xen_version(void);
 bool xen_get_vcpu_ctx(xen_interface_t* xen, domid_t domID, unsigned int vcpu, vcpu_guest_context_any_t* regs);


### PR DESCRIPTION
Dear Tamas,

I want to ask for incorporating this pull request to drakvuf. The changes were made in order to enable access to qemu's monitor interface by utilizing [human-monitor-commands][] via the function [`libxl_qemu_monitor_command(...)`][] of `<libxl.h>` , which can be accessed directly from drakvuf's core now, so that the aforementioned HMP-commands can be transferred to a specific Xen-guest by utilizing its [`xen_interface_t`][] and domID.

This addition might be useful for future plugins to interact with the guests. (It might be especially useful for performing HID simulation, which is the task I currently work on.)

If you want to test the code by yourself, you could use the following snippet:
``` C
const char* in = "info version"; 
char* out = NULL;
/* 
 * The following code effectively executes the command
 * { "execute": "human-monitor-command", "arguments": { "command-line": "info version" } }
 *  on the guest specified by the variable of type drakvuf_t.
 */
drakvuf_send_qemu_monitor_command(drakvuf, in, &out); // drakvuf has to be of type drakvuf_t
PRINT_DEBUG("[QMPTEST] Result: %s", out);
```

The following files were modified to accomplish the access of qemu's monitor:
-   `src/libdrakvuf/drakvuf.c`
-   `src/libdrakvuf/libdrakvuf.h`
-   `src/xen_helper/xen_helper.c`
-   `src/xen_helper/xen_helper.h`

Thanks already in advance for reviewing this PR.

Best regards  
Jan

  [human-monitor-commands]: https://qemu-project.gitlab.io/qemu/interop/qemu-qmp-ref.html#qapidoc-2399
  [`<libxl.h>`]: https://github.com/xen-project/xen/blob/e25aa9939ae0cd8317605be3d5c5611b76bc4ab4/tools/include/libxl.h#L2761
  [`libxl_qemu_monitor_command(...)`]: https://github.com/xen-project/xen/blob/e25aa9939ae0cd8317605be3d5c5611b76bc4ab4/tools/libs/light/libxl_qmp.c#L905
  [`xen_interface_t`]: https://github.com/tklengyel/drakvuf/blob/9605ac160f2636c352d2901a83e1bd7f86bb8779/src/xen_helper/xen_helper.h#L123