### PR TITLE
logical bug in is_stopped function

### DIFF
--- a/src/drakvuf.cpp
+++ b/src/drakvuf.cpp
@@ -188,7 +188,7 @@ static bool is_stopped(drakvuf_t drakvuf, void* data)
     }
     else
     {
-        rc = rc || !d->_drakvuf_c->stop_plugins(d->plugin_list);
+        rc = rc || d->_drakvuf_c->stop_plugins(d->plugin_list);
         PRINT_DEBUG("[STOP] Check plugins %d\n", rc);
         return rc == 0;
     }


### PR DESCRIPTION
I've noticed that my plugin does not work at the end of the analysis and I I've found why.
So, `stop_plugins` returns 1 if some plugin is in `pending`  state but then it is inverted into 0 in `is_stopped` function.
Then function returns `rc == 0` as if all plugins have been stopped which is incorrect. 