### PR TITLE
Assign NULL to freed resources

### DIFF
--- a/src/libdrakvuf/drakvuf.c
+++ b/src/libdrakvuf/drakvuf.c
@@ -157,11 +157,18 @@ void drakvuf_close(drakvuf_t drakvuf, const bool pause)
 
     g_rec_mutex_clear(&drakvuf->vmi_lock);
     g_free(drakvuf->offsets);
+    drakvuf->offsets = NULL;
     g_free(drakvuf->bitfields);
+    drakvuf->bitfields = NULL;
     g_free(drakvuf->sizes);
+    drakvuf->sizes = NULL;
+    g_rec_mutex_clear(&drakvuf->vmi_lock);
     g_free(drakvuf->dom_name);
+    drakvuf->dom_name = NULL;
     g_free(drakvuf->json_kernel_path);
+    drakvuf->json_kernel_path = NULL;
     g_free(drakvuf->json_wow_path);
+    drakvuf->json_wow_path = NULL;
     g_free(drakvuf);
 }
 


### PR DESCRIPTION
This was part of my hunt for use-after-free bug.

The idea to assigning NULL to freed resources was given to me as a good practice some time ago.