### PR TITLE
Fix libinjector timeouts

### DIFF
--- a/src/libinjector/win/methods/win_createproc.c
+++ b/src/libinjector/win/methods/win_createproc.c
@@ -201,13 +201,6 @@ event_response_t handle_createproc(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
             return override_step(injector, STEP4, VMI_EVENT_RESPONSE_SET_REGISTERS);
             break;
         }
-        case STEP5: // cleanup
-        {
-            drakvuf_remove_trap(drakvuf, info->trap, NULL);
-            drakvuf_interrupt(drakvuf, SIGDRAKVUFERROR);
-            event = VMI_EVENT_RESPONSE_NONE;
-            break;
-        }
         default:
         {
             PRINT_DEBUG("Should not be here\n");
@@ -218,7 +211,7 @@ event_response_t handle_createproc(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
     return event;
 }
 
-static event_response_t cleanup(drakvuf_t drakvuf __attribute__((unused)), drakvuf_trap_info_t* info)
+static event_response_t cleanup(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 {
     injector_t injector = info->trap->data;
 
@@ -227,8 +220,11 @@ static event_response_t cleanup(drakvuf_t drakvuf __attribute__((unused)), drakv
     if (injector->rc == INJECTOR_SUCCEEDED)
         injector->rc = INJECTOR_FAILED;
 
+    drakvuf_remove_trap(drakvuf, info->trap, NULL);
+    drakvuf_interrupt(drakvuf, SIGDRAKVUFERROR);
+
     memcpy(info->regs, &injector->x86_saved_regs, sizeof(x86_registers_t));
-    return override_step(injector, STEP5, VMI_EVENT_RESPONSE_SET_REGISTERS);
+    return VMI_EVENT_RESPONSE_SET_REGISTERS;
 }
 
 

--- a/src/libinjector/win/methods/win_read_file.c
+++ b/src/libinjector/win/methods/win_read_file.c
@@ -259,7 +259,7 @@ event_response_t handle_readfile_x64(drakvuf_t drakvuf, drakvuf_trap_info_t* inf
             injector->rc = INJECTOR_SUCCEEDED;
 
             drakvuf_remove_trap(drakvuf, info->trap, NULL);
-            drakvuf_interrupt(drakvuf, SIGDRAKVUFERROR);
+            drakvuf_interrupt(drakvuf, SIGINT);
 
             memcpy(info->regs, &injector->x86_saved_regs, sizeof(x86_registers_t));
             event = VMI_EVENT_RESPONSE_SET_REGISTERS;

--- a/src/libinjector/win/methods/win_read_file.c
+++ b/src/libinjector/win/methods/win_read_file.c
@@ -107,7 +107,7 @@
 #include <libinjector/win/method_helpers.h>
 
 static bool process_read_file(drakvuf_t drakvuf, drakvuf_trap_info_t* info, uint32_t* num_bytes);
-static event_response_t cleanup(injector_t injector, drakvuf_trap_info_t* info);
+static event_response_t cleanup(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
 
 event_response_t handle_readfile_x64(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 {
@@ -125,7 +125,7 @@ event_response_t handle_readfile_x64(drakvuf_t drakvuf, drakvuf_trap_info_t* inf
             if (!setup_virtual_alloc_stack(injector, info->regs))
             {
                 PRINT_DEBUG("Failed to setup virtual alloc for passing inputs!\n");
-                return cleanup(injector, info);
+                return cleanup(drakvuf, info);
             }
 
             info->regs->rip = injector->exec_func;
@@ -142,7 +142,7 @@ event_response_t handle_readfile_x64(drakvuf_t drakvuf, drakvuf_trap_info_t* inf
             if (!setup_memset_stack(injector, info->regs))
             {
                 PRINT_DEBUG("Failed to setup memset stack for passing inputs!\n");
-                return cleanup(injector, info);
+                return cleanup(drakvuf, info);
             }
 
             info->regs->rip = injector->memset;
@@ -155,7 +155,7 @@ event_response_t handle_readfile_x64(drakvuf_t drakvuf, drakvuf_trap_info_t* inf
             if (!setup_expand_env_stack(injector, info->regs))
             {
                 PRINT_DEBUG("Failed to setup stack for passing inputs!\n");
-                return cleanup(injector, info);
+                return cleanup(drakvuf, info);
             }
 
             info->regs->rip = injector->expand_env;
@@ -167,18 +167,18 @@ event_response_t handle_readfile_x64(drakvuf_t drakvuf, drakvuf_trap_info_t* inf
             if (!info->regs->rax)
             {
                 PRINT_DEBUG("Failed to expand environment variables!\n");
-                return cleanup(injector, info);
+                return cleanup(drakvuf, info);
             }
             PRINT_DEBUG("Env expand status: %lx\n", info->regs->rax);
 
             if (info->regs->rax * 2 > FILE_BUF_SIZE)
             {
                 PRINT_DEBUG("Env expand reported more than the buffer can carry.\n");
-                return cleanup(injector, info);
+                return cleanup(drakvuf, info);
             }
 
             if (!setup_create_file(drakvuf, info))
-                return cleanup(injector, info);
+                return cleanup(drakvuf, info);
 
             info->regs->rip = injector->create_file;
             event = VMI_EVENT_RESPONSE_SET_REGISTERS;
@@ -189,12 +189,12 @@ event_response_t handle_readfile_x64(drakvuf_t drakvuf, drakvuf_trap_info_t* inf
             PRINT_DEBUG("File create result %lx\n", info->regs->rax);
 
             if (is_fun_error(drakvuf, info, "Couldn't open guest file"))
-                return cleanup(injector, info);
+                return cleanup(drakvuf, info);
 
             injector->file_handle = info->regs->rax;
 
             if (!open_host_file(injector, "wb"))
-                return cleanup(injector, info);
+                return cleanup(drakvuf, info);
 
             PRINT_DEBUG("Reading file...\n");
 
@@ -213,12 +213,12 @@ event_response_t handle_readfile_x64(drakvuf_t drakvuf, drakvuf_trap_info_t* inf
             PRINT_DEBUG("File read result: %lx\n", info->regs->rax);
 
             if (is_fun_error(drakvuf, info, "Failed to read guest file"))
-                return cleanup(injector, info);
+                return cleanup(drakvuf, info);
 
             uint32_t num_bytes;
 
             if (!process_read_file(drakvuf, info, &num_bytes))
-                return cleanup(injector, info);
+                return cleanup(drakvuf, info);
 
             if (num_bytes != 0)
             {
@@ -226,7 +226,7 @@ event_response_t handle_readfile_x64(drakvuf_t drakvuf, drakvuf_trap_info_t* inf
                 if (!setup_read_file_stack(injector, info->regs))
                 {
                     PRINT_DEBUG("Failed to setup stack for passing inputs!\n");
-                    return cleanup(injector, info);
+                    return cleanup(drakvuf, info);
                 }
 
                 info->regs->rip = injector->read_file;
@@ -239,7 +239,7 @@ event_response_t handle_readfile_x64(drakvuf_t drakvuf, drakvuf_trap_info_t* inf
                 if (!setup_close_handle_stack(injector, info->regs))
                 {
                     PRINT_DEBUG("Failed to setup stack for closing handle\n");
-                    return cleanup(injector, info);
+                    return cleanup(drakvuf, info);
                 }
                 info->regs->rip = injector->close_handle;
             }
@@ -253,7 +253,7 @@ event_response_t handle_readfile_x64(drakvuf_t drakvuf, drakvuf_trap_info_t* inf
             fclose(injector->host_file);
 
             if (is_fun_error(drakvuf, info, "Could not close File handle"))
-                return cleanup(injector, info);
+                return cleanup(drakvuf, info);
 
             memcpy(info->regs, &injector->x86_saved_regs, sizeof(x86_registers_t));
 
@@ -280,8 +280,10 @@ event_response_t handle_readfile_x64(drakvuf_t drakvuf, drakvuf_trap_info_t* inf
     return event;
 }
 
-static event_response_t cleanup(injector_t injector, drakvuf_trap_info_t* info)
+static event_response_t cleanup(drakvuf_t drakvuf __attribute__((unused)), drakvuf_trap_info_t* info)
 {
+    injector_t injector = info->trap->data;
+
     PRINT_DEBUG("Exiting prematurely\n");
     memcpy(info->regs, &injector->x86_saved_regs, sizeof(x86_registers_t));
     return override_step(injector, STEP8, VMI_EVENT_RESPONSE_SET_REGISTERS);

--- a/src/libinjector/win/methods/win_shellcode.c
+++ b/src/libinjector/win/methods/win_shellcode.c
@@ -106,7 +106,7 @@
 #include <win/win_functions.h>
 #include <win/method_helpers.h>
 
-static event_response_t cleanup(injector_t injector, drakvuf_trap_info_t* info);
+static event_response_t cleanup(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
 static bool inject_payload(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
 
 event_response_t handle_win_shellcode(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
@@ -125,7 +125,7 @@ event_response_t handle_win_shellcode(drakvuf_t drakvuf, drakvuf_trap_info_t* in
             if (!setup_virtual_alloc_stack(injector, info->regs))
             {
                 PRINT_DEBUG("Failed to setup virtual alloc for passing inputs!\n");
-                return cleanup(injector, info);
+                return cleanup(drakvuf, info);
             }
 
             info->regs->rip = injector->exec_func;
@@ -142,7 +142,7 @@ event_response_t handle_win_shellcode(drakvuf_t drakvuf, drakvuf_trap_info_t* in
             if (!setup_memset_stack(injector, info->regs))
             {
                 PRINT_DEBUG("Failed to setup memset stack for passing inputs!\n");
-                return cleanup(injector, info);
+                return cleanup(drakvuf, info);
             }
 
             info->regs->rip = injector->memset;
@@ -152,7 +152,7 @@ event_response_t handle_win_shellcode(drakvuf_t drakvuf, drakvuf_trap_info_t* in
         case STEP3: // inject payload
         {
             if (!inject_payload(drakvuf, info))
-                return cleanup(injector, info);
+                return cleanup(drakvuf, info);
 
             event = VMI_EVENT_RESPONSE_SET_REGISTERS;
             break;
@@ -183,8 +183,10 @@ event_response_t handle_win_shellcode(drakvuf_t drakvuf, drakvuf_trap_info_t* in
     return event;
 }
 
-static event_response_t cleanup(injector_t injector, drakvuf_trap_info_t* info)
+static event_response_t cleanup(drakvuf_t drakvuf __attribute__((unused)), drakvuf_trap_info_t* info)
 {
+    injector_t injector = info->trap->data;
+
     fprintf(stderr, "Exiting prematurely\n");
 
     if (injector->rc == INJECTOR_SUCCEEDED)

--- a/src/libinjector/win/methods/win_shellcode.c
+++ b/src/libinjector/win/methods/win_shellcode.c
@@ -162,15 +162,11 @@ event_response_t handle_win_shellcode(drakvuf_t drakvuf, drakvuf_trap_info_t* in
             PRINT_DEBUG("Shellcode executed\n");
             injector->rc = INJECTOR_SUCCEEDED;
 
-            memcpy(info->regs, &injector->x86_saved_regs, sizeof(x86_registers_t));
-            event = VMI_EVENT_RESPONSE_SET_REGISTERS;
-            break;
-        }
-        case STEP5:
-        {
             drakvuf_remove_trap(drakvuf, info->trap, NULL);
             drakvuf_interrupt(drakvuf, SIGDRAKVUFERROR);
-            event = VMI_EVENT_RESPONSE_NONE;
+
+            memcpy(info->regs, &injector->x86_saved_regs, sizeof(x86_registers_t));
+            event = VMI_EVENT_RESPONSE_SET_REGISTERS;
             break;
         }
         default:
@@ -183,7 +179,7 @@ event_response_t handle_win_shellcode(drakvuf_t drakvuf, drakvuf_trap_info_t* in
     return event;
 }
 
-static event_response_t cleanup(drakvuf_t drakvuf __attribute__((unused)), drakvuf_trap_info_t* info)
+static event_response_t cleanup(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 {
     injector_t injector = info->trap->data;
 
@@ -192,8 +188,11 @@ static event_response_t cleanup(drakvuf_t drakvuf __attribute__((unused)), drakv
     if (injector->rc == INJECTOR_SUCCEEDED)
         injector->rc = INJECTOR_FAILED;
 
+    drakvuf_remove_trap(drakvuf, info->trap, NULL);
+    drakvuf_interrupt(drakvuf, SIGDRAKVUFERROR);
+
     memcpy(info->regs, &injector->x86_saved_regs, sizeof(x86_registers_t));
-    return override_step(injector, STEP5, VMI_EVENT_RESPONSE_SET_REGISTERS);
+    return VMI_EVENT_RESPONSE_SET_REGISTERS;
 }
 
 static bool write_payload_to_guest_memory(drakvuf_t drakvuf, drakvuf_trap_info_t* info)

--- a/src/libinjector/win/methods/win_shellcode.c
+++ b/src/libinjector/win/methods/win_shellcode.c
@@ -163,7 +163,7 @@ event_response_t handle_win_shellcode(drakvuf_t drakvuf, drakvuf_trap_info_t* in
             injector->rc = INJECTOR_SUCCEEDED;
 
             drakvuf_remove_trap(drakvuf, info->trap, NULL);
-            drakvuf_interrupt(drakvuf, SIGDRAKVUFERROR);
+            drakvuf_interrupt(drakvuf, SIGINT);
 
             memcpy(info->regs, &injector->x86_saved_regs, sizeof(x86_registers_t));
             event = VMI_EVENT_RESPONSE_SET_REGISTERS;

--- a/src/libinjector/win/methods/win_shellexec.c
+++ b/src/libinjector/win/methods/win_shellexec.c
@@ -143,7 +143,7 @@ event_response_t handle_shellexec(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
             injector->rc = INJECTOR_SUCCEEDED;
 
             drakvuf_remove_trap(drakvuf, info->trap, NULL);
-            drakvuf_interrupt(drakvuf, SIGDRAKVUFERROR);
+            drakvuf_interrupt(drakvuf, SIGINT);
 
             memcpy(info->regs, &injector->x86_saved_regs, sizeof(x86_registers_t));
             event = VMI_EVENT_RESPONSE_SET_REGISTERS;

--- a/src/libinjector/win/methods/win_shellexec.c
+++ b/src/libinjector/win/methods/win_shellexec.c
@@ -106,7 +106,7 @@
 #include <win/win_functions.h>
 #include <win/method_helpers.h>
 
-static event_response_t cleanup(injector_t injector, drakvuf_trap_info_t* info);
+static event_response_t cleanup(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
 
 event_response_t handle_shellexec(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 {
@@ -124,7 +124,7 @@ event_response_t handle_shellexec(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
             if (!setup_shell_execute_stack(injector, info->regs))
             {
                 fprintf(stderr, "Failed to setup shellexec stack\n");
-                return cleanup(injector, info);
+                return cleanup(drakvuf, info);
             }
 
             info->regs->rip = injector->exec_func;
@@ -136,7 +136,7 @@ event_response_t handle_shellexec(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
             // For some reason ShellExecute could return ERROR_FILE_NOT_FOUND(6) while
             // successfully opening file.
             if (info->regs->rax != 6 && is_fun_error(drakvuf, info, "ShellExecute failed"))
-                return cleanup(injector, info);
+                return cleanup(drakvuf, info);
 
             PRINT_DEBUG("ShellExecute successful\n");
 
@@ -163,8 +163,10 @@ event_response_t handle_shellexec(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
     return event;
 }
 
-static event_response_t cleanup(injector_t injector, drakvuf_trap_info_t* info)
+static event_response_t cleanup(drakvuf_t drakvuf __attribute__((unused)), drakvuf_trap_info_t* info)
 {
+    injector_t injector = info->trap->data;
+
     fprintf(stderr, "Exiting prematurely\n");
 
     if (injector->rc == INJECTOR_SUCCEEDED)

--- a/src/libinjector/win/methods/win_terminate.c
+++ b/src/libinjector/win/methods/win_terminate.c
@@ -102,7 +102,7 @@ event_response_t handle_win_terminate(drakvuf_t drakvuf, drakvuf_trap_info_t* in
             PRINT_DEBUG("Process %d terminated successfully!\n", injector->terminate_pid);
 
             drakvuf_remove_trap(drakvuf, info->trap, NULL);
-            drakvuf_interrupt(drakvuf, SIGDRAKVUFERROR);
+            drakvuf_interrupt(drakvuf, SIGINT);
 
             memcpy(info->regs, &injector->x86_saved_regs, sizeof(x86_registers_t));
             event = VMI_EVENT_RESPONSE_SET_REGISTERS;

--- a/src/libinjector/win/methods/win_terminate.c
+++ b/src/libinjector/win/methods/win_terminate.c
@@ -3,7 +3,7 @@
 #include <win/method_helpers.h>
 #include <win/win_functions.h>
 
-static event_response_t cleanup(injector_t injector, drakvuf_trap_info_t* info);
+static event_response_t cleanup(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
 
 static bool setup_open_process_stack(injector_t injector, x86_registers_t* regs)
 {
@@ -74,7 +74,7 @@ event_response_t handle_win_terminate(drakvuf_t drakvuf, drakvuf_trap_info_t* in
             PRINT_DEBUG("Open process %d to terminate it.\n", injector->terminate_pid);
 
             if (!setup_open_process_stack(injector, info->regs))
-                return cleanup(injector, info);
+                return cleanup(drakvuf, info);
 
             info->regs->rip = injector->open_process;
             event = VMI_EVENT_RESPONSE_SET_REGISTERS;
@@ -83,12 +83,12 @@ event_response_t handle_win_terminate(drakvuf_t drakvuf, drakvuf_trap_info_t* in
         case STEP2:
         {
             if (is_fun_error(drakvuf, info, "Could not open process handle"))
-                return cleanup(injector, info);
+                return cleanup(drakvuf, info);
 
             PRINT_DEBUG("Process %d opened with handle %#lx. Terminate it!\n", injector->terminate_pid, info->regs->rax);
 
             if (!setup_create_remote_thread_stack(injector, info->regs))
-                return cleanup(injector, info);
+                return cleanup(drakvuf, info);
 
             info->regs->rip = injector->exec_func;
             event = VMI_EVENT_RESPONSE_SET_REGISTERS;
@@ -97,7 +97,7 @@ event_response_t handle_win_terminate(drakvuf_t drakvuf, drakvuf_trap_info_t* in
         case STEP3:
         {
             if (is_fun_error(drakvuf, info, "Could not terminate process"))
-                return cleanup(injector, info);
+                return cleanup(drakvuf, info);
 
             PRINT_DEBUG("Process %d terminated successfully!\n", injector->terminate_pid);
 
@@ -121,8 +121,10 @@ event_response_t handle_win_terminate(drakvuf_t drakvuf, drakvuf_trap_info_t* in
     return event;
 }
 
-static event_response_t cleanup(injector_t injector, drakvuf_trap_info_t* info)
+static event_response_t cleanup(drakvuf_t drakvuf __attribute__((unused)), drakvuf_trap_info_t* info)
 {
+    injector_t injector = info->trap->data;
+
     PRINT_DEBUG("Exiting prematurely\n");
 
     if (injector->rc == INJECTOR_SUCCEEDED)

--- a/src/libinjector/win/methods/win_write_file.c
+++ b/src/libinjector/win/methods/win_write_file.c
@@ -106,7 +106,7 @@
 #include "win_functions.h"
 #include "method_helpers.h"
 
-static event_response_t cleanup(injector_t injector, drakvuf_trap_info_t* info);
+static event_response_t cleanup(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
 static bool write_chunk_to_buffer(injector_t injector, x86_registers_t* regs, uint8_t* buf, size_t amount);
 
 event_response_t handle_writefile(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
@@ -124,7 +124,7 @@ event_response_t handle_writefile(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
             if (!setup_virtual_alloc_stack(injector, info->regs))
             {
                 PRINT_DEBUG("Failed to setup virtual alloc for passing inputs!\n");
-                return cleanup(injector, info);
+                return cleanup(drakvuf, info);
             }
 
             info->regs->rip = injector->exec_func;
@@ -141,7 +141,7 @@ event_response_t handle_writefile(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
             if (!setup_memset_stack(injector, info->regs))
             {
                 PRINT_DEBUG("Failed to setup memset stack for passing inputs!\n");
-                return cleanup(injector, info);
+                return cleanup(drakvuf, info);
             }
 
             info->regs->rip = injector->memset;
@@ -154,7 +154,7 @@ event_response_t handle_writefile(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
             if (!setup_expand_env_stack(injector, info->regs))
             {
                 PRINT_DEBUG("Failed to setup stack for passing inputs!\n");
-                return cleanup(injector, info);
+                return cleanup(drakvuf, info);
             }
 
             info->regs->rip = injector->expand_env;
@@ -164,7 +164,7 @@ event_response_t handle_writefile(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
         case STEP4: // open file handle
         {
             if (is_fun_error(drakvuf, info, "Failed to expand environment variables!\n"))
-                return cleanup(injector, info);
+                return cleanup(drakvuf, info);
 
             PRINT_DEBUG("Env expand status: %lx\n", info->regs->rax);
 
@@ -186,12 +186,12 @@ event_response_t handle_writefile(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
             PRINT_DEBUG("File create result %lx\n", info->regs->rax);
 
             if (is_fun_error(drakvuf, info, "Couldn't open guest file"))
-                return cleanup(injector, info);
+                return cleanup(drakvuf, info);
 
             injector->file_handle = info->regs->rax;
 
             if (!open_host_file(injector, "rb"))
-                return cleanup(injector, info);
+                return cleanup(drakvuf, info);
 
         }
         // fall through
@@ -201,7 +201,7 @@ event_response_t handle_writefile(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
             size_t amount;
 
             if (is_fun_error(drakvuf, info, "Failed to write to the guest file"))
-                return cleanup(injector, info);
+                return cleanup(drakvuf, info);
 
             PRINT_DEBUG("Writing file...\n");
             amount = fread(buf + FILE_BUF_RESERVED, 1, FILE_BUF_SIZE - FILE_BUF_RESERVED, injector->host_file);
@@ -210,7 +210,7 @@ event_response_t handle_writefile(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
             if (ferror(injector->host_file))
             {
                 fprintf(stderr, "Failed to read the chunk of file.\n");
-                return cleanup(injector, info);
+                return cleanup(drakvuf, info);
             }
 
             if (!amount)
@@ -221,7 +221,7 @@ event_response_t handle_writefile(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
                 if (!setup_close_handle_stack(injector, info->regs))
                 {
                     PRINT_DEBUG("Failed to setup stack for closing handle\n");
-                    return cleanup(injector, info);
+                    return cleanup(drakvuf, info);
                 }
 
                 info->regs->rip = injector->close_handle;
@@ -232,12 +232,12 @@ event_response_t handle_writefile(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
                 PRINT_DEBUG("Writing...\n");
 
                 if (!write_chunk_to_buffer(injector, info->regs, buf + FILE_BUF_RESERVED, amount))
-                    return cleanup(injector, info);
+                    return cleanup(drakvuf, info);
 
                 if (!setup_write_file_stack(injector, info->regs, amount))
                 {
                     PRINT_DEBUG("Failed to setup stack for passing inputs!\n");
-                    return cleanup(injector, info);
+                    return cleanup(drakvuf, info);
                 }
 
                 info->regs->rip = injector->write_file;
@@ -251,7 +251,7 @@ event_response_t handle_writefile(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
             fclose(injector->host_file);
 
             if (is_fun_error(drakvuf, info, "Could not close File handle"))
-                return cleanup(injector, info);
+                return cleanup(drakvuf, info);
 
             memcpy(info->regs, &injector->x86_saved_regs, sizeof(x86_registers_t));
 
@@ -278,8 +278,10 @@ event_response_t handle_writefile(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
     return event;
 }
 
-static event_response_t cleanup(injector_t injector, drakvuf_trap_info_t* info)
+static event_response_t cleanup(drakvuf_t drakvuf __attribute__((unused)), drakvuf_trap_info_t* info)
 {
+    injector_t injector = info->trap->data;
+
     PRINT_DEBUG("Exiting prematurely\n");
     memcpy(info->regs, &injector->x86_saved_regs, sizeof(x86_registers_t));
     return override_step(injector, STEP8, VMI_EVENT_RESPONSE_SET_REGISTERS);

--- a/src/libinjector/win/methods/win_write_file.c
+++ b/src/libinjector/win/methods/win_write_file.c
@@ -257,7 +257,7 @@ event_response_t handle_writefile(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
             injector->rc = INJECTOR_SUCCEEDED;
 
             drakvuf_remove_trap(drakvuf, info->trap, NULL);
-            drakvuf_interrupt(drakvuf, SIGDRAKVUFERROR);
+            drakvuf_interrupt(drakvuf, SIGINT);
 
             memcpy(info->regs, &injector->x86_saved_regs, sizeof(x86_registers_t));
             event = VMI_EVENT_RESPONSE_SET_REGISTERS;

--- a/src/libinjector/win/methods/win_write_file.c
+++ b/src/libinjector/win/methods/win_write_file.c
@@ -253,19 +253,14 @@ event_response_t handle_writefile(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
             if (is_fun_error(drakvuf, info, "Could not close File handle"))
                 return cleanup(drakvuf, info);
 
-            memcpy(info->regs, &injector->x86_saved_regs, sizeof(x86_registers_t));
-
             PRINT_DEBUG("File operation executed OK\n");
             injector->rc = INJECTOR_SUCCEEDED;
 
-            event = VMI_EVENT_RESPONSE_SET_REGISTERS;
-            break;
-        }
-        case STEP8: // exit loop
-        {
             drakvuf_remove_trap(drakvuf, info->trap, NULL);
             drakvuf_interrupt(drakvuf, SIGDRAKVUFERROR);
-            event = VMI_EVENT_RESPONSE_NONE;
+
+            memcpy(info->regs, &injector->x86_saved_regs, sizeof(x86_registers_t));
+            event = VMI_EVENT_RESPONSE_SET_REGISTERS;
             break;
         }
         default:
@@ -278,13 +273,17 @@ event_response_t handle_writefile(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
     return event;
 }
 
-static event_response_t cleanup(drakvuf_t drakvuf __attribute__((unused)), drakvuf_trap_info_t* info)
+static event_response_t cleanup(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 {
     injector_t injector = info->trap->data;
 
     PRINT_DEBUG("Exiting prematurely\n");
+
+    drakvuf_remove_trap(drakvuf, info->trap, NULL);
+    drakvuf_interrupt(drakvuf, SIGDRAKVUFERROR);
+
     memcpy(info->regs, &injector->x86_saved_regs, sizeof(x86_registers_t));
-    return override_step(injector, STEP8, VMI_EVENT_RESPONSE_SET_REGISTERS);
+    return VMI_EVENT_RESPONSE_SET_REGISTERS;
 }
 
 static bool write_chunk_to_buffer(injector_t injector, x86_registers_t* regs, uint8_t* buf, size_t amount)


### PR DESCRIPTION
libinjector, win: Fix intermittent timeouts

After restoring the saved CPU registers, each injection method waits
for the next trap before exiting the injector loop. This means that
the target thread, continuing to execute the original program, needs
to trigger the same trap before the injector can finish. And that leads
to unpredictable waits. For example, waits of a few minutes were
observed when testing injector against explorer.exe under Windows 7
Enterprise (x64). Further, injector could wait forever in case the
target thread never revisits the trap.

The waits were introduced when refactoring injection methods in commit
3fdb3704de7c ("win_injector: seperate readfile and writefile to
different files  (#1319)").

Fix this issue by arranging for the injector loop to exit immediately
after restoring the saved CPU registers.