### PR TITLE
Procdump fix

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -764,6 +764,7 @@ int main(int argc, char** argv)
 #if defined(ENABLE_PLUGIN_PROCDUMP) || defined(ENABLE_PLUGIN_PROCDUMP2)
             case opt_procdump_timeout:
                 options.procdump_timeout = strtoul(optarg, NULL, 0);
+                break;
             case opt_procdump_dir:
                 options.procdump_dir = optarg;
                 break;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -286,6 +286,8 @@ static void print_usage()
         "\t                           Stop printing addresses of string arguments in apimon and memdump\n"
 #endif
 #if defined(ENABLE_PLUGIN_PROCDUMP) || defined(ENABLE_PLUGIN_PROCDUMP2)
+        "\t --procdump-timeout <timeout>\n"
+        "\t                           Timeout (in seconds) to finish process memory dumps\n"
         "\t --procdump-dir <directory>\n"
         "\t                           Where to store processes dumps\n"
         "\t --compress-procdumps\n"
@@ -427,6 +429,7 @@ int main(int argc, char** argv)
         opt_memdump_disable_set_thread,
         opt_memdump_disable_shellcode_detect,
         opt_dll_hooks_list,
+        opt_procdump_timeout,
         opt_procdump_dir,
         opt_compress_procdumps,
         opt_procdump_disable_dump_on_finish,
@@ -494,6 +497,7 @@ int main(int argc, char** argv)
         {"memdump-disable-set-thread", no_argument, NULL, opt_memdump_disable_set_thread},
         {"memdump-disable-shellcode-detect", no_argument, NULL, opt_memdump_disable_shellcode_detect},
         {"dll-hooks-list", required_argument, NULL, opt_dll_hooks_list},
+        {"procdump-timeout", required_argument, NULL, opt_procdump_timeout},
         {"procdump-dir", required_argument, NULL, opt_procdump_dir},
         {"compress-procdumps", no_argument, NULL, opt_compress_procdumps},
         {"procdump-disable-dump-on-finish", no_argument, NULL, opt_procdump_disable_dump_on_finish},
@@ -758,6 +762,8 @@ int main(int argc, char** argv)
                 break;
 #endif
 #if defined(ENABLE_PLUGIN_PROCDUMP) || defined(ENABLE_PLUGIN_PROCDUMP2)
+            case opt_procdump_timeout:
+                options.procdump_timeout = strtoul(optarg, NULL, 0);
             case opt_procdump_dir:
                 options.procdump_dir = optarg;
                 break;

--- a/src/plugins/plugins.cpp
+++ b/src/plugins/plugins.cpp
@@ -403,6 +403,7 @@ int drakvuf_plugins::start(const drakvuf_plugin_t plugin_id,
                 {
                     procdump2_config config =
                     {
+                        .timeout = options->procdump_timeout,
                         .procdump_dir = options->procdump_dir,
                         .compress_procdumps = options->compress_procdumps,
                         .procdump_on_finish = options->procdump_on_finish,

--- a/src/plugins/plugins.h
+++ b/src/plugins/plugins.h
@@ -148,6 +148,7 @@ struct plugins_options
     bool userhook_no_addr;              // PLUGIN_MEMDUMP, PLUGIN_APIMON
     const char* clr_profile;            // PLUGIN_MEMDUMP
     const char* mscorwks_profile;       // PLUGIN_MEMDUMP
+    uint32_t procdump_timeout;          // PLUGIN_PROCDUMP
     const char* procdump_dir;           // PLUGIN_PROCDUMP
     bool compress_procdumps = false;    // PLUGIN_PROCDUMP
     vmi_pid_t procdump_on_finish;       // PLUGIN_PROCDUMP2

--- a/src/plugins/procdump2/private2.h
+++ b/src/plugins/procdump2/private2.h
@@ -163,17 +163,19 @@ using vads_t = std::map<addr_t, vad_info2>;
 
 enum class procdump_stage
 {
-    need_suspend,  // 0
-    suspend,       // 1
-    pending,       // 2
-    get_irql,      // 3
-    allocate_pool, // 4
-    copy_memory,   // 5
-    resume,        // 6
-    awaken,        // 7
-    finished,      // 8
-    target_fail,   // 9
-    invalid        // 10
+    need_suspend,     // 0
+    suspend,          // 1
+    pending,          // 2
+    get_irql,         // 3
+    allocate_pool,    // 4
+    prepare_minidump, // 5
+    copy_memory,      // 6
+    resume,           // 7
+    awaken,           // 8
+    finished,         // 9
+    target_fail,      // 10
+    timeout,          // 11
+    invalid           // 12
 };
 
 struct return_ctx
@@ -264,6 +266,25 @@ struct procdump2_ctx
             return true;
         else
             return false;
+    }
+
+    const char* status()
+    {
+        switch (stage)
+        {
+            case procdump_stage::finished:
+                return "Success";
+            case procdump_stage::timeout:
+                return "Timeout";
+            case procdump_stage::target_fail:
+                return "WakeUp";
+            case procdump_stage::prepare_minidump:
+                return "PrepareMinidump";
+            case procdump_stage::allocate_pool:
+                return "AllocatePool";
+            default:
+                return "Fail";
+        }
     }
 };
 

--- a/src/plugins/procdump2/private2.h
+++ b/src/plugins/procdump2/private2.h
@@ -172,7 +172,8 @@ enum class procdump_stage
     resume,        // 6
     awaken,        // 7
     finished,      // 8
-    invalid        // 9
+    target_fail,   // 9
+    invalid        // 10
 };
 
 struct return_ctx
@@ -223,6 +224,9 @@ struct procdump2_ctx
     string    target_process_name;
     vmi_pid_t target_process_pid{0};
 
+    const uint8_t TARGET_RESUSPEND_COUNT_MAX{5};
+    uint8_t target_resuspend_count{0};
+
     /* Data */
     size_t         current_dump_size{0};
     addr_t         pool{0}; // TODO Use "class pool" here
@@ -252,6 +256,14 @@ struct procdump2_ctx
         writer = ProcdumpWriterFactory::build(
                 procdump_dir + "/"s + data_file_name,
                 use_compression);
+    }
+
+    bool on_target_resuspend()
+    {
+        if (++target_resuspend_count < TARGET_RESUSPEND_COUNT_MAX)
+            return true;
+        else
+            return false;
     }
 };
 

--- a/src/plugins/procdump2/procdump2.cpp
+++ b/src/plugins/procdump2/procdump2.cpp
@@ -126,6 +126,7 @@
 procdump2::procdump2(drakvuf_t drakvuf, const procdump2_config* config,
     output_format_t output)
     : pluginex(drakvuf, output)
+    , timeout{config->timeout}
     , procdump_dir{config->procdump_dir ?: ""}
     , procdump_on_finish(config->procdump_on_finish)
     , use_compression{config->compress_procdumps}
@@ -224,6 +225,8 @@ procdump2::~procdump2()
 
 bool procdump2::stop_impl()
 {
+    if (!begin_stop_at)
+        begin_stop_at = g_get_real_time() / G_USEC_PER_SEC;
     if (procdump_on_finish &&
         !is_active_process(procdump_on_finish) &&
         !is_process_handled(procdump_on_finish))
@@ -231,36 +234,38 @@ bool procdump2::stop_impl()
         vmi_pid_t target_process_pid = procdump_on_finish;
         addr_t target_process_base = 0;
         addr_t dtb = 0;
-        if ( !drakvuf_get_process_by_pid(drakvuf, target_process_pid, &target_process_base, &dtb) )
-        {
-            print_failure(nullptr, target_process_pid, "Failed to get process base");
-            return true;
-        }
-        auto ctx = std::make_shared<procdump2_ctx>(
-                false,
-                target_process_base,
-                std::string(drakvuf_get_process_name(drakvuf, target_process_base, true)),
+        if ( drakvuf_get_process_by_pid(drakvuf,
                 target_process_pid,
-                procdumps_count++,
-                procdump_dir,
-                use_compression);
-        ctx->stage = procdump_stage::need_suspend;
-        ctx->wait_awaken = false;
-        PRINT_DEBUG("[PROCDUMP] [%d:%d] "
-            "Dispatch new process\n"
-            , ctx->target_process_pid, static_cast<int>(ctx->stage)
-        );
+                &target_process_base,
+                &dtb) )
+        {
+            auto ctx = std::make_shared<procdump2_ctx>(
+                    false,
+                    target_process_base,
+                    std::string(drakvuf_get_process_name(drakvuf,
+                            target_process_base, true)),
+                    target_process_pid,
+                    procdumps_count++,
+                    procdump_dir,
+                    use_compression);
+            ctx->stage = procdump_stage::need_suspend;
+            ctx->wait_awaken = false;
+            PRINT_DEBUG("[PROCDUMP] [%d:%d] "
+                "Dispatch new process\n"
+                , ctx->target_process_pid, static_cast<int>(ctx->stage)
+            );
 
 
-        /* Save new target process into the list */
-        this->active[target_process_pid] = ctx;
+            /* Save new target process into the list */
+            this->active[target_process_pid] = ctx;
 
-        /* NOTE This prevents errors on subsequent calls to the stop method
-         *
-         * If "wait stop plugins" option been used then multiple calls to stop
-         * method would occur.
-         */
-        procdump_on_finish = 0;
+            /* NOTE This prevents errors on subsequent calls to the stop method
+            *
+            * If "wait stop plugins" option been used then multiple calls to
+            * stop method would occur.
+            */
+            procdump_on_finish = 0;
+        }
     }
 
     if (!is_plugin_active())
@@ -374,16 +379,8 @@ event_response_t procdump2::dispatcher(drakvuf_trap_info_t* info)
         return VMI_EVENT_RESPONSE_SET_REGISTERS;
     }
 
-    if ( is_stopping() && !is_plugin_active() )
-    {
-        PRINT_DEBUG("[PROCDUMP] [%8zu] [%d:%d] "
-            "Interrupt drakvuf loop\n"
-            , info->event_uid
-            , info->attached_proc_data.pid, info->attached_proc_data.tid
-        );
-        drakvuf_interrupt(drakvuf, 1);
+    if (is_stopping())
         return VMI_EVENT_RESPONSE_NONE;
-    }
 
     /* Check if there is something to processes. */
     if (this->active.empty())
@@ -433,6 +430,12 @@ void procdump2::dispatch_active(drakvuf_trap_info_t* info, std::shared_ptr<procd
         , info->attached_proc_data.pid, info->attached_proc_data.tid
         , ctx->target_process_pid, static_cast<int>(ctx->stage)
     );
+
+    if (is_stopping() &&
+        timeout &&
+        g_get_real_time() / G_USEC_PER_SEC - begin_stop_at > timeout)
+        ctx->stage = procdump_stage::timeout;
+
     switch (ctx->stage)
     {
         case procdump_stage::suspend:
@@ -474,7 +477,7 @@ void procdump2::dispatch_active(drakvuf_trap_info_t* info, std::shared_ptr<procd
                     {
                         // TODO Resume target process?
                         restore(info, ctx->working.regs);
-                        finish_task(ctx);
+                        finish_task(info, ctx);
                         this->working_threads.erase(info->attached_proc_data.tid);
                     }
                 }
@@ -495,16 +498,15 @@ void procdump2::dispatch_active(drakvuf_trap_info_t* info, std::shared_ptr<procd
                 {
                     // TODO Resume target process?
                     restore(info, ctx->working.regs);
-                    finish_task(ctx);
+                    finish_task(info, ctx);
                     this->working_threads.erase(info->attached_proc_data.tid);
                 }
             }
             else
             {
-                print_failure(info, ctx, "Failed to allocate pool");
                 // TODO Resume target process?
                 restore(info, ctx->working.regs);
-                finish_task(ctx);
+                finish_task(info, ctx);
                 this->working_threads.erase(info->attached_proc_data.tid);
             }
         }
@@ -526,16 +528,6 @@ void procdump2::dispatch_active(drakvuf_trap_info_t* info, std::shared_ptr<procd
 
             if (ctx->vads.empty())
             {
-                ctx->writer->finish();
-                save_file_metadata(ctx, &info->attached_proc_data);
-                fmt::print(m_output_format, "procdump", drakvuf, info,
-                    keyval("TargetPID", fmt::Nval(ctx->target_process_pid)),
-                    keyval("TargetName", fmt::Qstr(ctx->target_process_name)),
-                    keyval("DumpReason", fmt::Qstr("TerminateProcess")),
-                    keyval("DumpSize", fmt::Nval(ctx->size)),
-                    keyval("SN", fmt::Nval(ctx->idx))
-                );
-
                 PRINT_DEBUG("[PROCDUMP] [%8zu] [%d:%d] [%d:%d] "
                     "Resume %s process\n"
                     , info->event_uid
@@ -578,19 +570,22 @@ void procdump2::dispatch_active(drakvuf_trap_info_t* info, std::shared_ptr<procd
              */
             restore(info, ctx->working.regs);
             if (ctx->stage == procdump_stage::awaken || !ctx->wait_awaken)
-                finish_task(ctx);
+            {
+                ctx->stage = procdump_stage::finished;
+                finish_task(info, ctx);
+            }
             else
                 ctx->stage = procdump_stage::finished;
             this->working_threads.erase(info->attached_proc_data.tid);
         }
         break;
         case procdump_stage::invalid:
-            print_failure(info, ctx, "Active process get invalid stage");
         case procdump_stage::target_fail:
+        case procdump_stage::timeout:
         default:
             // TODO Resume target process?
             restore(info, ctx->working.regs);
-            finish_task(ctx);
+            finish_task(info, ctx);
             this->working_threads.erase(info->attached_proc_data.tid);
     }
 }
@@ -682,16 +677,10 @@ bool procdump2::dispatch_new(drakvuf_trap_info_t* info)
          */
         addr_t dtb = 0;
         if ( !drakvuf_get_process_by_handle(drakvuf, info, handle, &target_process_base, &dtb) )
-        {
-            print_failure(info, "Failed to get target process base");
             return false;
-        }
 
         if ( !drakvuf_get_process_pid(drakvuf, target_process_base, &target_process_pid) )
-        {
-            print_failure(info, "Failed to get target process PID");
             return false;
-        }
 
         target_process_name = std::string(drakvuf_get_process_name(drakvuf, target_process_base, true));
     }
@@ -809,7 +798,7 @@ bool procdump2::dispatch_wakeup(
             if (ctx->stage == procdump_stage::resume)
                 ctx->stage = procdump_stage::awaken;
             else
-                finish_task(ctx);
+                finish_task(info, ctx);
             return true;
         default:
             if (is_target)
@@ -830,7 +819,6 @@ bool procdump2::dispatch_wakeup(
                 }
                 else
                 {
-                    print_failure(info, ctx, "Target process wake up");
                     ctx->stage = procdump_stage::target_fail;
                     restore(info, ctx->target.regs);
                 }
@@ -1048,8 +1036,20 @@ std::shared_ptr<procdump2_ctx> procdump2::continues_task(drakvuf_trap_info_t* in
     return nullptr;
 }
 
-void procdump2::finish_task(std::shared_ptr<procdump2_ctx> ctx)
+void procdump2::finish_task(drakvuf_trap_info_t* info,
+    std::shared_ptr<procdump2_ctx> ctx)
 {
+    ctx->writer->finish();
+    save_file_metadata(ctx, &info->attached_proc_data);
+    fmt::print(m_output_format, "procdump", drakvuf, info,
+        keyval("TargetPID", fmt::Nval(ctx->target_process_pid)),
+        keyval("TargetName", fmt::Qstr(ctx->target_process_name)),
+        keyval("DumpReason", fmt::Qstr("TerminateProcess")),
+        keyval("DumpSize", fmt::Nval(ctx->size)),
+        keyval("SN", fmt::Nval(ctx->idx)),
+        keyval("Status", fmt::Qstr(ctx->status()))
+    );
+
     this->finished.insert(ctx->target_process_pid);
     if (ctx->pool)
         pools->free(ctx->pool);
@@ -1187,13 +1187,11 @@ static bool dump_mmvad(drakvuf_t drakvuf, mmvad_info_t* mmvad,
 
 bool procdump2::prepare_minidump(drakvuf_trap_info_t* info, std::shared_ptr<procdump2_ctx> ctx)
 {
+    ctx->stage = procdump_stage::prepare_minidump;
     // Get virtual address space map of the process
     drakvuf_traverse_mmvad(drakvuf, ctx->target_process_base, dump_mmvad, ctx.get());
     if (ctx->vads.empty())
-    {
-        print_failure(info, ctx, "Empty VADs list");
         return false;
-    }
 
     uint32_t time_stamp = g_get_real_time() / G_USEC_PER_SEC;
 
@@ -1248,30 +1246,6 @@ bool procdump2::prepare_minidump(drakvuf_trap_info_t* info, std::shared_ptr<proc
         return false;
     }
     return true;
-}
-
-void procdump2::print_failure(drakvuf_trap_info_t* info, std::shared_ptr<procdump2_ctx> ctx, const std::string& message)
-{
-    fmt::print(m_output_format, "procdump_fail", drakvuf, info,
-        keyval("TargetProcess", fmt::Nval(ctx->target_process_pid)),
-        keyval("Stage", fmt::Nval(static_cast<int>(ctx->stage))),
-        keyval("Message", fmt::Qstr(message))
-    );
-}
-
-void procdump2::print_failure(drakvuf_trap_info_t* info, vmi_pid_t target_process_pid, const std::string& message)
-{
-    fmt::print(m_output_format, "procdump_fail", drakvuf, info,
-        keyval("TargetProcess", fmt::Nval(target_process_pid)),
-        keyval("Message", fmt::Qstr(message))
-    );
-}
-
-void procdump2::print_failure(drakvuf_trap_info_t* info, const std::string& message)
-{
-    fmt::print(m_output_format, "procdump_fail", drakvuf, info,
-        keyval("Message", fmt::Qstr(message))
-    );
 }
 
 void procdump2::read_vm(addr_t dtb,
@@ -1374,7 +1348,7 @@ void procdump2::save_file_metadata(std::shared_ptr<procdump2_ctx> ctx, proc_data
     json_object_object_add(jobj, "TargetPID", json_object_new_int(ctx->target_process_pid));
     json_object_object_add(jobj, "TargetName", json_object_new_string(ctx->target_process_name.data()));
     json_object_object_add(jobj, "Compression", json_object_new_string(use_compression ? "gzip" : "none"));
-
+    json_object_object_add(jobj, "Status", json_object_new_string(ctx->status()));
     json_object_object_add(jobj, "DataFileName", json_object_new_string(ctx->data_file_name.data()));
 
     fprintf(fp, "%s\n", json_object_get_string(jobj));

--- a/src/plugins/procdump2/procdump2.h
+++ b/src/plugins/procdump2/procdump2.h
@@ -117,6 +117,7 @@
 
 struct procdump2_config
 {
+    uint32_t timeout;
     const char* procdump_dir;
     bool compress_procdumps;
     vmi_pid_t procdump_on_finish;
@@ -139,6 +140,7 @@ public:
 
 private:
     /* Config */
+    uint32_t                                             timeout{0};
     // TODO Use `std::filesystem::path`
     std::string const                                    procdump_dir;
     // TODO Rename
@@ -150,6 +152,7 @@ private:
     uint64_t                                             procdumps_count{0};
     std::unique_ptr<pool_manager>                        pools;
     std::map<vmi_pid_t, std::shared_ptr<procdump2_ctx>>  active;
+    uint32_t                                             begin_stop_at{0};
     /* Set of finished tasks.
      *
      * Prevents process dump on second call of NtTerminateProcess.
@@ -216,16 +219,13 @@ private:
 
     /* Routines */
     std::shared_ptr<procdump2_ctx> continues_task(drakvuf_trap_info_t*);
-    void finish_task(std::shared_ptr<procdump2_ctx>);
+    void finish_task(drakvuf_trap_info_t*, std::shared_ptr<procdump2_ctx>);
     addr_t get_function_va(std::string_view, std::string_view);
     std::pair<addr_t, size_t> get_memory_region(drakvuf_trap_info_t*, std::shared_ptr<procdump2_ctx>);
     bool is_active_process(vmi_pid_t pid);
     bool is_process_handled(vmi_pid_t pid);
     bool is_plugin_active();
     bool prepare_minidump(drakvuf_trap_info_t*, std::shared_ptr<procdump2_ctx>);
-    void print_failure(drakvuf_trap_info_t*, std::shared_ptr<procdump2_ctx>, const std::string& message);
-    void print_failure(drakvuf_trap_info_t*, vmi_pid_t, const std::string& message);
-    void print_failure(drakvuf_trap_info_t*, const std::string& message);
     void read_vm(addr_t, std::shared_ptr<procdump2_ctx> procdump_ctx, bool);
     void restore(drakvuf_trap_info_t*, x86_registers_t&);
     void save_file_metadata(std::shared_ptr<procdump2_ctx>, proc_data_t*);


### PR DESCRIPTION
Additional timeout is used to prevent BSODs on plug-in stop.

The BSOD occur because on stop signal the plug-in doesn't remove hooks but perform new injects to dump target process. Thus on global timeout the plug-in destructor is called and VM is leaved in broken state on last injection.

Also the code is changed to store metadata for partial dumps. And dump status is inserted into "procdump" event and metadata.

The other error fixed is end-less "PsSuspendProcess" injection loop. In some cases the target process is awaken. And the VM catch BSOD on several dozens of "PsSuspendProcess" injections. I don't know the reason of BSOD. Though I believe that the end-less loop should be fixed.