### PR TITLE
Add drakvuf_get_struct_field_type_name

### DIFF
--- a/src/libdrakvuf/json-profile.c
+++ b/src/libdrakvuf/json-profile.c
@@ -263,21 +263,21 @@ const char* drakvuf_get_struct_field_type_name(drakvuf_t drakvuf, const char* st
     struct json_object* json_user_types;
     if (!json_object_object_get_ex(json_profile, "user_types", &json_user_types))
     {
-        PRINT_DEBUG("[!] Failed to find `user_types` section.\n");
+        PRINT_DEBUG("Failed to find `user_types` section.\n");
         return NULL;
     }
 
     struct json_object* json_struct;
     if (!json_object_object_get_ex(json_user_types, struct_name, &json_struct))
     {
-        PRINT_DEBUG("[!] Failed to find %s in user_types.\n", struct_name);
+        PRINT_DEBUG("Failed to find %s in user_types.\n", struct_name);
         return NULL;
     }
 
     struct json_object* json_fields;
     if (!json_object_object_get_ex(json_struct, "fields", &json_fields))
     {
-        PRINT_DEBUG("[!] %s has no `fields` key.\n", struct_name);
+        PRINT_DEBUG("%s has no `fields` key.\n", struct_name);
         return NULL;
     }
 
@@ -297,14 +297,14 @@ const char* drakvuf_get_struct_field_type_name(drakvuf_t drakvuf, const char* st
             struct json_object* json_field_subtype;
             if (!json_object_object_get_ex(json_field_val, "type", &json_field_subtype))
             {
-                PRINT_DEBUG("[!] Failed to find `type` key.\n");
+                PRINT_DEBUG("Failed to find `type` key.\n");
                 return NULL;
             }
 
             struct json_object* json_field_subkind;
             if (!json_object_object_get_ex(json_field_subtype, "kind", &json_field_subkind))
             {
-                PRINT_DEBUG("[!] Failed to find `kind` key.\n");
+                PRINT_DEBUG("Failed to find `kind` key.\n");
                 return NULL;
             }
             if (strcmp(json_object_get_string(json_field_subkind), "struct") != 0)
@@ -313,21 +313,21 @@ const char* drakvuf_get_struct_field_type_name(drakvuf_t drakvuf, const char* st
             struct json_object* json_anonymous_struct_name;
             if (!json_object_object_get_ex(json_field_subtype, "name", &json_anonymous_struct_name))
             {
-                PRINT_DEBUG("[!] Failed to find `name` key\n");
+                PRINT_DEBUG("Failed to find `name` key\n");
                 return NULL;
             }
 
             struct json_object* json_anonymous_struct;
             if (!json_object_object_get_ex(json_user_types, json_object_get_string(json_anonymous_struct_name), &json_anonymous_struct))
             {
-                PRINT_DEBUG("[!] Failed to find %s in user_types.\n", json_object_get_string(json_anonymous_struct_name));
+                PRINT_DEBUG("Failed to find %s in user_types.\n", json_object_get_string(json_anonymous_struct_name));
                 return NULL;
             }
 
             struct json_object* json_anonymous_struct_fields;
             if (!json_object_object_get_ex(json_anonymous_struct, "fields", &json_anonymous_struct_fields))
             {
-                PRINT_DEBUG("[!] Failed to find `fields` key.\n");
+                PRINT_DEBUG("Failed to find `fields` key.\n");
                 return NULL;
             }
 
@@ -337,21 +337,21 @@ const char* drakvuf_get_struct_field_type_name(drakvuf_t drakvuf, const char* st
     }
     if (!json_field)
     {
-        PRINT_DEBUG("[!] Failed to find %s\n", field_name);
+        PRINT_DEBUG("Failed to find %s\n", field_name);
         return NULL;
     }
 
     struct json_object* json_struct_type;
     if (!json_object_object_get_ex(json_field, "type", &json_struct_type))
     {
-        PRINT_DEBUG("[!] Failed to find `type` key.\n");
+        PRINT_DEBUG("Failed to find `type` key.\n");
         return NULL;
     }
 
     struct json_object* json_type_name;
     if (!json_object_object_get_ex(json_struct_type, "name", &json_type_name))
     {
-        PRINT_DEBUG("[!] Failed to find `name` key.\n");
+        PRINT_DEBUG("Failed to find `name` key.\n");
         return NULL;
     }
 

--- a/src/libdrakvuf/json-profile.c
+++ b/src/libdrakvuf/json-profile.c
@@ -246,6 +246,105 @@ err_exit:
     return NULL;
 }
 
+/**
+ * Useful when one wants to find rva of typedef as compiler will treat it as an
+ * anonymous structure.
+ * The returned string is managed by json_object and should not be freed by the user.
+ *
+ * @param[in] drakvuf Drakvuf instance.
+ * @param[in] struct_name Name of the struct containing `field_name`.
+ * @param[in] field_name Name of the field that we want to retrieve type name.
+ * @return string or NULL on failure
+ */
+const char* drakvuf_get_struct_field_type_name(drakvuf_t drakvuf, const char* struct_name, const char* field_name)
+{
+    struct json_object* json_profile = vmi_get_kernel_json(drakvuf->vmi);
+
+    struct json_object* json_user_types;
+    if (!json_object_object_get_ex(json_profile, "user_types", &json_user_types)) {
+        PRINT_DEBUG("[!] Failed to find `user_types` section.\n");
+        return NULL;
+    }
+
+    struct json_object* json_struct;
+    if (!json_object_object_get_ex(json_user_types, struct_name, &json_struct)) {
+        PRINT_DEBUG("[!] Failed to find %s in user_types.\n", struct_name);
+        return NULL;
+    }
+
+    struct json_object* json_fields;
+    if (!json_object_object_get_ex(json_struct, "fields", &json_fields)) {
+        PRINT_DEBUG("[!] %s has no `fields` key.\n", struct_name);
+        return NULL;
+    }
+
+    struct json_object* json_field = NULL;
+    if (!json_object_object_get_ex(json_fields, field_name, &json_field)) {
+        // Check recursively all unnamed structure fields aswell, as many fields in linux are wrapped in anonymous structures for structure randomization.
+        struct json_object_iterator it = json_object_iter_begin(json_fields);
+        struct json_object_iterator it_end = json_object_iter_end(json_fields);
+        for (; !json_object_iter_equal(&it, &it_end); json_object_iter_next(&it)) {
+            if (strncmp(json_object_iter_peek_name(&it), "unnamed", strlen("unnamed")) != 0)
+                continue;
+
+            json_object* json_field_val = json_object_iter_peek_value(&it);
+
+            struct json_object* json_field_subtype;
+            if (!json_object_object_get_ex(json_field_val, "type", &json_field_subtype)) {
+                PRINT_DEBUG("[!] Failed to find `type` key.\n");
+                return NULL;
+            }
+
+            struct json_object* json_field_subkind;
+            if (!json_object_object_get_ex(json_field_subtype, "kind", &json_field_subkind)) {
+                PRINT_DEBUG("[!] Failed to find `kind` key.\n");
+                return NULL;
+            }
+            if (strcmp(json_object_get_string(json_field_subkind), "struct") != 0)
+                continue;
+
+            struct json_object* json_anonymous_struct_name;
+            if (!json_object_object_get_ex(json_field_subtype, "name", &json_anonymous_struct_name)) {
+                PRINT_DEBUG("[!] Failed to find `name` key\n");
+                return NULL;
+            }
+
+            struct json_object *json_anonymous_struct;
+            if (!json_object_object_get_ex(json_user_types, json_object_get_string(json_anonymous_struct_name), &json_anonymous_struct)) {
+                PRINT_DEBUG("[!] Failed to find %s in user_types.\n", json_object_get_string(json_anonymous_struct_name));
+                return NULL;
+            }
+
+            struct json_object* json_anonymous_struct_fields;
+            if (!json_object_object_get_ex(json_anonymous_struct, "fields", &json_anonymous_struct_fields)) {
+                PRINT_DEBUG("[!] Failed to find `fields` key.\n");
+                return NULL;
+            }
+
+            if (json_object_object_get_ex(json_anonymous_struct_fields, field_name, &json_field))
+                break;
+        }
+    }
+    if (!json_field) {
+        PRINT_DEBUG("[!] Failed to find %s\n", field_name);
+        return NULL;
+    }
+
+    struct json_object* json_struct_type;
+    if (!json_object_object_get_ex(json_field, "type", &json_struct_type)) {
+        PRINT_DEBUG("[!] Failed to find `type` key.\n");
+        return NULL;
+    }
+
+    struct json_object* json_type_name;
+    if (!json_object_object_get_ex(json_struct_type, "name", &json_type_name)) {
+        PRINT_DEBUG("[!] Failed to find `name` key.\n");
+        return NULL;
+    }
+
+    return json_object_get_string(json_type_name);
+}
+
 void drakvuf_free_symbols(symbols_t* symbols)
 {
     uint32_t i;

--- a/src/libdrakvuf/json-profile.c
+++ b/src/libdrakvuf/json-profile.c
@@ -261,42 +261,49 @@ const char* drakvuf_get_struct_field_type_name(drakvuf_t drakvuf, const char* st
     struct json_object* json_profile = vmi_get_kernel_json(drakvuf->vmi);
 
     struct json_object* json_user_types;
-    if (!json_object_object_get_ex(json_profile, "user_types", &json_user_types)) {
+    if (!json_object_object_get_ex(json_profile, "user_types", &json_user_types))
+    {
         PRINT_DEBUG("[!] Failed to find `user_types` section.\n");
         return NULL;
     }
 
     struct json_object* json_struct;
-    if (!json_object_object_get_ex(json_user_types, struct_name, &json_struct)) {
+    if (!json_object_object_get_ex(json_user_types, struct_name, &json_struct))
+    {
         PRINT_DEBUG("[!] Failed to find %s in user_types.\n", struct_name);
         return NULL;
     }
 
     struct json_object* json_fields;
-    if (!json_object_object_get_ex(json_struct, "fields", &json_fields)) {
+    if (!json_object_object_get_ex(json_struct, "fields", &json_fields))
+    {
         PRINT_DEBUG("[!] %s has no `fields` key.\n", struct_name);
         return NULL;
     }
 
     struct json_object* json_field = NULL;
-    if (!json_object_object_get_ex(json_fields, field_name, &json_field)) {
+    if (!json_object_object_get_ex(json_fields, field_name, &json_field))
+    {
         // Check recursively all unnamed structure fields aswell, as many fields in linux are wrapped in anonymous structures for structure randomization.
         struct json_object_iterator it = json_object_iter_begin(json_fields);
         struct json_object_iterator it_end = json_object_iter_end(json_fields);
-        for (; !json_object_iter_equal(&it, &it_end); json_object_iter_next(&it)) {
+        for (; !json_object_iter_equal(&it, &it_end); json_object_iter_next(&it))
+        {
             if (strncmp(json_object_iter_peek_name(&it), "unnamed", strlen("unnamed")) != 0)
                 continue;
 
             json_object* json_field_val = json_object_iter_peek_value(&it);
 
             struct json_object* json_field_subtype;
-            if (!json_object_object_get_ex(json_field_val, "type", &json_field_subtype)) {
+            if (!json_object_object_get_ex(json_field_val, "type", &json_field_subtype))
+            {
                 PRINT_DEBUG("[!] Failed to find `type` key.\n");
                 return NULL;
             }
 
             struct json_object* json_field_subkind;
-            if (!json_object_object_get_ex(json_field_subtype, "kind", &json_field_subkind)) {
+            if (!json_object_object_get_ex(json_field_subtype, "kind", &json_field_subkind))
+            {
                 PRINT_DEBUG("[!] Failed to find `kind` key.\n");
                 return NULL;
             }
@@ -304,19 +311,22 @@ const char* drakvuf_get_struct_field_type_name(drakvuf_t drakvuf, const char* st
                 continue;
 
             struct json_object* json_anonymous_struct_name;
-            if (!json_object_object_get_ex(json_field_subtype, "name", &json_anonymous_struct_name)) {
+            if (!json_object_object_get_ex(json_field_subtype, "name", &json_anonymous_struct_name))
+            {
                 PRINT_DEBUG("[!] Failed to find `name` key\n");
                 return NULL;
             }
 
-            struct json_object *json_anonymous_struct;
-            if (!json_object_object_get_ex(json_user_types, json_object_get_string(json_anonymous_struct_name), &json_anonymous_struct)) {
+            struct json_object* json_anonymous_struct;
+            if (!json_object_object_get_ex(json_user_types, json_object_get_string(json_anonymous_struct_name), &json_anonymous_struct))
+            {
                 PRINT_DEBUG("[!] Failed to find %s in user_types.\n", json_object_get_string(json_anonymous_struct_name));
                 return NULL;
             }
 
             struct json_object* json_anonymous_struct_fields;
-            if (!json_object_object_get_ex(json_anonymous_struct, "fields", &json_anonymous_struct_fields)) {
+            if (!json_object_object_get_ex(json_anonymous_struct, "fields", &json_anonymous_struct_fields))
+            {
                 PRINT_DEBUG("[!] Failed to find `fields` key.\n");
                 return NULL;
             }
@@ -325,19 +335,22 @@ const char* drakvuf_get_struct_field_type_name(drakvuf_t drakvuf, const char* st
                 break;
         }
     }
-    if (!json_field) {
+    if (!json_field)
+    {
         PRINT_DEBUG("[!] Failed to find %s\n", field_name);
         return NULL;
     }
 
     struct json_object* json_struct_type;
-    if (!json_object_object_get_ex(json_field, "type", &json_struct_type)) {
+    if (!json_object_object_get_ex(json_field, "type", &json_struct_type))
+    {
         PRINT_DEBUG("[!] Failed to find `type` key.\n");
         return NULL;
     }
 
     struct json_object* json_type_name;
-    if (!json_object_object_get_ex(json_struct_type, "name", &json_type_name)) {
+    if (!json_object_object_get_ex(json_struct_type, "name", &json_type_name))
+    {
         PRINT_DEBUG("[!] Failed to find `name` key.\n");
         return NULL;
     }

--- a/src/libdrakvuf/libdrakvuf.h
+++ b/src/libdrakvuf/libdrakvuf.h
@@ -350,7 +350,10 @@ bool json_get_struct_member_rva(drakvuf_t drakvuf,
     const char* struct_name,
     const char* symbol,
     addr_t* rva) NOEXCEPT;
-
+const char* drakvuf_get_struct_field_type_name(
+    drakvuf_t drakvuf,
+    const char* struct_name,
+    const char* field_name) NOEXCEPT;
 bool json_get_struct_members_array_rva(
     drakvuf_t drakvuf,
     json_object* json_profile,


### PR DESCRIPTION
Useful when one wants to find rva of typedef.

**Example**
Let's say the types are defined as:
```c
typedef struct {
    int a;
} inner_t;

struct outer {
    inner_t inner;
};
```
and for variable `struct outer o` and we want to get the value of: `o.inner.a`. 
Unfortunately such approach won't work:
```c
addr_t outer_inner_rva;
drakvuf_get_kernel_struct_member_rva(drakvuf, "outer", "inner", &outer_inner_rva);

addr_t inner_t_a_rva;
drakvuf_get_kernel_struct_member_rva(drakvuf, "inner_t", "a", &inner_t_a_rva); // this won't work
```

as there is not `inner_t` in json profile:
```json
"outer": {
    "fields": {
        "inner": {
            "type": {
                "kind": "struct",
                "name": "unnamed_XYZ"
            },
            "offset": 0
        }
    },
    [...]
},
"unnamed_XYZ": {
    "fields": {
        "a": {
            "type": {
                "kind": "base",
                "name": "int"
            },
            "offset": 0
        }
    }
}
```

This PR. introduces a workaround for above problem:
```c
addr_t inner_t_a_rva;
drakvuf_get_kernel_struct_member_rva(drakvuf, drakvuf_get_struct_field_type_name(drakvuf, "outer", "inner"), "a", &inner_t_a_rva);
```