### PR TITLE
fileextractor: fix return_hook creation

### DIFF
--- a/src/plugins/fileextractor/fileextractor.cpp
+++ b/src/plugins/fileextractor/fileextractor.cpp
@@ -161,10 +161,14 @@ void fileextractor::createfile_cb_impl(drakvuf_t,
     drakvuf_trap_info_t* info,
     addr_t handle)
 {
+    auto hook_id = make_hook_id(info);
     auto hook = createReturnHook<createfile_result_t>(info,
-            &fileextractor::createfile_ret_cb);
+            &fileextractor::createfile_ret_cb, UNLIMITED_TTL);
     auto params = libhook::GetTrapParams<createfile_result_t>(hook->trap_);
+    params->setResultCallParams(info);
     params->handle = handle;
+
+    createfile_ret_hooks[hook_id] = std::move(hook);
 }
 
 event_response_t fileextractor::createfile_ret_cb(drakvuf_t,
@@ -208,6 +212,9 @@ event_response_t fileextractor::createfile_ret_cb(drakvuf_t,
                     file);
         }
     }
+
+    auto hook_id = make_hook_id(info);
+    createfile_ret_hooks.erase(hook_id);
 
     return VMI_EVENT_RESPONSE_NONE;
 }

--- a/src/plugins/fileextractor/fileextractor.h
+++ b/src/plugins/fileextractor/fileextractor.h
@@ -169,6 +169,7 @@ private:
     std::unique_ptr<libhook::SyscallHook> createsection_hook;
     std::unique_ptr<libhook::SyscallHook> createfile_hook;
     std::unique_ptr<libhook::SyscallHook> openfile_hook;
+    std::map<uint64_t, std::unique_ptr<libhook::ReturnHook>> createfile_ret_hooks;
 
     /* VA of functions to be injected */
     addr_t queryvolumeinfo_va = 0;


### PR DESCRIPTION
Actually, the plugin didn't work, because created return_hook was immediately destroyed.