### PR TITLE
libinjector: fix potential null pointer dereferences

### DIFF
--- a/src/libinjector/injector.c
+++ b/src/libinjector/injector.c
@@ -142,7 +142,8 @@ injector_status_t injector_start_app(
     }
     else if (drakvuf_get_os_type(drakvuf) == VMI_OS_LINUX)
     {
-        *injected_pid = 0;
+        if (injected_pid)
+            *injected_pid = 0;
 
         if (!tid)
             tid = pid;

--- a/src/libinjector/win_injector.c
+++ b/src/libinjector/win_injector.c
@@ -2422,7 +2422,8 @@ injector_status_t injector_start_app_on_win(
     }
 
     rc = injector->rc;
-    *injected_pid = injector->pid;
+    if (injected_pid)
+        *injected_pid = injector->pid;
     PRINT_DEBUG("Finished with injection. Ret: %i.\n", rc);
 
     switch (method)


### PR DESCRIPTION
libinjector: fix potential null pointer dereferences of injected_pid parameter