### PR TITLE
removed zero page write

### DIFF
--- a/src/plugins/dkommon/dkommon.cpp
+++ b/src/plugins/dkommon/dkommon.cpp
@@ -168,15 +168,6 @@ static std::set<std::string> enumerate_drivers(dkommon* plugin, drakvuf_t drakvu
     return drivers_list;
 }
 
-static event_response_t notify_zero_page_write(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
-{
-    auto plugin = static_cast<dkommon*>(info->trap->data);
-    fmt::print(plugin->format, "dkommon", drakvuf, info,
-        keyval("Message", fmt::Qstr("Zero Page Write"))
-    );
-    return 0;
-}
-
 static void process_visitor(drakvuf_t drakvuf, addr_t process, void* pass_ctx)
 {
     auto plugin = static_cast<dkommon*>(pass_ctx);
@@ -307,9 +298,6 @@ dkommon::dkommon(drakvuf_t drakvuf, const void* config, output_format_t output)
         PRINT_DEBUG("[DKOMMON] Failed to setup critical traps\n");
         throw -1;
     }
-
-    zeropage_trap.cb = notify_zero_page_write;
-    if (!drakvuf_add_trap(drakvuf, &zeropage_trap)) throw -1;
 }
 
 dkommon::~dkommon()

--- a/src/plugins/dkommon/dkommon.h
+++ b/src/plugins/dkommon/dkommon.h
@@ -125,19 +125,6 @@ public:
     dkommon(drakvuf_t drakvuf, const void* config, output_format_t output);
     ~dkommon();
     bool stop_impl() override;
-
-private:
-    drakvuf_trap_t zeropage_trap =
-    {
-        .type = MEMACCESS,
-        .memaccess.gfn = 0,
-        .memaccess.type = PRE,
-        .memaccess.access = VMI_MEMACCESS_W,
-        .data = this,
-        .name = nullptr,
-        .ttl = UNLIMITED_TTL,
-        .ah_cb = nullptr
-    };
 };
 
 #endif


### PR DESCRIPTION
The plugin tries to detect null pointer dereference which only happens with virtual memory, but hooks null physical page where IVT for bios is located.