### PR TITLE
procdump: fix logical error on state switch

### DIFF
--- a/src/plugins/procdump2/procdump2.cpp
+++ b/src/plugins/procdump2/procdump2.cpp
@@ -624,9 +624,10 @@ void procdump2::dispatch_active(drakvuf_trap_info_t* info, std::shared_ptr<procd
              * task should be removed here.
              */
             restore(info, ctx->working.regs);
-            ctx->stage(procdump_stage::finished);
             if (ctx->stage() == procdump_stage::awaken || !ctx->wait_awaken)
                 finish_task(info, ctx);
+            else
+                ctx->stage(procdump_stage::finished);
             this->working_threads.erase(info->attached_proc_data.tid);
         }
         break;


### PR DESCRIPTION
The error occur due to state switch before `if`. This results in not removable tasks in list in rare cases. Thus plug-in could not stop in timeout provided via `--procdump-timeout` option.