### PR TITLE
Fix potential dereference of nullptr (CID 361179)

### DIFF
--- a/src/plugins/hidsim/hid_injection.cpp
+++ b/src/plugins/hidsim/hid_injection.cpp
@@ -210,6 +210,13 @@ static int get_display_dimensions(qmp_connection* qc, dimensions* dims)
 
     /* Extracts display size from .ppm-file created by screendump */
     FILE* f = fopen(tmp_path, "r");
+    if (!f)
+    {
+        fprintf(stderr, "[HIDSIM] [INJECTOR] Error extracting display size from"
+            " %s\n", tmp_path);
+        return -1;
+    }
+
     char ppm_hdr[3];
     int matches = 0;
 


### PR DESCRIPTION
Dear Tamas,

this patch fixes a defect which identified by Coverity as CID 361179. 
It addresses a potential dereference of a nullptr stemming from an unchecked return value in `get_display_dimensions(...)`.

Thanks already in advance for reviewing and considering this PR.

Best regards
Jan