### PR TITLE
Disable rootkitmon plugin by default until memory leaks are fixed

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -476,7 +476,7 @@ AC_ARG_ENABLE([plugin_rootkitmon],
   [AS_HELP_STRING([--disable-plugin-rootkitmon],
     [Enable rootkitmon plugin @<:@yes@:>@])],
   [plugin_rootkitmon="$enableval"],
-  [plugin_rootkitmon="yes"])
+  [plugin_rootkitmon="no"])
 AM_CONDITIONAL([PLUGIN_ROOTKITMON], [test x$plugin_rootkitmon = xyes])
 if test x$plugin_rootkitmon = xyes; then
   AC_DEFINE_UNQUOTED(ENABLE_PLUGIN_ROOTKITMON, 1, "")


### PR DESCRIPTION
The CI had a regression with Valgrind with the Xen 4.15.1 upgrade. Rootkitmon got merged with no valgrind tests. Now that valgrind is operational again it is spotted leaks (see #1329). Don't enable plugin by default until leaks are fixed.