### PR TITLE
libdrakvuf: optimize get windows process data

### DIFF
--- a/src/drakvuf.cpp
+++ b/src/drakvuf.cpp
@@ -214,11 +214,12 @@ drakvuf_c::drakvuf_c(const char* domain,
     bool libvmi_conf,
     addr_t kpgd,
     bool fast_singlestep,
-    uint64_t limited_traps_ttl)
+    uint64_t limited_traps_ttl,
+    bool libdrakvuf_get_userid)
     : leave_paused{ leave_paused }
     , format{ output }
 {
-    if (!drakvuf_init(&drakvuf, domain, json_kernel_path, json_wow_path, verbose, libvmi_conf, kpgd, fast_singlestep, limited_traps_ttl))
+    if (!drakvuf_init(&drakvuf, domain, json_kernel_path, json_wow_path, verbose, libvmi_conf, kpgd, fast_singlestep, limited_traps_ttl, libdrakvuf_get_userid))
     {
         drakvuf_close(drakvuf, leave_paused);
         throw std::runtime_error("drakvuf_init() failed");

--- a/src/drakvuf.h
+++ b/src/drakvuf.h
@@ -161,7 +161,8 @@ public:
         bool libvmi_conf,
         addr_t kpgd,
         bool fast_singlestep,
-        uint64_t limited_traps_ttl);
+        uint64_t limited_traps_ttl,
+        bool libdrakvuf_get_userid);
     ~drakvuf_c();
 
     int is_initialized();

--- a/src/injector.c
+++ b/src/injector.c
@@ -299,7 +299,7 @@ int main(int argc, char** argv)
     sigaction(SIGINT, &act, NULL);
     sigaction(SIGALRM, &act, NULL);
 
-    if (!drakvuf_init(&drakvuf, domain, json_kernel_path, NULL, verbose, libvmi_conf, kpgd, false, UNLIMITED_TTL))
+    if (!drakvuf_init(&drakvuf, domain, json_kernel_path, NULL, verbose, libvmi_conf, kpgd, false, UNLIMITED_TTL, true))
     {
         fprintf(stderr, "Failed to initialize on domain %s\n", domain);
         return 1;

--- a/src/libdrakvuf/drakvuf.c
+++ b/src/libdrakvuf/drakvuf.c
@@ -165,7 +165,7 @@ void drakvuf_close(drakvuf_t drakvuf, const bool pause)
     g_free(drakvuf);
 }
 
-bool drakvuf_init(drakvuf_t* drakvuf, const char* domain, const char* json_kernel_path, const char* json_wow_path, bool _verbose, bool libvmi_conf, addr_t kpgd, bool fast_singlestep, uint64_t limited_traps_ttl)
+bool drakvuf_init(drakvuf_t* drakvuf, const char* domain, const char* json_kernel_path, const char* json_wow_path, bool _verbose, bool libvmi_conf, addr_t kpgd, bool fast_singlestep, uint64_t limited_traps_ttl, bool get_userid)
 {
 
     if ( !domain )
@@ -177,6 +177,7 @@ bool drakvuf_init(drakvuf_t* drakvuf, const char* domain, const char* json_kerne
 
     *drakvuf = (drakvuf_t)g_try_malloc0(sizeof(struct drakvuf));
 
+    (*drakvuf)->get_userid = get_userid;
     (*drakvuf)->limited_traps_ttl = limited_traps_ttl;
     (*drakvuf)->context_switch_intercept_processes = NULL;
     (*drakvuf)->enable_cr3_based_interception = false;

--- a/src/libdrakvuf/libdrakvuf.h
+++ b/src/libdrakvuf/libdrakvuf.h
@@ -385,7 +385,8 @@ bool drakvuf_init (drakvuf_t* drakvuf,
     const bool libvmi_conf,
     const addr_t kpgd,
     const bool fast_singlestep,
-    uint64_t limited_traps_ttl) NOEXCEPT;
+    uint64_t limited_traps_ttl,
+    bool get_userid) NOEXCEPT;
 bool drakvuf_init_os (drakvuf_t drakvuf) NOEXCEPT;
 void drakvuf_close (drakvuf_t drakvuf, const bool pause) NOEXCEPT;
 int drakvuf_send_qemu_monitor_command(drakvuf_t drakvuf, const char* in, char** out);

--- a/src/libdrakvuf/linux-processes.c
+++ b/src/libdrakvuf/linux-processes.c
@@ -363,7 +363,10 @@ bool linux_get_process_data( drakvuf_t drakvuf, addr_t base_addr, proc_data_priv
             proc_data->name = linux_get_process_name(drakvuf, base_addr, true);
             if ( linux_get_process_ppid(drakvuf, base_addr, &proc_data->ppid))
             {
-                proc_data->userid = linux_get_process_userid(drakvuf, base_addr);
+                if (drakvuf->get_userid)
+                    proc_data->userid = linux_get_process_userid(drakvuf, base_addr);
+                else
+                    proc_data->userid = 0;
                 linux_get_process_tid(drakvuf, base_addr, &proc_data->tid);
                 if ( proc_data->tid )
                     return true;

--- a/src/libdrakvuf/private.h
+++ b/src/libdrakvuf/private.h
@@ -192,6 +192,7 @@ struct drakvuf
     char* json_wow_path;
     json_object* json_wow;
     bool libvmi_conf;
+    bool get_userid;
 
     xen_interface_t* xen;
     os_interface_t osi;

--- a/src/libdrakvuf/win-processes.c
+++ b/src/libdrakvuf/win-processes.c
@@ -1277,7 +1277,10 @@ bool win_get_process_data( drakvuf_t drakvuf, addr_t base_addr, proc_data_priv_t
         {
             if ( win_get_process_ppid( drakvuf, base_addr, &proc_data->ppid ) )
             {
-                proc_data->userid = win_get_process_userid( drakvuf, base_addr );
+                if (drakvuf->get_userid)
+                    proc_data->userid = win_get_process_userid( drakvuf, base_addr );
+                else
+                    proc_data->userid = 0;
                 proc_data->name   = win_get_process_name( drakvuf, base_addr, true );
 
                 if ( proc_data->name )

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -347,6 +347,8 @@ static void print_usage()
         "\t --json-netio <path to json>\n"
         "\t                           The JSON profile for netio.sys\n"
 #endif
+        "\t --libdrakvuf-not-get-userid\n"
+        "\t                           Don't collect user id in get process data\n"
         "\t -h, --help                Show this help\n"
     );
 }
@@ -389,6 +391,7 @@ int main(int argc, char** argv)
     bool context_based_interception = false;
     GSList* context_processes = NULL;
     bool procdump_on_finish = true;
+    bool libdrakvuf_get_userid = true;
 
     eprint_current_time();
 
@@ -458,7 +461,8 @@ int main(int argc, char** argv)
         opt_rootkitmon_json_fwpkclnt,
         opt_rootkitmon_json_fltmgr,
         opt_callbackmon_json_netio,
-        opt_json_hal
+        opt_json_hal,
+        opt_libdrakvuf_not_get_userid,
     };
     const option long_opts[] =
     {
@@ -526,6 +530,7 @@ int main(int argc, char** argv)
         {"json-fltmgr", required_argument, NULL, opt_rootkitmon_json_fltmgr},
         {"json-netio", required_argument, NULL, opt_callbackmon_json_netio},
         {"json-hal", required_argument, NULL, opt_json_hal},
+        {"libdrakvuf-not-get-userid", no_argument, NULL, opt_libdrakvuf_not_get_userid},
         {NULL, 0, NULL, 0}
     };
     const char* opts = "r:d:i:I:e:m:t:D:o:vx:a:f:spT:S:Mc:nblgj:k:w:W:hF:C";
@@ -846,6 +851,9 @@ int main(int argc, char** argv)
             case 'h':
                 print_usage();
                 return drakvuf_exit_code_t::SUCCESS;
+            case opt_libdrakvuf_not_get_userid:
+                libdrakvuf_get_userid = false;
+                break;
             default:
                 if (isalnum(c))
                     fprintf(stderr, "Unrecognized option: %c\n", c);
@@ -870,7 +878,7 @@ int main(int argc, char** argv)
 
     try
     {
-        drakvuf = std::make_unique<drakvuf_c>(domain, json_kernel_path, json_wow_path, output, verbose, leave_paused, libvmi_conf, kpgd, fast_singlestep, limited_traps_ttl);
+        drakvuf = std::make_unique<drakvuf_c>(domain, json_kernel_path, json_wow_path, output, verbose, leave_paused, libvmi_conf, kpgd, fast_singlestep, limited_traps_ttl, libdrakvuf_get_userid);
     }
     catch (const std::exception& e)
     {

--- a/src/proc_stat.cpp
+++ b/src/proc_stat.cpp
@@ -181,7 +181,7 @@ int main(int argc, char** argv)
 
 
     /* initialize the Drakvuf library */
-    if (!drakvuf_init(&drakvuf, domain, profile, NULL, false, false, 0, false, UNLIMITED_TTL))
+    if (!drakvuf_init(&drakvuf, domain, profile, NULL, false, false, 0, false, UNLIMITED_TTL, true))
     {
         printf("Failed to initialize Drakvuf\n");
         goto done;

--- a/src/repl.cpp
+++ b/src/repl.cpp
@@ -195,7 +195,7 @@ int main(int argc, char** argv)
     sigaction(SIGINT, &act, NULL);
     sigaction(SIGALRM, &act, NULL);
 
-    if (!drakvuf_init(&drakvuf, domain, json_kernel_path, NULL, verbose, libvmi_conf, kpgd, false, UNLIMITED_TTL))
+    if (!drakvuf_init(&drakvuf, domain, json_kernel_path, NULL, verbose, libvmi_conf, kpgd, false, UNLIMITED_TTL, true))
     {
         fprintf(stderr, "Failed to initialize on domain %s\n", domain);
         return 1;

--- a/src/xtf.c
+++ b/src/xtf.c
@@ -196,7 +196,7 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    if (!drakvuf_init(&drakvuf, argv[1], NULL, NULL, true, false, 0, false, UNLIMITED_TTL))
+    if (!drakvuf_init(&drakvuf, argv[1], NULL, NULL, true, false, 0, false, UNLIMITED_TTL, true))
     {
         fprintf(stderr, "Failed to initialize on domain %s\n", argv[1]);
         return 1;


### PR DESCRIPTION
With the optimizations provided:
* The whole `EPROCESS` structure is read at once and then parsed for `PID`, `PPID`, process name and image file name address.
* The `UserID` filed is made optional.

The optimization allows to avoid multiple `vmi_read`'s.

It have been tested that marker event occur faster (about 15%) with this optimizations.