### PR TITLE
drakvuf: fix stop plug-ins

### DIFF
--- a/src/drakvuf.cpp
+++ b/src/drakvuf.cpp
@@ -188,7 +188,7 @@ static bool is_stopped(drakvuf_t drakvuf, void* data)
     }
     else
     {
-        rc = rc || d->_drakvuf_c->stop_plugins(d->plugin_list);
+        rc = d->_drakvuf_c->stop_plugins(d->plugin_list);
         PRINT_DEBUG("[STOP] Check plugins %d\n", rc);
         return rc == 0;
     }


### PR DESCRIPTION
Logical error. If _drakvuf_ would been stopped like `drakvuf_interrupt(drakvuf, 1)` then endless loop occur.