### PR TITLE
rootkitmon memoryleak fix

### DIFF
--- a/src/plugins/rootkitmon/rootkitmon.cpp
+++ b/src/plugins/rootkitmon/rootkitmon.cpp
@@ -232,6 +232,7 @@ static sha256_checksum_t calc_checksum(vmi_instance_t vmi, addr_t address, size_
         throw -1;
     }
 
+    g_checksum_free(checksum);
     return out;
 }
 


### PR DESCRIPTION
The leak was due to missing `g_checksum_free` call.
Addressing https://github.com/tklengyel/drakvuf/issues/1329.