### PR TITLE
Workaround possible PF injection in case of request_page_fault failure

### DIFF
--- a/src/libusermode/running.cpp
+++ b/src/libusermode/running.cpp
@@ -267,7 +267,7 @@ event_response_t hook_process_cb(
         }
     }
 
-    userhook_plugin->pf_in_progress.erase(std::make_pair(info->proc_data.pid, info->proc_data.tid));
+    userhook_plugin->remove_pf_in_progress(info->proc_data.pid, info->proc_data.tid);
 
     // Now let's try to resolve physical address of the target function.
     addr_t func_pa = 0;
@@ -284,10 +284,10 @@ event_response_t hook_process_cb(
             }
 
             // Otherwise request page fault, exit and wait for hook_process_cb to be hit again.
+            userhook_plugin->add_pf_in_progress(info->proc_data.pid, info->proc_data.tid);
             if (VMI_SUCCESS == vmi_request_page_fault(vmi, info->vcpu, rh_data->func_addr, 0))
             {
                 rh_data->state = HOOK_PAGEFAULT_RETRY;
-                userhook_plugin->pf_in_progress.insert(std::make_pair(info->proc_data.pid, info->proc_data.tid));
                 return VMI_EVENT_RESPONSE_NONE;
             }
             else

--- a/src/libusermode/uh-private.hpp
+++ b/src/libusermode/uh-private.hpp
@@ -215,8 +215,6 @@ public:
     // map pid -> list of hooked dlls
     std::map<vmi_pid_t, std::vector<dll_t>> loaded_dlls;
 
-    std::set<std::pair<vmi_pid_t, uint32_t /*thread_id*/>> pf_in_progress;
-
     static userhook& get_instance(drakvuf_t drakvuf)
     {
         static userhook instance(drakvuf);
@@ -233,6 +231,19 @@ public:
     bool add_running_rh_trap(drakvuf_t drakvuf, drakvuf_trap_t* trap);
     void remove_running_rh_trap(drakvuf_t drakvuf, drakvuf_trap_t* trap);
 
+    void add_pf_in_progress(vmi_pid_t pid, uint32_t tid)
+    {
+        pf_in_progress.insert(std::make_pair(pid, tid));
+    }
+    void remove_pf_in_progress(vmi_pid_t pid, uint32_t tid)
+    {
+        pf_in_progress.erase(std::make_pair(pid, tid));
+    }
+    bool is_pf_in_progress(vmi_pid_t pid, uint32_t tid)
+    {
+        return pf_in_progress.find(std::make_pair(pid, tid)) != pf_in_progress.end();
+    }
+
 private:
     userhook(drakvuf_t drakvuf); // Force get_instance().
     ~userhook();
@@ -242,6 +253,7 @@ private:
     // internaly inside library.
     std::vector<drakvuf_trap_t*> running_traps;
     std::vector<drakvuf_trap_t*> running_rh_traps;
+    std::set<std::pair<vmi_pid_t, uint32_t /*thread_id*/>> pf_in_progress;
 };
 
 


### PR DESCRIPTION
From drakvuf stderr:

	[USERHOOK] Export info not accessible, page fault 774c0000
	VMI_ERROR: xen_request_page_fault error -1 injecting page fault exception
	[USERHOOK] Failed to request page fault for DTB 63cbb000, address 774c1000
	[USERHOOK] Entered system service handler
	[USERHOOK] Not suppressing service exception - not our fault

It looks like the `vmi_request_page_fault` returned response that it could not
inject a page fault, but it did. The situation happened only once.

I could not understand from the XEN source code how this could happen.
The hypervisor either returns an error or does what it was asked to do.