### PR TITLE
filetracer: fix KV output format for empty mask

### DIFF
--- a/src/plugins/filetracer/win_acl.cpp
+++ b/src/plugins/filetracer/win_acl.cpp
@@ -603,7 +603,10 @@ string read_acl(vmi_instance_t vmi, access_context_t* ctx, size_t* offsets, stri
                 break;
 
             case OUTPUT_KV:
-                fmt << ",Type=\"" << type << "\"," << hex << showbase << mask << ",SID=\"" << sid << '"';
+                fmt << ",Type=\"" << type << "\"";
+                if (!mask.empty())
+                    fmt << "," << hex << showbase << mask;
+                fmt << ",SID=\"" << sid << '"';
                 break;
 
             case OUTPUT_JSON:


### PR DESCRIPTION
The KV output format been broken on empty `mask` field. E.g.:
```
filetracer Time=1648457161.131638,PID=1564,PPID=608,TID=5760,ProcessName="\Device\HarddiskVolume2\Windows\servicing\TrustedInstaller.exe",Method=NtCreateFile,FileName="\??\C:\Windows\Logs\CBS\CBS.log",FileHandle=0x11C,OBJ_CASE_INSENSITIVE=1,SE_DACL_PRESENT=1,Dacl=4,Type="ACCESS_ALLOWED_ACE_TYPE",DELETE=1,READ_CONTROL=1,WRITE_DAC=1,WRITE_OWNER=1,SYNCHRONIZE=1,STANDARD_RIGHTS_ALL=1,GENERIC_WRITE=1,GENERIC_READ=1,SID="S-1-5-32-544",Type="ACCESS_ALLOWED_ACE_TYPE",DELETE=1,READ_CONTROL=1,WRITE_DAC=1,WRITE_OWNER=1,SYNCHRONIZE=1,STANDARD_RIGHTS_ALL=1,GENERIC_WRITE=1,GENERIC_READ=1,SID="S-1-5
-18",Type="ACCESS_ALLOWED_ACE_TYPE",DELETE=1,SYNCHRONIZE=1,GENERIC_WRITE=1,GENERIC_READ=1,SID="Local Service",Type="ACCESS_ALLOWED_ACE_TYPE",DELETE=1,READ_CONTROL=1,WRITE_DAC=1,WRITE_OWNER=1,SYNCHRONIZE=1,STANDARD_RIGHTS_ALL=1,GENERIC_WRITE=1,GENERIC_READ=1,SID="S-1-5-18",Type="ACCESS_ALLOWED_ACE_TYPE",,SID="",FILE_READ_ATTRIBUTES=1,SYNCHRONIZE=1,GENERIC_WRITE=1,GENERIC_READ=1,FILE_ATTRIBUTE_NORMAL=1,FILE_OPEN=1,FILE_SYNCHRONOUS_IO_NONALERT=1,FILE_NON_DIRECTORY_FILE=1,Status="SUCCESS"
```

Note `,,SID=` here.