### PR TITLE
exmon: use drakvuf_get_kernel_struct_members_array_rva function

### DIFF
--- a/src/libdrakvuf/drakvuf.c
+++ b/src/libdrakvuf/drakvuf.c
@@ -576,7 +576,7 @@ bool json_get_struct_members_array_rva(
     drakvuf_t drakvuf,
     json_object* json,
     const char* struct_name_symbol_array[][2],
-    addr_t array_size,
+    size_t array_size,
     addr_t* rva)
 {
     return json_lookup_array(

--- a/src/libdrakvuf/json-profile.c
+++ b/src/libdrakvuf/json-profile.c
@@ -119,16 +119,14 @@ bool json_lookup_array(
     drakvuf_t drakvuf,
     json_object* json,
     const char* symbol_subsymbol_array[][2],
-    addr_t array_size,
+    size_t array_size,
     addr_t* rva,
     addr_t* size)
 {
-    bool ret = false;
-
     if (!json)
     {
         fprintf(stderr, "JSON profile is NULL!\n");
-        return ret;
+        return false;
     }
 
     int errors = 0;
@@ -161,10 +159,7 @@ bool json_lookup_array(
         }
     }
 
-    if (errors == 0)
-        ret = true;
-
-    return ret;
+    return (errors == 0);
 }
 
 symbols_t* json_get_symbols(json_object* json)

--- a/src/libdrakvuf/json-profile.h
+++ b/src/libdrakvuf/json-profile.h
@@ -109,7 +109,7 @@ bool json_lookup_array(
     drakvuf_t drakvuf,
     json_object* json,
     const char* symbol_subsymbol_array[][2],
-    addr_t array_size,
+    size_t array_size,
     addr_t* address,
     addr_t* size);
 

--- a/src/libdrakvuf/libdrakvuf.h
+++ b/src/libdrakvuf/libdrakvuf.h
@@ -356,13 +356,13 @@ bool json_get_struct_members_array_rva(
     drakvuf_t drakvuf,
     json_object* json_profile,
     const char* struct_name_subsymbol_array[][2],
-    addr_t array_size,
+    size_t array_size,
     addr_t* rva) NOEXCEPT;
 static inline
 bool drakvuf_get_kernel_struct_members_array_rva(
     drakvuf_t drakvuf,
     const char* struct_name_subsymbol_array[][2],
-    addr_t array_size,
+    size_t array_size,
     addr_t* rva)
 {
     vmi_instance_t vmi = drakvuf_lock_and_get_vmi(drakvuf);

--- a/src/plugins/exmon/exmon.cpp
+++ b/src/plugins/exmon/exmon.cpp
@@ -322,9 +322,8 @@ exmon::exmon(drakvuf_t drakvuf, output_format_t output)
 
     this->pm = drakvuf_get_page_mode(drakvuf);
 
-    for (int i=0; i<__OFFSET_MAX; i++)
-        if (!drakvuf_get_kernel_struct_member_rva(drakvuf, offset_names[i][0], offset_names[i][1], &this->offsets[i]))
-            PRINT_DEBUG("Failed to find kernel struct member rva.\n");
+    if (!drakvuf_get_kernel_struct_members_array_rva(drakvuf, offset_names, __OFFSET_MAX, this->offsets))
+        PRINT_DEBUG("Failed to find all kernel struct member rvas for exmon.\n");
 
     if ( !drakvuf_get_kernel_struct_size(drakvuf, "_KTRAP_FRAME", &this->ktrap_frame_size) )
     {


### PR DESCRIPTION
exmon: use drakvuf_get_kernel_struct_members_array_rva function instead of manual iteration