### PR TITLE
new plugin callbackmon

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -484,6 +484,16 @@ if test x$plugin_rootkitmon = xyes; then
   AC_DEFINE_UNQUOTED(ENABLE_PLUGIN_ROOTKITMON, 1, "")
 fi
 
+AC_ARG_ENABLE([plugin_callbackmon],
+  [AS_HELP_STRING([--disable-plugin-callbackmon],
+    [Enable callbackmon plugin @<:@yes@:>@])],
+  [plugin_callbackmon="$enableval"],
+  [plugin_callbackmon="yes"])
+AM_CONDITIONAL([PLUGIN_CALLBACKMON], [test x$plugin_callbackmon = xyes])
+if test x$plugin_rootkitmon = xyes; then
+  AC_DEFINE_UNQUOTED(ENABLE_PLUGIN_CALLBACKMON, 1, "")
+fi
+
 AC_ARG_ENABLE([DISABLE_ATOMS],
   [AS_HELP_STRING([--disable-atoms],
     [Disable atom table parsing in hidsim plugin @<:@no@:>@])],
@@ -781,6 +791,7 @@ LibHookTest:  $plugin_libhooktest
 IPT:          $plugin_ipt
 HidSim:       $plugin_hidsim
 Rootkitmon:   $plugin_rootkitmon
+Callbackmon:  $plugin_callbackmon
 -------------------------------------------------------------------------------
 Deprecated Plugins
 WMIMon:       $plugin_wmimon

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -343,6 +343,10 @@ static void print_usage()
         "\t --json-fltmgr <path to json>\n"
         "\t                           The JSON profile for fltmgr.sys\n"
 #endif
+#ifdef ENABLE_PLUGIN_CALLBACKMON
+        "\t --json-netio <path to json>\n"
+        "\t                           The JSON profile for netio.sys\n"
+#endif
         "\t -h, --help                Show this help\n"
     );
 }
@@ -453,6 +457,7 @@ int main(int argc, char** argv)
         opt_hidsim_random_clicks,
         opt_rootkitmon_json_fwpkclnt,
         opt_rootkitmon_json_fltmgr,
+        opt_callbackmon_json_netio,
         opt_json_hal
     };
     const option long_opts[] =
@@ -519,6 +524,7 @@ int main(int argc, char** argv)
         {"hid-random-clicks", no_argument, NULL, opt_hidsim_random_clicks},
         {"json-fwpkclnt", required_argument, NULL, opt_rootkitmon_json_fwpkclnt},
         {"json-fltmgr", required_argument, NULL, opt_rootkitmon_json_fltmgr},
+        {"json-netio", required_argument, NULL, opt_callbackmon_json_netio},
         {"json-hal", required_argument, NULL, opt_json_hal},
         {NULL, 0, NULL, 0}
     };
@@ -829,6 +835,11 @@ int main(int argc, char** argv)
                 break;
             case opt_rootkitmon_json_fltmgr:
                 options.fltmgr_profile = optarg;
+                break;
+#endif
+#ifdef ENABLE_PLUGIN_CALLBACKMON
+            case opt_callbackmon_json_netio:
+                options.netio_profile = optarg;
                 break;
 #endif
 

--- a/src/plugins/Makefile.am
+++ b/src/plugins/Makefile.am
@@ -338,6 +338,11 @@ sources += rootkitmon/rootkitmon.h
 sources += rootkitmon/private.h
 endif
 
+if PLUGIN_CALLBACKMON
+sources += callbackmon/callbackmon.cpp
+sources += callbackmon/callbackmon.h
+endif
+
 ###############################################################################
 sources += plugins.cpp plugins.h plugins_ex.cpp plugins_ex.h plugin_utils.cpp plugin_utils.h private.h type_traits_helpers.h hook_helpers.h
 sources += output_format.h output_format/common.h output_format/csvfmt.h output_format/deffmt.h output_format/jsonfmt.h output_format/kvfmt.h

--- a/src/plugins/callbackmon/README.md
+++ b/src/plugins/callbackmon/README.md
@@ -1,0 +1,31 @@
+# Abstract
+
+The _callbackmon_ plug-in detects overwritten/deleted/added callbacks in various kernel structures.
+
+## Description
+
+The plug-in collects already installed callbacks at the beginning of the analysis and compares them with the snapshot, created at the end of analysis.
+
+List of structures that callbackmon currently monitors:
+
+* `PspCreateProcessNotifyRoutine`
+* `PspCreateThreadNotifyRoutine`
+* `PspLoadImageNotifyRoutine`
+* `KeBugCheckCallbackListHead`
+* `KeBugCheckReasonCallbackListHead`
+* `CallbackListHead`
+* `SeFileSystemNotifyRoutinesHead`
+* `PopRegisteredPowerSettingCallbacks`
+* `IopNotifyShutdownQueueHead`
+* `IopNotifyLastChanceShutdownQueueHead`
+* `RtlpDebugPrintCallbackList`
+* `IopFsNotifyChangeQueueHead`
+* `IopDriverReinitializeQueueHead`
+* `IopBootDriverReinitializeQueueHead`
+* `KiNmiCallbackListHead`
+* `IopUpdatePriorityCallbackRoutine`
+* `PnpProfileNotifyList`
+* `PnpDeviceClassNotifyList`
+* `EmpCallbackListHead`
+* `PsWin32CallBack`
+* `netio.sys gWfpGlobal callbacks`

--- a/src/plugins/callbackmon/callbackmon.cpp
+++ b/src/plugins/callbackmon/callbackmon.cpp
@@ -1,6 +1,6 @@
 /*********************IMPORTANT DRAKVUF LICENSE TERMS***********************
  *                                                                         *
- * DRAKVUF (C) 2014-2021 Tamas K Lengyel.                                  *
+ * DRAKVUF (C) 2014-2022 Tamas K Lengyel.                                  *
  * Tamas K Lengyel is hereinafter referred to as the author.               *
  * This program is free software; you may redistribute and/or modify it    *
  * under the terms of the GNU General Public License as published by the   *

--- a/src/plugins/callbackmon/callbackmon.cpp
+++ b/src/plugins/callbackmon/callbackmon.cpp
@@ -1,0 +1,496 @@
+/*********************IMPORTANT DRAKVUF LICENSE TERMS***********************
+ *                                                                         *
+ * DRAKVUF (C) 2014-2021 Tamas K Lengyel.                                  *
+ * Tamas K Lengyel is hereinafter referred to as the author.               *
+ * This program is free software; you may redistribute and/or modify it    *
+ * under the terms of the GNU General Public License as published by the   *
+ * Free Software Foundation; Version 2 ("GPL"), BUT ONLY WITH ALL OF THE   *
+ * CLARIFICATIONS AND EXCEPTIONS DESCRIBED HEREIN.  This guarantees your   *
+ * right to use, modify, and redistribute this software under certain      *
+ * conditions.  If you wish to embed DRAKVUF technology into proprietary   *
+ * software, alternative licenses can be acquired from the author.         *
+ *                                                                         *
+ * Note that the GPL places important restrictions on "derivative works",  *
+ * yet it does not provide a detailed definition of that term.  To avoid   *
+ * misunderstandings, we interpret that term as broadly as copyright law   *
+ * allows.  For example, we consider an application to constitute a        *
+ * derivative work for the purpose of this license if it does any of the   *
+ * following with any software or content covered by this license          *
+ * ("Covered Software"):                                                   *
+ *                                                                         *
+ * o Integrates source code from Covered Software.                         *
+ *                                                                         *
+ * o Reads or includes copyrighted data files.                             *
+ *                                                                         *
+ * o Is designed specifically to execute Covered Software and parse the    *
+ * results (as opposed to typical shell or execution-menu apps, which will *
+ * execute anything you tell them to).                                     *
+ *                                                                         *
+ * o Includes Covered Software in a proprietary executable installer.  The *
+ * installers produced by InstallShield are an example of this.  Including *
+ * DRAKVUF with other software in compressed or archival form does not     *
+ * trigger this provision, provided appropriate open source decompression  *
+ * or de-archiving software is widely available for no charge.  For the    *
+ * purposes of this license, an installer is considered to include Covered *
+ * Software even if it actually retrieves a copy of Covered Software from  *
+ * another source during runtime (such as by downloading it from the       *
+ * Internet).                                                              *
+ *                                                                         *
+ * o Links (statically or dynamically) to a library which does any of the  *
+ * above.                                                                  *
+ *                                                                         *
+ * o Executes a helper program, module, or script to do any of the above.  *
+ *                                                                         *
+ * This list is not exclusive, but is meant to clarify our interpretation  *
+ * of derived works with some common examples.  Other people may interpret *
+ * the plain GPL differently, so we consider this a special exception to   *
+ * the GPL that we apply to Covered Software.  Works which meet any of     *
+ * these conditions must conform to all of the terms of this license,      *
+ * particularly including the GPL Section 3 requirements of providing      *
+ * source code and allowing free redistribution of the work as a whole.    *
+ *                                                                         *
+ * Any redistribution of Covered Software, including any derived works,    *
+ * must obey and carry forward all of the terms of this license, including *
+ * obeying all GPL rules and restrictions.  For example, source code of    *
+ * the whole work must be provided and free redistribution must be         *
+ * allowed.  All GPL references to "this License", are to be treated as    *
+ * including the terms and conditions of this license text as well.        *
+ *                                                                         *
+ * Because this license imposes special exceptions to the GPL, Covered     *
+ * Work may not be combined (even as part of a larger work) with plain GPL *
+ * software.  The terms, conditions, and exceptions of this license must   *
+ * be included as well.  This license is incompatible with some other open *
+ * source licenses as well.  In some cases we can relicense portions of    *
+ * DRAKVUF or grant special permissions to use it in other open source     *
+ * software.  Please contact tamas.k.lengyel@gmail.com with any such       *
+ * requests.  Similarly, we don't incorporate incompatible open source     *
+ * software into Covered Software without special permission from the      *
+ * copyright holders.                                                      *
+ *                                                                         *
+ * If you have any questions about the licensing restrictions on using     *
+ * DRAKVUF in other works, are happy to help.  As mentioned above,         *
+ * alternative license can be requested from the author to integrate       *
+ * DRAKVUF into proprietary applications and appliances.  Please email     *
+ * tamas.k.lengyel@gmail.com for further information.                      *
+ *                                                                         *
+ * If you have received a written license agreement or contract for        *
+ * Covered Software stating terms other than these, you may choose to use  *
+ * and redistribute Covered Software under those terms instead of these.   *
+ *                                                                         *
+ * Source is provided to this software because we believe users have a     *
+ * right to know exactly what a program is going to do before they run it. *
+ * This also allows you to audit the software for security holes.          *
+ *                                                                         *
+ * Source code also allows you to port DRAKVUF to new platforms, fix bugs, *
+ * and add new features.  You are highly encouraged to submit your changes *
+ * on https://github.com/tklengyel/drakvuf, or by other methods.           *
+ * By sending these changes, it is understood (unless you specify          *
+ * otherwise) that you are offering unlimited, non-exclusive right to      *
+ * reuse, modify, and relicense the code.  DRAKVUF will always be          *
+ * available Open Source, but this is important because the inability to   *
+ * relicense code has caused devastating problems for other Free Software  *
+ * projects (such as KDE and NASM).                                        *
+ * To specify special license conditions of your contributions, just say   *
+ * so when you send them.                                                  *
+ *                                                                         *
+ * This program is distributed in the hope that it will be useful, but     *
+ * WITHOUT ANY WARRANTY; without even the implied warranty of              *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the DRAKVUF   *
+ * license file for more details (it's in a COPYING file included with     *
+ * DRAKVUF, and also available from                                        *
+ * https://github.com/tklengyel/drakvuf/COPYING)                           *
+ *                                                                         *
+ ***************************************************************************/
+#include <libdrakvuf/libdrakvuf.h>
+#include <libvmi/libvmi.h>
+#include <libdrakvuf/private.h>
+#include <plugins/plugins_ex.h>
+#include <plugins/output_format.h>
+#include <mutex>
+
+#include "callbackmon.h"
+
+static constexpr uint16_t win_vista_ver     = 6000;
+static constexpr uint16_t win_vista_sp1_ver = 6001;
+static constexpr uint16_t win_7_sp1_ver     = 7601;
+static constexpr uint16_t win_8_1_ver       = 9600;
+static constexpr uint16_t win_10_rs1_ver    = 14393;
+static constexpr uint16_t win_10_1803_ver   = 17134;
+
+static std::once_flag once;
+static addr_t name_rva;
+static addr_t base_rva;
+static addr_t size_rva;
+
+static const std::vector<const char*> callout_syms =
+{
+    "PspW32ProcessCallout",
+    "PspW32ThreadCallout",
+    "ExGlobalAtomTableCallout",
+    "KeGdiFlushUserBatch",
+    "PopEventCallout",
+    "PopStateCallout",
+    "PopWin32InfoCallout",
+    "PspW32JobCallout",
+    "ExDesktopOpenProcedureCallout",
+    "ExDesktopOkToCloseProcedureCallout",
+    "ExDesktopCloseProcedureCallout",
+    "ExDesktopDeleteProcedureCallout",
+    "ExWindowStationOkToCloseProcedureCallout",
+    "ExWindowStationCloseProcedureCallout",
+    "ExWindowStationDeleteProcedureCallout",
+    "ExWindowStationParseProcedureCallout",
+    "ExWindowStationOpenProcedureCallout",
+    "ExLicensingWin32Callout"
+};
+
+// Map of Windows version -> [callout structure size, callout size offset, callout base offset]
+static const std::unordered_map<uint16_t, std::tuple<size_t, size_t, size_t>> wfp_offsets =
+{
+    { win_7_sp1_ver, { 0x40, 0x548, 0x550 } },
+    { win_10_1803_ver, { 0x50, 0x190, 0x198 } },
+};
+
+namespace
+{
+struct pass_ctx
+{
+    addr_t cb_va;
+    std::string name = "<Unknown>";
+    addr_t base_va = 0;
+
+    explicit pass_ctx(drakvuf_t drakvuf, addr_t cb_va) : cb_va(cb_va)
+    {
+        std::call_once(once, [&]()
+        {
+            if (!drakvuf_get_kernel_struct_member_rva(drakvuf, "_LDR_DATA_TABLE_ENTRY", "FullDllName",  &name_rva) ||
+                !drakvuf_get_kernel_struct_member_rva(drakvuf, "_LDR_DATA_TABLE_ENTRY", "DllBase",      &base_rva) ||
+                !drakvuf_get_kernel_struct_member_rva(drakvuf, "_LDR_DATA_TABLE_ENTRY", "SizeOfImage",  &size_rva))
+            {
+                throw -1;
+            }
+        });
+    };
+};
+}
+
+static inline size_t get_process_cb_table_size(uint16_t winver)
+{
+    if (winver >= win_vista_sp1_ver)
+        return 64;
+    else if (winver == win_vista_ver)
+        return 12;
+    else
+        return 8;
+}
+
+static inline size_t get_thread_cb_table_size(uint16_t winver)
+{
+    return (winver >= win_vista_ver ? 64 : 8);
+}
+
+static inline size_t get_image_cb_table_size(uint16_t winver)
+{
+    return (winver >= win_8_1_ver ? 64 : 8);
+}
+
+static inline size_t get_cb_table_size(vmi_instance_t vmi, const std::string& type)
+{
+    uint16_t winver = vmi_get_win_buildnumber(vmi);
+    if (type == "image")
+        return get_image_cb_table_size(winver);
+    else if (type == "process")
+        return get_process_cb_table_size(winver);
+    else
+        return get_thread_cb_table_size(winver);
+}
+
+static inline size_t get_power_cb_offset(vmi_instance_t vmi)
+{
+    uint16_t winver = vmi_get_win_buildnumber(vmi);
+
+    if (winver >= win_10_rs1_ver)
+        return vmi_get_address_width(vmi) == 8 ? 0x50 : 0x38;
+    else
+        return vmi_get_address_width(vmi) == 8 ? 0x40 : 0x28;
+}
+
+static void driver_visitor(drakvuf_t drakvuf, addr_t ldr_table, void* ctx)
+{
+    auto data = static_cast<pass_ctx*>(ctx);
+
+    vmi_lock_guard vmi(drakvuf);
+    addr_t base;
+    uint32_t size;
+    if (VMI_SUCCESS != vmi_read_addr_va(vmi, ldr_table + base_rva, 4, &base) ||
+        VMI_SUCCESS != vmi_read_32_va(vmi, ldr_table + size_rva, 4, &size))
+    {
+        throw -1;
+    }
+
+    if (data->cb_va >= base && data->cb_va < base + size)
+    {
+        unicode_string_t* module_name = drakvuf_read_unicode_va(vmi, ldr_table + name_rva, 4);
+        if (module_name && module_name->contents)
+        {
+            data->name.assign(reinterpret_cast<char*>(module_name->contents));
+            vmi_free_unicode_str(module_name);
+        }
+
+        data->base_va = base;
+    }
+}
+
+static inline std::pair<std::string, addr_t> get_module_by_addr(drakvuf_t drakvuf, addr_t addr)
+{
+    pass_ctx ctx{ drakvuf, addr };
+    drakvuf_enumerate_drivers(drakvuf, driver_visitor, &ctx);
+    return { ctx.name, ctx.base_va };
+}
+
+callbackmon::callbackmon(drakvuf_t drakvuf, const callbackmon_config* config, output_format_t output)
+    : pluginex(drakvuf, output), config{ *config }, format{ output }
+{
+    const addr_t krnl_base = drakvuf_get_kernel_base(drakvuf);
+    const size_t ptrsize   = drakvuf_get_address_width(drakvuf);
+    const size_t fast_ref  = (ptrsize == 8 ? 15 : 7);
+    addr_t drv_obj_rva, mj_array_rva;
+    if (!drakvuf_get_kernel_struct_member_rva(drakvuf, "_DEVICE_OBJECT", "DriverObject", &drv_obj_rva) ||
+        !drakvuf_get_kernel_struct_member_rva(drakvuf, "_DRIVER_OBJECT", "MajorFunction", &mj_array_rva))
+    {
+        throw -1;
+    }
+
+    vmi_lock_guard vmi(drakvuf);
+    auto get_ksymbol_va = [&](const char* symb) -> addr_t
+    {
+        addr_t rva = 0;
+        if (!drakvuf_get_kernel_symbol_rva(drakvuf, symb, &rva))
+            throw -1;
+        return rva + krnl_base;
+    };
+    // Linked list based callbacks
+    auto consume_callbacks = [&](const char* symb, const int64_t cb_off) -> std::vector<addr_t>
+    {
+        std::vector<addr_t> out;
+        addr_t head = get_ksymbol_va(symb);
+        addr_t entry = 0;
+        // Read flink entry
+        if (VMI_SUCCESS != vmi_read_addr_va(vmi, head, 4, &entry))
+            throw -1;
+        while (entry != head && entry)
+        {
+            addr_t callback = 0;
+            if (VMI_SUCCESS != vmi_read_addr_va(vmi, entry + cb_off, 4, &callback) ||
+                VMI_SUCCESS != vmi_read_addr_va(vmi, entry, 4, &entry))
+                throw -1;
+            if (callback) out.push_back(callback);
+        }
+        return out;
+    };
+    // Array based callbacks
+    auto consume_callbacks_ex = [&](const char* symb, const size_t count) -> std::vector<addr_t>
+    {
+        std::vector<addr_t> out;
+        addr_t cb_base = get_ksymbol_va(symb);
+
+        for (size_t i = 0; i < count; i++)
+        {
+            addr_t entry = 0, callback = 0;
+            if (VMI_SUCCESS != vmi_read_addr_va(vmi, cb_base + i * ptrsize, 4, &entry))
+                throw -1;
+
+            // Strip ref count
+            entry &= ~fast_ref;
+            if (!entry)
+                continue;
+
+            if (VMI_SUCCESS != vmi_read_addr_va(vmi, entry + ptrsize, 4, &callback))
+                throw -1;
+            out.push_back(callback);
+        }
+        return out;
+    };
+    // Extract IRP_MJ_SHUTDOWN from device objects
+    auto extract_cb = [&](std::vector<addr_t> dev_objs) -> std::vector<addr_t>
+    {
+        constexpr size_t irp_mj_shutdown = 0x10;
+        for (auto& dev_obj : dev_objs)
+        {
+            addr_t drv_obj = 0;
+            if (VMI_SUCCESS != vmi_read_addr_va(vmi, dev_obj + drv_obj_rva, 4, &drv_obj) ||
+                VMI_SUCCESS != vmi_read_addr_va(vmi, drv_obj + mj_array_rva + irp_mj_shutdown * ptrsize, 4, &dev_obj))
+                throw -1;
+        }
+        return dev_objs;
+    };
+    // Extract PsWin32Callouts
+    auto consume_w32callouts = [&]() -> std::vector<addr_t>
+    {
+        std::vector<addr_t> out;
+        if (vmi_get_win_buildnumber(vmi) < win_8_1_ver)
+        {
+            for (const auto& sym : callout_syms)
+            {
+                addr_t fn = 0;
+                if (VMI_SUCCESS != vmi_read_addr_va(vmi, get_ksymbol_va(sym), 4, &fn))
+                    throw -1;
+                out.push_back(fn);
+            }
+        }
+        else
+        {
+            addr_t cb_block, fn;
+            if (VMI_SUCCESS != vmi_read_addr_va(vmi, get_ksymbol_va("PsWin32CallBack"), 4, &cb_block))
+                throw -1;
+            // Strip ref count
+            cb_block &= ~fast_ref;
+            if (VMI_SUCCESS != vmi_read_addr_va(vmi, cb_block + ptrsize, 4, &fn))
+                throw -1;
+            out.push_back(fn);
+        }
+        return out;
+    };
+    // Extract Wfp Callouts
+    auto consume_wfpcallouts = [&](const char* profile) -> std::vector<addr_t>
+    {
+        std::vector<addr_t> out;
+        const uint16_t ver = vmi_get_win_buildnumber(vmi);
+        // only Windows 7 sp1 x64 and Windows 10 1803 x64 currently supported
+        if (wfp_offsets.find(ver) == wfp_offsets.end() || !profile)
+            return {};
+        // Get gWfpGlobal RVA
+        auto profile_json = json_object_from_file(profile);
+        if (!profile_json)
+            throw -1;
+
+        addr_t gwfp_rva;
+        json_get_symbol_rva(drakvuf, profile_json, "gWfpGlobal", &gwfp_rva);
+        json_object_put(profile_json);
+
+        addr_t list_head;
+        if (VMI_SUCCESS != vmi_read_addr_ksym(vmi, "PsLoadedModuleList", &list_head))
+            throw -1;
+        addr_t netio_base;
+        if (!drakvuf_get_module_base_addr(drakvuf, list_head, "netio.sys", &netio_base))
+            throw -1;
+        addr_t gwfp;
+        if (VMI_SUCCESS != vmi_read_addr_va(vmi, netio_base + gwfp_rva, 4, &gwfp))
+            throw -1;
+
+        const auto& [callout_size, size_off, callout_off] = wfp_offsets.at(ver);
+        addr_t callout_base, callout_count;
+        // Read callout count and callout base address
+        if (VMI_SUCCESS != vmi_read_addr_va(vmi, gwfp + size_off, 4, &callout_count) ||
+            VMI_SUCCESS != vmi_read_addr_va(vmi, gwfp + callout_off, 4, &callout_base))
+            throw -1;
+
+        for (addr_t callout = callout_base; callout < callout_base + callout_count* callout_size; callout += callout_size)
+        {
+            addr_t cb1 = 0, cb2 = 0;
+            if (VMI_SUCCESS != vmi_read_addr_va(vmi, callout + 2 * ptrsize, 4, &cb1) ||
+                VMI_SUCCESS != vmi_read_addr_va(vmi, callout + 2 * ptrsize + ptrsize, 4, &cb2))
+                throw -1;
+
+            if (cb1) out.push_back(cb1);
+            if (cb2) out.push_back(cb2);
+        }
+        return out;
+    };
+
+    this->process_cb   = consume_callbacks_ex("PspCreateProcessNotifyRoutine", get_cb_table_size(vmi, "process"));
+    this->thread_cb    = consume_callbacks_ex("PspCreateThreadNotifyRoutine",  get_cb_table_size(vmi, "thread"));
+    this->image_cb     = consume_callbacks_ex("PspLoadImageNotifyRoutine",     get_cb_table_size(vmi, "image"));
+    this->bugcheck_cb  = consume_callbacks("KeBugCheckCallbackListHead", 2 * ptrsize);
+    this->bcreason_cb  = consume_callbacks("KeBugCheckReasonCallbackListHead", 2 * ptrsize);
+    this->registry_cb  = consume_callbacks("CallbackListHead", 5 * ptrsize);
+    this->logon_cb     = consume_callbacks("SeFileSystemNotifyRoutinesHead", 1 * ptrsize);
+    this->power_cb     = consume_callbacks("PopRegisteredPowerSettingCallbacks", get_power_cb_offset(vmi));
+    this->shtdwn_cb    = extract_cb(consume_callbacks("IopNotifyShutdownQueueHead", 2 * ptrsize));
+    this->shtdwn_lst_cb= extract_cb(consume_callbacks("IopNotifyLastChanceShutdownQueueHead", 2 * ptrsize));
+    this->dbgprint_cb  = consume_callbacks("RtlpDebugPrintCallbackList", -2 * ptrsize);
+    this->fschange_cb  = consume_callbacks("IopFsNotifyChangeQueueHead", 3 * ptrsize);
+    this->drvreinit_cb = consume_callbacks("IopDriverReinitializeQueueHead", 3 * ptrsize);
+    this->drvreinit2_cb= consume_callbacks("IopBootDriverReinitializeQueueHead", 3 * ptrsize);
+    this->nmi_cb       = consume_callbacks("KiNmiCallbackListHead", 1 * ptrsize);
+    this->priority_cb  = consume_callbacks_ex("IopUpdatePriorityCallbackRoutine", 8);
+    this->pnp_prof_cb  = consume_callbacks("PnpProfileNotifyList", 4 * ptrsize);
+    this->pnp_class_cb = consume_callbacks("PnpDeviceClassNotifyList", 5 * ptrsize);
+    this->emp_cb       = consume_callbacks("EmpCallbackListHead", -3 * ptrsize);
+    this->w32callouts  = consume_w32callouts();
+    this->wfpcallouts  = consume_wfpcallouts(this->config.netio_profile);
+}
+
+bool callbackmon::stop_impl()
+{
+    auto snapshot = std::make_unique<callbackmon>(drakvuf, &config, format);
+
+    auto report = [&](const auto& list_name, const auto& addr, const auto& action)
+    {
+        const auto& [name, base] = get_module_by_addr(drakvuf, addr);
+        fmt::print(format, "callbackmon", drakvuf, nullptr,
+            keyval("Type", fmt::Qstr("Callback")),
+            keyval("ListName", fmt::Qstr(list_name)),
+            keyval("Module", fmt::Qstr(name)),
+            keyval("RVA", fmt::Xval(base ? addr - base : 0)),
+            keyval("Action", fmt::Qstr(action))
+        );
+    };
+
+    auto check_callbacks = [&](const auto& previous, const auto& current, const auto& list_name)
+    {
+        auto walk_list = [&](const auto& previous, const auto& current, const auto& action)
+        {
+            for (const auto& cb : current)
+                if (std::find(previous.begin(), previous.end(), cb) != previous.end())
+                    report(list_name, cb, action);
+        };
+        walk_list(previous, current, "Added");
+        walk_list(current, previous, "Removed");
+    };
+
+    auto check_callouts = [&](const auto& previous, const auto& current)
+    {
+
+        uint16_t winver;
+        {
+            vmi_lock_guard vmi(drakvuf);
+            winver = vmi_get_win_buildnumber(vmi);
+        }
+        if (winver < win_8_1_ver)
+        {
+            for (size_t i = 0; i < callout_syms.size(); i++)
+                if (previous[i] != current[i])
+                    report(callout_syms[i], current[i], "Replaced");
+        }
+        else
+        {
+            if (previous[0] != current[0])
+                report("PsWin32CallBack", current[0], "Replaced");
+        }
+    };
+
+    check_callbacks(this->process_cb,   snapshot->process_cb,    "ProcessNotify");
+    check_callbacks(this->thread_cb,    snapshot->thread_cb,     "ThreadNotify");
+    check_callbacks(this->image_cb,     snapshot->image_cb,      "ImageNotify");
+    check_callbacks(this->bugcheck_cb,  snapshot->bugcheck_cb,   "BugCheck");
+    check_callbacks(this->bcreason_cb,  snapshot->bcreason_cb,   "BugCheckReason");
+    check_callbacks(this->registry_cb,  snapshot->registry_cb,   "Registry");
+    check_callbacks(this->logon_cb,     snapshot->logon_cb,      "LogonSession");
+    check_callbacks(this->power_cb,     snapshot->power_cb,      "PowerSettings");
+    check_callbacks(this->shtdwn_cb,    snapshot->shtdwn_cb,     "Shutdown");
+    check_callbacks(this->shtdwn_lst_cb, snapshot->shtdwn_lst_cb, "ShutdownLast");
+    check_callbacks(this->dbgprint_cb,  snapshot->dbgprint_cb,   "DbgPrint");
+    check_callbacks(this->fschange_cb,  snapshot->fschange_cb,   "FsChange");
+    check_callbacks(this->drvreinit_cb, snapshot->drvreinit_cb,  "DriverReinit");
+    check_callbacks(this->drvreinit2_cb, snapshot->drvreinit2_cb, "DriverReinitBoot");
+    check_callbacks(this->nmi_cb,       snapshot->nmi_cb,        "NMI");
+    check_callbacks(this->priority_cb,  snapshot->priority_cb,   "UpdatePriority");
+    check_callbacks(this->pnp_prof_cb,  snapshot->pnp_prof_cb,   "PnPProfile");
+    check_callbacks(this->pnp_class_cb, snapshot->pnp_class_cb,  "PnPClass");
+    check_callbacks(this->emp_cb,       snapshot->emp_cb,        "EMP");
+    check_callbacks(this->wfpcallouts,  snapshot->wfpcallouts,   "WfpCallouts");
+    check_callouts (this->w32callouts,  snapshot->w32callouts);
+
+    return true;
+}

--- a/src/plugins/callbackmon/callbackmon.h
+++ b/src/plugins/callbackmon/callbackmon.h
@@ -1,6 +1,6 @@
 /*********************IMPORTANT DRAKVUF LICENSE TERMS***********************
  *                                                                         *
- * DRAKVUF (C) 2014-2022 Tamas K Lengyel.                                  *
+ * DRAKVUF (C) 2014-2021 Tamas K Lengyel.                                  *
  * Tamas K Lengyel is hereinafter referred to as the author.               *
  * This program is free software; you may redistribute and/or modify it    *
  * under the terms of the GNU General Public License as published by the   *
@@ -106,62 +106,110 @@
 #include "plugins/plugins_ex.h"
 #include "private.h"
 
-struct rootkitmon_config
+struct callbackmon_config
 {
-    const char* fwpkclnt_profile;
-    const char* fltmgr_profile;
+    const char* netio_profile = nullptr;
 };
 
-class rootkitmon : public pluginex
+class callbackmon : public pluginex
 {
 public:
-    rootkitmon(drakvuf_t drakvuf, const rootkitmon_config* config, output_format_t output);
-    rootkitmon(const rootkitmon&) = delete;
-    rootkitmon& operator=(const rootkitmon&) = delete;
-    ~rootkitmon();
+    callbackmon(drakvuf_t drakvuf, const callbackmon_config* config, output_format_t output);
 
-    event_response_t final_check_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
+    const callbackmon_config config;
+    const output_format_t format;
 
-    std::unique_ptr<libhook::ManualHook> register_profile_hook(drakvuf_t drakvuf, const char* profile, const char* dll_name,
-        const char* func_name, hook_cb_t callback);
-    std::unique_ptr<libhook::ManualHook> register_reg_hook(hook_cb_t callback, register_t reg);
-    std::unique_ptr<libhook::ManualHook> register_mem_hook(hook_cb_t callback, addr_t pa, vmi_mem_access_t access);
-
-    std::set<driver_t> enumerate_driver_objects(vmi_instance_t vmi);
-    std::set<driver_t> enumerate_directory(vmi_instance_t vmi, addr_t addr);
-    unicode_string_t* get_object_type_name(vmi_instance_t vmi, addr_t object);
-    device_stack_t enumerate_driver_stacks(vmi_instance_t vmi, addr_t driver_object);
-    bool enumerate_cores(vmi_instance_t vmi);
-
-    void check_driver_integrity(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
-    void check_driver_objects(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
-    void check_descriptors(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
+    std::vector<addr_t> process_cb;
+    std::vector<addr_t> thread_cb;
+    std::vector<addr_t> image_cb;
+    std::vector<addr_t> bugcheck_cb;
+    std::vector<addr_t> bcreason_cb;
+    std::vector<addr_t> registry_cb;
+    std::vector<addr_t> logon_cb;
+    std::vector<addr_t> power_cb;
+    std::vector<addr_t> shtdwn_cb;
+    std::vector<addr_t> shtdwn_lst_cb;
+    std::vector<addr_t> dbgprint_cb;
+    std::vector<addr_t> fschange_cb;
+    std::vector<addr_t> drvreinit_cb;
+    std::vector<addr_t> drvreinit2_cb;
+    std::vector<addr_t> nmi_cb;
+    std::vector<addr_t> priority_cb;
+    std::vector<addr_t> emp_cb;
+    std::vector<addr_t> pnp_prof_cb;
+    std::vector<addr_t> pnp_class_cb;
+    std::vector<addr_t> w32callouts;
+    std::vector<addr_t> wfpcallouts;
 
     virtual bool stop_impl() override;
-
-    const output_format_t format;
-    win_ver_t winver;
-
-    size_t* offsets;
-    size_t guest_ptr_size;
-    bool is32bit;
-    size_t object_header_size;
-
-    bool done_final_analysis;
-    bool not_supported;
-
-    addr_t halprivatetable;
-    addr_t type_idx_table;
-    uint8_t ob_header_cookie;
-
-    std::unordered_map<driver_t, std::vector<checksum_data_t>> driver_sections_checksums;
-    std::unordered_map<driver_t, sha256_checksum_t> driver_object_checksums;
-    // _DRIVER_OBJECT -> _DEVICE_OBJECT -> [_DEVICE_OBJECT, ...]
-    std::unordered_map<driver_t, device_stack_t> driver_stacks;
-    // VCPU -> Descriptor
-    std::unordered_map<unsigned int, descriptors_t> descriptors;
-    // VCPU -> MSR_LSTAR
-    std::unordered_map<unsigned int, addr_t> msr_lstar;
-    std::vector<std::unique_ptr<libhook::ManualHook>> manual_hooks;
-    std::vector<std::unique_ptr<libhook::SyscallHook>> syscall_hooks;
 };
+
+/*
+process, thread, image:
+typedef struct _EX_CALLBACK_ROUTINE_BLOCK {
+    EX_RUNDOWN_REF RundownProtect;
+    PEX_CALLBACK_FUNCTION Function;
+    PVOID Context;
+} EX_CALLBACK_ROUTINE_BLOCK, *PEX_CALLBACK_ROUTINE_BLOCK;
+
+bugcheck:
+typedef struct _KBUGCHECK_CALLBACK_RECORD {
+    LIST_ENTRY Entry;
+    PKBUGCHECK_CALLBACK_ROUTINE CallbackRoutine;
+    __field_bcount_opt(Length) PVOID Buffer;
+    ULONG Length;
+    PUCHAR Component;
+    ULONG_PTR Checksum;
+    UCHAR State;
+} KBUGCHECK_CALLBACK_RECORD, *PKBUGCHECK_CALLBACK_RECORD;
+
+bugcheckreason:
+typedef struct _KBUGCHECK_REASON_CALLBACK_RECORD {
+    LIST_ENTRY Entry;
+    PKBUGCHECK_REASON_CALLBACK_ROUTINE CallbackRoutine;
+    PUCHAR Component;
+    ULONG_PTR Checksum;
+    KBUGCHECK_CALLBACK_REASON Reason;
+    UCHAR State;
+} KBUGCHECK_REASON_CALLBACK_RECORD, *PKBUGCHECK_REASON_CALLBACK_RECORD;
+
+registry:
+typedef struct _CM_CALLBACK_CONTEXT_BLOCK {
+    LIST_ENTRY CallbackListEntry;
+    LONG PreCallListCount;
+    LARGE_INTEGER Cookie;
+    PVOID CallerContext;
+    PEX_CALLBACK_FUNCTION Function;
+    UNICODE_STRING Altitude;
+    LIST_ENTRY ObjectContextListHead;
+} CM_CALLBACK_CONTEXT_BLOCK, *PCM_CALLBACK_CONTEXT_BLOCK;
+
+fschange:
+typedef struct _NOTIFICATION_PACKET {
+    LIST_ENTRY ListEntry;
+    PDRIVER_OBJECT DriverObject;
+    PDRIVER_FS_NOTIFICATION NotificationRoutine;
+} NOTIFICATION_PACKET, *PNOTIFICATION_PACKET;
+
+drvreinit, drvreinit2:
+typedef struct _REINIT_PACKET {
+    LIST_ENTRY ListEntry;
+    PDRIVER_OBJECT DriverObject;
+    PDRIVER_REINITIALIZE DriverReinitializationRoutine;
+    PVOID Context;
+} REINIT_PACKET, *PREINIT_PACKET;
+
+NMI:
+typedef struct _NMI_CALLBACK_BLOCK {
+    _NMI_CALLBACK_BLOCK* Next;
+    NMI_CALLBACK* CallbackRoutine;
+    PVOID Context;
+    _NMI_CALLBACK_BLOCK* Prev;
+};
+
+logon:
+typedef struct _SEP_LOGON_SESSION_TERMINATED_NOTIFICATION {
+    struct _SEP_LOGON_SESSION_TERMINATED_NOTIFICATION *Next;
+    PSE_LOGON_SESSION_TERMINATED_ROUTINE CallbackRoutine;
+} SEP_LOGON_SESSION_TERMINATED_NOTIFICATION, *PSEP_LOGON_SESSION_TERMINATED_NOTIFICATION;
+*/

--- a/src/plugins/callbackmon/callbackmon.h
+++ b/src/plugins/callbackmon/callbackmon.h
@@ -1,6 +1,6 @@
 /*********************IMPORTANT DRAKVUF LICENSE TERMS***********************
  *                                                                         *
- * DRAKVUF (C) 2014-2021 Tamas K Lengyel.                                  *
+ * DRAKVUF (C) 2014-2022 Tamas K Lengyel.                                  *
  * Tamas K Lengyel is hereinafter referred to as the author.               *
  * This program is free software; you may redistribute and/or modify it    *
  * under the terms of the GNU General Public License as published by the   *

--- a/src/plugins/plugins.cpp
+++ b/src/plugins/plugins.cpp
@@ -137,6 +137,7 @@
 #include "ipt/ipt.h"
 #include "hidsim/hidsim.h"
 #include "rootkitmon/rootkitmon.h"
+#include "callbackmon/callbackmon.h"
 
 drakvuf_plugins::drakvuf_plugins(const drakvuf_t _drakvuf, output_format_t _output, os_t _os)
     : drakvuf{ _drakvuf }, output{ _output }, os{ _os }
@@ -485,6 +486,17 @@ int drakvuf_plugins::start(const drakvuf_plugin_t plugin_id,
                         .fltmgr_profile = options->fltmgr_profile,
                     };
                     this->plugins[plugin_id] = std::make_unique<rootkitmon>(this->drakvuf, &config, this->output);
+                    break;
+                }
+#endif
+#ifdef ENABLE_PLUGIN_CALLBACKMON
+                case PLUGIN_CALLBACKMON:
+                {
+                    callbackmon_config config =
+                    {
+                        .netio_profile = options->netio_profile,
+                    };
+                    this->plugins[plugin_id] = std::make_unique<callbackmon>(this->drakvuf, &config, this->output);
                     break;
                 }
 #endif

--- a/src/plugins/plugins.h
+++ b/src/plugins/plugins.h
@@ -172,6 +172,7 @@ struct plugins_options
     bool hidsim_random_clicks;          // PLUGIN_HIDSIM
     const char* fwpkclnt_profile;       // PLUGIN_ROOTKITMON
     const char* fltmgr_profile;         // PLUGIN_ROOTKITMON
+    const char* netio_profile;          // PLUGIN_CALLBACKMON
 };
 
 typedef enum drakvuf_plugin
@@ -209,6 +210,7 @@ typedef enum drakvuf_plugin
     PLUGIN_IPT,
     PLUGIN_HIDSIM,
     PLUGIN_ROOTKITMON,
+    PLUGIN_CALLBACKMON,
     __DRAKVUF_PLUGIN_LIST_MAX
 } drakvuf_plugin_t;
 
@@ -247,6 +249,7 @@ static const char* drakvuf_plugin_names[] =
     [PLUGIN_IPT] = "ipt",
     [PLUGIN_HIDSIM] = "hidsim",
     [PLUGIN_ROOTKITMON] = "rootkitmon",
+    [PLUGIN_CALLBACKMON] = "callbackmon",
 };
 
 static const bool drakvuf_plugin_os_support[__DRAKVUF_PLUGIN_LIST_MAX][VMI_OS_WINDOWS+1] =
@@ -284,6 +287,7 @@ static const bool drakvuf_plugin_os_support[__DRAKVUF_PLUGIN_LIST_MAX][VMI_OS_WI
     [PLUGIN_IPT]          = { [VMI_OS_WINDOWS] = 1, [VMI_OS_LINUX] = 1 },
     [PLUGIN_HIDSIM]       = { [VMI_OS_WINDOWS] = 1, [VMI_OS_LINUX] = 1 },
     [PLUGIN_ROOTKITMON]   = { [VMI_OS_WINDOWS] = 1, [VMI_OS_LINUX] = 0 },
+    [PLUGIN_CALLBACKMON]  = { [VMI_OS_WINDOWS] = 1, [VMI_OS_LINUX] = 0 },
 };
 
 class plugin


### PR DESCRIPTION
Hello!
This is the new plugin that aims to find installed/removed/hooked callbacks in kernel. We've found that some rootkits directly modify underlying data structures with callbacks bypassing api hooks.
I've also added more informative output compared to rootkitmon.
`Module` : module name that contains callback function
`RVA` : address within the module
`ListName` : callback type
`Action` : removed/added/replaced

CC: @disaykin