### PR TITLE
plugins: add namespaces for private structures

### DIFF
--- a/src/plugins/filedelete/filedelete.cpp
+++ b/src/plugins/filedelete/filedelete.cpp
@@ -118,6 +118,7 @@
 #include "filedelete.h"
 #include "private.h"
 
+using namespace filedelete;
 using std::ostringstream;
 using std::string;
 

--- a/src/plugins/filedelete/filedelete2_helpers.cpp
+++ b/src/plugins/filedelete/filedelete2_helpers.cpp
@@ -108,6 +108,8 @@
 
 #include <libinjector/libinjector.h>
 
+using namespace filedelete;
+
 void free_pool(std::map<addr_t, bool>& pools, addr_t va)
 {
     for (auto pool: pools)

--- a/src/plugins/filedelete/private.h
+++ b/src/plugins/filedelete/private.h
@@ -108,6 +108,9 @@
 #define FILE_DISPOSITION_INFORMATION 13
 #define FILE_DELETE_ON_CLOSE 0x1000
 
+namespace filedelete
+{
+
 enum offset
 {
     FILE_OBJECT_TYPE,
@@ -318,5 +321,7 @@ bool inject_memcpy(drakvuf_t drakvuf, drakvuf_trap_info_t* info, vmi_instance_t 
 void free_resources(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
 void free_pool(std::map<addr_t, bool>& pools, addr_t va);
 addr_t find_pool(std::map<addr_t, bool>& pools);
+
+}
 
 #endif // FILEDELETE_PRIVATE_H

--- a/src/plugins/filetracer/linux.cpp
+++ b/src/plugins/filetracer/linux.cpp
@@ -125,6 +125,8 @@
 #include "filetracer.h"
 #include "private.h"
 
+using namespace filetracer_ns;
+
 static void free_gstrings(struct linux_wrapper& lw)
 {
 

--- a/src/plugins/filetracer/private.h
+++ b/src/plugins/filetracer/private.h
@@ -110,6 +110,9 @@
 #include "win.h"
 #include "linux.h"
 
+namespace filetracer_ns
+{
+
 struct win_objattrs_t
 {
     std::string file_path;
@@ -685,5 +688,7 @@ static const flags_str_t linux_lseek_whence =
     REGISTER_FLAG(LSEEK_DATA),
     REGISTER_FLAG(LSEEK_HOLE),
 };
+
+}
 
 #endif

--- a/src/plugins/filetracer/win.cpp
+++ b/src/plugins/filetracer/win.cpp
@@ -125,6 +125,8 @@
 #include "win.h"
 #include "win_acl.h"
 
+using namespace filetracer_ns;
+
 extern const flags_str_t generic_ar;
 
 static auto build_security_descriptor(const win_objattrs_t& attrs)

--- a/src/plugins/filetracer/win_acl.cpp
+++ b/src/plugins/filetracer/win_acl.cpp
@@ -117,6 +117,7 @@ using std::setfill;
 using std::setw;
 using std::string;
 using std::stringstream;
+using namespace filetracer_ns;
 
 namespace
 {
@@ -543,7 +544,7 @@ string read_acl(vmi_instance_t vmi, access_context_t* ctx, size_t* offsets, stri
             break;
 
         case OUTPUT_KV:
-            fmt << base_name << ':' << ace_count;
+            fmt << base_name << '=' << ace_count;
             break;
 
         case OUTPUT_JSON:

--- a/src/plugins/procmon/private.h
+++ b/src/plugins/procmon/private.h
@@ -107,6 +107,9 @@
 
 #include "linux.h"
 
+namespace procmon
+{
+
 struct linux_wrapper
 {
     vmi_pid_t pid = 0;
@@ -125,6 +128,8 @@ struct linux_wrapper
     std::string command_line;
     std::map<std::string, std::string> envp;
 };
+
+}
 
 #define ARG_MAX 131072
 

--- a/src/plugins/syscalls/linux.cpp
+++ b/src/plugins/syscalls/linux.cpp
@@ -111,6 +111,9 @@
 #include "private.h"
 #include "linux.h"
 
+namespace syscalls_ns
+{
+
 // Builds the argument buffer from the current context, returns status
 static std::vector<uint64_t> linux_build_argbuf(vmi_instance_t vmi,
     drakvuf_trap_info_t* info, syscalls* s,
@@ -333,4 +336,6 @@ void setup_linux(drakvuf_t drakvuf, syscalls* s)
         free_trap(trap);
         throw -1;
     }
+}
+
 }

--- a/src/plugins/syscalls/linux.h
+++ b/src/plugins/syscalls/linux.h
@@ -105,9 +105,12 @@
 #ifndef SYSCALLS_LINUX_H
 #define SYSCALLS_LINUX_H
 
-void setup_linux(drakvuf_t drakvuf, syscalls* s);
-
 #include "private.h"
+
+namespace syscalls_ns
+{
+
+void setup_linux(drakvuf_t drakvuf, syscalls* s);
 
 /**
  * Older Linux kernels pass the arguments to the syscall functions via
@@ -841,6 +844,8 @@ static const syscall_t* linux_syscalls[] =
 
 // The actual max depends on the arch and actual kernel version
 #define NUM_SYSCALLS_LINUX sizeof(linuxsc::linux_syscalls)/sizeof(syscall_t*)
+
+}
 
 }
 #endif // SYSCALLS_LINUX_H

--- a/src/plugins/syscalls/private.h
+++ b/src/plugins/syscalls/private.h
@@ -105,6 +105,9 @@
 #ifndef SYSCALLS_PRIVATE_H
 #define SYSCALLS_PRIVATE_H
 
+namespace syscalls_ns
+{
+
 typedef enum
 {
     DIR_IN,
@@ -496,5 +499,7 @@ struct wrapper
     addr_t stack_fingerprint;
 };
 void free_trap(gpointer p);
+
+}
 
 #endif // commoncsproto_h

--- a/src/plugins/syscalls/syscalls.cpp
+++ b/src/plugins/syscalls/syscalls.cpp
@@ -116,6 +116,11 @@
 #include "win.h"
 #include "linux.h"
 
+using namespace syscalls_ns;
+
+namespace syscalls_ns
+{
+
 static std::string extract_string(syscalls* s, drakvuf_t drakvuf, drakvuf_trap_info_t* info, const arg_t& arg, addr_t val)
 {
     char* cstr = nullptr;
@@ -289,6 +294,8 @@ void free_trap(gpointer p)
         g_slice_free(struct wrapper, t->data);
 
     g_slice_free(drakvuf_trap_t, t);
+}
+
 }
 
 syscalls::syscalls(drakvuf_t drakvuf, const syscalls_config* c, output_format_t output)

--- a/src/plugins/syscalls/win.cpp
+++ b/src/plugins/syscalls/win.cpp
@@ -115,6 +115,9 @@
 #include "private.h"
 #include "win.h"
 
+namespace syscalls_ns
+{
+
 static event_response_t ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 {
     //Loads a pointer to the plugin, which is responsible for the trap
@@ -489,4 +492,6 @@ char* win_extract_string(syscalls* s, drakvuf_t drakvuf, drakvuf_trap_info_t* in
     }
 
     return nullptr;
+}
+
 }

--- a/src/plugins/syscalls/win.h
+++ b/src/plugins/syscalls/win.h
@@ -105,6 +105,9 @@
 #ifndef SYSCALLS_WIN_H
 #define SYSCALLS_WIN_H
 
+namespace syscalls_ns
+{
+
 void setup_windows(drakvuf_t drakvuf, syscalls* s);
 char* win_extract_string(syscalls* s, drakvuf_t drakvuf, drakvuf_trap_info_t* info, const arg_t& arg, addr_t val);
 
@@ -6026,5 +6029,7 @@ static const syscall_t* win32k[] =
 
 #define NUM_SYSCALLS_NT sizeof(nt)/sizeof(syscall_t*)
 #define NUM_SYSCALLS_WIN32K sizeof(win32k)/sizeof(syscall_t*)
+
+}
 
 #endif


### PR DESCRIPTION
Do not use structures with the same name in different translation units.
This results in undefined behavior because the linker mistakenly merges
them into a single symbol.

As a result, we can get the following error in runtime:

	free(): invalid pointer