### PR TITLE
Fix printing syscall name after it has been freed

### DIFF
--- a/src/plugins/syscalls/syscalls.h
+++ b/src/plugins/syscalls/syscalls.h
@@ -121,6 +121,7 @@ class syscalls: public pluginex
 {
 public:
     GSList* traps; // NOTE Non "pluginex" support for linux
+    GSList* strings_to_free;
     GHashTable* filter;
     json_object* win32k_json;
 


### PR DESCRIPTION
When we encounter a new syscall without an internal definition its not safe to pass `symbol->name` as `trap->name` as it gets freed. We really only ought to copy the new syscall name if no internal definition is found, and use the internal definition's name if it is found as its already statically allocated.

Why this bug only triggered for syscalls with no internal definitions is unclear, by the looks of it it should have affected all syscalls. Perhaps some compiler optimization happened to hide it?

Fixes #1398 