### PR TITLE
Enhance random HID even simulation by the ability to inject random clicks

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -332,6 +332,8 @@ static void print_usage()
         "\t                           The HID events in the template will be replayed in a loop.\n"
         "\t --hid-monitor-gui\n"
         "\t                           Monitor the GUI to try to detect clickable buttons. This requires the presence of a win32k-profile, which has to be specified via -W\n"
+        "\t --hid-random-clicks\n"
+        "\t                           Inject random clicks and double clicks, if no template is specified. Spares the bottom-left 20 percent of the screen\n"
 #endif
 #ifdef ENABLE_PLUGIN_ROOTKITMON
         "\t --json-fwpkclnt <path to json>\n"
@@ -443,6 +445,7 @@ int main(int argc, char** argv)
         opt_objmon_disable_duplicate_hook,
         opt_hidsim_template,
         opt_hidsim_monitor_gui,
+        opt_hidsim_random_clicks,
         opt_rootkitmon_json_fwpkclnt,
         opt_rootkitmon_json_fltmgr,
     };
@@ -505,6 +508,7 @@ int main(int argc, char** argv)
         {"objmon-disable-duplicate-hook", no_argument, NULL, opt_objmon_disable_duplicate_hook},
         {"hid-template", required_argument, NULL, opt_hidsim_template},
         {"hid-monitor-gui", no_argument, NULL, opt_hidsim_monitor_gui},
+        {"hid-random-clicks", no_argument, NULL, opt_hidsim_random_clicks},
         {"json-fwpkclnt", required_argument, NULL, opt_rootkitmon_json_fwpkclnt},
         {"json-fltmgr", required_argument, NULL, opt_rootkitmon_json_fltmgr},
         {NULL, 0, NULL, 0}
@@ -814,6 +818,9 @@ int main(int argc, char** argv)
                 break;
             case opt_hidsim_monitor_gui:
                 options.hidsim_monitor_gui = true;
+                break;
+            case opt_hidsim_random_clicks:
+                options.hidsim_random_clicks = true;
                 break;
 #endif
 #ifdef ENABLE_PLUGIN_ROOTKITMON

--- a/src/plugins/hidsim/gui_monitor.cpp
+++ b/src/plugins/hidsim/gui_monitor.cpp
@@ -285,7 +285,7 @@ bool check_platform_support(drakvuf_t drakvuf)
     if (wbi.version == VMI_OS_WINDOWS_7)
     {
 
-        PRINT_DEBUG("[HIDSIM] GUI reconstruction supported"
+        PRINT_DEBUG("[HIDSIM] GUI reconstruction supported "
             "on Windows 7\n");
         return true;
     }

--- a/src/plugins/hidsim/hid_injection.cpp
+++ b/src/plugins/hidsim/hid_injection.cpp
@@ -144,6 +144,7 @@
 #define MAX_SLEEP 10 * 1000000
 #define CLK_MEAN 6
 #define CLK_SIGMA 6
+#define DISPLAY_BORDER 0.2
 /*
  * Replaces the flawed rand()-function of C's standard library with the
  * Mersenne Twister implementation
@@ -621,8 +622,8 @@ static int run_random_injection(qmp_connection* qc, bool is_rand_clicks,
     int MAX_DIST_Y = (1<<15)/4;
     int MIN_DIST_Y = -1 * MAX_DIST_Y;
     /* Spare areas (probably taskbar and icons) */
-    int LEFT_THRES = (1<<16) * 0.2;
-    int BOTTOM_THRES = (1<<16) - ((1<<16) * 0.2);
+    int LEFT_THRES = (1<<16) * DISPLAY_BORDER;
+    int BOTTOM_THRES = (1<<16) * (1.0 - DISPLAY_BORDER);
 
     int sleep = 0;
     int time_frame = 0;
@@ -659,6 +660,7 @@ static int run_random_injection(qmp_connection* qc, bool is_rand_clicks,
                 if (moves_next_click <= 0
                     && (oy + dy) < BOTTOM_THRES && (ox + dx) > LEFT_THRES)
                     is_click = true;
+
             }
         }
         /* Calculates the actual distance to cover */

--- a/src/plugins/hidsim/hid_injection.cpp
+++ b/src/plugins/hidsim/hid_injection.cpp
@@ -142,7 +142,8 @@
 /* Throttle injection down to 50 microsecond intervals */
 #define TIME_BIN 50
 #define MAX_SLEEP 10 * 1000000
-
+#define CLK_MEAN 6
+#define CLK_SIGMA 6
 /*
  * Replaces the flawed rand()-function of C's standard library with the
  * Mersenne Twister implementation
@@ -596,7 +597,7 @@ void translate(qmp_connection* qc, dimensions* dim, int time_frame,
 }
 
 /* Injects random mouse movements */
-static int run_random_injection(qmp_connection* qc,
+static int run_random_injection(qmp_connection* qc, bool is_rand_clicks,
     std::atomic<uint32_t>* coords, std::atomic<bool>* has_to_stop)
 {
     PRINT_DEBUG("[HIDSIM] [INJECTOR] Injecting random mouse movements\n");
@@ -619,6 +620,9 @@ static int run_random_injection(qmp_connection* qc,
     int MIN_DIST_X = -1 * MAX_DIST_X;
     int MAX_DIST_Y = (1<<15)/4;
     int MIN_DIST_Y = -1 * MAX_DIST_Y;
+    /* Spare areas (probably taskbar and icons) */
+    int LEFT_THRES = (1<<16) * 0.2;
+    int BOTTOM_THRES = (1<<16) - ((1<<16) * 0.2);
 
     int sleep = 0;
     int time_frame = 0;
@@ -626,6 +630,7 @@ static int run_random_injection(qmp_connection* qc,
     int s = _rand()%512;
 
     bool is_click = false;
+    int moves_next_click = gaussian_rand(CLK_MEAN, CLK_SIGMA);
 
     /* Loops, until stopped */
     while (!has_to_stop->load())
@@ -646,7 +651,15 @@ static int run_random_injection(qmp_connection* qc,
             /* Calculates the random displacement of the mouse cursor */
             dx = rand_approx_uniform(MIN_DIST_X, MAX_DIST_X);
             dy = rand_approx_uniform(MIN_DIST_Y, MAX_DIST_Y);
+            if (is_rand_clicks)
+            {
+                moves_next_click--;
 
+                /* Inject clicks, if CLICK_THRESHOLD moves, since last click */
+                if (moves_next_click <= 0
+                    && (oy + dy) < BOTTOM_THRES && (ox + dx) > LEFT_THRES)
+                    is_click = true;
+            }
         }
         /* Calculates the actual distance to cover */
         int dist = (int) hypot(dx, dy);
@@ -672,11 +685,24 @@ static int run_random_injection(qmp_connection* qc,
             PRINT_DEBUG("[HIDSIM] [INJECTOR] Clicking now at %d x %d\n", ox, oy);
             is_click = false;
             click(qc, left);
+
+            if (is_rand_clicks)
+            {
+                moves_next_click = gaussian_rand(CLK_MEAN, CLK_SIGMA);
+
+                /* Simple heuristic for employing double clicks and keypresses */
+                if (moves_next_click % 2 == 0)
+                {
+                    click(qc, left);
+                }
+            }
         }
         /* Gaussian distributed waiting between smooth movements */
         sleep = (int) gaussian_rand(0, 10000);
+
         if (sleep>0)
             usleep(sleep);
+
         s++;
     }
 
@@ -815,7 +841,7 @@ static int hid_cleanup(qmp_connection* qc, int fd, FILE* f)
 }
 
 /* Worker thread function */
-int hid_inject(const char* sock_path, const char* template_path,
+int hid_inject(const char* sock_path, const char* template_path, bool is_rand_clicks,
     std::atomic<uint32_t>* coords, std::atomic<bool>* has_to_stop)
 {
     /* Initializes qmp connection */
@@ -870,7 +896,7 @@ int hid_inject(const char* sock_path, const char* template_path,
     }
     else
     {
-        sc = run_random_injection(&qc, coords, has_to_stop);
+        sc = run_random_injection(&qc, is_rand_clicks, coords, has_to_stop);
     }
     if (sc != 0)
         fprintf(stderr, "[HIDSIM] [INJECTOR] Error performing HID injection\n");

--- a/src/plugins/hidsim/hid_injection.cpp
+++ b/src/plugins/hidsim/hid_injection.cpp
@@ -142,8 +142,11 @@
 /* Throttle injection down to 50 microsecond intervals */
 #define TIME_BIN 50
 #define MAX_SLEEP 10 * 1000000
-#define CLK_MEAN 6
-#define CLK_SIGMA 6
+/* Mean move count for injecting random clicks */
+#define CLK_MEAN 5
+/* Sigma of the distribution of moves for injecting random clicks */
+#define CLK_SIGMA 5
+/* Screen area to spare for clicking in percent  */
 #define DISPLAY_BORDER 0.2
 /*
  * Replaces the flawed rand()-function of C's standard library with the

--- a/src/plugins/hidsim/hid_injection.h
+++ b/src/plugins/hidsim/hid_injection.h
@@ -115,6 +115,7 @@
 
 /* Injects random HID events or events specified in a template file */
 int hid_inject(const char* sock_path, const char* template_path,
-    std::atomic<uint32_t>* coords, std::atomic<bool>* has_to_stop);
+    bool is_rand_clicks, std::atomic<uint32_t>* coords,
+    std::atomic<bool>* has_to_stop);
 
 #endif

--- a/src/plugins/hidsim/hidsim.cpp
+++ b/src/plugins/hidsim/hidsim.cpp
@@ -186,6 +186,13 @@ hidsim::hidsim(drakvuf_t drakvuf, const hidsim_config* config)
             this->template_path.c_str());
     }
 
+    if (config->is_rand_clicks)
+    {
+        this->is_rand_clicks = config->is_rand_clicks;
+    }
+    else
+        this->is_rand_clicks = false;
+
     /* Prepares monitoring, if requested */
     if (config->is_monitor)
     {
@@ -198,7 +205,7 @@ hidsim::hidsim(drakvuf_t drakvuf, const hidsim_config* config)
 
     /* Starts injection thread */
     this->thread_inject = std::thread(hid_inject, sock_path.c_str(),
-            template_path.c_str(), &coords, &has_to_stop);
+            template_path.c_str(), is_rand_clicks, &coords, &has_to_stop);
 
     /* GUI Reconstruction thread */
     if (this->is_monitor && this->is_gui_support)

--- a/src/plugins/hidsim/hidsim.h
+++ b/src/plugins/hidsim/hidsim.h
@@ -122,6 +122,7 @@ struct hidsim_config
     const char* template_fp;
     const char* win32k_profile;
     bool is_monitor;
+    bool is_rand_clicks;
 };
 
 class hidsim : public plugin
@@ -141,6 +142,7 @@ private:
 
     bool is_monitor;
     bool is_gui_support;
+    bool is_rand_clicks;
 
     /* Worker threads */
     std::thread thread_inject;

--- a/src/plugins/plugins.cpp
+++ b/src/plugins/plugins.cpp
@@ -467,6 +467,7 @@ int drakvuf_plugins::start(const drakvuf_plugin_t plugin_id,
                         .template_fp = options->hidsim_template,
                         .is_monitor = options->hidsim_monitor_gui,
                         .win32k_profile = options->win32k_profile,
+                        .is_rand_clicks = options->hidsim_random_clicks,
                     };
                     this->plugins[plugin_id] = std::make_unique<hidsim>(this->drakvuf, &config);
                     break;

--- a/src/plugins/plugins.h
+++ b/src/plugins/plugins.h
@@ -166,6 +166,7 @@ struct plugins_options
     bool objmon_disable_duplicate_hook; // PLUGIN_OBJMON
     const char* hidsim_template;        // PLUGIN_HIDSIM
     bool hidsim_monitor_gui;            // PLUGIN_HIDSIM
+    bool hidsim_random_clicks;          // PLUGIN_HIDSIM
     const char* fwpkclnt_profile;       // PLUGIN_ROOTKITMON
     const char* fltmgr_profile;         // PLUGIN_ROOTKITMON
 };


### PR DESCRIPTION
Dear Tamas, 

this patch enhances the `hidsim`-plugin by the ability to inject random clicks, which is often needed to pass the passive RTTs employed by evasive malware.  In order to activate this behavior, a new CLI switch named `--hid-random-clicks` is introduced, which can be used to toggle it on. 

Thanks already in advance for reviewing and considering this PR.

Best regards
Jan