### PR TITLE
libdrakvuf: print special names for kernel threads t

### DIFF
--- a/src/libdrakvuf/linux-processes.c
+++ b/src/libdrakvuf/linux-processes.c
@@ -322,6 +322,22 @@ char* linux_get_process_name(drakvuf_t drakvuf, addr_t process_base, bool fullpa
             return NULL;
         }
 
+        if (!mm_struct)
+        {
+            // This is a kernel thread (with null pointer to mm_struct)
+            vmi_pid_t pid;
+            if (linux_get_process_pid(drakvuf, process_base, &pid))
+            {
+                gchar tmp[32] = {0};
+                if (g_snprintf(tmp, 32, "kthread-%d", pid) >= 0)
+                    return g_strdup(tmp);
+                else
+                    return NULL;
+            }
+            else
+                return NULL;
+        }
+
         ctx.addr = mm_struct + drakvuf->offsets[MM_STRUCT_EXE_FILE];
         addr_t exe_file;
         if (VMI_FAILURE == vmi_read_addr(drakvuf->vmi, &ctx, &exe_file))


### PR DESCRIPTION
The `task_struct` for Linux kernel threads contains null pointer (https://stackoverflow.com/a/25956682 , https://qr.ae/pvFGw3 ).

This results in errors like this:
```
1654086286.801804 Can't get exe_file from mm_struct
```

Thus we get empty names in some cases.

With the patch we set special name `kthread-PID`. This makes drakvuf output more clean.