### PR TITLE
Do not use an address of the stack where pointer to trap structure ar…

### DIFF
--- a/src/libdrakvuf/drakvuf.c
+++ b/src/libdrakvuf/drakvuf.c
@@ -473,9 +473,9 @@ bool drakvuf_add_trap(drakvuf_t drakvuf, drakvuf_trap_t* trap)
     if (!trap->ah_cb)
         trap->ah_cb = drakvuf_unhook_trap;
 
-    if (g_hash_table_lookup(drakvuf->remove_traps, &trap))
+    if (g_hash_table_lookup(drakvuf->remove_traps, trap))
     {
-        g_hash_table_remove(drakvuf->remove_traps, &trap);
+        g_hash_table_remove(drakvuf->remove_traps, trap);
         return 1;
     }
 
@@ -516,16 +516,14 @@ void drakvuf_remove_trap(drakvuf_t drakvuf, drakvuf_trap_t* trap,
 {
     if ( drakvuf->in_callback)
     {
-        struct free_trap_wrapper* free_wrapper = (struct free_trap_wrapper*)g_hash_table_lookup(drakvuf->remove_traps, &trap);
+        struct free_trap_wrapper* free_wrapper = (struct free_trap_wrapper*)g_hash_table_lookup(drakvuf->remove_traps, trap);
 
         if (!free_wrapper)
         {
             free_wrapper = (struct free_trap_wrapper*)g_slice_alloc0(sizeof(struct free_trap_wrapper));
             free_wrapper->free_routine = free_routine;
             free_wrapper->trap = trap;
-            g_hash_table_insert(drakvuf->remove_traps,
-                g_memdup(&trap, sizeof(void*)),
-                free_wrapper);
+            g_hash_table_insert(drakvuf->remove_traps, trap, free_wrapper);
         }
 
         free_wrapper->counter++;

--- a/src/libdrakvuf/vmi.c
+++ b/src/libdrakvuf/vmi.c
@@ -189,7 +189,7 @@ void process_free_requests(drakvuf_t drakvuf)
     }
 
     g_hash_table_destroy(drakvuf->remove_traps);
-    drakvuf->remove_traps = g_hash_table_new_full(g_int64_hash, g_int64_equal, free, NULL);
+    drakvuf->remove_traps = g_hash_table_new_full(g_direct_hash, g_direct_equal, NULL, NULL);
 }
 
 static bool refresh_shadow_copy(vmi_instance_t vmi, struct memcb_pass* pass)
@@ -1677,7 +1677,7 @@ bool init_vmi(drakvuf_t drakvuf, bool fast_singlestep)
     drakvuf->memaccess_lookup_gfn = g_hash_table_new_full(g_int64_hash, g_int64_equal, free, free_wrapper);
     drakvuf->memaccess_lookup_trap = g_hash_table_new_full(g_direct_hash, g_direct_equal, NULL, NULL);
     drakvuf->remapped_gfns = g_hash_table_new_full(g_int64_hash, g_int64_equal, NULL, free_remapped_gfn);
-    drakvuf->remove_traps = g_hash_table_new_full(g_int64_hash, g_int64_equal, free, NULL);
+    drakvuf->remove_traps = g_hash_table_new_full(g_direct_hash, g_direct_equal, NULL, NULL);
 
     unsigned int i;
     /*


### PR DESCRIPTION
…e stored as a key of the `remove_traps` hash table.

This can lead to restoration of previously removed trap instead of addition of newly created one:

    ...
    drakvuf_trap_t* trap = info->trap;
    drakvuf_remove_trap(trap); <-- (1)
    trap = create_new_trap(...);
    drakvuf_add_trap(trap); <-- (2)
    ...

Function parameter on (1) and (2) may be placed on the same address. So `drakvuf_add_trap` simply removes &trap from
`remove_traps` hash table:

    ...
    if (g_hash_table_lookup(drakvuf->remove_traps, &trap))
    {
        g_hash_table_remove(drakvuf->remove_traps, &trap);
        return 1;
    }
    ...

This also eliminates static code analysis defect reported by CodeQL:

    "Local variable address stored in non-local memory"

    g_hash_table_insert(drakvuf->remove_traps,
                g_memdup(&trap, sizeof(void*)), <--
                free_wrapper);