### PR TITLE
[ci] fix codeQL run on master branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
 
   compile:
     runs-on: ${{ matrix.os }}
-    if: ${{ github.event_name != 'push' }}
+    if: ${{ github.event_name == 'pull_request' }}
     needs:
       - init
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: ci
 on:
   pull_request:
     branches: [ master ]
+  push:
+    branches: [ master ]
 jobs:
   init:
     runs-on: ${{ matrix.os }}
@@ -79,6 +81,7 @@ jobs:
 
   compile:
     runs-on: ${{ matrix.os }}
+    if: ${{ github.event_name != 'push' }}
     needs:
       - init
     strategy:
@@ -138,6 +141,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     needs:
       - init
+    if: ${{ github.event_name == 'pull_request' }}
     strategy:
         matrix:
           os:
@@ -260,6 +264,7 @@ jobs:
           - 'ubuntu-20.04'
     needs:
       - init
+    if: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies


### PR DESCRIPTION
codeQL also needs to be run on master branch. This should fix that error introduced in https://github.com/tklengyel/drakvuf/pull/1293

only `codeQL` will be run when on master. `scan-build`, `compile` and `tarbuild` should be skipped