### PR TITLE
Fix memory leaks in retrieve_winstas_from_procs

### DIFF
--- a/src/plugins/hidsim/gui/vmi_win_gui_parser.cpp
+++ b/src/plugins/hidsim/gui/vmi_win_gui_parser.cpp
@@ -824,6 +824,7 @@ status_t retrieve_winstas_from_procs(vmi_instance_t vmi, GArray* winstas)
         {
             fprintf(stderr, "Failed to read ThreadListHead-pointer at %" PRIx64 "\n",
                 current_process + symbol_offsets.thread_list_head_offset);
+            g_array_free(winstas, true);
             return VMI_FAILURE;
         }
 
@@ -843,6 +844,7 @@ status_t retrieve_winstas_from_procs(vmi_instance_t vmi, GArray* winstas)
                 {
                     fprintf(stderr, "Failed to read ThreadListHead-pointer at %" PRIx64 "\n",
                         current_process + symbol_offsets.thread_list_head_offset);
+                    g_array_free(winstas, true);
                     return VMI_FAILURE;
                 }
 
@@ -944,6 +946,7 @@ status_t retrieve_winstas_from_procs(vmi_instance_t vmi, GArray* winstas)
         if (VMI_FAILURE == vmi_read_addr_va(vmi, cur_list_entry, 0, &next_list_entry))
         {
             fprintf(stderr, "Failed to read next pointer in loop at %" PRIx64 "\n", cur_list_entry);
+            g_array_free(winstas, true);
             return VMI_FAILURE;
         }
 


### PR DESCRIPTION
Dear Tamas, 

this PR fixes memory leaks inside the function `retrieve_winstas_from_procs`, which where identified by @manorit2001 in the course of the CI tests connected to #1300. This patch ensures, that memory allocated in the b/m function will be freed on fails.

Best regards 
Jan   