### PR TITLE
new plugin rootkitmon

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -472,6 +472,16 @@ if test x$plugin_hidsim = xyes; then
   AC_DEFINE_UNQUOTED(ENABLE_PLUGIN_HIDSIM, 1, "")
 fi
 
+AC_ARG_ENABLE([plugin_rootkitmon],
+  [AS_HELP_STRING([--disable-plugin-rootkitmon],
+    [Enable rootkitmon plugin @<:@yes@:>@])],
+  [plugin_rootkitmon="$enableval"],
+  [plugin_rootkitmon="yes"])
+AM_CONDITIONAL([PLUGIN_ROOTKITMON], [test x$plugin_rootkitmon = xyes])
+if test x$plugin_rootkitmon = xyes; then
+  AC_DEFINE_UNQUOTED(ENABLE_PLUGIN_ROOTKITMON, 1, "")
+fi
+
 AC_ARG_ENABLE([DISABLE_ATOMS],
   [AS_HELP_STRING([--disable-atoms],
     [Disable atom table parsing in hidsim plugin @<:@no@:>@])],
@@ -780,6 +790,7 @@ Exploitmon:   $plugin_exploitmon
 LibHookTest:  $plugin_libhooktest
 IPT:          $plugin_ipt
 HidSim:       $plugin_hidsim
+Rootkitmon:   $plugin_rootkitmon
 -------------------------------------------------------------------------------
 Deprecated Plugins
 WMIMon:       $plugin_wmimon

--- a/src/libdrakvuf/libdrakvuf.h
+++ b/src/libdrakvuf/libdrakvuf.h
@@ -585,6 +585,10 @@ bool drakvuf_enumerate_processes_with_module(drakvuf_t drakvuf,
     bool (*visitor_func)(drakvuf_t drakvuf, const module_info_t* module_info, void* visitor_ctx),
     void* visitor_ctx) NOEXCEPT;
 
+bool drakvuf_enumerate_drivers(drakvuf_t drakvuf,
+    void (*visitor_func)(drakvuf_t drakvuf, addr_t process, void* visitor_ctx),
+    void* visitor_ctx) NOEXCEPT;
+
 bool drakvuf_enumerate_process_modules(drakvuf_t drakvuf,
     addr_t eprocess,
     bool (*visitor_func)(drakvuf_t drakvuf, const module_info_t* module_info, bool* need_free, bool* need_stop, void* visitor_ctx),

--- a/src/libdrakvuf/os.c
+++ b/src/libdrakvuf/os.c
@@ -540,6 +540,14 @@ bool drakvuf_enumerate_processes_with_module(drakvuf_t drakvuf, const char* modu
     return false;
 }
 
+bool drakvuf_enumerate_drivers(drakvuf_t drakvuf, void (*visitor_func)(drakvuf_t drakvuf, addr_t driver, void* visitor_ctx), void* visitor_ctx)
+{
+    if ( drakvuf->osi.enumerate_drivers )
+        return drakvuf->osi.enumerate_drivers(drakvuf, visitor_func, visitor_ctx);
+
+    return false;
+}
+
 bool drakvuf_enumerate_process_modules(drakvuf_t drakvuf, addr_t eprocess, bool (*visitor_func)(drakvuf_t drakvuf, const module_info_t* module_info, bool* need_free, bool* need_stop, void* visitor_ctx), void* visitor_ctx)
 {
     if ( drakvuf->osi.enumerate_process_modules )

--- a/src/libdrakvuf/os.h
+++ b/src/libdrakvuf/os.h
@@ -226,6 +226,9 @@ typedef struct os_interface
     bool (*enumerate_processes_with_module)
     (drakvuf_t drakvuf, const char* module_name, bool (*visitor_func)(drakvuf_t drakvuf, const module_info_t* module_info, void* visitor_ctx), void* visitor_ctx);
 
+    bool (*enumerate_drivers)
+    (drakvuf_t drakvuf, void (*visitor_func)(drakvuf_t drakvuf, addr_t driver, void* visitor_ctx), void* visitor_ctx);
+
     bool (*enumerate_process_modules)
     (drakvuf_t drakvuf, addr_t eprocess, bool (*visitor_func)(drakvuf_t drakvuf, const module_info_t* module_info, bool* need_free, bool* need_stop, void* visitor_ctx), void* visitor_ctx);
 

--- a/src/libdrakvuf/win.c
+++ b/src/libdrakvuf/win.c
@@ -559,6 +559,7 @@ bool set_os_windows(drakvuf_t drakvuf)
     drakvuf->osi.get_function_return_address = win_get_function_return_address;
     drakvuf->osi.enumerate_processes = win_enumerate_processes;
     drakvuf->osi.enumerate_processes_with_module = win_enumerate_processes_with_module;
+    drakvuf->osi.enumerate_drivers = win_enumerate_drivers;
     drakvuf->osi.enumerate_process_modules = win_enumerate_process_modules;
     drakvuf->osi.is_crashreporter = win_is_crashreporter;
     drakvuf->osi.find_mmvad = win_find_mmvad;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -329,6 +329,12 @@ static void print_usage()
         "\t --hid-monitor-gui\n"
         "\t                           Monitor the GUI to try to detect clickable buttons. This requires the presence of a win32k-profile, which has to be specified via -W\n"
 #endif
+#ifdef ENABLE_PLUGIN_ROOTKITMON
+        "\t --json-fwpkclnt <path to json>\n"
+        "\t                           The JSON profile for fwpkclnt.sys\n"
+        "\t --json-fltmgr <path to json>\n"
+        "\t                           The JSON profile for fltmgr.sys\n"
+#endif
         "\t -h, --help                Show this help\n"
     );
 }
@@ -431,6 +437,8 @@ int main(int argc, char** argv)
         opt_objmon_disable_duplicate_hook,
         opt_hidsim_template,
         opt_hidsim_monitor_gui,
+        opt_rootkitmon_json_fwpkclnt,
+        opt_rootkitmon_json_fltmgr,
     };
     const option long_opts[] =
     {
@@ -490,6 +498,8 @@ int main(int argc, char** argv)
         {"objmon-disable-duplicate-hook", no_argument, NULL, opt_objmon_disable_duplicate_hook},
         {"hid-template", required_argument, NULL, opt_hidsim_template},
         {"hid-monitor-gui", no_argument, NULL, opt_hidsim_monitor_gui},
+        {"json-fwpkclnt", required_argument, NULL, opt_rootkitmon_json_fwpkclnt},
+        {"json-fltmgr", required_argument, NULL, opt_rootkitmon_json_fltmgr},
         {NULL, 0, NULL, 0}
     };
     const char* opts = "r:d:i:I:e:m:t:D:o:vx:a:f:spT:S:Mc:nblgj:k:w:W:hF:C";
@@ -792,6 +802,14 @@ int main(int argc, char** argv)
                 break;
             case opt_hidsim_monitor_gui:
                 options.hidsim_monitor_gui = true;
+                break;
+#endif
+#ifdef ENABLE_PLUGIN_ROOTKITMON
+            case opt_rootkitmon_json_fwpkclnt:
+                options.fwpkclnt_profile = optarg;
+                break;
+            case opt_rootkitmon_json_fltmgr:
+                options.fltmgr_profile = optarg;
                 break;
 #endif
 

--- a/src/plugins/Makefile.am
+++ b/src/plugins/Makefile.am
@@ -331,6 +331,12 @@ sources += hidsim/gui_monitor.cpp
 sources += hidsim/gui_monitor.h
 endif
 
+if PLUGIN_ROOTKITMON
+sources += rootkitmon/rootkitmon.cpp
+sources += rootkitmon/rootkitmon.h
+sources += rootkitmon/private.h
+endif
+
 ###############################################################################
 sources += plugins.cpp plugins.h plugins_ex.cpp plugins_ex.h plugin_utils.cpp plugin_utils.h private.h type_traits_helpers.h hook_helpers.h
 sources += output_format.h output_format/common.h output_format/csvfmt.h output_format/deffmt.h output_format/jsonfmt.h output_format/kvfmt.h

--- a/src/plugins/plugins.cpp
+++ b/src/plugins/plugins.cpp
@@ -136,6 +136,7 @@
 #include "exploitmon/exploitmon.h"
 #include "ipt/ipt.h"
 #include "hidsim/hidsim.h"
+#include "rootkitmon/rootkitmon.h"
 
 drakvuf_plugins::drakvuf_plugins(const drakvuf_t _drakvuf, output_format_t _output, os_t _os)
     : drakvuf{ _drakvuf }, output{ _output }, os{ _os }
@@ -462,6 +463,18 @@ int drakvuf_plugins::start(const drakvuf_plugin_t plugin_id,
                         .win32k_profile = options->win32k_profile,
                     };
                     this->plugins[plugin_id] = std::make_unique<hidsim>(this->drakvuf, &config);
+                    break;
+                }
+#endif
+#ifdef ENABLE_PLUGIN_ROOTKITMON
+                case PLUGIN_ROOTKITMON:
+                {
+                    rootkitmon_config config =
+                    {
+                        .fwpkclnt_profile = options->fwpkclnt_profile,
+                        .fltmgr_profile = options->fltmgr_profile,
+                    };
+                    this->plugins[plugin_id] = std::make_unique<rootkitmon>(this->drakvuf, &config, this->output);
                     break;
                 }
 #endif

--- a/src/plugins/plugins.h
+++ b/src/plugins/plugins.h
@@ -166,6 +166,8 @@ struct plugins_options
     bool objmon_disable_duplicate_hook; // PLUGIN_OBJMON
     const char* hidsim_template;        // PLUGIN_HIDSIM
     bool hidsim_monitor_gui;            // PLUGIN_HIDSIM
+    const char* fwpkclnt_profile;       // PLUGIN_ROOTKITMON
+    const char* fltmgr_profile;         // PLUGIN_ROOTKITMON
 };
 
 typedef enum drakvuf_plugin
@@ -202,6 +204,7 @@ typedef enum drakvuf_plugin
     PLUGIN_EXPLOITMON,
     PLUGIN_IPT,
     PLUGIN_HIDSIM,
+    PLUGIN_ROOTKITMON,
     __DRAKVUF_PLUGIN_LIST_MAX
 } drakvuf_plugin_t;
 
@@ -239,6 +242,7 @@ static const char* drakvuf_plugin_names[] =
     [PLUGIN_EXPLOITMON] = "exploitmon",
     [PLUGIN_IPT] = "ipt",
     [PLUGIN_HIDSIM] = "hidsim",
+    [PLUGIN_ROOTKITMON] = "rootkitmon",
 };
 
 static const bool drakvuf_plugin_os_support[__DRAKVUF_PLUGIN_LIST_MAX][VMI_OS_WINDOWS+1] =
@@ -275,6 +279,7 @@ static const bool drakvuf_plugin_os_support[__DRAKVUF_PLUGIN_LIST_MAX][VMI_OS_WI
     [PLUGIN_EXPLOITMON]   = { [VMI_OS_WINDOWS] = 1, [VMI_OS_LINUX] = 0 },
     [PLUGIN_IPT]          = { [VMI_OS_WINDOWS] = 1, [VMI_OS_LINUX] = 1 },
     [PLUGIN_HIDSIM]       = { [VMI_OS_WINDOWS] = 1, [VMI_OS_LINUX] = 1 },
+    [PLUGIN_ROOTKITMON]   = { [VMI_OS_WINDOWS] = 1, [VMI_OS_LINUX] = 0 },
 };
 
 class plugin

--- a/src/plugins/rootkitmon/private.h
+++ b/src/plugins/rootkitmon/private.h
@@ -227,8 +227,8 @@ struct nt_headers_t
     optional_header_t  optional_header;
 
     inline const section_header_t* get_section(int n) const
-    { 
-        return n >= file_header.num_sections ? nullptr : 
+    {
+        return n >= file_header.num_sections ? nullptr :
             reinterpret_cast<const section_header_t*>(
                 (const uint8_t*)&optional_header + file_header.size_optional_header) + n;
     }
@@ -256,10 +256,10 @@ struct dos_header_t
     uint16_t e_oeminfo;
     uint16_t e_res2[ 10 ];
     uint32_t e_lfanew;
-    
+
     inline const nt_headers_t* get_nt_headers() const
-    { 
-        return reinterpret_cast<const nt_headers_t*>((const uint8_t*)this + e_lfanew); 
+    {
+        return reinterpret_cast<const nt_headers_t*>((const uint8_t*)this + e_lfanew);
     }
 };
 static_assert(64 == sizeof(dos_header_t), "Dos header size mismatch");
@@ -274,14 +274,14 @@ struct checksum_data_t
 union gdt_entry_t
 {
     uint64_t entry;
-    struct 
+    struct
     {
         uint16_t limit_low;
         uint16_t base_low;
         uint8_t  base_mid;
         uint8_t  type : 4;
         uint8_t  s    : 1;
-        uint8_t  dpl  : 2; 
+        uint8_t  dpl  : 2;
         uint8_t  present : 1;
         uint8_t  limit_high : 4;
         uint8_t  avail: 1;

--- a/src/plugins/rootkitmon/private.h
+++ b/src/plugins/rootkitmon/private.h
@@ -102,110 +102,206 @@
  *                                                                         *
  ***************************************************************************/
 
-#ifndef WIN_H
-#define WIN_H
+#ifndef ROOTKITMON_PRIVATE_H
+#define ROOTKITMON_PRIVATE_H
 
-#include <libvmi/libvmi.h>
-#include "libdrakvuf.h"
-#include "os.h"
-#include "win-exports.h"
+// PDEVICE_OBJECT
+using device_t  = addr_t;
+// LDR_DATA_TABLE_ENTRY of the driver
+using driver_t  = addr_t;
+using device_stack_t = std::unordered_map<device_t, std::vector<device_t>>;
+using sha256_checksum_t = std::array<uint8_t, 32>;
 
-bool win_get_current_irql(drakvuf_t drakvuf, drakvuf_trap_info_t* info, uint8_t* irql);
+enum
+{
+    EPROCESS_UNIQUE_PROCESS_ID,
+    LDR_DATA_TABLE_ENTRY_DLLBASE,
+    LDR_DATA_TABLE_ENTRY_SIZEOFIMAGE,
+    LDR_DATA_TABLE_ENTRY_BASEDLLNAME,
+    OBJECT_DIRECTORY_ENTRY_CHAINLINK,
+    OBJECT_DIRECTORY_ENTRY_OBJECT,
+    OBJECT_HEADER_TYPEINDEX,
+    OBJECT_TYPE_NAME,
+    DRIVER_OBJECT_DEVICEOBJECT,
+    DRIVER_OBJECT_STARTIO,
+    DRIVER_OBJECT_DRIVERNAME,
+    DEVICE_OBJECT_ATTACHEDDEVICE,
+    DEVICE_OBJECT_DRIVEROBJECT,
+    DEVICE_OBJECT_NEXTDEVICE,
+    __OFFSET_MAX
+};
 
-addr_t win_get_current_thread(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
+static const char* offset_names[__OFFSET_MAX][2] =
+{
+    [EPROCESS_UNIQUE_PROCESS_ID] = {"_EPROCESS", "UniqueProcessId"},
+    [LDR_DATA_TABLE_ENTRY_DLLBASE] = { "_LDR_DATA_TABLE_ENTRY", "DllBase" },
+    [LDR_DATA_TABLE_ENTRY_SIZEOFIMAGE] = { "_LDR_DATA_TABLE_ENTRY", "SizeOfImage" },
+    [LDR_DATA_TABLE_ENTRY_BASEDLLNAME] = { "_LDR_DATA_TABLE_ENTRY", "BaseDllName" },
+    [OBJECT_DIRECTORY_ENTRY_CHAINLINK] = { "_OBJECT_DIRECTORY_ENTRY", "ChainLink" },
+    [OBJECT_DIRECTORY_ENTRY_OBJECT] = { "_OBJECT_DIRECTORY_ENTRY", "Object" },
+    [OBJECT_HEADER_TYPEINDEX] = { "_OBJECT_HEADER", "TypeIndex" },
+    [OBJECT_TYPE_NAME] = { "_OBJECT_TYPE", "Name" },
+    [DRIVER_OBJECT_DEVICEOBJECT] = { "_DRIVER_OBJECT", "DeviceObject" },
+    [DRIVER_OBJECT_STARTIO] = { "_DRIVER_OBJECT", "DriverStartIo" },
+    [DRIVER_OBJECT_DRIVERNAME] = { "_DRIVER_OBJECT", "DriverName" },
+    [DEVICE_OBJECT_ATTACHEDDEVICE] = { "_DEVICE_OBJECT", "AttachedDevice" },
+    [DEVICE_OBJECT_DRIVEROBJECT] = { "_DEVICE_OBJECT", "DriverObject" },
+    [DEVICE_OBJECT_NEXTDEVICE] = { "_DEVICE_OBJECT", "NextDevice" },
+};
 
-addr_t win_get_current_thread_teb(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
+static constexpr uint32_t mem_not_paged = 0x08000000;
+static constexpr uint32_t mem_execute = 0x20000000;
+static constexpr uint32_t mem_write = 0x80000000;
 
-addr_t win_get_current_thread_stackbase(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
+struct section_header_t
+{
+    char     name[8];
+    uint32_t virtual_size;
+    uint32_t virtual_address;
+    uint32_t size_raw_data;
+    uint32_t ptr_raw_data;
+    uint32_t ptr_relocs;
+    uint32_t ptr_line_numbers;
+    uint16_t num_relocs;
+    uint16_t num_line_numbers;
+    uint32_t characteristics;
 
-addr_t win_get_current_process(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
+    inline std::string get_name() const
+    {
+        return { name, 8 };
+    }
+};
+static_assert(40 == sizeof(section_header_t), "Section header size mismatch");
 
-addr_t win_get_current_attached_process(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
+struct file_header_t
+{
+    uint16_t machine;
+    uint16_t num_sections;
+    uint32_t timedatestamp;
+    uint32_t ptr_symbol_table;
+    uint32_t num_symbols;
+    uint16_t size_optional_header;
+    uint16_t characteristics;
+};
+static_assert(20 == sizeof(file_header_t), "File header size mismatch");
 
-bool win_get_last_error(drakvuf_t drakvuf, drakvuf_trap_info_t* info, uint32_t* err, const char** err_str);
+struct optional_header_t
+{
+    uint16_t magic;
+    uint8_t  major_version;
+    uint8_t  minor_version;
+    uint32_t size_code;
+    uint32_t size_init_data;
+    uint32_t size_uninit_data;
+    uint32_t entry_point;
+    uint32_t base_code;
+    uint64_t image_base;
+    uint32_t section_alignment;
+    uint32_t file_alignment;
+    uint16_t major_os_version;
+    uint16_t minor_os_version;
+    uint16_t major_image_version;
+    uint16_t minor_image_version;
+    uint16_t major_subsystem_version;
+    uint16_t minor_subsystem_version;
+    uint32_t win32_version_value;
+    uint32_t size_image;
+    uint32_t size_headers;
+    uint32_t checksum;
+    uint16_t subsystem;
+    uint16_t dll_characteristics;
+    uint64_t size_stack_reserve;
+    uint64_t size_stack_commit;
+    uint64_t size_heap_reserve;
+    uint64_t size_heap_commit;
+    uint32_t loader_flags;
+    uint32_t num_rva_sizes;
+    uint64_t data_directories[16];
+};
+static_assert(240 == sizeof(optional_header_t), "Optional header size mismatch");
 
-char* win_get_process_name(drakvuf_t drakvuf, addr_t eprocess_base, bool fullpath);
+struct nt_headers_t
+{
+    uint32_t           signature;
+    file_header_t      file_header;
+    optional_header_t  optional_header;
 
-char* win_get_process_commandline(drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t eprocess_base);
+    inline const section_header_t* get_section(int n) const
+    { 
+        return n >= file_header.num_sections ? nullptr : 
+            reinterpret_cast<const section_header_t*>(
+                (const uint8_t*)&optional_header + file_header.size_optional_header) + n;
+    }
+};
+static_assert(4 + 20 + 240 == sizeof(nt_headers_t), "NT headers size mismatch");
 
-bool win_get_process_pid(drakvuf_t drakvuf, addr_t eprocess_base, int32_t* pid);
+struct dos_header_t
+{
+    uint16_t e_magic;
+    uint16_t e_cblp;
+    uint16_t e_cp;
+    uint16_t e_crlc;
+    uint16_t e_cparhdr;
+    uint16_t e_minalloc;
+    uint16_t e_maxalloc;
+    uint16_t e_ss;
+    uint16_t e_sp;
+    uint16_t e_csum;
+    uint16_t e_ip;
+    uint16_t e_cs;
+    uint16_t e_lfarlc;
+    uint16_t e_ovno;
+    uint16_t e_res[ 4 ];
+    uint16_t e_oemid;
+    uint16_t e_oeminfo;
+    uint16_t e_res2[ 10 ];
+    uint32_t e_lfanew;
+    
+    inline const nt_headers_t* get_nt_headers() const
+    { 
+        return reinterpret_cast<const nt_headers_t*>((const uint8_t*)this + e_lfanew); 
+    }
+};
+static_assert(64 == sizeof(dos_header_t), "Dos header size mismatch");
 
-char* win_get_current_process_name(drakvuf_t drakvuf, drakvuf_trap_info_t* info, bool fullpath);
+struct checksum_data_t
+{
+    addr_t virtual_address;
+    addr_t virtual_size;
+    sha256_checksum_t checksum;
+};
 
-int64_t win_get_process_userid(drakvuf_t drakvuf, addr_t eprocess_base);
+union gdt_entry_t
+{
+    uint64_t entry;
+    struct 
+    {
+        uint16_t limit_low;
+        uint16_t base_low;
+        uint8_t  base_mid;
+        uint8_t  type : 4;
+        uint8_t  s    : 1;
+        uint8_t  dpl  : 2; 
+        uint8_t  present : 1;
+        uint8_t  limit_high : 4;
+        uint8_t  avail: 1;
+        uint8_t  l    : 1;
+        uint8_t  d    : 1;
+        uint8_t  g    : 1;
+        uint8_t  base_high;
+    };
+};
+static_assert(8 == sizeof(gdt_entry_t), "Generic segment descriptor size mismatch");
 
-unicode_string_t* win_get_process_csdversion(drakvuf_t drakvuf, addr_t eprocess_base);
-
-int64_t win_get_current_process_userid(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
-
-bool win_get_process_dtb(drakvuf_t drakvuf, addr_t process_base, addr_t* dtb);
-
-bool win_get_current_thread_id(drakvuf_t drakvuf, drakvuf_trap_info_t* info, uint32_t* thread_id);
-
-bool win_get_thread_previous_mode(drakvuf_t drakvuf, addr_t kthread, privilege_mode_t* previous_mode);
-
-bool win_get_current_thread_previous_mode(drakvuf_t drakvuf,
-    drakvuf_trap_info_t* info,
-    privilege_mode_t* previous_mode);
-
-bool win_is_ethread(drakvuf_t drakvuf, addr_t dtb, addr_t ethread_addr);
-
-bool win_is_eprocess(drakvuf_t drakvuf, addr_t dtb, addr_t eprocess_addr);
-bool win_is_process_suspended(drakvuf_t drakvuf, addr_t process, bool* status);
-
-bool win_get_module_list(drakvuf_t drakvuf, addr_t eprocess_base, addr_t* module_list);
-bool win_get_module_list_wow( drakvuf_t drakvuf, access_context_t* ctx, addr_t wow_peb, addr_t* module_list );
-
-bool win_get_module_base_addr(drakvuf_t drakvuf, addr_t module_list_head, const char* module_name, addr_t* base_addr_out);
-bool win_get_module_base_addr_ctx(drakvuf_t drakvuf, addr_t module_list_head, access_context_t* ctx, const char* module_name, addr_t* base_addr_out);
-module_info_t* win_get_module_info_ctx( drakvuf_t drakvuf, addr_t module_list_head, access_context_t* ctx, const char* module_name );
-module_info_t* win_get_module_info_ctx_wow( drakvuf_t drakvuf, addr_t module_list_head, access_context_t* ctx, const char* module_name );
-
-typedef bool (process_module_visitor_t)(drakvuf_t drakvuf, module_info_t* module_info, bool* need_free, bool* need_stop, void* visitor_ctx);
-bool win_enumerate_module_info_ctx(drakvuf_t drakvuf, addr_t module_list_head, access_context_t* ctx, process_module_visitor_t visitor_func, void* visitor_ctx);
-bool win_enumerate_module_info_ctx_wow(drakvuf_t drakvuf, addr_t module_list_head, access_context_t* ctx, process_module_visitor_t visitor_func, void* visitor_ctx);
-
-typedef bool (process_const_module_visitor_t)(drakvuf_t drakvuf, const module_info_t* module_info, bool* need_free, bool* need_stop, void* visitor_ctx);
-bool win_enumerate_process_modules(drakvuf_t drakvuf, addr_t eprocess, process_const_module_visitor_t visitor_func, void* visitor_ctx);
-
-bool win_find_eprocess(drakvuf_t drakvuf, vmi_pid_t find_pid, const char* find_procname, addr_t* eprocess_addr);
-
-bool win_enumerate_processes(drakvuf_t drakvuf, void (*visitor_func)(drakvuf_t drakvuf, addr_t eprocess, void* visitor_ctx), void* visitor_ctx);
-bool win_enumerate_processes_with_module(drakvuf_t drakvuf, const char* module_name, bool (*visitor_func)(drakvuf_t drakvuf, const module_info_t* module_info, void* visitor_ctx), void* visitor_ctx);
-bool win_enumerate_drivers(drakvuf_t drakvuf, void (*visitor_func)(drakvuf_t drakvuf, addr_t driver, void* visitor_ctx), void* visitor_ctx);
-
-bool win_is_crashreporter(drakvuf_t drakvuf, drakvuf_trap_info_t* info, vmi_pid_t* pid);
-
-bool win_get_process_ppid( drakvuf_t drakvuf, addr_t process_base, int32_t* ppid );
-
-bool win_get_process_data( drakvuf_t drakvuf, addr_t process_base, proc_data_priv_t* proc_data );
-
-gchar* win_reg_keyhandle_path( drakvuf_t drakvuf, drakvuf_trap_info_t* info, uint64_t key_handle );
-
-char* win_get_filename_from_handle(drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t handle);
-
-bool win_is_wow64(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
-
-addr_t win_get_function_argument(drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t argument_number);
-addr_t win_get_function_return_address(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
-
-bool win_inject_traps_modules(drakvuf_t drakvuf, drakvuf_trap_t* trap, addr_t list_head, vmi_pid_t pid);
-
-bool win_find_mmvad(drakvuf_t drakvuf, addr_t eprocess, addr_t vaddr, mmvad_info_t* out_mmvad);
-
-bool win_traverse_mmvad(drakvuf_t drakvuf, addr_t eprocess, mmvad_callback callback, void* callback_data);
-bool win_is_mmvad_commited(drakvuf_t drakvuf, mmvad_info_t* mmvad);
-uint64_t win_mmvad_commit_charge(drakvuf_t drakvuf, mmvad_info_t* mmvad, uint64_t* width);
-uint32_t win_mmvad_type(drakvuf_t drakvuf, mmvad_info_t* mmvad);
-
-bool win_get_pid_from_handle(drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t handle, vmi_pid_t* pid);
-bool win_get_tid_from_handle(drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t handle, uint32_t* tid);
-
-addr_t win_get_wow_peb(drakvuf_t drakvuf, access_context_t* ctx, addr_t eprocess);
-bool win_get_wow_context(drakvuf_t drakvuf, addr_t ethread, addr_t* wow_ctx);
-bool win_get_user_stack32(drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t* stack_ptr, addr_t* frame_ptr);
-bool win_get_user_stack64(drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t* stack_ptr);
-
-bool win_check_return_context(drakvuf_trap_info_t* info, vmi_pid_t pid, uint32_t tid, addr_t rsp);
+struct descriptors_t
+{
+    addr_t idtr_base;
+    addr_t idtr_limit;
+    sha256_checksum_t idt_checksum;
+    addr_t gdtr_base;
+    addr_t gdtr_limit;
+    // Pair of descriptor entry VA and its parsed entry
+    std::vector<std::pair<addr_t, gdt_entry_t>> gdt;
+};
 
 #endif

--- a/src/plugins/rootkitmon/rootkitmon.cpp
+++ b/src/plugins/rootkitmon/rootkitmon.cpp
@@ -327,7 +327,8 @@ bool rootkitmon::enumerate_cores(vmi_instance_t vmi)
             auto gdt = enumerate_gdt(vmi, gdtr_base, gdtr_limit);
 
             // Save descriptor values
-            this->descriptors[vcpu] = {
+            this->descriptors[vcpu] =
+            {
                 idtr_base,
                 idtr_limit,
                 idt_checksum,
@@ -546,13 +547,13 @@ event_response_t rootkitmon::final_check_cb(drakvuf_t drakvuf, drakvuf_trap_info
             {
                 fmt::print(this->format, "rootkitmon", drakvuf, info,
                     keyval("Reason", fmt::Qstr("IDTR base modification")));
-                    break;
+                break;
             }
             if (desc_info.idt_checksum != t_desc_info.idt_checksum)
             {
                 fmt::print(this->format, "rootkitmon", drakvuf, info,
                     keyval("Reason", fmt::Qstr("IDT modification")));
-                    break;
+                break;
             }
         }
 
@@ -563,13 +564,13 @@ event_response_t rootkitmon::final_check_cb(drakvuf_t drakvuf, drakvuf_trap_info
             {
                 fmt::print(this->format, "rootkitmon", drakvuf, info,
                     keyval("Reason", fmt::Qstr("GDTR base modification")));
-                    break;
+                break;
             }
             if (desc_info.gdt.size() != t_desc_info.gdt.size())
             {
                 fmt::print(this->format, "rootkitmon", drakvuf, info,
                     keyval("Reason", fmt::Qstr("GDT modification")));
-                    break;
+                break;
             }
             else
             {
@@ -642,7 +643,10 @@ std::unique_ptr<libhook::ManualHook> rootkitmon::register_profile_hook(drakvuf_t
     trap->cb = callback;
     trap->ttl = UNLIMITED_TTL;
 
-    auto hook = createManualHook(trap, [](drakvuf_trap_t* trap_) { delete trap_; });
+    auto hook = createManualHook(trap, [](drakvuf_trap_t* trap_)
+    {
+        delete trap_;
+    });
     if (!hook)
     {
         PRINT_DEBUG("[ROOTKITMON] Failed to hook %s\n", func_name);
@@ -667,7 +671,10 @@ std::unique_ptr<libhook::ManualHook> rootkitmon::register_mem_hook(event_respons
     trap->ah_cb = nullptr;
     trap->cb = callback;
 
-    auto hook = createManualHook(trap, [](drakvuf_trap_t* trap_) { delete trap_; });
+    auto hook = createManualHook(trap, [](drakvuf_trap_t* trap_)
+    {
+        delete trap_;
+    });
     if (!hook)
     {
         PRINT_DEBUG("[ROOTKITMON] Failed to hook 0x%lx\n", pa >> 12);
@@ -690,7 +697,10 @@ std::unique_ptr<libhook::ManualHook> rootkitmon::register_reg_hook(event_respons
     trap->cb = callback;
     trap->ttl = UNLIMITED_TTL;
 
-    auto hook = createManualHook(trap, [](drakvuf_trap_t* trap_) { delete trap_; });
+    auto hook = createManualHook(trap, [](drakvuf_trap_t* trap_)
+    {
+        delete trap_;
+    });
     if (!hook)
     {
         PRINT_DEBUG("[ROOTKITMON] Failed to hook register\n");

--- a/src/plugins/rootkitmon/rootkitmon.cpp
+++ b/src/plugins/rootkitmon/rootkitmon.cpp
@@ -1,0 +1,967 @@
+/*********************IMPORTANT DRAKVUF LICENSE TERMS***********************
+ *                                                                         *
+ * DRAKVUF (C) 2014-2021 Tamas K Lengyel.                                  *
+ * Tamas K Lengyel is hereinafter referred to as the author.               *
+ * This program is free software; you may redistribute and/or modify it    *
+ * under the terms of the GNU General Public License as published by the   *
+ * Free Software Foundation; Version 2 ("GPL"), BUT ONLY WITH ALL OF THE   *
+ * CLARIFICATIONS AND EXCEPTIONS DESCRIBED HEREIN.  This guarantees your   *
+ * right to use, modify, and redistribute this software under certain      *
+ * conditions.  If you wish to embed DRAKVUF technology into proprietary   *
+ * software, alternative licenses can be acquired from the author.         *
+ *                                                                         *
+ * Note that the GPL places important restrictions on "derivative works",  *
+ * yet it does not provide a detailed definition of that term.  To avoid   *
+ * misunderstandings, we interpret that term as broadly as copyright law   *
+ * allows.  For example, we consider an application to constitute a        *
+ * derivative work for the purpose of this license if it does any of the   *
+ * following with any software or content covered by this license          *
+ * ("Covered Software"):                                                   *
+ *                                                                         *
+ * o Integrates source code from Covered Software.                         *
+ *                                                                         *
+ * o Reads or includes copyrighted data files.                             *
+ *                                                                         *
+ * o Is designed specifically to execute Covered Software and parse the    *
+ * results (as opposed to typical shell or execution-menu apps, which will *
+ * execute anything you tell them to).                                     *
+ *                                                                         *
+ * o Includes Covered Software in a proprietary executable installer.  The *
+ * installers produced by InstallShield are an example of this.  Including *
+ * DRAKVUF with other software in compressed or archival form does not     *
+ * trigger this provision, provided appropriate open source decompression  *
+ * or de-archiving software is widely available for no charge.  For the    *
+ * purposes of this license, an installer is considered to include Covered *
+ * Software even if it actually retrieves a copy of Covered Software from  *
+ * another source during runtime (such as by downloading it from the       *
+ * Internet).                                                              *
+ *                                                                         *
+ * o Links (statically or dynamically) to a library which does any of the  *
+ * above.                                                                  *
+ *                                                                         *
+ * o Executes a helper program, module, or script to do any of the above.  *
+ *                                                                         *
+ * This list is not exclusive, but is meant to clarify our interpretation  *
+ * of derived works with some common examples.  Other people may interpret *
+ * the plain GPL differently, so we consider this a special exception to   *
+ * the GPL that we apply to Covered Software.  Works which meet any of     *
+ * these conditions must conform to all of the terms of this license,      *
+ * particularly including the GPL Section 3 requirements of providing      *
+ * source code and allowing free redistribution of the work as a whole.    *
+ *                                                                         *
+ * Any redistribution of Covered Software, including any derived works,    *
+ * must obey and carry forward all of the terms of this license, including *
+ * obeying all GPL rules and restrictions.  For example, source code of    *
+ * the whole work must be provided and free redistribution must be         *
+ * allowed.  All GPL references to "this License", are to be treated as    *
+ * including the terms and conditions of this license text as well.        *
+ *                                                                         *
+ * Because this license imposes special exceptions to the GPL, Covered     *
+ * Work may not be combined (even as part of a larger work) with plain GPL *
+ * software.  The terms, conditions, and exceptions of this license must   *
+ * be included as well.  This license is incompatible with some other open *
+ * source licenses as well.  In some cases we can relicense portions of    *
+ * DRAKVUF or grant special permissions to use it in other open source     *
+ * software.  Please contact tamas.k.lengyel@gmail.com with any such       *
+ * requests.  Similarly, we don't incorporate incompatible open source     *
+ * software into Covered Software without special permission from the      *
+ * copyright holders.                                                      *
+ *                                                                         *
+ * If you have any questions about the licensing restrictions on using     *
+ * DRAKVUF in other works, are happy to help.  As mentioned above,         *
+ * alternative license can be requested from the author to integrate       *
+ * DRAKVUF into proprietary applications and appliances.  Please email     *
+ * tamas.k.lengyel@gmail.com for further information.                      *
+ *                                                                         *
+ * If you have received a written license agreement or contract for        *
+ * Covered Software stating terms other than these, you may choose to use  *
+ * and redistribute Covered Software under those terms instead of these.   *
+ *                                                                         *
+ * Source is provided to this software because we believe users have a     *
+ * right to know exactly what a program is going to do before they run it. *
+ * This also allows you to audit the software for security holes.          *
+ *                                                                         *
+ * Source code also allows you to port DRAKVUF to new platforms, fix bugs, *
+ * and add new features.  You are highly encouraged to submit your changes *
+ * on https://github.com/tklengyel/drakvuf, or by other methods.           *
+ * By sending these changes, it is understood (unless you specify          *
+ * otherwise) that you are offering unlimited, non-exclusive right to      *
+ * reuse, modify, and relicense the code.  DRAKVUF will always be          *
+ * available Open Source, but this is important because the inability to   *
+ * relicense code has caused devastating problems for other Free Software  *
+ * projects (such as KDE and NASM).                                        *
+ * To specify special license conditions of your contributions, just say   *
+ * so when you send them.                                                  *
+ *                                                                         *
+ * This program is distributed in the hope that it will be useful, but     *
+ * WITHOUT ANY WARRANTY; without even the implied warranty of              *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the DRAKVUF   *
+ * license file for more details (it's in a COPYING file included with     *
+ * DRAKVUF, and also available from                                        *
+ * https://github.com/tklengyel/drakvuf/COPYING)                           *
+ *                                                                         *
+ ***************************************************************************/
+#include <glib.h>
+#include <libvmi/libvmi.h>
+#include <unordered_map>
+#include <set>
+#include "plugins/output_format.h"
+#include "rootkitmon.h"
+#include "private.h"
+
+std::vector<const char*> hook_targets =
+{
+    "PspSetCreateProcessNotifyRoutine",
+    "PsSetCreateThreadNotifyRoutine",
+    "PsSetLoadImageNotifyRoutine",
+    "CmpRegisterCallbackInternal",
+    "ObRegisterCallbacks",
+    "FsRtlRegisterFileSystemFilterCallbacks",
+    "IoRegisterContainerNotification",
+    "IoRegisterFsRegistrationChange",
+    "IoRegisterPlugPlayNotification",
+    "IoWMISetNotificationCallback",
+    "KeRegisterBugCheckCallback",
+    "SeRegisterLogonSessionTerminatedRoutine",
+};
+
+static bool translate_ksym2p(vmi_instance_t vmi, const char* symbol, addr_t* addr)
+{
+    addr_t temp_va;
+    if (VMI_SUCCESS != vmi_translate_ksym2v(vmi, symbol, &temp_va))
+    {
+        PRINT_DEBUG("[ROOTKITMON] Failed to translate symbol to virtual address\n");
+        return false;
+    }
+    if (VMI_SUCCESS != vmi_translate_kv2p(vmi, temp_va, addr))
+    {
+        PRINT_DEBUG("[ROOTKITMON] Failed to translate virtual address to physical\n");
+        return false;
+    }
+    return true;
+}
+
+static uint64_t align_by_page(uint64_t value)
+{
+    auto aligned_size   = value & ~(VMI_PS_4KB - 1);
+    auto size_remainder = value &  (VMI_PS_4KB - 1);
+    if (size_remainder)
+        aligned_size += VMI_PS_4KB;
+    return aligned_size;
+}
+
+/**
+ * Enumerate PE sections with mem_execute and mem_not_paged flags.
+ * Returns vector of <virtual address, aligned section size>
+ */
+static std::vector<std::pair<addr_t, size_t>> get_pe_code_sections(void* module, addr_t read_imagebase)
+{
+    std::vector<std::pair<addr_t, size_t>> out;
+
+    auto dos_h = static_cast<dos_header_t*>(module);
+    for (size_t i = 0; i < dos_h->get_nt_headers()->file_header.num_sections; i++)
+    {
+        auto section = dos_h->get_nt_headers()->get_section(i);
+        // Some sections (PAGE, INIT) might not be present in memory, that's why
+        // we process only non pagable sections.
+        // It is important to check for write access as well since there are sections
+        // with RWX access rights on win7 and below. e.g. RWEXEC in hal.dll and ntoskrnl.
+        if (section->characteristics & mem_execute
+            && section->characteristics & mem_not_paged
+            && !(section->characteristics & mem_write))
+        {
+            auto aligned_size = align_by_page(section->virtual_size);
+            out.emplace_back(section->virtual_address + read_imagebase, aligned_size);
+        }
+    }
+    return out;
+}
+
+/**
+ * Given address and size, calculate SHA256 of a given memory region.
+ * Partially taken from memdump plugin.
+ */
+static sha256_checksum_t calc_checksum(vmi_instance_t vmi, addr_t address, size_t size)
+{
+    sha256_checksum_t out{ 0 };
+
+    auto aligned_size = align_by_page(size);
+    auto intra_page_offset = address & (VMI_PS_4KB - 1);
+
+    auto num_pages = aligned_size / VMI_PS_4KB;
+
+    std::vector<void*> access_ptrs(num_pages, nullptr);
+
+    ACCESS_CONTEXT(ctx,
+        .translate_mechanism = VMI_TM_PROCESS_PID,
+        .pid = 4,
+        .addr = address
+    );
+
+    if (VMI_SUCCESS != vmi_mmap_guest(vmi, &ctx, num_pages, access_ptrs.data()))
+    {
+        PRINT_DEBUG("[ROOTKITMON] Failed to map guest VA 0x%lx\n", ctx.addr);
+        return out;
+    }
+
+    auto checksum = g_checksum_new(G_CHECKSUM_SHA256);
+
+    for (size_t i = 0; i < num_pages; i++)
+    {
+        size_t write_size = size;
+
+        if (write_size > VMI_PS_4KB - intra_page_offset)
+            write_size = VMI_PS_4KB - intra_page_offset;
+
+        if (access_ptrs[i])
+        {
+            g_checksum_update(checksum, (const uint8_t*)access_ptrs[i] + intra_page_offset, write_size);
+            munmap(access_ptrs[i], VMI_PS_4KB);
+        }
+
+        intra_page_offset = 0;
+        size -= write_size;
+    }
+
+    size_t buffer_size = out.size();
+    g_checksum_get_digest(checksum, out.data(), &buffer_size);
+
+    if (buffer_size != out.size())
+    {
+        PRINT_DEBUG("[ROOTKITMON] SHA256 checksum digest size mismatch\n");
+        throw -1;
+    }
+
+    return out;
+}
+
+/**
+ * Enumerate present GDT entries.
+ * Returns vector of <virtual address of gdt entry, parsed gdt entry>
+*/
+static std::vector<std::pair<addr_t, gdt_entry_t>> enumerate_gdt(vmi_instance_t vmi, addr_t gdt_base, size_t gdt_limit)
+{
+    // address -> gdt_entry_t
+    std::vector<std::pair<addr_t, gdt_entry_t>> gdt;
+
+    for (size_t i = 0; i <= gdt_limit; i += sizeof(gdt_entry_t))
+    {
+        gdt_entry_t entry{};
+        // Read uint64_t entry
+        if (VMI_SUCCESS != vmi_read_va(vmi, gdt_base + i, 4, sizeof(entry), (void*)&entry, nullptr))
+        {
+            PRINT_DEBUG("[ROOTKITMON] Failed to read GDT entry\n");
+            throw -1;
+        }
+
+        // Save only present entries
+        if (entry.present)
+        {
+            gdt.emplace_back(gdt_base + i, entry);
+        }
+    }
+    return gdt;
+}
+
+
+/**
+ * This is the callback of the fwpkclnt.sys function FwpmCalloutAdd0.
+*/
+static event_response_t wfp_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
+{
+    auto plugin = static_cast<rootkitmon*>(info->trap->data);
+    fmt::print(plugin->format, "rootkitmon", drakvuf, info,
+        keyval("Reason", fmt::Qstr(info->trap->name)));
+    return VMI_EVENT_RESPONSE_NONE;
+}
+
+/**
+ * This is the callback of the fltmgr.sys function FltRegisterFilter.
+*/
+static event_response_t flt_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
+{
+    auto plugin = static_cast<rootkitmon*>(info->trap->data);
+    fmt::print(plugin->format, "rootkitmon", drakvuf, info,
+        keyval("Reason", fmt::Qstr(info->trap->name)));
+    return VMI_EVENT_RESPONSE_NONE;
+}
+
+/**
+ * This is the callback of the memory trap.
+ * If an instruction writes into the page where HalPrivateDispatchTable located, this callback is executed.
+*/
+static event_response_t halprivatetable_overwrite_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
+{
+    auto plugin = static_cast<rootkitmon*>(info->trap->data);
+    // Table size is unknown, assume 0x100 bytes
+    if (info->trap_pa >= plugin->halprivatetable && info->trap_pa < plugin->halprivatetable + 0x100)
+    {
+        fmt::print(plugin->format, "rootkitmon", drakvuf, info,
+            keyval("Reason", fmt::Qstr("HalPrivateDispatchTable overwrite")));
+    }
+    return VMI_EVENT_RESPONSE_NONE;
+}
+
+bool rootkitmon::enumerate_cores(vmi_instance_t vmi)
+{
+    for (size_t vcpu = 0; vcpu < vmi_get_num_vcpus(vmi); vcpu++)
+    {
+        uint64_t idtr_base = 0, gdtr_base = 0;
+        uint64_t idtr_limit = 0, gdtr_limit = 0;
+        uint64_t lstar = 0;
+
+        if (VMI_SUCCESS == vmi_get_vcpureg(vmi, &idtr_base, IDTR_BASE, vcpu) &&
+            VMI_SUCCESS == vmi_get_vcpureg(vmi, &idtr_limit, IDTR_LIMIT, vcpu) &&
+            VMI_SUCCESS == vmi_get_vcpureg(vmi, &gdtr_base, GDTR_BASE, vcpu) &&
+            VMI_SUCCESS == vmi_get_vcpureg(vmi, &gdtr_limit, GDTR_LIMIT, vcpu) &&
+            VMI_SUCCESS == vmi_get_vcpureg(vmi, &lstar, MSR_LSTAR, vcpu))
+        {
+            PRINT_DEBUG("[ROOTKITMON] [VCPU] %zu IDTR 0x%lx:0x%lx\n", vcpu, idtr_base, idtr_limit);
+            PRINT_DEBUG("[ROOTKITMON] [VCPU] %zu GDTR 0x%lx:0x%lx\n", vcpu, gdtr_base, gdtr_limit);
+            PRINT_DEBUG("[ROOTKITMON] [VCPU] %zu LSTAR 0x%lx\n", vcpu, lstar);
+
+            // Calculate IDT checksum
+            auto idt_checksum = calc_checksum(vmi, idtr_base, idtr_limit + 1);
+
+            // Enumerate GDT entries
+            auto gdt = enumerate_gdt(vmi, gdtr_base, gdtr_limit);
+
+            // Save descriptor values
+            this->descriptors[vcpu] = {
+                idtr_base,
+                idtr_limit,
+                idt_checksum,
+                gdtr_base,
+                gdtr_limit,
+                gdt
+            };
+
+            // Save msr value
+            this->msr_lstar[vcpu] = lstar;
+        }
+        else
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+/**
+ * This callback is executed on every discovered driver.
+ * It is used to calculate checksums of driver sections.
+ * @driver - LDR_DATA_TABLE_ENTRY pointer.
+*/
+static void driver_visitor(drakvuf_t drakvuf, addr_t driver, void* ctx)
+{
+    auto plugin = static_cast<rootkitmon*>(ctx);
+    addr_t imagebase;
+    vmi_lock_guard vmi(drakvuf);
+    // Read driver image base
+    if (VMI_SUCCESS != vmi_read_addr_va(vmi, driver + plugin->offsets[LDR_DATA_TABLE_ENTRY_DLLBASE], 4, &imagebase))
+    {
+        PRINT_DEBUG("[ROOTKITMON] Failed to read driver image base\n");
+        throw -1;
+    }
+
+    ACCESS_CONTEXT(a_ctx,
+        .translate_mechanism = VMI_TM_PROCESS_PID,
+        .pid = 4,
+        .addr = imagebase
+    );
+
+    // Map 1 4KB page with PE header
+    void* module = nullptr;
+    if (VMI_SUCCESS != vmi_mmap_guest(vmi, &a_ctx, 1, &module))
+    {
+        PRINT_DEBUG("[ROOTKITMON] Failed to map guest VA 0x%lx\n", a_ctx.addr);
+        return;
+    }
+
+    // Checksum every section and save it into `driver_sections_checksums`
+    for (const auto& [virt_addr, virt_size] : get_pe_code_sections(module, imagebase))
+    {
+        auto aligned_size = align_by_page(virt_size);
+
+        checksum_data_t data =
+        {
+            .virtual_address = virt_addr,
+            .virtual_size = aligned_size,
+            .checksum = calc_checksum(vmi, virt_addr, aligned_size)
+        };
+        plugin->driver_sections_checksums[driver].push_back(data);
+
+    }
+    munmap(module, VMI_PS_4KB);
+}
+
+/**
+ * This trap is used to make final analysis.
+*/
+event_response_t rootkitmon::final_check_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
+{
+    // Process only first callback call
+    if (is_stopping() && !done_final_analysis)
+    {
+        PRINT_DEBUG("[ROOTKITMON] Making final analysis\n");
+
+        //=======================================
+        // Check driver sections checksum
+        // Save old checksums
+        auto past_drivers_checksums = std::move(this->driver_sections_checksums);
+        this->driver_sections_checksums.clear();
+        // Collect new checksums
+        drakvuf_enumerate_drivers(drakvuf, driver_visitor, static_cast<void*>(this));
+        // Compare
+        for (const auto& [driver, infos] : this->driver_sections_checksums)
+        {
+            // Find driver object
+            if (past_drivers_checksums.find(driver) == past_drivers_checksums.end())
+                continue;
+
+            const auto& p_infos = past_drivers_checksums[driver];
+
+            for (const auto& checksum_data : infos)
+            {
+                for (const auto& p_checksum_data : p_infos)
+                {
+                    if (checksum_data.virtual_address == p_checksum_data.virtual_address)
+                    {
+                        if (checksum_data.checksum != p_checksum_data.checksum)
+                        {
+                            {
+                                vmi_lock_guard vmi(drakvuf);
+                                unicode_string_t* drvname = drakvuf_read_unicode_va(vmi, driver + this->offsets[LDR_DATA_TABLE_ENTRY_BASEDLLNAME], 4);
+                                if (drvname)
+                                {
+                                    fmt::print(this->format, "rootkitmon", drakvuf, info,
+                                        keyval("Reason", fmt::Qstr("Driver section modification")),
+                                        keyval("Driver", fmt::Qstr((const char*)drvname->contents)));
+                                    vmi_free_unicode_str(drvname);
+                                }
+                                else
+                                {
+                                    fmt::print(this->format, "rootkitmon", drakvuf, info,
+                                        keyval("Reason", fmt::Qstr("Driver section modification")),
+                                        keyval("Driver", fmt::Qstr("Unknown")));
+                                }
+                            }
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+
+        //=======================================
+        // Check driver object checksums and driver stacks
+        // Save old checksums and stacks
+        auto past_driver_object_checksums = std::move(this->driver_object_checksums);
+        auto past_driver_stacks = std::move(this->driver_stacks);
+        this->driver_object_checksums.clear();
+        this->driver_stacks.clear();
+        // Collect new info
+        {
+            vmi_lock_guard vmi(drakvuf);
+            if (!this->is32bit)
+                for (const auto& drv_object : this->enumerate_driver_objects(vmi))
+                {
+                    this->driver_object_checksums[drv_object] = calc_checksum(vmi, drv_object + this->offsets[DRIVER_OBJECT_STARTIO], this->guest_ptr_size * 30);
+                    this->driver_stacks[drv_object] = this->enumerate_driver_stacks(vmi, drv_object);
+                }
+        }
+        // Compare dispatch table checksums
+        for (const auto& [drv_object, checksum] : this->driver_object_checksums)
+        {
+            // Find driver object
+            if (past_driver_object_checksums.find(drv_object) == past_driver_object_checksums.end())
+                continue;
+
+            const auto& p_checksum = past_driver_object_checksums[drv_object];
+
+            if (checksum != p_checksum)
+            {
+                fmt::print(this->format, "rootkitmon", drakvuf, info,
+                    keyval("Reason", fmt::Qstr("Driver object modification")));
+            }
+        }
+        // Compare driver stacks
+        for (const auto& [drv_object, dev_stacks] : this->driver_stacks)
+        {
+            // Find driver object
+            if (past_driver_stacks.find(drv_object) == past_driver_stacks.end())
+                continue;
+
+            auto& p_dev_stacks = past_driver_stacks[drv_object];
+
+            for (const auto& [dev_object, dev_stack] : dev_stacks)
+            {
+                // Find device object
+                if (p_dev_stacks.find(dev_object) == p_dev_stacks.end())
+                    continue;
+
+                const auto& p_dev_stack = p_dev_stacks[dev_object];
+
+                // Size mismatch == stack modification
+                if (p_dev_stack.size() != dev_stack.size())
+                {
+                    fmt::print(this->format, "rootkitmon", drakvuf, info,
+                        keyval("Reason", fmt::Qstr("Driver stack modification")));
+                    continue;
+                }
+
+                for (size_t i = 0; i < dev_stack.size(); i++)
+                {
+                    // Dev object hijack
+                    if (dev_stack[i] != p_dev_stack[i])
+                    {
+                        fmt::print(this->format, "rootkitmon", drakvuf, info,
+                            keyval("Reason", fmt::Qstr("Driver stack modification")));
+                        break;
+                    }
+                }
+            }
+        }
+
+        //=======================================
+        // Check per core specific registers
+        auto past_descriptors = std::move(this->descriptors);
+        auto past_lstar = std::move(this->msr_lstar);
+        this->descriptors.clear();
+        this->msr_lstar.clear();
+
+        {
+            vmi_lock_guard vmi(drakvuf);
+            if (!enumerate_cores(vmi))
+            {
+                PRINT_DEBUG("[ROOTKITMON] Failed to enumerate descriptors\n");
+                throw -1;
+            }
+        }
+
+        for (const auto& [vcpu, desc_info] : this->descriptors)
+        {
+            const auto& t_desc_info = past_descriptors[vcpu];
+            if (desc_info.idtr_base != t_desc_info.idtr_base)
+            {
+                fmt::print(this->format, "rootkitmon", drakvuf, info,
+                    keyval("Reason", fmt::Qstr("IDTR base modification")));
+                    break;
+            }
+            if (desc_info.idt_checksum != t_desc_info.idt_checksum)
+            {
+                fmt::print(this->format, "rootkitmon", drakvuf, info,
+                    keyval("Reason", fmt::Qstr("IDT modification")));
+                    break;
+            }
+        }
+
+        for (const auto& [vcpu, desc_info] : this->descriptors)
+        {
+            const auto& t_desc_info = past_descriptors[vcpu];
+            if (desc_info.gdtr_base != t_desc_info.gdtr_base)
+            {
+                fmt::print(this->format, "rootkitmon", drakvuf, info,
+                    keyval("Reason", fmt::Qstr("GDTR base modification")));
+                    break;
+            }
+            if (desc_info.gdt.size() != t_desc_info.gdt.size())
+            {
+                fmt::print(this->format, "rootkitmon", drakvuf, info,
+                    keyval("Reason", fmt::Qstr("GDT modification")));
+                    break;
+            }
+            else
+            {
+                for (size_t i = 0; i < desc_info.gdt.size(); i++)
+                {
+                    const auto& [addr, entry] = desc_info.gdt[i];
+                    const auto& [t_addr, t_entry] = t_desc_info.gdt[i];
+
+                    if (addr != t_addr)
+                    {
+                        fmt::print(this->format, "rootkitmon", drakvuf, info,
+                            keyval("Reason", fmt::Qstr("GDT modification")));
+                        break;
+                    }
+                }
+            }
+        }
+
+        //=======================================
+        // Check msr lstar modification
+        for (const auto& [vcpu, lstar] : this->msr_lstar)
+        {
+            if (past_lstar[vcpu] != lstar)
+            {
+                fmt::print(this->format, "rootkitmon", drakvuf, info,
+                    keyval("Reason", fmt::Qstr("LSTAR modification")));
+            }
+        }
+
+        done_final_analysis = true;
+    }
+    return VMI_EVENT_RESPONSE_NONE;
+}
+
+event_response_t rootkitmon::callback_hooks_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
+{
+    fmt::print(this->format, "rootkitmon", drakvuf, info,
+        keyval("Reason", fmt::Qstr(info->trap->name)));
+    return VMI_EVENT_RESPONSE_NONE;
+}
+
+std::unique_ptr<libhook::ManualHook> rootkitmon::register_profile_hook(drakvuf_t drakvuf, const char* profile, const char* dll_name,
+    const char* func_name, event_response_t (*callback)(drakvuf_t, drakvuf_trap_info_t*))
+{
+    addr_t func_rva = 0;
+    auto profile_json = json_object_from_file(profile);
+    if (!profile_json)
+    {
+        PRINT_DEBUG("[ROOTKITMON] Failed to load JSON debug info for %s\n", dll_name);
+        throw -1;
+    }
+    if (!json_get_symbol_rva(drakvuf, profile_json, func_name, &func_rva))
+    {
+        PRINT_DEBUG("[ROOTKITMON] Failed to find %s RVA in json for %s\n", func_name, dll_name);
+        throw -1;
+    }
+
+    json_object_put(profile_json);
+
+    auto trap = new drakvuf_trap_t();
+    trap->breakpoint.lookup_type = LOOKUP_PID;
+    trap->breakpoint.pid = 4;
+    trap->breakpoint.addr_type = ADDR_RVA;
+    trap->breakpoint.module = dll_name;
+    trap->breakpoint.rva = func_rva;
+    trap->type = BREAKPOINT;
+    trap->data = (void*)this;
+    trap->ah_cb = nullptr;
+    trap->name = func_name;
+    trap->cb = callback;
+    trap->ttl = UNLIMITED_TTL;
+
+    auto hook = createManualHook(trap, [](drakvuf_trap_t* trap_) { delete trap_; });
+    if (!hook)
+    {
+        PRINT_DEBUG("[ROOTKITMON] Failed to hook %s\n", func_name);
+        throw -1;
+    }
+    else
+    {
+        return hook;
+    }
+}
+
+std::unique_ptr<libhook::ManualHook> rootkitmon::register_mem_hook(event_response_t (*callback)(drakvuf_t, drakvuf_trap_info_t*), addr_t pa, vmi_mem_access_t access)
+{
+    auto trap = new drakvuf_trap_t();
+    trap->type = MEMACCESS;
+    trap->memaccess.gfn = pa >> 12;
+    trap->memaccess.type = PRE;
+    trap->memaccess.access = access;
+    trap->data = (void*)this;
+    trap->name = nullptr;
+    trap->ttl = UNLIMITED_TTL;
+    trap->ah_cb = nullptr;
+    trap->cb = callback;
+
+    auto hook = createManualHook(trap, [](drakvuf_trap_t* trap_) { delete trap_; });
+    if (!hook)
+    {
+        PRINT_DEBUG("[ROOTKITMON] Failed to hook 0x%lx\n", pa >> 12);
+        throw -1;
+    }
+    else
+    {
+        return hook;
+    }
+}
+
+std::unique_ptr<libhook::ManualHook> rootkitmon::register_reg_hook(event_response_t (*callback)(drakvuf_t, drakvuf_trap_info_t*), register_t reg)
+{
+    auto trap = new drakvuf_trap_t();
+    trap->type = REGISTER;
+    trap->reg = reg;
+    trap->data = (void*)this;
+    trap->ah_cb = nullptr;
+    trap->name = nullptr;
+    trap->cb = callback;
+    trap->ttl = UNLIMITED_TTL;
+
+    auto hook = createManualHook(trap, [](drakvuf_trap_t* trap_) { delete trap_; });
+    if (!hook)
+    {
+        PRINT_DEBUG("[ROOTKITMON] Failed to hook register\n");
+        throw -1;
+    }
+    else
+    {
+        return hook;
+    }
+}
+
+unicode_string_t* rootkitmon::get_object_type_name(vmi_instance_t vmi, addr_t object)
+{
+    addr_t ob_header = object - this->object_header_size + this->guest_ptr_size;
+    uint8_t type_index;
+
+    // Object header is always present before actual object
+    if (VMI_SUCCESS != vmi_read_8_va(vmi, ob_header + this->offsets[OBJECT_HEADER_TYPEINDEX], 4, &type_index))
+        return nullptr;
+
+    if (this->winver == VMI_OS_WINDOWS_10)
+        type_index = type_index ^ ((ob_header >> 8) & 0xff) ^ this->ob_header_cookie;
+
+    addr_t ob_type;
+    if (VMI_SUCCESS != vmi_read_addr_va(vmi, this->type_idx_table + type_index * this->guest_ptr_size, 4, &ob_type))
+        return nullptr;
+
+    return drakvuf_read_unicode_va(vmi, ob_type + this->offsets[OBJECT_TYPE_NAME], 4);
+}
+
+
+std::set<driver_t> rootkitmon::enumerate_directory(vmi_instance_t vmi, addr_t directory)
+{
+    std::set<driver_t> out;
+
+    for (int i = 0; i < 37; i++)
+    {
+        addr_t hashbucket = 0;
+        if (VMI_SUCCESS != vmi_read_addr_va(vmi, directory + this->guest_ptr_size * i, 4, &hashbucket) || !hashbucket)
+            continue;
+
+        while (true)
+        {
+            addr_t object = 0;
+            if (VMI_SUCCESS != vmi_read_addr_va(vmi, hashbucket + this->offsets[OBJECT_DIRECTORY_ENTRY_OBJECT], 4, &object) || !object)
+                break;
+
+            unicode_string_t* obj_name = get_object_type_name(vmi, object);
+            if (obj_name)
+            {
+                if (!strcmp((const char*)obj_name->contents, "Driver"))
+                    out.insert(object);
+
+                if (!strcmp((const char*)obj_name->contents, "Directory"))
+                    for (auto obj : enumerate_directory(vmi, object))
+                        out.insert(obj);
+
+                vmi_free_unicode_str(obj_name);
+            }
+
+            if (VMI_SUCCESS != vmi_read_addr_va(vmi, hashbucket + this->offsets[OBJECT_DIRECTORY_ENTRY_CHAINLINK], 4, &hashbucket) || !hashbucket)
+                break;
+        }
+    }
+    return out;
+}
+
+std::set<driver_t> rootkitmon::enumerate_driver_objects(vmi_instance_t vmi)
+{
+    // Get root directory object VA
+    addr_t root_directory_object;
+    if (VMI_SUCCESS != vmi_read_addr_ksym(vmi, "ObpRootDirectoryObject", &root_directory_object))
+    {
+        PRINT_DEBUG("[ROOTKITMON] Failed to translate ObpRootDirectoryObject to VA\n");
+        throw -1;
+    }
+
+    // Enumerate directories recursively
+    return enumerate_directory(vmi, root_directory_object);
+}
+
+
+/**
+ * Every driver can have N number of devices. Every device can be attached to a different device of a different driver,
+ * hence the name driver stack.
+ * The device object that is pointed to by the AttachedDevice member of _DEVICE_OBJECT structure typically is
+ * the device object of a filter driver, which intercepts I/O requests originally targeted to the device
+ * represent by the device object.
+*/
+device_stack_t rootkitmon::enumerate_driver_stacks(vmi_instance_t vmi, addr_t driver_object)
+{
+    device_stack_t stacks;
+
+    // Read first device object
+    addr_t device_object;
+    if (VMI_SUCCESS != vmi_read_addr_va(vmi, driver_object + offsets[DRIVER_OBJECT_DEVICEOBJECT], 4, &device_object))
+    {
+        PRINT_DEBUG("[ROOTKITMON] Failed to read device object\n");
+        throw -1;
+    }
+
+    // Loop over `NextDevice` member of _DEVICE_OBJECT structure
+    while (device_object)
+    {
+        // Read first attached device
+        addr_t attached_device;
+        if (VMI_SUCCESS != vmi_read_addr_va(vmi, device_object + offsets[DEVICE_OBJECT_ATTACHEDDEVICE], 4, &attached_device))
+        {
+            PRINT_DEBUG("[ROOTKITMON] Failed to read AttachedDevice object\n");
+            throw -1;
+        }
+
+        // Loop over `AttachedDevice` member of _DEVICE_OBJECT structure
+        while (attached_device)
+        {
+            // Save into the stack of a `device_object`
+            stacks[device_object].push_back(attached_device);
+
+            // Read next `AttachedDevice`
+            if (VMI_SUCCESS != vmi_read_addr_va(vmi, attached_device + offsets[DEVICE_OBJECT_ATTACHEDDEVICE], 4, &attached_device))
+            {
+                PRINT_DEBUG("[ROOTKITMON] Failed to read AttachedDevice\n");
+                throw -1;
+            }
+        }
+
+        // Read next `NextDevice`
+        if (VMI_SUCCESS != vmi_read_addr_va(vmi, device_object + offsets[DEVICE_OBJECT_NEXTDEVICE], 4, &device_object))
+        {
+            PRINT_DEBUG("[ROOTKITMON] Failed to read next device object\n");
+            throw -1;
+        }
+    }
+    return stacks;
+}
+
+rootkitmon::rootkitmon(drakvuf_t drakvuf, const rootkitmon_config* config, output_format_t output)
+    : pluginex(drakvuf, output), format(output), offsets(new size_t[__OFFSET_MAX]),
+      done_final_analysis(false), not_supported(false)
+{
+    if (drakvuf_get_page_mode(drakvuf) != VMI_PM_IA32E)
+    {
+        this->guest_ptr_size = 4;
+        this->is32bit = true;
+    }
+    else
+    {
+        this->guest_ptr_size = 8;
+        this->is32bit = false;
+    }
+
+    {
+        vmi_lock_guard vmi(drakvuf);
+        win_build_info_t build_info;
+        if (!vmi_get_windows_build_info(vmi.vmi, &build_info))
+            throw -1;
+
+        this->winver = build_info.version;
+    }
+
+    for (const auto& target : hook_targets)
+    {
+        auto hook = createSyscallHook(target, &rootkitmon::callback_hooks_cb);
+        if (!hook)
+        {
+            PRINT_DEBUG("[ROOTKITMON] Failed to hook %s\n", target);
+        }
+        else
+        {
+            hook->trap_->name = target;
+            this->syscall_hooks.push_back(std::move(hook));
+        }
+    }
+
+    if (!config->fwpkclnt_profile)
+    {
+        PRINT_DEBUG("[ROOTKITMON] No profile for fwpkclnt.sys was given!\n");
+    }
+    else
+    {
+        manual_hooks.push_back(register_profile_hook(drakvuf, config->fwpkclnt_profile, "fwpkclnt.sys", "FwpmCalloutAdd0", wfp_cb));
+    }
+
+    if (!config->fltmgr_profile)
+    {
+        PRINT_DEBUG("[ROOTKITMON] No profile for fltmgr.sys was given!\n");
+    }
+    else
+    {
+        manual_hooks.push_back(register_profile_hook(drakvuf, config->fltmgr_profile, "fltmgr.sys", "FltRegisterFilter", flt_cb));
+    }
+
+    if (!drakvuf_get_kernel_struct_members_array_rva(drakvuf, offset_names, __OFFSET_MAX, this->offsets))
+    {
+        PRINT_DEBUG("[ROOTKITMON] Failed to get kernel struct member offsets\n");
+        throw -1;
+    }
+
+    drakvuf_enumerate_drivers(drakvuf, driver_visitor, static_cast<void*>(this));
+
+    vmi_lock_guard vmi(drakvuf);
+
+    // Hook HalPrivateDispatchTable on write
+    if (!translate_ksym2p(vmi, "HalPrivateDispatchTable", &(this->halprivatetable)))
+    {
+        PRINT_DEBUG("[ROOTKITMON] Failed to translate symbol to physical address\n");
+        throw -1;
+    }
+    manual_hooks.push_back(register_mem_hook(halprivatetable_overwrite_cb, this->halprivatetable, VMI_MEMACCESS_W));
+
+    if (!drakvuf_get_kernel_struct_size(drakvuf, "_OBJECT_HEADER", &this->object_header_size))
+    {
+        PRINT_DEBUG("[ROOTKITMON] Failed to get _OBJECT_HEADER struct size\n");
+        throw -1;
+    }
+
+    if (VMI_SUCCESS != vmi_translate_ksym2v(vmi, "ObTypeIndexTable", &this->type_idx_table))
+    {
+        PRINT_DEBUG("[ROOTKITMON] Failed to translate ObTypeIndexTable to VA\n");
+        throw -1;
+    }
+
+    if (this->winver == VMI_OS_WINDOWS_10 && VMI_SUCCESS != vmi_read_8_ksym(vmi, "ObHeaderCookie", &this->ob_header_cookie))
+    {
+        PRINT_DEBUG("[ROOTKITMON] Failed to locate header cookie\n");
+        throw -1;
+    }
+
+    if (!this->is32bit)
+        for (const auto& drv_object : enumerate_driver_objects(vmi))
+        {
+            auto address = drv_object + offsets[DRIVER_OBJECT_STARTIO];
+            // 28 Major functions + DriverUnload + DriverStartIo = 30 pointers
+            driver_object_checksums[drv_object] = calc_checksum(vmi, address, this->guest_ptr_size * 30);
+            // Enumerate all device_stacks of a particular driver
+            driver_stacks[drv_object] = enumerate_driver_stacks(vmi, drv_object);
+        }
+
+    // Enumerate descriptors on all cores
+    if (!enumerate_cores(vmi))
+    {
+        PRINT_DEBUG("[ROOTKITMON] Failed to enumerate descriptors\n");
+        throw -1;
+    }
+    PRINT_DEBUG("[ROOTKITMON] Done init\n");
+}
+
+rootkitmon::~rootkitmon()
+{
+    delete[] offsets;
+}
+
+bool rootkitmon::stop()
+{
+    if (!is_stopping() && !done_final_analysis)
+    {
+        m_is_stopping = true;
+        PRINT_DEBUG("[ROOTKITMON] Injecting KiDeliverApc\n");
+        // Hook dummy function so we could make final system analysis
+        auto hook = createSyscallHook("KiDeliverApc", &rootkitmon::final_check_cb);
+        if (!hook)
+        {
+            // Skip final analysis
+            PRINT_DEBUG("[ROOTKITMON] Failed to hook KiDeliverApc\n");
+            done_final_analysis = true;
+            return true;
+        }
+        this->syscall_hooks.push_back(std::move(hook));
+        // Return status `Pending`
+        return false;
+    }
+    // Return status `Pending`
+    return done_final_analysis;
+}


### PR DESCRIPTION
Hello again! This is the new plugin `rootkitmon` that is used to detect malicious behavior in kernel space. The plugin extensively uses `libhook` library and made with performance in mind because you don't want to waste precious cpu time doing rootkit checks if most of your malware samples are in usermode. That's why the most volatile structures are only checked at the end of the analysis.

Current features:
1. protect `MSR LSTAR`
2. protect `_DRIVER_OBJECT`
3. protect `IDT/GDT`
4. protect non pageable driver code sections
5. protect `HalPrivateDispatchTable`
6. monitor adding/deleting `_DEVICE_OBJECTS`
5. monitor various system callback registration functions including `FwpmCalloutAdd0`.
6. monitor calls to `FltRegisterFilter`

We've already got plans on what to add more and how to improve already present detection vectors but it's good for the initial phase. The plugin was run thousand times and tested with the help of @disaykin  and @skvl.
