### PR TITLE
Add `hiddump` - a utility to record HID events 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ ltmain.sh
 m4/*.m4
 src/dirwatch/dirwatch
 src/dirwatch/distributor
+src/helpers/hiddump/hiddump
 test-drive
 ylwrap
 

--- a/configure.ac
+++ b/configure.ac
@@ -683,6 +683,9 @@ if test x$repl = xyes; then
   AC_DEFINE_UNQUOTED(ENABLE_REPL, 1, "")
 fi
 
+PKG_CHECK_MODULES([X11], [x11], [lx11=1], [lx11=0])
+AM_CONDITIONAL([HAVE_LIBX11], [test x$lx11 = x1])
+
 #####################################################
 
 AC_CONFIG_FILES([Makefile src/Makefile
@@ -694,6 +697,7 @@ AC_CONFIG_FILES([Makefile src/Makefile
                  src/libusermode/Makefile
                  src/librepl/Makefile
                  src/libhook/Makefile
+                 src/helpers/hiddump/Makefile
                ])
 
 AC_OUTPUT

--- a/package/depends.sh
+++ b/package/depends.sh
@@ -17,7 +17,7 @@ else
     apt-get update
 fi
 
-apt-get --quiet --yes install build-essential git wget curl cmake flex bison libjson-c-dev autoconf-archive clang python3-dev libsystemd-dev nasm bc
+apt-get --quiet --yes install build-essential git wget curl cmake flex bison libjson-c-dev autoconf-archive clang python3-dev libsystemd-dev nasm bc libx11-dev
 
 wget -O /usr/local/go1.15.3.linux-amd64.tar.gz https://golang.org/dl/go1.15.3.linux-amd64.tar.gz
 tar -C /usr/local -xzf /usr/local/go1.15.3.linux-amd64.tar.gz

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -19,6 +19,7 @@ parts:
         - build-essential
         - pkg-config
         - libglib2.0-dev
+        - libx11-dev
         - clang
         - libtool
         - automake

--- a/src/helpers/hiddump/Makefile.am
+++ b/src/helpers/hiddump/Makefile.am
@@ -102,88 +102,17 @@
 #                                                                         #
 #*************************************************************************#
 
-bin_PROGRAMS = drakvuf injector proc_stat
+if HAVE_LIBX11
+bin_PROGRAMS = hiddump
 
-SUBDIRS = xen_helper libdrakvuf libinjector plugins dirwatch libusermode libhook helpers/hiddump
+hiddump_SOURCES = hiddump.c
 
-drakvuf_SOURCES = main.cpp drakvuf.cpp drakvuf.h exitcodes.h
-injector_SOURCES = injector.c
-proc_stat_SOURCES = proc_stat.cpp
+AM_CPPFLAGS = $(CPPFLAGS) $(GLIB_CFLAGS)
+AM_CFLAGS =  $(CFLAGS) $(GLIB_CFLAGS) $(X11_CFLAGS)
+AM_LDFLAGS = $(LDFLAGS) $(GLIB_LIBS) $(X11_LIBS)
 
-AM_CPPFLAGS = $(CPPFLAGS)
-AM_CPPFLAGS += $(VMI_CFLAGS)
-AM_CPPFLAGS += $(GLIB_CFLAGS)
-AM_CPPFLAGS += $(JSONC_CFLAGS)
-AM_CPPFLAGS += $(ZLIB_CFLAGS)
-AM_CPPFLAGS += -I$(top_srcdir) -I$(srcdir)
-
-AM_LDFLAGS =  $(LDFLAGS)
-AM_LDFLAGS += $(VMI_LIBS)
-AM_LDFLAGS += $(GLIB_LIBS)
-AM_LDFLAGS += $(JSONC_LIBS)
-AM_LDFLAGS += $(ZLIB_LIBS)
-
-AM_CFLAGS = $(CFLAGS)
-AM_CXXFLAGS = $(CXXFLAGS)
-
-if HARDENING
-AM_CFLAGS += $(HARDEN_CFLAGS) -DHARDENING
-AM_CXXFLAGS += $(HARDEN_CFLAGS) -DHARDENING
-AM_LDFLAGS += $(HARDEN_LDFLAGS)
+if DEBUG
+AM_CFLAGS += -Werror -Wall -Wextra -Wno-missing-field-initializers
 endif
 
-if SANITIZE
-AM_CFLAGS += $(SANITIZE_CFLAGS)
-AM_CXXFLAGS += $(SANITIZE_CFLAGS)
-AM_LDFLAGS += $(SANITIZE_LDFLAGS)
-endif
-
-# Note that -pg is incompatible with HARDENING
-if !DEBUG
-AM_CXXFLAGS += -Wno-c99-designator -Wno-reorder-init-list
-AM_CXXFLAGS += -Wno-unknown-warning-option
-else
-AM_CFLAGS += -DDRAKVUF_DEBUG -Werror -Wall -Wextra -g -ggdb3
-AM_CXXFLAGS += -DDRAKVUF_DEBUG -Werror -Wall -Wextra -g -ggdb3
-AM_CXXFLAGS += -Wformat -Wformat-security
-AM_CXXFLAGS += -ferror-limit=0 -Wno-unknown-warning-option
-AM_CXXFLAGS += -Wno-c99-designator -Wno-reorder-init-list
-if !HARDENING
-AM_CFLAGS += -pg
-AM_CXXFLAGS += -pg
-endif
-endif
-
-drakvuf_LDADD = libdrakvuf/libdrakvuf.la
-drakvuf_LDADD += xen_helper/libxenhelper.la
-drakvuf_LDADD += plugins/libdrakvufplugins.la
-drakvuf_LDADD += libinjector/libinjector.la
-drakvuf_LDADD += libusermode/libusermode.la
-drakvuf_LDADD += libhook/libhook.la
-
-injector_LDADD = libdrakvuf/libdrakvuf.la
-injector_LDADD += libinjector/libinjector.la
-
-proc_stat_LDADD = libdrakvuf/libdrakvuf.la
-
-if XTF
-bin_PROGRAMS += xtf
-xtf_SOURCES = xtf.c
-xtf_LDADD = libdrakvuf/libdrakvuf.la
-endif
-
-if REPL
-bin_PROGRAMS += repl
-
-SUBDIRS += librepl
-
-repl_SOURCES = repl.cpp
-
-drakvuf_LDADD += librepl/librepl.la
-
-repl_LDADD = librepl/librepl.la
-repl_LDADD += libdrakvuf/libdrakvuf.la
-
-repl_CXXFLAGS = $(AM_CXXFLAGS) -fpie
-repl_LDFLAGS = $(AM_LDFLAGS) -Wl,-E
 endif

--- a/src/helpers/hiddump/hiddump.c
+++ b/src/helpers/hiddump/hiddump.c
@@ -1,0 +1,618 @@
+/*********************IMPORTANT DRAKVUF LICENSE TERMS***********************
+ *                                                                         *
+ * DRAKVUF (C) 2014-2021 Tamas K Lengyel.                                  *
+ * Tamas K Lengyel is hereinafter referred to as the author.               *
+ * This program is free software; you may redistribute and/or modify it    *
+ * under the terms of the GNU General Public License as published by the   *
+ * Free Software Foundation; Version 2 ("GPL"), BUT ONLY WITH ALL OF THE   *
+ * CLARIFICATIONS AND EXCEPTIONS DESCRIBED HEREIN.  This guarantees your   *
+ * right to use, modify, and redistribute this software under certain      *
+ * conditions.  If you wish to embed DRAKVUF technology into proprietary   *
+ * software, alternative licenses can be acquired from the author.         *
+ *                                                                         *
+ * Note that the GPL places important restrictions on "derivative works",  *
+ * yet it does not provide a detailed definition of that term.  To avoid   *
+ * misunderstandings, we interpret that term as broadly as copyright law   *
+ * allows.  For example, we consider an application to constitute a        *
+ * derivative work for the purpose of this license if it does any of the   *
+ * following with any software or content covered by this license          *
+ * ("Covered Software"):                                                   *
+ *                                                                         *
+ * o Integrates source code from Covered Software.                         *
+ *                                                                         *
+ * o Reads or includes copyrighted data files.                             *
+ *                                                                         *
+ * o Is designed specifically to execute Covered Software and parse the    *
+ * results (as opposed to typical shell or execution-menu apps, which will *
+ * execute anything you tell them to).                                     *
+ *                                                                         *
+ * o Includes Covered Software in a proprietary executable installer.  The *
+ * installers produced by InstallShield are an example of this.  Including *
+ * DRAKVUF with other software in compressed or archival form does not     *
+ * trigger this provision, provided appropriate open source decompression  *
+ * or de-archiving software is widely available for no charge.  For the    *
+ * purposes of this license, an installer is considered to include Covered *
+ * Software even if it actually retrieves a copy of Covered Software from  *
+ * another source during runtime (such as by downloading it from the       *
+ * Internet).                                                              *
+ *                                                                         *
+ * o Links (statically or dynamically) to a library which does any of the  *
+ * above.                                                                  *
+ *                                                                         *
+ * o Executes a helper program, module, or script to do any of the above.  *
+ *                                                                         *
+ * This list is not exclusive, but is meant to clarify our interpretation  *
+ * of derived works with some common examples.  Other people may interpret *
+ * the plain GPL differently, so we consider this a special exception to   *
+ * the GPL that we apply to Covered Software.  Works which meet any of     *
+ * these conditions must conform to all of the terms of this license,      *
+ * particularly including the GPL Section 3 requirements of providing      *
+ * source code and allowing free redistribution of the work as a whole.    *
+ *                                                                         *
+ * Any redistribution of Covered Software, including any derived works,    *
+ * must obey and carry forward all of the terms of this license, including *
+ * obeying all GPL rules and restrictions.  For example, source code of    *
+ * the whole work must be provided and free redistribution must be         *
+ * allowed.  All GPL references to "this License", are to be treated as    *
+ * including the terms and conditions of this license text as well.        *
+ *                                                                         *
+ * Because this license imposes special exceptions to the GPL, Covered     *
+ * Work may not be combined (even as part of a larger work) with plain GPL *
+ * software.  The terms, conditions, and exceptions of this license must   *
+ * be included as well.  This license is incompatible with some other open *
+ * source licenses as well.  In some cases we can relicense portions of    *
+ * DRAKVUF or grant special permissions to use it in other open source     *
+ * software.  Please contact tamas.k.lengyel@gmail.com with any such       *
+ * requests.  Similarly, we don't incorporate incompatible open source     *
+ * software into Covered Software without special permission from the      *
+ * copyright holders.                                                      *
+ *                                                                         *
+ * If you have any questions about the licensing restrictions on using     *
+ * DRAKVUF in other works, are happy to help.  As mentioned above,         *
+ * alternative license can be requested from the author to integrate       *
+ * DRAKVUF into proprietary applications and appliances.  Please email     *
+ * tamas.k.lengyel@gmail.com for further information.                      *
+ *                                                                         *
+ * If you have received a written license agreement or contract for        *
+ * Covered Software stating terms other than these, you may choose to use  *
+ * and redistribute Covered Software under those terms instead of these.   *
+ *                                                                         *
+ * Source is provided to this software because we believe users have a     *
+ * right to know exactly what a program is going to do before they run it. *
+ * This also allows you to audit the software for security holes.          *
+ *                                                                         *
+ * Source code also allows you to port DRAKVUF to new platforms, fix bugs, *
+ * and add new features.  You are highly encouraged to submit your changes *
+ * on https://github.com/tklengyel/drakvuf, or by other methods.           *
+ * By sending these changes, it is understood (unless you specify          *
+ * otherwise) that you are offering unlimited, non-exclusive right to      *
+ * reuse, modify, and relicense the code.  DRAKVUF will always be          *
+ * available Open Source, but this is important because the inability to   *
+ * relicense code has caused devastating problems for other Free Software  *
+ * projects (such as KDE and NASM).                                        *
+ * To specify special license conditions of your contributions, just say   *
+ * so when you send them.                                                  *
+ *                                                                         *
+ * This program is distributed in the hope that it will be useful, but     *
+ * WITHOUT ANY WARRANTY; without even the implied warranty of              *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the DRAKVUF   *
+ * license file for more details (it's in a COPYING file included with     *
+ * DRAKVUF, and also available from                                        *
+ * https://github.com/tklengyel/drakvuf/COPYING)                           *
+ *                                                                         *
+ *                                                                         *
+ * This file - named hiddump.c - was written by Jan Gruber.                *
+ * It is distributed as part of DRAKVUF under the same license and serve   *
+ * as a utility to record HID events for later playback inside a guest VM. *
+ *                                                                         *
+ * To compile it, use the following command                                *
+ *       gcc -o hiddump hiddump.c -lX11                                    *
+ *                                                                         *
+ * To run it, use the following command                                    *
+ *       ./hiddump [-h] [-e /dev/input/eventX] [file]                      *
+ ***************************************************************************/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include<sys/stat.h>
+#include <string.h>
+#include <signal.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <poll.h>
+
+/* Input event codes */
+#include <linux/input.h>
+
+/* Needed for retrieval display dimensions */
+#include <X11/Xlib.h>
+
+#define FIND_EVENT_FILE_CMD "cat /proc/bus/input/devices | grep mouse\0" //head -n1 | cut -d' ' -f3
+#define DEVICE_PATH_STUB "/dev/input/\0"
+#define MAX_EVENT_FILES 5
+#define POLL_TIMEOUT 1
+
+/* Defines the dword magic number for the resulting binary output file
+ *
+ * Construction of file's magic number:
+ * Take string 'DRAK' (0x44 0x52 0x41 0x4b) and add 0x80 to each char
+ *   0x4452414b + 0x80808080
+ * = 0xc4d2c1cb <- probably unique, with high bit set on each byte
+ */
+#define DRAK_MAGIC_NUMBER 0xc4d2c1cb
+
+/* Stop condition */
+static volatile sig_atomic_t is_stopping = 0;
+
+/* Signal handler callback */
+static void handle_signal(int signum)
+{
+    is_stopping = 1;
+    fprintf(stderr, "Received signal %d - stopping\n", signum);
+}
+
+/* Sets callbacks for incoming signals to ensure clean shutdown */
+static int install_signal_handler(const int signum)
+{
+    struct sigaction act;
+
+    memset(&act, 0, sizeof act);
+    sigemptyset(&act.sa_mask);
+    act.sa_handler = handle_signal;
+    act.sa_flags = 0;
+    if (sigaction(signum, &act, NULL) == -1)
+        return errno;
+
+    return 0;
+}
+
+/* Finds event file to retrieve mouse events */
+int find_event_file(char** file)
+{
+    FILE* fp;
+    char result[0x100];
+
+    /* Opens the command for reading. */
+    fp = popen(FIND_EVENT_FILE_CMD, "r");
+
+    if (fp == NULL)
+    {
+        fprintf(stderr, "Failed to run command to find event file\n");
+        return 1;
+    }
+    char* pos = NULL;
+
+    /* Reads the output a line at a time - output it. */
+    while (fgets(result, sizeof(result), fp) != NULL)
+    {
+        pos = strstr(result, "event");
+        if (!pos)
+            continue;
+    }
+
+    /* Terminates process */
+    pclose(fp);
+
+    if (pos)
+    {
+        /* Removes ' \n' from end of line */
+        pos[strlen(pos) - 2] = '\0';
+
+        size_t len = strlen(DEVICE_PATH_STUB) + strlen(pos) + 1;
+        *file = (char*) malloc(sizeof(char) * len);
+        memset(*file, 0, len);
+
+        /* Constructs device path */
+        strcpy(*file, "/dev/input/");
+        snprintf(*file + strlen(*file), len, "%s", pos);
+        return 0;
+    }
+    return 1;
+}
+
+/* Retrieves display dimensions */
+int get_dimensions(unsigned int* w, unsigned int* h)
+{
+    Display* display;
+
+    /* Gets connection to X11 display server */
+    if ((display = XOpenDisplay(NULL)) == NULL )
+    {
+        return 1;
+    }
+    unsigned int ujunk;
+    int junk;
+    Window wjunk;
+
+    /* Get the root window size */
+    int ret = XGetGeometry(display, XDefaultRootWindow(display),
+            &wjunk, &junk, &junk, w, h, &ujunk, &ujunk);
+
+    XCloseDisplay(display);
+
+    return ret?0:1;
+}
+
+int center_cursor(unsigned int width, unsigned int height)
+{
+    Display* display;
+    Window root_window;
+
+    /* Gets connection to X11 display server */
+    if ((display = XOpenDisplay(NULL)) == NULL)
+    {
+        if (display)
+            free(display);
+        return 1;
+    }
+    root_window = XRootWindow(display, 0);
+
+    /* Moves cursor */
+    if (XWarpPointer(display, None, root_window, 0, 0, 0, 0, width / 2, height / 2) == 0)
+        return 1;
+
+    /* Flushes the output buffer to update the cursor's position */
+    XFlush(display);
+
+    XCloseDisplay(display);
+    return 0;
+}
+
+
+void write_file_header(FILE* f)
+{
+    /* Writes 3 dwords as file header
+     *
+     * 0xcb 0xc1 0xd2 0xc4 == Magic number
+     * 0x44 0x52 0x41 0x4b == 'DRAK'
+     * 0x00 0x01 0x00 0x00 ==  version 0.1
+     */
+    int magic = DRAK_MAGIC_NUMBER;
+    fwrite(&magic, sizeof(magic), 1, f);
+
+    u_int32_t drak= 0x4b415244;
+    fwrite(&drak, sizeof(drak), 1, f); // don't write null byte
+
+    u_int32_t i = 0x00000001;
+    fwrite(&i, sizeof(i), 1, f);
+}
+
+void store_event(struct timeval* rel_t, unsigned short* type, unsigned short* code, int* val, FILE* fout)
+{
+    fwrite(rel_t, sizeof(struct timeval), 1, fout);
+    fwrite(type, sizeof(unsigned short), 1, fout);
+    fwrite(code, sizeof(unsigned short), 1, fout);
+    fwrite(val, sizeof(int), 1, fout);
+}
+
+int normalize(int value, double factor)
+{
+    int res;
+    double d = factor * (double)value;
+
+    if (value < 0)
+    {
+        res = (int)(d - 0.5);
+    }
+    else
+        res = (int)(d + 0.5);
+
+    return res;
+}
+
+int poll_events(struct pollfd* fds, size_t n, FILE* fout, int seconds, double x_factor, double y_factor)
+{
+    struct timeval t1, t2, rel_t, end_t;
+
+    /* Sets time frame to record */
+    if (seconds > 0)
+    {
+        gettimeofday(&end_t, NULL);
+        end_t.tv_sec += seconds;
+    }
+    else
+    {
+        end_t.tv_sec = seconds;
+        end_t.tv_usec = 0;
+    }
+
+    /* Sets start time, all timestamps are relative to t1 */
+    gettimeofday(&t1, NULL);
+
+    /* Received event */
+    struct input_event ie;
+
+    int val = 0;
+    int ret = -1;
+    int nr = 0;
+    /* Loops until time is up or SIGINT or SIGTERM is received */
+    while (!is_stopping)
+    {
+        ret = poll(fds, n, POLL_TIMEOUT);
+
+        if (ret == -1)
+        {
+            fprintf(stderr, "Poll failed: %s.\n", strerror(errno));
+            return 1;
+        }
+
+        /* Loops over polled pollfd structs */
+        for (size_t i = 0; i < n; i++)
+        {
+            /* Checks, if theres data to read */
+            if (fds[i].revents & POLLIN)
+            {
+                nr = read(fds[i].fd, &ie, sizeof(struct input_event));
+
+                if (nr != sizeof(struct input_event))
+                    continue;
+
+                timersub(&ie.time, &t1, &rel_t);
+
+                /* Handles mouse movements */
+                if (ie.type == EV_REL)
+                {
+                    switch (ie.code)
+                    {
+                        /* Remap for screen size independence */
+                        case REL_X:
+                            val = normalize(ie.value, x_factor);
+                            fprintf(stderr, "%ld.%06ld: REL_X %d\n", rel_t.tv_sec, rel_t.tv_usec, val);
+                            break;
+
+                        case REL_Y:
+                            val = normalize(ie.value, y_factor);
+                            fprintf(stderr, "%ld.%06ld: REL_Y %d\n", rel_t.tv_sec, rel_t.tv_usec, val);
+                            break;
+
+                        case REL_WHEEL:
+                            val = ie.value;
+                            fprintf(stderr, "%ld.%ld: REL_WHEEL %d\n", rel_t.tv_sec, rel_t.tv_usec, val);
+                            break;
+
+                        /* Continue, if the event code is not of interest */
+                        default:
+                            continue;
+                    }
+                    store_event(&rel_t, &(ie.type), &(ie.code), &val, fout);
+                }
+
+                /* Handles button presses, no need to normalize */
+                if (ie.type == EV_KEY)
+                {
+                    switch (ie.code)
+                    {
+                        case BTN_LEFT:
+                            val = ie.value;
+                            fprintf(stderr, "%ld.%ld: BTN_LEFT %d\n", rel_t.tv_sec, rel_t.tv_usec, (int)val);
+                            break;
+                        case BTN_MIDDLE:
+                            val = ie.value;
+                            fprintf(stderr, "%ld.%ld: BTN_MIDDLE %d\n", rel_t.tv_sec, rel_t.tv_usec, (int)val);
+                            break;
+                        case BTN_RIGHT:
+                            val = ie.value;
+                            fprintf(stderr, "%ld.%ld: BTN_RIGHT %d\n", rel_t.tv_sec, rel_t.tv_usec, (int)val);
+                            break;
+                        default:
+                            /* Key presses, no need to normalize */
+                            fprintf(stderr, "%ld.%ld: Key press %d %d\n", rel_t.tv_sec, rel_t.tv_usec, ie.code, ie.value);
+                            val = ie.value;
+                            break;
+                    }
+                    store_event(&rel_t, &(ie.type), &(ie.code), &val, fout);
+                }
+                val = 0;
+            }
+        }
+
+        /* Checks, if capture time is up */
+        gettimeofday(&t2, NULL);
+        if (end_t.tv_sec > 0 && timercmp(&t2, &end_t, >))
+            is_stopping = 1;
+    }
+    return 0;
+}
+
+int populate_fds(struct pollfd* fds, char** event_files, size_t n)
+{
+    int fd_event;
+
+    for (size_t i = 0; i < n; i++)
+    {
+        /* Opens event file */
+        fd_event = open(event_files[i], O_RDONLY);
+
+        if (fd_event == -1)
+        {
+            fprintf(stderr, "Error opening device %s\n", event_files[i]);
+            return 1;
+        }
+        fds[i].fd = fd_event;
+        fds[i].events = POLLIN;
+    }
+    return 0;
+}
+int record(char** event_files, size_t n, const char* output_file, int seconds)
+{
+    int ret;
+
+    /* Prepares event files to poll from */
+    struct pollfd fds[n];
+    ret = populate_fds(fds, event_files, n);
+
+    if (ret == 1)
+        return 1;
+
+    FILE* fout;
+
+    /* Opens output file or STDOUT, if not specified */
+    if (output_file && strlen(output_file) > 0)
+    {
+        fprintf(stderr, "Opening %s\n", output_file);
+
+        /* Use creat-syscall to open file with restrictive permissions right away */
+        int fd = creat(output_file, 0644);
+        if (fd == -1)
+        {
+            perror("creat()");
+            return 1;
+        }
+
+        fout = fdopen(fd, "w");
+    }
+    else
+    {
+        /* Write to stdout */
+        fout = fdopen(dup(fileno(stdout)), "w");
+    }
+
+    if (fout == NULL)
+    {
+        fprintf(stderr, "Could not open file %s\n",
+            output_file && strlen(output_file) > 0 ? output_file : "stdout");
+        return 1;
+    }
+
+    write_file_header(fout);
+
+    /* Retrieves display dimensions, needed for coordate normalization */
+    unsigned int w, h = -1;
+
+    if (get_dimensions(&w, &h) == 1)
+    {
+        fprintf(stderr, "Failed to retrieve display dimensions");
+        return 1;
+    }
+    fprintf(stderr, "Screen dimensions: %d x %d\n", w, h);
+
+    /* Centers cursor for reproducible replay */
+    if (center_cursor(w, h) != 0)
+    {
+        fprintf(stderr, "Could not center cursor");
+        return 1;
+    }
+
+    /* Map recorded coordinates into  value range used by QMP */
+    double x_scale = (float)(1<<15)/w;
+    double y_scale = (float)(1<<15)/h;
+    fprintf(stderr, "Scaling factors: X * %f -  Y * %f\n", x_scale, y_scale);
+
+    poll_events(fds, n, fout, seconds, x_scale, y_scale);
+
+    if (fclose(fout) != 0)
+        return 1;
+
+    fprintf(stderr, "File successfully closed.\n");
+
+    return 0;
+}
+
+void print_help(const char* prog_name)
+{
+    fprintf(stderr, "usage: %s [-h] [-e /dev/input/eventX] [file]\n", prog_name);
+    fprintf(stderr, "\nA utility to record HID events\n");
+    fprintf(stderr, "\npositional arguments:\n");
+    fprintf(stderr, "  file\t\tbinary file to store events\n");
+    fprintf(stderr, "\noptional arguments:\n");
+    fprintf(stderr, "  -h\t\t\tshow this help message and exit\n");
+    fprintf(stderr, "  -e <eventfile>\tevent file to read events from;\n\t\t  multiple event files can be specifed -e file1 -e file2 (max. 3)\n");
+    fprintf(stderr, "  -d <seconds>\t\ttime frame in seconds to record events\n");
+    fprintf(stderr, "\nexamples:\n");
+    fprintf(stderr, "  # capture mouse events infinitely\n");
+    fprintf(stderr, "  %s > events.in \n", prog_name);
+    fprintf(stderr, "\n  # read from specified event files for 20 secs\n");
+    fprintf(stderr, "  %s -e /dev/input/event7 -e /dev/input/event16 -d 20 events.bin\n", prog_name);
+    fprintf(stderr, "\nIf no output file is specified as a positional argument, all events will be sent to stdout.\n");
+    fprintf(stderr, "If no event file is specified via '-e', the default event file for mouse events will be used.\n");
+    fprintf(stderr, "To capture events of a specific input device, use '-e' after retrieving the relevant event file via\n");
+    fprintf(stderr, "\n\tls -l /dev/input/by-id | grep -E \"mouse|kbd\"\n");
+    fprintf(stderr, "\nor alternatively\n");
+    fprintf(stderr, "\n\tcat /proc/bus/input/devices | grep -E \"mouse|kdb\"\n");
+    fprintf(stderr, "\n%s Copyright\t\t(C) 2021 Jan Gruber\n", prog_name);
+    exit(EXIT_SUCCESS);
+}
+
+int main(int argc, char** argv)
+{
+    /* Variables for file interaction */
+    char* event_files[MAX_EVENT_FILES] = {NULL};
+    size_t eidx = 0;
+    char* output_file = NULL;
+    int duration = -1;
+
+    /* Variables for argument handling */
+    int opt;
+    extern char* optarg;
+    extern int optind, opterr, optopt;
+
+    /* Installs signal handler to ensure clean shut down */
+    if (install_signal_handler(SIGINT) || install_signal_handler(SIGTERM) ||
+        install_signal_handler(SIGHUP))
+    {
+        fprintf(stderr, "Error setting up signal handlers\n");
+        return EXIT_FAILURE;
+    }
+
+    /* Reads CLI arguments */
+    while ((opt = getopt(argc, argv, "e:d:h")) != -1)
+    {
+        switch (opt)
+        {
+            case 'e':
+                fprintf(stderr, "Using event file %s\n", optarg);
+                char* evt = strdup(optarg);
+                event_files[eidx] = evt;
+                eidx++;
+                break;
+            case 'd':
+                duration = atoi(optarg);
+                fprintf(stderr, "Setting duration %d secs\n", duration);
+                break;
+            case ':':
+                fprintf(stderr, "Error: Option needs a value\n");
+                print_help(argv[0]);
+                break;
+            case 'h':
+            /* Fall through */
+            default:
+                print_help(argv[0]);
+                return EXIT_SUCCESS;
+        }
+    }
+
+    /* Finds active event file, if not a single one was supplied via -e */
+    if (eidx == 0)
+    {
+        char* event_file = NULL;
+        if (find_event_file(&event_file) != 0)
+        {
+            fprintf(stderr, "Failed to retrieve event file; Specify it explicitely!\n");
+            return EXIT_FAILURE;
+        }
+        event_files[eidx++] = event_file;
+        fprintf(stderr, "Retrieved mouse event file %s\n", event_file);
+    }
+
+    /* Handles positional argument */
+    for (; optind < argc; optind++)
+    {
+        output_file = strdup(argv[optind]);
+        fprintf(stderr, "Writing output to %s\n", output_file);
+        break;
+    }
+
+    /* Start recording mouse movements */
+    record(event_files, eidx, output_file, duration);
+
+    /* Clean up heap allocated variables */
+    if (output_file)
+        free(output_file);
+
+    for (size_t i = 0; i < MAX_EVENT_FILES; i++)
+        if (event_files[i])
+            free(event_files[i]);
+
+    return EXIT_SUCCESS;
+}

--- a/src/helpers/hiddump/readme.org
+++ b/src/helpers/hiddump/readme.org
@@ -1,0 +1,101 @@
+* hiddump
+A utility to record HID events.
+
+** Overview
+~hiddump~ is a utility program to capture HID events on a Linux system and store relative and normalized versions of those events in a binary file, which can then serve later as a template for sending those recorded HID events to an analysis guest by utilizing the plugin ~hidsim~ and the CLI argument ~--hid-template /path/to/events.bin~.
+
+** Dependencies
+~hiddump~ is written in plain C and depends only on GlibC and X11. GlibC is required for general system interaction and the X window system is needed to read the screen dimensions. A task, which is actually needed to perform the mapping of mouse coordinates into a normalized value range. To ensure the availability of the the [[https://packages.debian.org/search?keywords=libx11-dev][X11-library]], run ~sudo apt install libx11-dev~ on a Debian-based box.
+** Compilation
+The compilation of this tool is performed by Drakvuf's-automake system. The only requirement for this is, that the a/m X11-library is available on the system running =configure= and =make=. So if you build Drakvuf on a machine with an X server, just run the usual compilation steps from within Drakvuf's root directory:
+
+#+begin_src shell
+  ./autogen.sh
+  ./configure --enable-debug
+  make -j6
+#+end_src
+
+If you want or need to compile the tool separately, this can be accomplished with the following command:
+
+~gcc -o hiddump hiddump.c -lX11~.
+
+** Usage
+To run the tool, make sure to acquire root-privileges beforehand, which are needed to access the event-files, serving the events of the HID-devices. If you run it without any parameters, ~hiddump~ will try to find the current mouse-event file. (Note: this has been tested under Ubuntu 18.04 and 20.04) Then these mouse events will be captured for an inifinite amount of time until the user stops recording by typing =Ctrl+C=. Captured events will be outputted to stdout, while verbose debug information is sent to stderr. So the most basic usage of the tool is illustrated by the following command:
+
+#+begin_src shell
+  sudo ./src/helpers/hiddump > events.bin
+#+end_src
+
+The resulting binary event data can be either redirected from stdout like in the example above or can be alternatively written directly to a file specified by a positional argument. If you want to capture events only for a certain amount of time, use the short option ~-d~ to specify the capture interval in seconds. To record events of one or multiple specific HID-devices, use ~-e /dev/input/eventXX~. Right now five event-files can be monitored at the same time at maximum.
+
+A comprehensive example of ~hiddump~'s usage could be the following one, which reads events for 30 seconds from two devices and saves those events in ~/tmp/events.bin~.
+
+#+begin_src shell
+  sudo ./hiddump -e /dev/input/event16 -e /dev/input/8 -d 30 /tmp/events.bin
+#+end_src
+
+~hiddump~ serves the following, self-explaining help page:
+
+#+begin_example
+      usage: ./hiddump [-h] [-e /dev/input/eventX] [file]
+
+      A utility to record HID events
+
+      positional arguments:
+	file          binary file to store events
+
+      optional arguments:
+	-h                    show this help message and exit
+	-e <eventfile>        event file to read events from;
+	  multiple event files can be specifed -e file1 -e file2 (max. 3)
+	-d <seconds>          time frame in seconds to record events
+
+      examples:
+	# capture mouse events infinitely
+	./hiddump > events.in
+
+	# read from specified event files for 20 secs
+	./hiddump -e /dev/input/event7 -e /dev/input/event16 -d 20 events.bin
+
+	<snip>
+#+end_example
+
+In order to identify relevant event files and retrieve their path, use the following commands:
+
+#+begin_src shell
+  ls -l /dev/input/by-id | grep -E 'mouse|kbd'
+#+end_src
+
+or alternatively
+
+#+begin_src shell
+  cat /proc/bus/input/devices  | grep -E 'mouse|kdb'
+#+end_src
+
+** Inner workings of the tool
+~hiddump~ utilizes the [[https://www.kernel.org/doc/html/latest/input/input_uapi.html][input subsystem]] of the Linux kernel to record HID events. When executed, ~hiddump~ reads ~input_event~-structs from one or multiple event files under ~/dev/input/~, which are continuosly polled during the recording period. The timing information, which is provided in the form of ~timeval~-structs, is converted to a relative timestamp starting at the beginning of the recording. If the event houses coordinates, then those are mapped to a value range, which qemu uses in its monitor protocol. After retrieval and normalization of the events, they are be dumped to ~stdout~ or written to a specified file in a binary representation, which is presented below. By using the input event format of the Linux input subsystem the tool builds upon a proven format and a stable interface.
+
+** File format
+To preserve the relative and normalized HID events for later use, the ~input_event~-structs are stored sequentially in a binary file, whereas each entry consists of the following fields:
+
+#+begin_src C
+  struct input_event {
+      struct timeval time;     // relative to the start
+      unsigned short type;     // EV_REL, EV_KEY, etc.
+      unsigned short code;     // REL_X, BTN_LEFT, etc.
+      unsigned int value;      // Coordinates, button down, etc.
+  };
+#+end_src
+
+In order to be able to identify a file as a valid HID template file, which was created by ~hiddump~ and which contains HID data in the specified format, a short header is prepended at the beginning of the
+file. The header consists of 12 bytes in total. Its magic number =0xc4d2c1cb= is derived from the string 'DRAK'.
+
+#+begin_example
+  | Symbol                    | Size  | Content             |
+  |---------------------------+-------+---------------------|
+  | Magic number              | DWORD | 0xCB 0xC1 0xD2 0xC4 |
+  | ASCII identifier ('DRAK') | DWORD | 0x44 0x52 0x41 0x4b |
+  | Version information       | DWORD | 0x01 0x00 0x00 0x00 |
+#+end_example
+
+Output in this form can be used for the simulation of human-like interaction with the help of the plugin ~hidsim~.


### PR DESCRIPTION
Dear Tamas,

this PR adds a utility program named `hiddump` to the tools-directory. `hiddump` captures HID events and stores relative and normalized versions of those events in a file, which can then serve later as a template for sending HID events to an analysis guest. 

### Inner working of the tool

To record those events, the input subsystem of the Linux kernel is utilized. The `hiddump` reads `input_event`-structs from one or multiple event files under `/dev/input/`, which are continuosly polled during the recording period. The timing information, which is provided in the form of `timeval`-structs, is converted to a relative timestamp starting at the beginning of the recording. If the event houses coordinates, those are mapped to a value range, which qemu uses in its monitor protocol. Afterwards the events are dumped to `stdout` or written to a specified file in binary representation. By using the input event format of the Linux input subsystem the tool builds upon a proven format and a stable interface.

### Usage

The tool can be build with the command   
`gcc -o hiddump hiddump.c -lX11`.   
_Edit: The compilation of the tool is now hooked into the automake-system. It is performed, if the X11-library (-lX11) is available._

`hiddump` can then be used as follows:
```
    usage: ./hiddump [-h] [-e /dev/input/eventX] [file]

    A utility to record HID events

    positional arguments:
      file          binary file to store events

    optional arguments:
      -h                    show this help message and exit
      -e <eventfile>        event file to read events from;
                multiple event files can be specifed -e file1 -e file2 (max. 3)
      -d <seconds>          time frame in seconds to record events

    examples:
      # capture mouse events infinitely
      ./hiddump > events.in

      # read from specified event files for 20 secs
      ./hiddump -e /dev/input/event7 -e /dev/input/event16 -d 20 events.bin

    If no output file is specified as a positional argument, all events will be sent to stdout.
    If no event file is specified via '-e', the default event file for mouse events will be used.
    To capture events of a specific input device, use '-e' after retrieving the relevant event file via

        ls -l /dev/input/by-id | grep -E "mouse|kbd"

    or alternatively

        cat /proc/bus/input/devices | grep -E "mouse|kdb"
```

### File format 
To preserve the relative and normalized HID events for later use, the `input_event`-structs are stored sequentially in a binary file, whereas each entry consists of the following fields:

``` c
struct input_event {
	struct timeval time;     // relative to the start
	unsigned short type;     // EV_REL, EV_KEY, etc.
	unsigned short code;     // REL_X, BTN_LEFT, etc.
	unsigned int value;      // Coordinates, button down, etc.
};
```
In order to be able to identify a file as a valid HID template file, which was created by `hiddump` and contains HID events in the specified format, a short header is prepended at the beginning of the file. The header consists of 12 bytes in total. The magic number is derived from the string 'DRAK'.
```
| Symbol                    | Size  | Content             |
|---------------------------+-------+---------------------|
| Magic number              | DWORD | 0xCB 0xC1 0xD2 0xC4 |
| ASCII identifier ('DRAK') | DWORD | 0x44 0x52 0x41 0x4b |
| Version information       | DWORD | 0x01 0x00 0x00 0x00 |
```

I am planning to feed the output of the newly added tool `hiddump`, which follows the a/m file format, into the plugin for simulating human interaction, on which I am working actively.

Thank you already in advance for considering this pull request.
If you see any general issues with the concept or the code, please let me know.

Best regards,
Jan 
