### PR TITLE
deb: Add libgnutls28-dev to Xen build dependencies

### DIFF
--- a/package/depends.sh
+++ b/package/depends.sh
@@ -29,6 +29,9 @@ then
     apt-get --quiet --yes install python-is-python2
 fi
 
+# libgnutls28 is required for the password-protected VNC to work in Xen 4.16+.
+# See: https://bugs.gentoo.org/832494
+apt-get install -y libgnutls28-dev
 apt-get --quiet --yes build-dep xen
 apt-get autoremove -y
 apt-get clean


### PR DESCRIPTION
Compiling Xen without libgnutls leads to a semi-broken VNC,
and a cryptic error while creating a domain:

qemu-system-i386: -vnc 0.0.0.0:0,password=on,to=99: Cipher backend does not support DES algorithm

Fix this by adding libgnutls28-dev to the compilation environment.

See: https://bugs.gentoo.org/832494