### PR TITLE
libuserhook: load page with MmCopyVirtualMemory instead of direct PF

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -545,6 +545,13 @@ AC_ARG_ENABLE([debug],
   [debug="no"])
 AM_CONDITIONAL([DEBUG], [test x$debug = xyes])
 
+AC_ARG_ENABLE([libusermode-injections],
+  [AS_HELP_STRING([--enable-libusermode-injections],
+    [Use injections instead of page faults in libusermode @<:@no@:>@])],
+  [libusermode-injections="$enableval"],
+  [libusermode-injections="no"])
+AM_CONDITIONAL([LIBUSERMODE_USE_INJECTION], [test x$libusermode-injections = xyes])
+
 AC_ARG_ENABLE([sanitize],
   [AS_HELP_STRING([--enable-sanitize],
     [Enable sanitizers to be compiled @<:@no@:>@])],

--- a/src/drakvuf.cpp
+++ b/src/drakvuf.cpp
@@ -214,11 +214,25 @@ drakvuf_c::drakvuf_c(const char* domain,
     addr_t kpgd,
     bool fast_singlestep,
     uint64_t limited_traps_ttl,
-    bool libdrakvuf_get_userid)
+    bool libdrakvuf_get_userid,
+    bool enable_active_callback_check)
     : leave_paused{ leave_paused }
     , format{ output }
 {
-    if (!drakvuf_init(&drakvuf, domain, json_kernel_path, json_wow_path, libvmi_conf, kpgd, fast_singlestep, limited_traps_ttl, libdrakvuf_get_userid))
+    bool success = drakvuf_init(
+            &drakvuf,
+            domain,
+            json_kernel_path,
+            json_wow_path,
+            libvmi_conf,
+            kpgd,
+            fast_singlestep,
+            limited_traps_ttl,
+            libdrakvuf_get_userid,
+            enable_active_callback_check
+        );
+
+    if (!success)
     {
         drakvuf_close(drakvuf, leave_paused);
         throw std::runtime_error("drakvuf_init() failed");

--- a/src/drakvuf.h
+++ b/src/drakvuf.h
@@ -142,7 +142,8 @@ public:
         addr_t kpgd,
         bool fast_singlestep,
         uint64_t limited_traps_ttl,
-        bool libdrakvuf_get_userid);
+        bool libdrakvuf_get_userid,
+        bool enable_active_callback_check);
     ~drakvuf_c();
 
     int is_initialized();

--- a/src/injector.c
+++ b/src/injector.c
@@ -301,7 +301,7 @@ int main(int argc, char** argv)
     sigaction(SIGINT, &act, NULL);
     sigaction(SIGALRM, &act, NULL);
 
-    if (!drakvuf_init(&drakvuf, domain, json_kernel_path, NULL, libvmi_conf, kpgd, false, UNLIMITED_TTL, true))
+    if (!drakvuf_init(&drakvuf, domain, json_kernel_path, NULL, libvmi_conf, kpgd, false, UNLIMITED_TTL, true, false))
     {
         fprintf(stderr, "Failed to initialize on domain %s\n", domain);
         return 1;

--- a/src/libdrakvuf/os.c
+++ b/src/libdrakvuf/os.c
@@ -652,6 +652,20 @@ addr_t drakvuf_exportksym_to_va(drakvuf_t drakvuf, const vmi_pid_t pid, const ch
     return ret;
 }
 
+addr_t drakvuf_kernel_symbol_to_va(drakvuf_t drakvuf, const char* func)
+{
+    addr_t ret = 0;
+
+    if ( drakvuf->osi.kernel_symbol_to_va )
+    {
+        drakvuf_lock_and_get_vmi(drakvuf);
+        ret = drakvuf->osi.kernel_symbol_to_va(drakvuf, func);
+        drakvuf_release_vmi(drakvuf);
+    }
+
+    return ret;
+}
+
 addr_t drakvuf_exportsym_to_va(drakvuf_t drakvuf, addr_t process_addr,
     const char* module, const char* sym)
 {

--- a/src/libdrakvuf/os.h
+++ b/src/libdrakvuf/os.h
@@ -193,6 +193,8 @@ typedef struct os_interface
     bool (*get_module_base_addr_ctx)
     (drakvuf_t drakvuf, addr_t module_list_head, access_context_t* ctx, const char* module_name, addr_t* base_addr_out);
 
+    addr_t (*kernel_symbol_to_va)(drakvuf_t drakvuf, const char* func);
+
     addr_t (*exportksym_to_va)
     (drakvuf_t drakvuf, const vmi_pid_t pid, const char* proc_name, const char* mod_name, addr_t rva);
 

--- a/src/libdrakvuf/private.h
+++ b/src/libdrakvuf/private.h
@@ -253,6 +253,16 @@ struct drakvuf
     ipt_state_t ipt_state[MAX_DRAKVUF_VCPU];
 
     int64_t limited_traps_ttl;
+
+    /* This field is used to delay registers modification on injections.
+     * This fixes two issues:
+     * 1. Two plug-ins injects function call or modify registers.
+     * 2. One plug-in injects function call and other one reads modified registers.
+     */
+    bool vmi_response_set_registers[MAX_DRAKVUF_VCPU];
+    x86_registers_t regs_modified[MAX_DRAKVUF_VCPU];
+    GHashTable* injections_in_progress; // key: <pid:tid>
+    bool enable_active_callback_check;
 };
 
 struct breakpoint

--- a/src/libdrakvuf/win.c
+++ b/src/libdrakvuf/win.c
@@ -315,6 +315,25 @@ bool win_inject_traps_modules(drakvuf_t drakvuf, drakvuf_trap_t* trap, addr_t li
     return false;
 }
 
+addr_t win_kernel_symbol_to_va(drakvuf_t drakvuf, const char* func)
+{
+    addr_t rva;
+    if (!drakvuf_get_kernel_symbol_rva(drakvuf, func, &rva))
+    {
+        PRINT_DEBUG("Failed to get RVA of nt!%s\n", func);
+        return 0;
+    }
+
+    addr_t va = drakvuf_exportksym_to_va(drakvuf, 4, NULL, "ntoskrnl.exe", rva);
+    if (!va)
+    {
+        PRINT_DEBUG("Failed to get VA of nt!%s\n", func);
+        return 0;
+    }
+
+    return va;
+}
+
 bool win_get_module_base_addr_ctx(drakvuf_t drakvuf, addr_t module_list_head, access_context_t* ctx, const char* module_name, addr_t* base_addr_out)
 {
     struct find_module_visitor_ctx visitor_ctx = { .module_name = module_name, .ret = NULL };
@@ -531,6 +550,7 @@ bool set_os_windows(drakvuf_t drakvuf)
     drakvuf->osi.get_module_list_wow = win_get_module_list_wow;
     drakvuf->osi.find_process = win_find_eprocess;
     drakvuf->osi.inject_traps_modules = win_inject_traps_modules;
+    drakvuf->osi.kernel_symbol_to_va = win_kernel_symbol_to_va;
     drakvuf->osi.exportksym_to_va = ksym2va;
     drakvuf->osi.exportsym_to_va = eprocess_sym2va;
     drakvuf->osi.get_process_pid = win_get_process_pid;

--- a/src/libdrakvuf/win.h
+++ b/src/libdrakvuf/win.h
@@ -156,6 +156,8 @@ bool win_is_process_suspended(drakvuf_t drakvuf, addr_t process, bool* status);
 bool win_get_module_list(drakvuf_t drakvuf, addr_t eprocess_base, addr_t* module_list);
 bool win_get_module_list_wow( drakvuf_t drakvuf, access_context_t* ctx, addr_t wow_peb, addr_t* module_list );
 
+addr_t win_kernel_symbol_to_va(drakvuf_t drakvuf, const char* func);
+
 bool win_get_module_base_addr(drakvuf_t drakvuf, addr_t module_list_head, const char* module_name, addr_t* base_addr_out);
 bool win_get_module_base_addr_ctx(drakvuf_t drakvuf, addr_t module_list_head, access_context_t* ctx, const char* module_name, addr_t* base_addr_out);
 module_info_t* win_get_module_info_ctx( drakvuf_t drakvuf, addr_t module_list_head, access_context_t* ctx, const char* module_name );

--- a/src/libinjector/libinjector.h
+++ b/src/libinjector/libinjector.h
@@ -236,6 +236,16 @@ bool setup_stack_locked(drakvuf_t drakvuf,
     struct argument args[],
     int nb_args) NOEXCEPT;
 
+bool inject_function_call(
+    drakvuf_t drakvuf,
+    drakvuf_trap_info_t* info,
+    event_response_t (*cb)(drakvuf_t, drakvuf_trap_info_t*),
+    x86_registers_t* regs,
+    struct argument args[],
+    int nb_args,
+    addr_t function_addr,
+    addr_t* stack_pointer);
+
 injector_status_t injector_start_app(drakvuf_t drakvuf,
     vmi_pid_t pid,
     uint32_t tid, // optional, if tid=0 the first thread that gets scheduled is used

--- a/src/libusermode/Makefile.am
+++ b/src/libusermode/Makefile.am
@@ -102,7 +102,8 @@
 #                                                                         #
 #*************************************************************************#
 
-sources =  userhook.cpp running.cpp userhook.hpp uh-private.hpp
+sources =  userhook.cpp running.cpp userhook.hpp uh-private.hpp userhook_pf.cpp \
+           userhook_inject.cpp
 sources += printers/printers.hpp printers/printers.cpp printers/utils.hpp \
            printers/utils.cpp
 

--- a/src/libusermode/meson.build
+++ b/src/libusermode/meson.build
@@ -3,6 +3,8 @@ libusermode_h = include_directories(
 )
 libusermode = static_library('usermode',
     'userhook.cpp',
+    'userhook_pf.cpp',
+    'userhook_inject.cpp',
     'running.cpp',
     'printers/printers.cpp',
     'printers/utils.cpp',

--- a/src/libusermode/running.cpp
+++ b/src/libusermode/running.cpp
@@ -235,6 +235,7 @@ event_response_t hook_process_cb(
     rh_data_t* rh_data = static_cast<rh_data_t*>(info->trap->data);
     userhook* userhook_plugin = rh_data->userhook_plugin;
 
+#ifdef LIBUSERMODE_USE_INJECTION
     if (!rh_data->inject_in_progress)
     {
         if (info->proc_data.pid != rh_data->target_process_pid)
@@ -248,6 +249,10 @@ event_response_t hook_process_cb(
         memcpy(info->regs, &rh_data->regs, sizeof(x86_registers_t));
         rh_data->inject_in_progress = false;
     }
+#else
+    if (info->proc_data.pid != rh_data->target_process_pid)
+        return VMI_EVENT_RESPONSE_NONE;
+#endif
 
     if (rh_data->state == HOOK_FIRST_TRY)
     {
@@ -278,6 +283,10 @@ event_response_t hook_process_cb(
         }
     }
 
+#ifndef LIBUSERMODE_USE_INJECTION
+    userhook_plugin->pf_in_progress.erase(std::make_pair(info->proc_data.pid, info->proc_data.tid));
+#endif
+
     // Now let's try to resolve physical address of the target function.
     addr_t func_pa = 0;
     {
@@ -293,12 +302,16 @@ event_response_t hook_process_cb(
             }
 
             // Otherwise request page fault, exit and wait for hook_process_cb to be hit again.
+#ifndef LIBUSERMODE_USE_INJECTION
+            if (VMI_SUCCESS == vmi_request_page_fault(vmi, info->vcpu, rh_data->func_addr, 0))
+#else
             memcpy(&rh_data->regs, info->regs, sizeof(x86_registers_t));
             rh_data->target_process_tid = info->proc_data.tid;
             rh_data->target_process_rsp = info->regs->rsp;
             rh_data->inject_in_progress = true;
             addr_t stack_pointer;
             if (inject_copy_memory(userhook_plugin, drakvuf, info, info->trap->cb, rh_data->func_addr, &stack_pointer))
+#endif
             {
                 rh_data->state = HOOK_PAGEFAULT_RETRY;
                 userhook_plugin->pf_in_progress.insert(std::make_pair(info->proc_data.pid, info->proc_data.tid));

--- a/src/libusermode/uh-private.hpp
+++ b/src/libusermode/uh-private.hpp
@@ -145,8 +145,12 @@ struct rh_data_t
     // Additional data. Stored here for optimalization.
     target_hook_state state;
     vmi_pid_t target_process_pid;
+    uint32_t target_process_tid;
+    uint64_t target_process_rsp;
     addr_t target_process_dtb;
     addr_t func_addr;
+    x86_registers_t regs;
+    bool inject_in_progress{false};
 
     // We need to pass this around as we need offsets.
     userhook* userhook_plugin;
@@ -180,6 +184,9 @@ struct dll_t
     // internal, for page faults
     addr_t pf_current_addr;
     addr_t pf_max_addr;
+
+    bool in_progress{false};
+    x86_registers_t regs;
 };
 
 struct map_view_of_section_result_t : public call_result_t
@@ -205,6 +212,7 @@ class userhook : public pluginex
 {
 public:
     drakvuf_t m_drakvuf = nullptr;
+    addr_t copy_virt_mem_va{0};
 
     userhook(userhook const&) = delete;
     userhook& operator=(userhook const&) = delete;
@@ -244,5 +252,10 @@ private:
     std::vector<drakvuf_trap_t*> running_rh_traps;
 };
 
+bool inject_copy_memory(userhook* plugin, drakvuf_t drakvuf,
+    drakvuf_trap_info_t* info,
+    event_response_t (*cb)(drakvuf_t, drakvuf_trap_info_t*),
+    addr_t addr,
+    addr_t* stack_pointer);
 
 #endif

--- a/src/libusermode/userhook_inject.cpp
+++ b/src/libusermode/userhook_inject.cpp
@@ -1,0 +1,325 @@
+/*********************IMPORTANT DRAKVUF LICENSE TERMS***********************
+ *                                                                         *
+ * DRAKVUF (C) 2014-2022 Tamas K Lengyel.                                  *
+ * Tamas K Lengyel is hereinafter referred to as the author.               *
+ * This program is free software; you may redistribute and/or modify it    *
+ * under the terms of the GNU General Public License as published by the   *
+ * Free Software Foundation; Version 2 ("GPL"), BUT ONLY WITH ALL OF THE   *
+ * CLARIFICATIONS AND EXCEPTIONS DESCRIBED HEREIN.  This guarantees your   *
+ * right to use, modify, and redistribute this software under certain      *
+ * conditions.  If you wish to embed DRAKVUF technology into proprietary   *
+ * software, alternative licenses can be acquired from the author.         *
+ *                                                                         *
+ * Note that the GPL places important restrictions on "derivative works",  *
+ * yet it does not provide a detailed definition of that term.  To avoid   *
+ * misunderstandings, we interpret that term as broadly as copyright law   *
+ * allows.  For example, we consider an application to constitute a        *
+ * derivative work for the purpose of this license if it does any of the   *
+ * following with any software or content covered by this license          *
+ * ("Covered Software"):                                                   *
+ *                                                                         *
+ * o Integrates source code from Covered Software.                         *
+ *                                                                         *
+ * o Reads or includes copyrighted data files.                             *
+ *                                                                         *
+ * o Is designed specifically to execute Covered Software and parse the    *
+ * results (as opposed to typical shell or execution-menu apps, which will *
+ * execute anything you tell them to).                                     *
+ *                                                                         *
+ * o Includes Covered Software in a proprietary executable installer.  The *
+ * installers produced by InstallShield are an example of this.  Including *
+ * DRAKVUF with other software in compressed or archival form does not     *
+ * trigger this provision, provided appropriate open source decompression  *
+ * or de-archiving software is widely available for no charge.  For the    *
+ * purposes of this license, an installer is considered to include Covered *
+ * Software even if it actually retrieves a copy of Covered Software from  *
+ * another source during runtime (such as by downloading it from the       *
+ * Internet).                                                              *
+ *                                                                         *
+ * o Links (statically or dynamically) to a library which does any of the  *
+ * above.                                                                  *
+ *                                                                         *
+ * o Executes a helper program, module, or script to do any of the above.  *
+ *                                                                         *
+ * This list is not exclusive, but is meant to clarify our interpretation  *
+ * of derived works with some common examples.  Other people may interpret *
+ * the plain GPL differently, so we consider this a special exception to   *
+ * the GPL that we apply to Covered Software.  Works which meet any of     *
+ * these conditions must conform to all of the terms of this license,      *
+ * particularly including the GPL Section 3 requirements of providing      *
+ * source code and allowing free redistribution of the work as a whole.    *
+ *                                                                         *
+ * Any redistribution of Covered Software, including any derived works,    *
+ * must obey and carry forward all of the terms of this license, including *
+ * obeying all GPL rules and restrictions.  For example, source code of    *
+ * the whole work must be provided and free redistribution must be         *
+ * allowed.  All GPL references to "this License", are to be treated as    *
+ * including the terms and conditions of this license text as well.        *
+ *                                                                         *
+ * Because this license imposes special exceptions to the GPL, Covered     *
+ * Work may not be combined (even as part of a larger work) with plain GPL *
+ * software.  The terms, conditions, and exceptions of this license must   *
+ * be included as well.  This license is incompatible with some other open *
+ * source licenses as well.  In some cases we can relicense portions of    *
+ * DRAKVUF or grant special permissions to use it in other open source     *
+ * software.  Please contact tamas.k.lengyel@gmail.com with any such       *
+ * requests.  Similarly, we don't incorporate incompatible open source     *
+ * software into Covered Software without special permission from the      *
+ * copyright holders.                                                      *
+ *                                                                         *
+ * If you have any questions about the licensing restrictions on using     *
+ * DRAKVUF in other works, are happy to help.  As mentioned above,         *
+ * alternative license can be requested from the author to integrate       *
+ * DRAKVUF into proprietary applications and appliances.  Please email     *
+ * tamas.k.lengyel@gmail.com for further information.                      *
+ *                                                                         *
+ * If you have received a written license agreement or contract for        *
+ * Covered Software stating terms other than these, you may choose to use  *
+ * and redistribute Covered Software under those terms instead of these.   *
+ *                                                                         *
+ * Source is provided to this software because we believe users have a     *
+ * right to know exactly what a program is going to do before they run it. *
+ * This also allows you to audit the software for security holes.          *
+ *                                                                         *
+ * Source code also allows you to port DRAKVUF to new platforms, fix bugs, *
+ * and add new features.  You are highly encouraged to submit your changes *
+ * on https://github.com/tklengyel/drakvuf, or by other methods.           *
+ * By sending these changes, it is understood (unless you specify          *
+ * otherwise) that you are offering unlimited, non-exclusive right to      *
+ * reuse, modify, and relicense the code.  DRAKVUF will always be          *
+ * available Open Source, but this is important because the inability to   *
+ * relicense code has caused devastating problems for other Free Software  *
+ * projects (such as KDE and NASM).                                        *
+ * To specify special license conditions of your contributions, just say   *
+ * so when you send them.                                                  *
+ *                                                                         *
+ * This program is distributed in the hope that it will be useful, but     *
+ * WITHOUT ANY WARRANTY; without even the implied warranty of              *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the DRAKVUF   *
+ * license file for more details (it's in a COPYING file included with     *
+ * DRAKVUF, and also available from                                        *
+ * https://github.com/tklengyel/drakvuf/COPYING)                           *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifdef LIBUSERMODE_USE_INJECTION
+
+#include "userhook.hpp"
+#include "uh-private.hpp"
+
+
+bool inject_copy_memory(userhook* plugin, drakvuf_t drakvuf,
+    drakvuf_trap_info_t* info,
+    event_response_t (*cb)(drakvuf_t, drakvuf_trap_info_t*),
+    addr_t addr, addr_t* stack_pointer)
+{
+    x86_registers_t regs;
+    memcpy(&regs, info->regs, sizeof(x86_registers_t));
+
+    uint64_t buffer = 0;
+    uint64_t read_bytes = 0;
+    struct argument args[7] = {};
+    init_int_argument(&args[0], info->attached_proc_data.base_addr);
+    init_int_argument(&args[1], addr);
+    init_int_argument(&args[2], info->attached_proc_data.base_addr);
+    init_struct_argument(&args[3], buffer);
+    init_int_argument(&args[4], sizeof(buffer));
+    init_int_argument(&args[5], 0);
+    init_struct_argument(&args[6], read_bytes);
+
+    if (!inject_function_call(drakvuf, info, cb, &regs, args, 7, plugin->copy_virt_mem_va, stack_pointer))
+    {
+        PRINT_DEBUG("[USERHOOK] [%8zu] [%d:%d:%#lx]  "
+            "Failed to inject MmCopyVirtualMemory\n"
+            , info->event_uid
+            , info->attached_proc_data.pid, info->attached_proc_data.tid, info->regs->rsp
+        );
+        return false;
+    }
+
+    return true;
+}
+
+/**
+ * This is used in order to observe when 64 bit process is loading a new DLL.
+ * If the DLL is interesting, we perform further investigation and try to equip user mode hooks.
+ */
+static event_response_t map_view_of_section_ret_cb_2(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
+{
+    auto params = get_trap_params<map_view_of_section_result_t>(info);
+
+    if (!params->verify_result_call_params(drakvuf, info))
+        return VMI_EVENT_RESPONSE_NONE;
+
+    return hook_dll(drakvuf, info, params->base_address_ptr);
+}
+
+event_response_t internal_perform_hooking(drakvuf_t drakvuf, drakvuf_trap_info* info, userhook* plugin, dll_t* dll_meta)
+{
+    auto vmi = vmi_lock_guard(drakvuf);
+
+    // we have to make sure that addresses between [pf_current_addr, pf_max_addr]
+    // are available for reading otherwise vmi_translate_sym2v will fail unconditionally
+    // and we will be unable to add hooks
+
+    if (drakvuf_lookup_injection(drakvuf, info))
+        drakvuf_remove_injection(drakvuf, info);
+
+    drakvuf_trap_t* trap = nullptr;
+    map_view_of_section_result_t* params = nullptr;
+    if (!dll_meta->in_progress)
+    {
+        if (plugin->is_stopping())
+        {
+            PRINT_DEBUG("[USERHOOK] Premature stop\n");
+            return VMI_EVENT_RESPONSE_NONE;
+        }
+
+        PRINT_DEBUG("[USERHOOK] Start processing this dll_meta\n");
+        memcpy(&dll_meta->regs, info->regs, sizeof(x86_registers_t));
+        dll_meta->in_progress = true;
+
+        breakpoint_by_dtb_searcher bp;
+        trap = plugin->register_trap<map_view_of_section_result_t>(
+                info,
+                map_view_of_section_ret_cb_2,
+                bp.for_virt_addr(info->regs->rip).for_dtb(info->regs->cr3),
+                "NtMapViewOfSection ret v2");
+        if (!trap)
+            return VMI_EVENT_RESPONSE_NONE;
+    }
+    else
+    {
+        trap = info->trap;
+        if (plugin->is_stopping())
+        {
+            PRINT_DEBUG("[USERHOOK] Premature stop\n");
+            drakvuf_vmi_response_set_registers(drakvuf, info, &dll_meta->regs, true);
+            dll_meta->in_progress = false;
+            plugin->destroy_trap(trap);
+            return VMI_EVENT_RESPONSE_NONE;
+        }
+
+        PRINT_DEBUG("[USERHOOK] Continue processing this dll_meta\n");
+    }
+
+
+    params = get_trap_params<map_view_of_section_result_t>(trap);
+    if (!params)
+        return VMI_EVENT_RESPONSE_NONE;
+
+    while (dll_meta->pf_current_addr <= dll_meta->pf_max_addr)
+    {
+        page_info_t pinfo;
+        if (vmi_pagetable_lookup_extended(vmi, info->regs->cr3, dll_meta->pf_current_addr, &pinfo) == VMI_SUCCESS)
+        {
+            PRINT_DEBUG("[USERHOOK] Export info accessible OK %llx\n", (unsigned long long)dll_meta->pf_current_addr);
+            dll_meta->pf_current_addr += VMI_PS_4KB;
+            continue;
+        }
+
+        addr_t stack_pointer;
+        if (inject_copy_memory(plugin, drakvuf, info, trap->cb, dll_meta->pf_current_addr, &stack_pointer))
+        {
+            PRINT_DEBUG("[USERHOOK] Export info not accessible, page fault %llx\n", (unsigned long long)dll_meta->pf_current_addr);
+            dll_meta->pf_current_addr += VMI_PS_4KB;
+            params->set_result_call_params(info, stack_pointer);
+            return VMI_EVENT_RESPONSE_NONE;
+        }
+        else
+        {
+            PRINT_DEBUG("[USERHOOK] Failed to request page fault for DTB %llx, address %llx\n", (unsigned long long)info->regs->cr3, (unsigned long long)dll_meta->pf_current_addr);
+            return VMI_EVENT_RESPONSE_NONE;
+        }
+    }
+
+    // export info should be available, try hooking DLLs
+    for (auto& target : dll_meta->targets)
+    {
+        if (target.state == HOOK_FIRST_TRY || target.state == HOOK_PAGEFAULT_RETRY)
+        {
+            addr_t exec_func = 0;
+
+            if (target.type == HOOK_BY_NAME)
+            {
+                ACCESS_CONTEXT(ctx,
+                    .translate_mechanism = VMI_TM_PROCESS_DTB,
+                    .dtb = info->regs->cr3,
+                    .addr = dll_meta->v.real_dll_base
+                );
+
+                if (vmi_translate_sym2v(vmi, &ctx, target.target_name.c_str(), &exec_func) != VMI_SUCCESS)
+                {
+                    target.state = HOOK_FAILED;
+                    PRINT_DEBUG("[USERHOOK] Failed to hook %s: failed to translate symbol to address\n", target.target_name.c_str());
+                    continue;
+                }
+
+                target.offset = exec_func - dll_meta->v.real_dll_base;
+            }
+            else // HOOK_BY_OFFSET
+            {
+                exec_func = dll_meta->v.real_dll_base + target.offset;
+            }
+
+            if (target.state == HOOK_FIRST_TRY)
+            {
+                target.state = HOOK_FAILED;
+
+                if (is_pagetable_loaded(vmi, info, exec_func))
+                {
+                    if (make_trap(vmi, drakvuf, info, &target, exec_func))
+                        target.state = HOOK_OK;
+                }
+                else
+                {
+                    addr_t stack_pointer;
+                    if (inject_copy_memory(plugin, drakvuf, info, trap->cb, exec_func, &stack_pointer))
+                    {
+                        target.state = HOOK_PAGEFAULT_RETRY;
+                        params->set_result_call_params(info, stack_pointer);
+                        return VMI_EVENT_RESPONSE_NONE;
+                    }
+                    else
+                    {
+                        PRINT_DEBUG("[USERHOOK] Failed to request page fault for DTB %llx, address %llx\n",
+                            (unsigned long long)info->regs->cr3, (unsigned long long)dll_meta->pf_current_addr);
+                        drakvuf_vmi_response_set_registers(drakvuf, info, &dll_meta->regs, true);
+                        dll_meta->in_progress = false;
+                        plugin->destroy_trap(trap);
+                        return VMI_EVENT_RESPONSE_NONE;
+                    }
+                }
+            }
+            else if (target.state == HOOK_PAGEFAULT_RETRY)
+            {
+                target.state = HOOK_FAILED;
+
+                if (is_pagetable_loaded(vmi, info, exec_func))
+                {
+                    if (make_trap(vmi, drakvuf, info, &target, exec_func))
+                        target.state = HOOK_OK;
+                }
+            }
+            else
+            {
+                target.state = HOOK_FAILED;
+            }
+
+            PRINT_DEBUG("[USERHOOK] Hook %s (vaddr = 0x%llx, dll_base = 0x%llx, result = %s)\n",
+                target.target_name.c_str(),
+                (unsigned long long)exec_func,
+                (unsigned long long)dll_meta->v.real_dll_base,
+                target.state == HOOK_OK ? "OK" : "FAIL");
+        }
+    }
+
+    PRINT_DEBUG("[USERHOOK] Done, flag DLL as hooked\n");
+    drakvuf_vmi_response_set_registers(drakvuf, info, &dll_meta->regs, true);
+    dll_meta->in_progress = false;
+    dll_meta->v.is_hooked = true;
+    plugin->destroy_trap(trap);
+    return VMI_EVENT_RESPONSE_NONE;
+}
+
+#endif

--- a/src/plugins/filedelete/filedelete.cpp
+++ b/src/plugins/filedelete/filedelete.cpp
@@ -1370,25 +1370,6 @@ static void register_trap( drakvuf_t drakvuf, const char* syscall_name,
     if ( ! drakvuf_add_trap( drakvuf, trap ) ) throw -1;
 }
 
-static addr_t get_function_va(drakvuf_t drakvuf, const char* lib, const char* func_name)
-{
-    addr_t rva;
-    if ( !drakvuf_get_kernel_symbol_rva( drakvuf, func_name, &rva) )
-    {
-        PRINT_DEBUG("[FILEDELETE2] [Init] Failed to get RVA of %s\n", func_name);
-        throw -1;
-    }
-
-    addr_t va = drakvuf_exportksym_to_va(drakvuf, 4, nullptr, lib, rva);
-    if (!va)
-    {
-        PRINT_DEBUG("[FILEDELETE2] [Init] Failed to get VA of %s\n", func_name);
-        throw -1;
-    }
-
-    return va;
-}
-
 filedelete::filedelete(drakvuf_t drakvuf, const filedelete_config* c, output_format_t output)
     : drakvuf(drakvuf)
     , offsets(new size_t[__OFFSET_MAX])
@@ -1413,17 +1394,17 @@ filedelete::filedelete(drakvuf_t drakvuf, const filedelete_config* c, output_for
     }
     else
     {
-        this->queryvolumeinfo_va = get_function_va(drakvuf, "ntoskrnl.exe", "ZwQueryVolumeInformationFile");
-        this->queryinfo_va = get_function_va(drakvuf, "ntoskrnl.exe", "ZwQueryInformationFile");
-        this->createsection_va = get_function_va(drakvuf, "ntoskrnl.exe", "ZwCreateSection");
-        this->close_handle_va = get_function_va(drakvuf, "ntoskrnl.exe", "ZwClose");
-        this->mapview_va = get_function_va(drakvuf, "ntoskrnl.exe", "ZwMapViewOfSection");
-        this->unmapview_va = get_function_va(drakvuf, "ntoskrnl.exe", "ZwUnmapViewOfSection");
-        this->readfile_va = get_function_va(drakvuf, "ntoskrnl.exe", "ZwReadFile");
-        this->waitobject_va = get_function_va(drakvuf, "ntoskrnl.exe", "ZwWaitForSingleObject");
-        this->exallocatepool_va = get_function_va(drakvuf, "ntoskrnl.exe", "ExAllocatePoolWithTag");
-        this->exfreepool_va = get_function_va(drakvuf, "ntoskrnl.exe", "ExFreePoolWithTag");
-        this->memcpy_va = get_function_va(drakvuf, "ntoskrnl.exe", "RtlCopyMemoryNonTemporal");
+        this->queryvolumeinfo_va = drakvuf_kernel_symbol_to_va(drakvuf, "ZwQueryVolumeInformationFile");
+        this->queryinfo_va = drakvuf_kernel_symbol_to_va(drakvuf, "ZwQueryInformationFile");
+        this->createsection_va = drakvuf_kernel_symbol_to_va(drakvuf, "ZwCreateSection");
+        this->close_handle_va = drakvuf_kernel_symbol_to_va(drakvuf, "ZwClose");
+        this->mapview_va = drakvuf_kernel_symbol_to_va(drakvuf, "ZwMapViewOfSection");
+        this->unmapview_va = drakvuf_kernel_symbol_to_va(drakvuf, "ZwUnmapViewOfSection");
+        this->readfile_va = drakvuf_kernel_symbol_to_va(drakvuf, "ZwReadFile");
+        this->waitobject_va = drakvuf_kernel_symbol_to_va(drakvuf, "ZwWaitForSingleObject");
+        this->exallocatepool_va = drakvuf_kernel_symbol_to_va(drakvuf, "ExAllocatePoolWithTag");
+        this->exfreepool_va = drakvuf_kernel_symbol_to_va(drakvuf, "ExFreePoolWithTag");
+        this->memcpy_va = drakvuf_kernel_symbol_to_va(drakvuf, "RtlCopyMemoryNonTemporal");
 
         assert(sizeof(traps)/sizeof(traps[0]) > 3);
         register_trap(drakvuf, "NtSetInformationFile", &traps[0], setinformation_cb);

--- a/src/plugins/fileextractor/fileextractor.h
+++ b/src/plugins/fileextractor/fileextractor.h
@@ -234,7 +234,6 @@ private:
     bool save_file_chunk(int file_sequence_number,
         void* buffer,
         size_t size);
-    addr_t get_function_va(const char* lib, const char* func_name);
     uint64_t make_hook_id(drakvuf_trap_info_t*);
     uint64_t make_task_id(vmi_pid_t pid, handle_t handle);
     uint64_t make_task_id(task_t&);

--- a/src/plugins/plugins_ex.h
+++ b/src/plugins/plugins_ex.h
@@ -382,6 +382,13 @@ struct call_result_t
         target_rsp = info->regs->rsp;
     }
 
+    void set_result_call_params(const drakvuf_trap_info_t* info, addr_t stack_pointer)
+    {
+        target_pid = info->attached_proc_data.pid;
+        target_tid = info->attached_proc_data.tid;
+        target_rsp = stack_pointer;
+    }
+
     bool verify_result_call_params(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
     {
         return drakvuf_check_return_context(drakvuf, info, target_pid, target_tid, target_rsp);

--- a/src/plugins/procdump2/procdump2.h
+++ b/src/plugins/procdump2/procdump2.h
@@ -223,7 +223,6 @@ private:
     /* Routines */
     std::shared_ptr<procdump2_ctx> continues_task(drakvuf_trap_info_t*);
     void finish_task(drakvuf_trap_info_t*, std::shared_ptr<procdump2_ctx>);
-    addr_t get_function_va(std::string_view, std::string_view);
     std::pair<addr_t, size_t> get_memory_region(drakvuf_trap_info_t*, std::shared_ptr<procdump2_ctx>);
     bool is_active_process(vmi_pid_t pid);
     bool is_process_handled(vmi_pid_t pid);

--- a/src/plugins/syscalls/linux.cpp
+++ b/src/plugins/syscalls/linux.cpp
@@ -107,6 +107,8 @@
 #include <string>
 #include <vector>
 
+#include <libinjector/libinjector.h>
+
 #include "syscalls.h"
 #include "private.h"
 #include "linux.h"

--- a/src/plugins/syscalls/win.cpp
+++ b/src/plugins/syscalls/win.cpp
@@ -110,6 +110,7 @@
 #include <vector>
 
 #include <libdrakvuf/ntstatus.h>
+#include <libinjector/libinjector.h>
 
 #include "syscalls.h"
 #include "private.h"

--- a/src/proc_stat.cpp
+++ b/src/proc_stat.cpp
@@ -184,7 +184,7 @@ int main(int argc, char** argv)
 
 
     /* initialize the Drakvuf library */
-    if (!drakvuf_init(&drakvuf, domain, profile, NULL, false, 0, false, UNLIMITED_TTL, true))
+    if (!drakvuf_init(&drakvuf, domain, profile, NULL, false, 0, false, UNLIMITED_TTL, true, false))
     {
         printf("Failed to initialize Drakvuf\n");
         goto done;

--- a/src/repl.cpp
+++ b/src/repl.cpp
@@ -193,7 +193,7 @@ int main(int argc, char** argv)
     sigaction(SIGINT, &act, NULL);
     sigaction(SIGALRM, &act, NULL);
 
-    if (!drakvuf_init(&drakvuf, domain, json_kernel_path, NULL, libvmi_conf, kpgd, false, UNLIMITED_TTL, true))
+    if (!drakvuf_init(&drakvuf, domain, json_kernel_path, NULL, libvmi_conf, kpgd, false, UNLIMITED_TTL, true, false))
     {
         fprintf(stderr, "Failed to initialize on domain %s\n", domain);
         return 1;

--- a/src/xtf.c
+++ b/src/xtf.c
@@ -196,7 +196,7 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    if (!drakvuf_init(&drakvuf, argv[1], NULL, NULL, true, 0, false, UNLIMITED_TTL, true))
+    if (!drakvuf_init(&drakvuf, argv[1], NULL, NULL, true, 0, false, UNLIMITED_TTL, true, false))
     {
         fprintf(stderr, "Failed to initialize on domain %s\n", argv[1]);
         return 1;


### PR DESCRIPTION
This fixes "SYSTEM_SERVICE_EXCEPTION" BSOD.

The logical error results from relaying on system service handler for PF bypass. From STDERR (with my comments):
```
# VM-exit "X"
## Hook return from "NtMapViewOfSection" - "map_view_of_section_ret_cb".
1652304522.355615               Trap added @ PA 0x287a153 RPA 0xff085153 Page 10362 for NtMapViewOfSection ret.

# VM-exit "Х+1"
## Export table not fully loaded - inject #PF.
1652304522.358859 [USERHOOK] Export info not accessible, page fault 202000

# VM-exit "Х+1"
## "Entered system service handler" message is expected. And time delta is too small.
## Export table is expected to be fully loaded. Search for "imm32!ImmEnumInputContext".
## "vmi_translate_sym2v" fails. Set "target.state = HOOK_FAILED" and continue other "targets".
1652304522.358922 [USERHOOK] Failed to hook ImmEnumInputContext: failed to translate symbol to address
## Traverse all "targets" for the "DLL" and mark it hooked: "dll_meta->v.is_hooked = true".
1652304522.358941 [USERHOOK] Done, flag DLL as hooked
## For every plug-in call it's "post_cb".
1652304522.358977 [APIMON] DLL hooked - done
1652304522.358997 [RPCMON] DLL hooked - done
1652304522.359011 [HIDEVM] DLL hooked - done
## Remove breakpoint from "NtMapViewOfSection ret".
1652304522.359034 Removing breakpoint trap from 0x287a153.
1652304522.359053 Removing breakpoint trap from 0x287a153.
1652304522.359193 Removed memtrap for GFN 0x287a in altp2m view 1
1652304522.359225 Removed memtrap for GFN 0xff085 in altp2m view 1

# VM-exit "X+2"
1652304522.364722 [USERHOOK] Entered system service handler
1652304522.364771 [USERHOOK] Not suppressing service exception - not our fault

# BSOD is here (message from "bsodmon" in STDOUT)

1652304522.365096 DRAKVUF polling loop finished
1652304522.365123 Finished DRAKVUF main loop
```

One could notice that between messages `1652304522.358859 [USERHOOK] Export info not accessible, page fault 202000` and `1652304522.358922 [USERHOOK] Failed to hook ImmEnumInputContext: failed to translate symbol to address`:
* No message `Entered system service handler`.
* The time delta is about 100 micro sec. This value is too small. There is about 3000 micro sec between `X` and `X+1`. And about 5500 micro sec between `X+1` and `X+2`.

I have decided to use approach from `procdump2` plug-in: inject `MmCopyVirtualMemory`. This function:
* handles all page faults for us;
* there is no need to to allocate buffer in non paged pool we could read small value onto the stack;
* we could speed up the whole `drakvuf` by removing hook from system service handler.

I have leaved some of debug messages for the nearest future. It would be helpful if some issue occur.