### PR TITLE
procdump: fix BSOD on re-suspend fail

### DIFF
--- a/src/plugins/procdump2/private2.h
+++ b/src/plugins/procdump2/private2.h
@@ -174,7 +174,7 @@ enum class procdump_stage
     resume,           // 7
     awaken,           // 8
     finished,         // 9
-    target_fail,      // 10
+    target_wakeup,    // 10
     timeout,          // 11
     invalid           // 12
 };
@@ -227,7 +227,7 @@ struct procdump2_ctx
     string    target_process_name;
     vmi_pid_t target_process_pid{0};
 
-    const uint8_t TARGET_RESUSPEND_COUNT_MAX{5};
+    const uint8_t TARGET_RESUSPEND_COUNT_MAX{3};
     uint8_t target_resuspend_count{0};
 
     /* Data */
@@ -287,7 +287,7 @@ struct procdump2_ctx
                 return "Success";
             case procdump_stage::timeout:
                 return "Timeout";
-            case procdump_stage::target_fail:
+            case procdump_stage::target_wakeup:
                 return "WakeUp";
             case procdump_stage::prepare_minidump:
                 return "PrepareMinidump";

--- a/src/plugins/procdump2/procdump2.h
+++ b/src/plugins/procdump2/procdump2.h
@@ -186,6 +186,7 @@ private:
     addr_t resume_process_va{0};
     addr_t copy_virt_mem_va{0};
     addr_t current_irql_va{0};
+    addr_t delay_execution_va{0};
 
     /* Minidump info */
     // TODO Move to function
@@ -216,6 +217,7 @@ private:
     void get_irql(drakvuf_trap_info_t*, std::shared_ptr<procdump2_ctx>);
     void resume(drakvuf_trap_info_t*, std::shared_ptr<procdump2_ctx>);
     void suspend(drakvuf_trap_info_t*, addr_t, return_ctx&);
+    void delay_execution(drakvuf_trap_info_t*, std::shared_ptr<procdump2_ctx>);
 
     /* Routines */
     std::shared_ptr<procdump2_ctx> continues_task(drakvuf_trap_info_t*);


### PR DESCRIPTION
The BSOD scenario:
* The target process returns from `PsSuspendProcess`.
* After few retries to re-suspend it we restore its state and it continues the `NtTerminateProcess`.
* At this time the working thread injected `MmCopyVirtualMemory`.
* `MmCopyVirtualMemory` locks pages with `MmProbeAndLockPages`.
* The `PROCESS_HAS_LOCKED_PAGES` or `UNEXPECTED_KERNEL_MODE_TRAP` occur.

The fix delays execution of `NtTerminateProcess` with `KeDelayExecutionThread` until `MmCopyVirtualMemory` finishes.