### PR TITLE
Fix fread() error handling

### DIFF
--- a/src/libinjector/win/methods/win_write_file.c
+++ b/src/libinjector/win/methods/win_write_file.c
@@ -207,8 +207,15 @@ event_response_t handle_writefile_x64(drakvuf_t drakvuf, drakvuf_trap_info_t* in
             amount = fread(buf + FILE_BUF_RESERVED, 1, FILE_BUF_SIZE - FILE_BUF_RESERVED, injector->host_file);
             PRINT_DEBUG("Amount: %lx\n", amount);
 
-            if (!amount) // close if file has finished writing
+            if (ferror(injector->host_file))
             {
+                fprintf(stderr, "Failed to read the chunk of file.\n");
+                return cleanup(injector, info);
+            }
+
+            if (!amount)
+            {
+                // close if file has finished writing
                 PRINT_DEBUG("Finishing\n");
 
                 if (!setup_close_handle_stack(injector, info->regs))

--- a/src/plugins/hidsim/hid_injection.cpp
+++ b/src/plugins/hidsim/hid_injection.cpp
@@ -771,6 +771,11 @@ static int run_template_injection(qmp_connection* qc, FILE* f,
 
         /* Reads the follow-up event */
         nr = fread(&ie_next, sizeof(ie_next), 1, f);
+        if (ferror(f)) /* Error happened on reading */
+        {
+            fprintf(stderr, "[HIDSIM] [INJECTOR] Error reading file");
+            return 1;
+        }
 
         if (nr == 0) /* EOF was reached */
         {


### PR DESCRIPTION
There are places in libinjector and hidsim plugins when it would be good practice to check if fread made the deal successfully.
It accually can be useful on file read error on injection