### PR TITLE
libusermode: DLL search case insensitive, simple wildcard pattern

### DIFF
--- a/src/libusermode/userhook.cpp
+++ b/src/libusermode/userhook.cpp
@@ -1073,3 +1073,20 @@ bool drakvuf_are_userhooks_supported(drakvuf_t drakvuf)
 {
     return userhook::is_supported(drakvuf);
 }
+
+static bool dll_name_comparator(char x, char y)
+{
+    return std::toupper(x) == std::toupper(y);
+}
+
+void wanted_hooks_t::visit_hooks_for(const std::string& dll_name, std::function<void(const plugin_target_config_entry_t&)>&& visitor) const
+{
+    for (const auto& [pattern, wanted_hooks] : hooks)
+    {
+        if (std::search(dll_name.begin(), dll_name.end(), pattern.begin(), pattern.end(),
+                dll_name_comparator) != dll_name.end())
+        {
+            std::for_each(std::begin(wanted_hooks), std::end(wanted_hooks), visitor);
+        }
+    }
+}

--- a/src/libusermode/userhook.hpp
+++ b/src/libusermode/userhook.hpp
@@ -262,18 +262,7 @@ public:
         return hooks.empty();
     }
 
-    void visit_hooks_for(const std::string& dll_name, std::function<void(const plugin_target_config_entry_t&)>&& visitor) const
-    {
-        for (const auto& [pattern, wanted_hooks] : hooks)
-        {
-            if ((pattern == "*.dll" && dll_name.find(".dll") != std::string::npos) ||
-                std::search(dll_name.begin(), dll_name.end(), pattern.begin(), pattern.end(),
-                    [](char x, char y){return std::toupper(x) == std::toupper(y);}) != dll_name.end())
-            {
-                std::for_each(std::begin(wanted_hooks), std::end(wanted_hooks), visitor);
-            }
-        }
-    }
+    void visit_hooks_for(const std::string& dll_name, std::function<void(const plugin_target_config_entry_t&)>&& visitor) const;
 
 private:
     std::map<std::string, std::vector<plugin_target_config_entry_t>> hooks;

--- a/src/libusermode/userhook.hpp
+++ b/src/libusermode/userhook.hpp
@@ -266,7 +266,9 @@ public:
     {
         for (const auto& [pattern, wanted_hooks] : hooks)
         {
-            if (dll_name.find(pattern) != std::string::npos)
+            if ((pattern == "*.dll" && dll_name.find(".dll") != std::string::npos) ||
+                std::search(dll_name.begin(), dll_name.end(), pattern.begin(), pattern.end(),
+                    [](char x, char y){return std::toupper(x) == std::toupper(y);}) != dll_name.end())
             {
                 std::for_each(std::begin(wanted_hooks), std::end(wanted_hooks), visitor);
             }


### PR DESCRIPTION
Simplifies rules for use in `apimon` while DLL name comparison:
* Allow simple wildcard patter `*.dll`.
* Performs case insensitive search.