### PR TITLE
Add function to expose drakvuf_t's domID in libdrakvuf.h

### DIFF
--- a/src/libdrakvuf/drakvuf.c
+++ b/src/libdrakvuf/drakvuf.c
@@ -592,6 +592,11 @@ json_object* drakvuf_get_json_wow(drakvuf_t drakvuf)
     return drakvuf->json_wow;
 }
 
+uint16_t drakvuf_get_dom_id(drakvuf_t drakvuf)
+{
+    return drakvuf->domID;
+}
+
 addr_t drakvuf_get_kernel_base(drakvuf_t drakvuf)
 {
     return drakvuf->kernbase;

--- a/src/libdrakvuf/libdrakvuf.h
+++ b/src/libdrakvuf/libdrakvuf.h
@@ -408,6 +408,8 @@ os_t drakvuf_get_os_type(drakvuf_t drakvuf) NOEXCEPT;
 page_mode_t drakvuf_get_page_mode(drakvuf_t drakvuf) NOEXCEPT;
 int drakvuf_get_address_width(drakvuf_t drakvuf) NOEXCEPT;
 
+uint16_t drakvuf_get_dom_id(drakvuf_t drakvuf) NOEXCEPT;
+
 addr_t drakvuf_get_kernel_base(drakvuf_t drakvuf) NOEXCEPT;
 
 addr_t drakvuf_get_current_process(drakvuf_t drakvuf,


### PR DESCRIPTION
Dear Tamas, 

this patch exposes `drakvuf_t`'s member variable ` domID` by introducing a getter-function named `drakvuf_get_dom_id(...)` in `libdrakvuf.h`. The addition of this getter-function enables plugins to
retrieve the ID of the Xen guest of interest in a convenient way. 

Diverging from my initial statement to use libvmi's `vmi_get_vmid(...)` I decided to expose the domID directly in `libdrakvuf.h`, since this seems to me to be a cleaner way than calling `drakvuf_lock_and_get_vmi(..)` and releasing it  afterwards.

To accomplish exposing the domID, I decided to typedef `domid_t` inside `libdrakvuf.h`, which is originally typedef'ed inside `xen.h` but not exposed anywhere. If you think, the getter-function should return a plain uint16_t to omit this repeated typedef, please let me know.   

If there are any issues with the patch or if you disagree on this decision, please let me know. 

Thanks already in advance for considering the patch and merging it eventually. 

Best regards,  
    Jan

P.S.: Please excuse the temporary closure and reopening of this PR due to a compilation error, that I oversaw.
