### PR TITLE
injector: use gprs as default for injection

### DIFF
--- a/src/libinjector/injector_utils.h
+++ b/src/libinjector/injector_utils.h
@@ -109,4 +109,5 @@
 #include <libinjector/private.h>
 
 event_response_t override_step(injector_t injector, const injector_step_t step, event_response_t event);
+event_response_t handle_gprs_registers(drakvuf_t drakvuf, drakvuf_trap_info_t* info, event_response_t event);
 #endif

--- a/src/libinjector/linux/linux_injector.c
+++ b/src/libinjector/linux/linux_injector.c
@@ -219,7 +219,7 @@ event_response_t injector_int3_userspace_cb(drakvuf_t drakvuf, drakvuf_trap_info
     if (!injector->step_override)
         injector->step += 1;
 
-    return event;
+    return handle_gprs_registers(drakvuf, info, event);
 }
 
 static event_response_t wait_for_target_process_cr3_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
@@ -403,6 +403,7 @@ injector_status_t injector_start_app_on_linux(
     injector->method = method;
     injector->format = format;
     injector->step = STEP1;
+    injector->set_gprs_only = true;
 
     if (init_injector(injector))
     {

--- a/src/libinjector/linux/linux_utils.h
+++ b/src/libinjector/linux/linux_utils.h
@@ -160,6 +160,7 @@ struct injector
     // KEEP THESE IN TOP and in sync with the order in injector_utils.c
     injector_step_t step;
     bool step_override; // set this as true for jumping to some arbitrary step
+    bool set_gprs_only;
 
     // Inputs:
     vmi_pid_t target_pid;

--- a/src/libinjector/private.h
+++ b/src/libinjector/private.h
@@ -164,25 +164,25 @@ void injector_terminate_on_win(drakvuf_t drakvuf,
 void injector_free_win(injector_t injector);
 void injector_free_linux(injector_t injector);
 
-static inline void copy_gprs(registers_t* dst, registers_t* src)
+static inline void copy_gprs(x86_registers_t* dst, x86_registers_t* src)
 {
-    dst->x86.rip = src->x86.rip;
-    dst->x86.rsp = src->x86.rsp;
-    dst->x86.rbp = src->x86.rbp;
-    dst->x86.rax = src->x86.rax;
-    dst->x86.rbx = src->x86.rbx;
-    dst->x86.rcx = src->x86.rcx;
-    dst->x86.rdx = src->x86.rdx;
-    dst->x86.rdi = src->x86.rdi;
-    dst->x86.rsi = src->x86.rsi;
-    dst->x86.r8 = src->x86.r8;
-    dst->x86.r9 = src->x86.r9;
-    dst->x86.r10 = src->x86.r10;
-    dst->x86.r11 = src->x86.r11;
-    dst->x86.r12 = src->x86.r12;
-    dst->x86.r13 = src->x86.r13;
-    dst->x86.r14 = src->x86.r14;
-    dst->x86.r15 = src->x86.r15;
+    dst->rip = src->rip;
+    dst->rsp = src->rsp;
+    dst->rbp = src->rbp;
+    dst->rax = src->rax;
+    dst->rbx = src->rbx;
+    dst->rcx = src->rcx;
+    dst->rdx = src->rdx;
+    dst->rdi = src->rdi;
+    dst->rsi = src->rsi;
+    dst->r8 = src->r8;
+    dst->r9 = src->r9;
+    dst->r10 = src->r10;
+    dst->r11 = src->r11;
+    dst->r12 = src->r12;
+    dst->r13 = src->r13;
+    dst->r14 = src->r14;
+    dst->r15 = src->r15;
 }
 
 #endif /* LIBINJECTOR_PRIVATE_H */

--- a/src/libinjector/win/win_injector.c
+++ b/src/libinjector/win/win_injector.c
@@ -258,7 +258,7 @@ tidied:  // tidy up later
                 injector->step+=1;
 
             injector->step_override = false;
-            return event;
+            return handle_gprs_registers(drakvuf, info, event);
         }
         default:
         {
@@ -831,7 +831,7 @@ event_response_t injector_int3_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
                 drakvuf_get_last_error(injector->drakvuf, info, &injector->error_code.code, &injector->error_code.string);
             }
 
-            copy_gprs(&regs, &injector->saved_regs);
+            copy_gprs(&regs.x86, &injector->saved_regs.x86);
 
             if (injector->pid && injector->tid)
             {
@@ -930,7 +930,7 @@ tidied:  // tidy up later
                     injector->step+=1;
 
                 injector->step_override = false;
-                return event;
+                return handle_gprs_registers(drakvuf, info, event);
             }
             default:
             {
@@ -1343,6 +1343,7 @@ injector_status_t injector_start_app_on_win(
     injector->error_code.string = "<UNKNOWN>";
     injector->step = STEP1;
     injector->step_override = false;
+    injector->set_gprs_only = true;
 
     if (!initialize_injector_functions(drakvuf, injector, file, binary_path))
     {

--- a/src/libinjector/win/win_utils.h
+++ b/src/libinjector/win/win_utils.h
@@ -151,6 +151,7 @@ struct injector
     // KEEP THESE IN TOP and in sync with the order in injector_utils.c
     injector_step_t step;
     bool step_override; // set this as true for jumping to some arbitrary step
+    bool set_gprs_only;
 
     // Inputs:
     unicode_string_t* target_file_us;


### PR DESCRIPTION
Change only the general purpose registers during injection so that the registers don't somehow mess up the kernel structures of the operating system. This was the default behavior before for the windows injector, it was regressed for refactored methods in https://github.com/tklengyel/drakvuf/pull/1319

Note: Linux injector remains untested