### PR TITLE
include config.h in libinjector

### DIFF
--- a/src/libinjector/private.h
+++ b/src/libinjector/private.h
@@ -105,6 +105,8 @@
 #ifndef LIBINJECTOR_PRIVATE_H
 #define LIBINJECTOR_PRIVATE_H
 
+#include <config.h>
+
 #ifndef PRINT_DEBUG
 #ifdef DRAKVUF_DEBUG
 // defined in libdrakvuf

--- a/src/libinjector/win/win_injector.c
+++ b/src/libinjector/win/win_injector.c
@@ -377,7 +377,7 @@ static event_response_t inject_payload(drakvuf_t drakvuf, drakvuf_trap_info_t* i
         }
 
         // Get address of PspCallProcessNotifyRoutines() from the JSON debug info
-        if ( !drakvuf_get_function_rva(drakvuf, "PspCallProcessNotifyRoutines", &process_notify_rva) )
+        if ( !drakvuf_get_kernel_symbol_rva(drakvuf, "PspCallProcessNotifyRoutines", &process_notify_rva) )
         {
             PRINT_DEBUG("[-] Error getting PspCallProcessNotifyRoutines RVA\n");
             return 0;


### PR DESCRIPTION
I am having some troubles with these if defines locally, just testing the same hypothesis on the ci

FIXES: 
- Refactor in https://github.com/tklengyel/drakvuf/pull/754
- Includes `config.h` in `libinjector/private.h`