### PR TITLE
Fix/clean-up low impact issues in libinjector and libusermode

### DIFF
--- a/src/libinjector/win_injector.c
+++ b/src/libinjector/win_injector.c
@@ -1443,7 +1443,7 @@ static event_response_t injector_int3_cb(drakvuf_t drakvuf, drakvuf_trap_info_t*
             return 0;
         }
 
-        uint8_t buf[FILE_BUF_SIZE];
+        uint8_t buf[FILE_BUF_SIZE] = {0};;
         unicode_string_t in;
 
         ACCESS_CONTEXT(ctx);
@@ -1458,7 +1458,13 @@ static event_response_t injector_int3_cb(drakvuf_t drakvuf, drakvuf_trap_info_t*
         }
 
         vmi = drakvuf_lock_and_get_vmi(drakvuf);
-        vmi_read(vmi, &ctx, regs.x86.rax * 2, buf, NULL);
+        if (VMI_SUCCESS != vmi_read(vmi, &ctx, regs.x86.rax * 2, buf, NULL))
+        {
+            drakvuf_release_vmi(drakvuf);
+            PRINT_DEBUG("Failed to read buffer at %lx\n", regs.x86.rax * 2);
+            return 0;
+        }
+
         drakvuf_release_vmi(drakvuf);
         in.contents = buf;
         in.length = regs.x86.rax * 2;

--- a/src/libinjector/win_injector.c
+++ b/src/libinjector/win_injector.c
@@ -1982,7 +1982,8 @@ static void print_injection_info(output_format_t format, const char* file, injec
 
     if (*split_results_iterator)
     {
-        process_name = *(split_results_iterator++);
+        // Advance iterator to step over image/process name
+        split_results_iterator++;
     }
 
     if (*split_results_iterator)

--- a/src/libusermode/uh-private.hpp
+++ b/src/libusermode/uh-private.hpp
@@ -157,7 +157,7 @@ struct rh_data_t
         std::string dll_name, std::string func_name, callback_t cb, void* extra):
         target_process(target_process), dll_name(dll_name), func_name(func_name), cb(cb),
         extra(extra), state(HOOK_FIRST_TRY), target_process_pid(target_process_pid),
-        target_process_dtb(), userhook_plugin(userhook_plugin) {}
+        target_process_dtb(), func_addr(), userhook_plugin(userhook_plugin) {}
 
 
     static void free_trap(drakvuf_trap_t* trap)


### PR DESCRIPTION
Dear Tamas, 

this PR submits three patches, which fix the following issues identified by static code analysis with low to medium impact :

- CID 307533: Fix error handling in `injector_int3_cb(...)` by checking the return value from `vmi_read(...)`
- CID 309662: Remove unused value (and therefore unnecessary variable assignment) in `print_injection_info(...)` 
- CID 304049: Add initialization of the scalar field `func_addr` of struct `rh_data_t` in `uh-private.hpp`

Although those are only minor changes, I think, they might help to declutter the results of static code analysis.
Thank you already advance for considering this PR. 

Best regards  
Jan 

P.S.: I decided to not squash the commits this time, because they try to solve distinct issues. If you want me to do so, please let me know.