### PR TITLE
Add syscall trap name in syscalls plugin.

### DIFF
--- a/src/plugins/syscalls/win.cpp
+++ b/src/plugins/syscalls/win.cpp
@@ -333,7 +333,9 @@ static bool trap_syscall_table_entries(drakvuf_t drakvuf, vmi_instance_t vmi, sy
         auto trap = s->register_trap<wrapper_t>(
                 nullptr,
                 syscall_cb,
-                bp.for_virt_addr(syscall_va).for_dtb(cr3));
+                bp.for_virt_addr(syscall_va).for_dtb(cr3),
+                symbol ? symbol->name : nullptr);
+
         if (!trap)
         {
             PRINT_DEBUG("Failed to trap syscall %lu @ 0x%lx\n", syscall_num, syscall_va);


### PR DESCRIPTION
This fixes debug messages while syscal initializing:

               Trap added @ PA 0x2a41435 RPA 0xff002435 Page 10817 for (null).