### PR TITLE
win-syscalls: support for early initialization

### DIFF
--- a/src/plugins/syscalls/syscalls.cpp
+++ b/src/plugins/syscalls/syscalls.cpp
@@ -311,6 +311,7 @@ syscalls::syscalls(drakvuf_t drakvuf, const syscalls_config* c, output_format_t 
     , filter(NULL)
     , format{output}
     , offsets(NULL)
+    , win32k_profile{c->win32k_profile ?: ""}
 {
     this->os = drakvuf_get_os_type(drakvuf);
     this->kernel_base = drakvuf_get_kernel_base(drakvuf);

--- a/src/plugins/syscalls/syscalls.h
+++ b/src/plugins/syscalls/syscalls.h
@@ -135,6 +135,12 @@ public:
     addr_t sst[2][2]; // [0=nt][base, limit],[1=win32k][base,limit]
 
     addr_t kernel_base;
+    addr_t image_path_name;
+    std::string win32k_profile;
+
+    std::unique_ptr<libhook::SyscallHook> load_driver_hook;
+    std::unique_ptr<libhook::SyscallHook> create_process_hook;
+    std::unique_ptr<libhook::ReturnHook> wait_process_creation_hook;
 
     std::vector<std::pair<char const*, fmt::Aarg>> fmt_args; // cache
 
@@ -142,6 +148,12 @@ public:
     syscalls(const syscalls&) = delete;
     syscalls& operator=(const syscalls&) = delete;
     ~syscalls();
+
+    bool setup_win32k_syscalls(drakvuf_t drakvuf);
+
+    event_response_t load_driver_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
+    event_response_t create_process_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
+    event_response_t create_process_ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
 };
 
 #endif


### PR DESCRIPTION
support for early initialization (before launching of explorer.exe and loading of win32k.sys driver)