### PR TITLE
linux-filetracer: Fix some issues on FileName formatting

### DIFF
--- a/src/plugins/filetracer/linux.cpp
+++ b/src/plugins/filetracer/linux.cpp
@@ -145,13 +145,8 @@ static void print_info(drakvuf_t drakvuf, drakvuf_trap_info_t* info, linux_wrapp
 {
     linux_filetracer* f = (linux_filetracer*)info->trap->data;
 
-    std::vector<std::pair<std::string, fmt::Rstr<const char*>>> extra_args;
-    {
-        gchar* escaped_fname = drakvuf_escape_str(lw.filename->str);
-        extra_args.emplace_back(keyval("FileName", fmt::Rstr(const_cast<const char*>(escaped_fname))));
-        g_free(escaped_fname);
-    }
-
+    std::vector<std::pair<std::string, fmt::Aarg>> extra_args;
+    extra_args.emplace_back(keyval("FileName", fmt::Estr(const_cast<const char*>(lw.filename->str))));
     if (lw.modes->len)
         extra_args.emplace_back(keyval("Mode", fmt::Rstr(const_cast<const char*>(lw.modes->str))));
     if (lw.flags->len)

--- a/src/plugins/output_format/common.h
+++ b/src/plugins/output_format/common.h
@@ -250,8 +250,49 @@ struct Qstr<T,
     Qstr(T v): Rstr<std::string>(nullptr == v ? std::string("(null)") : std::string(v)) {}
 };
 
+/* format specific encoded string value */
+template<class T, class = void>
+struct Estr
+{
+    Estr(T v)
+    {
+        static_assert(always_false<T>::value, "should be the one of: const char*, std::string, std::string_view");
+    }
+};
+
+template<class T>
+struct Estr<T,
+           std::enable_if_t<
+           std::is_same_v<std::decay_t<T>, std::string>
+           || std::is_same_v<std::decay_t<T>, std::string_view>,
+           void>
+           >: Rstr<std::string>
+{
+    Estr(T v): Rstr<std::string>(std::string_view(v).empty() ? std::string("(null)") : std::move(v)) {}
+};
+
+template<class T>
+struct Estr<T,
+           std::enable_if_t<
+           std::is_same_v<T, const char*>
+           || std::is_same_v<T, char*>,
+           void>
+           >: Rstr<std::string>
+{
+    Estr(T v): Rstr<std::string>(nullptr == v ? std::string("(null)") : std::string(v)) {}
+};
+
 /* Any argument type */
-using Aarg = std::variant<fmt::Nval<unsigned long>, fmt::Xval<unsigned long>, fmt::Fval<long double>, fmt::Rstr<std::string>, fmt::Qstr<std::string>>;
+using Aarg = std::variant<
+    fmt::Nval<unsigned long>,
+    fmt::Xval<unsigned long>,
+    fmt::Fval<long double>,
+    fmt::Rstr<const char*>,
+    fmt::Rstr<std::string>,
+    fmt::Qstr<const char*>,
+    fmt::Qstr<std::string>,
+    fmt::Estr<const char*>,
+    fmt::Estr<std::string>>;
 
 } // namespace fmt
 

--- a/src/plugins/output_format/csvfmt.h
+++ b/src/plugins/output_format/csvfmt.h
@@ -186,6 +186,15 @@ struct DataPrinter
     }
 
     template <class Tv = T>
+    static bool print(std::ostream& os, const fmt::Estr<Tv>& data, char)
+    {
+        gchar* escaped = drakvuf_escape_str(data.value.c_str());
+        os << escaped;
+        g_free(escaped);
+        return true;
+    }
+
+    template <class Tv = T>
     static bool print(std::ostream& os, const std::function<bool(std::ostream&)>& printer, char)
     {
         auto pos = os.tellp();

--- a/src/plugins/output_format/deffmt.h
+++ b/src/plugins/output_format/deffmt.h
@@ -186,6 +186,15 @@ struct DataPrinter
     }
 
     template <class Tv = T>
+    static bool print(std::ostream& os, const fmt::Estr<Tv>& data, char)
+    {
+        gchar* escaped = drakvuf_escape_str(data.value.c_str());
+        os << escaped;
+        g_free(escaped);
+        return true;
+    }
+
+    template <class Tv = T>
     static bool print(std::ostream& os, const std::function<bool(std::ostream&)>& printer, char)
     {
         auto pos = os.tellp();

--- a/src/plugins/output_format/jsonfmt.h
+++ b/src/plugins/output_format/jsonfmt.h
@@ -170,6 +170,15 @@ public:
     }
 
     template <class Tv = T>
+    static bool print(std::ostream& os, const fmt::Estr<Tv>& data, char)
+    {
+        gchar* escaped = drakvuf_escape_str(data.value.c_str());
+        os << escaped;
+        g_free(escaped);
+        return true;
+    }
+
+    template <class Tv = T>
     static bool print(std::ostream& os, const std::function<bool(std::ostream&)>& printer, char)
     {
         auto pos = os.tellp();

--- a/src/plugins/output_format/kvfmt.h
+++ b/src/plugins/output_format/kvfmt.h
@@ -184,9 +184,20 @@ struct DataPrinter
     template <class Tv = T>
     static bool print(std::ostream& os, const fmt::Qstr<Tv>& data, char)
     {
+        return print_escaped(os, data.value);
+    }
+
+    template <class Tv = T>
+    static bool print(std::ostream& os, const fmt::Estr<Tv>& data, char)
+    {
+        return print_escaped(os, data.value);
+    }
+
+    static bool print_escaped(std::ostream& os, const std::string& value)
+    {
         char const* const hexdig = "0123456789ABCDEF";
         os << '"';
-        for (unsigned char c: data.value)
+        for (unsigned char c: value)
             switch (c)
             {
                 case '\r':


### PR DESCRIPTION
 * fix double escaping of FileName value in JSON; and
 * fix incorrect formatting of FileName value in KV.