### PR TITLE
windows-injector: handle case of writing empty file

### DIFF
--- a/src/libinjector/injector_utils.c
+++ b/src/libinjector/injector_utils.c
@@ -123,6 +123,11 @@ event_response_t override_step(injector_t injector, const injector_step_t step, 
     return event;
 }
 
+void fall_through_step(injector_t injector, const injector_step_t step)
+{
+    injector->step = step;
+}
+
 // One could not set all registers at once because the kernel structures could be affected.
 // For example on Windows 7 x64 GS BASE stores pointer to KPCR. If save
 // GS BASE on vCPU0 and start injections Windows scheduler could switch

--- a/src/libinjector/injector_utils.h
+++ b/src/libinjector/injector_utils.h
@@ -109,5 +109,6 @@
 #include <libinjector/private.h>
 
 event_response_t override_step(injector_t injector, const injector_step_t step, event_response_t event);
+void fall_through_step(injector_t injector, const injector_step_t step);
 event_response_t handle_gprs_registers(drakvuf_t drakvuf, drakvuf_trap_info_t* info, event_response_t event);
 #endif

--- a/src/libinjector/win/methods/win_write_file.c
+++ b/src/libinjector/win/methods/win_write_file.c
@@ -193,6 +193,7 @@ event_response_t handle_writefile(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
             if (!open_host_file(injector, "rb"))
                 return cleanup(drakvuf, info);
 
+            fall_through_step(injector, STEP6);
         }
         // fall through
         case STEP6: // read chunk from host and write to guest


### PR DESCRIPTION
In case of empty file writing, state machine has been in wrong step STEP5, because of falling through STEP6 without incrementing the step.