### PR TITLE
procdump: fix fragmented address spaces

### DIFF
--- a/src/plugins/procdump2/private2.h
+++ b/src/plugins/procdump2/private2.h
@@ -158,6 +158,7 @@ struct vad_info2
     uint32_t type; // TODO Use backed file name instead of type?
     uint64_t total_number_of_ptes;
     uint32_t idx;                       // index in prototype_ptes
+    bool is_memory_mapped_file;
 };
 using vads_t = std::map<addr_t, vad_info2>;
 
@@ -230,11 +231,21 @@ struct procdump2_ctx
     uint8_t target_resuspend_count{0};
 
     /* Data */
-    size_t         current_dump_size{0};
-    addr_t         pool{0}; // TODO Use "class pool" here
-    const uint64_t POOL_SIZE_IN_PAGES{0x400}; // TODO Move into "class pool"
+    // Target process virtual address space size
     size_t         size{0};
+
+    addr_t         current_read_bytes_va{0};
+    addr_t         current_dump_base{0};
+    size_t         current_dump_size{0};
+    bool           is_current_memory_mapped_file{false};
     vads_t         vads;
+
+    // Intermediate buffer in guest OS used for coping address space.
+    // The "MmCopyVirtualMemory" creates it's own intermediate buffer.
+    // Thus the memory usage is twice of that size. Be carefull.
+    // TODO Use "class pool" here
+    addr_t         pool{0};
+    const uint64_t POOL_SIZE_IN_PAGES{32}; // 128 KB
 
     /* Backup file context */
     string                          data_file_name;

--- a/src/plugins/procdump2/procdump2.h
+++ b/src/plugins/procdump2/procdump2.h
@@ -226,7 +226,8 @@ private:
     bool is_process_handled(vmi_pid_t pid);
     bool is_plugin_active();
     bool prepare_minidump(drakvuf_trap_info_t*, std::shared_ptr<procdump2_ctx>);
-    void read_vm(addr_t, std::shared_ptr<procdump2_ctx> procdump_ctx, bool);
+    void dump_zero_page(std::shared_ptr<procdump2_ctx>);
+    void read_vm(addr_t, std::shared_ptr<procdump2_ctx>, size_t);
     void restore(drakvuf_trap_info_t*, x86_registers_t&);
     void save_file_metadata(std::shared_ptr<procdump2_ctx>, proc_data_t*);
     bool start_copy_memory(drakvuf_trap_info_t*, std::shared_ptr<procdump2_ctx>);


### PR DESCRIPTION
It have been noticed that `MmCopyVirtualAddress` fails if any page in requested range is inaccessible. Thus it have been fixed how we use this system call.