### PR TITLE
Add new plugin: unixsocketmon

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -552,6 +552,16 @@ if test x$plugin_ebpfmon = xyes; then
   AC_DEFINE_UNQUOTED(ENABLE_PLUGIN_EBPFMON, 1, "")
 fi
 
+AC_ARG_ENABLE([plugin_unixsocketmon],
+  [AS_HELP_STRING([--disable-plugin-unixsocketmon],
+    [Enable the unixsocketmon plugin @<:@yes@:>@])],
+  [plugin_unixsocketmon="$enableval"],
+  [plugin_unixsocketmon="yes"])
+AM_CONDITIONAL([PLUGIN_UNIXSOCKETMON], [test x$plugin_unixsocketmon = xyes])
+if test x$plugin_unixsocketmon = xyes; then
+  AC_DEFINE_UNQUOTED(ENABLE_PLUGIN_UNIXSOCKETMON, 1, "")
+fi
+
 #####################################################
 
 AC_ARG_ENABLE([repl],

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -38,6 +38,7 @@ option('plugin-memdump', type : 'boolean', value : true)
 option('plugin-hidevm', type : 'boolean', value : true)
 option('plugin-ptracemon', type : 'boolean', value : true)
 option('plugin-ebpfmon', type : 'boolean', value : true)
+option('plugin-unixsocketmon', type : 'boolean', value : true)
 
 # Disabled by default plugins
 option('plugin-libhooktest', type : 'boolean', value : 'false')

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -361,6 +361,10 @@ static void print_usage()
         "\t --json-services <path to json>\n"
         "\t                           The JSON profile for services.exe\n"
 #endif
+#ifdef ENABLE_PLUGIN_UNIXSOCKETMON
+        "\t --unixsocketmon-max-size-print <size>\n"
+        "\t                           Max message size (in bytes) to print\n"
+#endif
         "\t --libdrakvuf-not-get-userid\n"
         "\t                           Don't collect user id in get process data\n"
         "\t -h, --help                Show this help\n"
@@ -483,6 +487,7 @@ int main(int argc, char** argv)
         opt_ignore_pid,
         opt_enable_active_callback_check,
         opt_exit_injection_thread,
+        opt_unixsocketmon_max_size,
     };
     const option long_opts[] =
     {
@@ -557,6 +562,7 @@ int main(int argc, char** argv)
         {"ignore-pid", required_argument, NULL, opt_ignore_pid},
         {"enable-active-callback-check", no_argument, NULL, opt_enable_active_callback_check},
         {"exit-injection-thread", no_argument, NULL, opt_exit_injection_thread},
+        {"unixsocketmon-max-size-print", required_argument, NULL, opt_unixsocketmon_max_size},
         {NULL, 0, NULL, 0}
     };
     const char* opts = "r:d:i:I:e:m:t:D:o:vx:a:f:spT:S:Mc:nblgj:k:w:W:hFC";
@@ -895,7 +901,11 @@ int main(int argc, char** argv)
                 options.services_profile = optarg;
                 break;
 #endif
-
+#ifdef ENABLE_PLUGIN_UNIXSOCKETMON
+            case opt_unixsocketmon_max_size:
+                options.unixsocketmon_max_size = strtoull(optarg, NULL, 0);
+                break;
+#endif
             case 'h':
                 print_usage();
                 return drakvuf_exit_code_t::SUCCESS;

--- a/src/plugins/Makefile.am
+++ b/src/plugins/Makefile.am
@@ -377,6 +377,12 @@ sources += ebpfmon/ebpfmon.h
 sources += ebpfmon/private.h
 endif
 
+if PLUGIN_UNIXSOCKETMON
+sources += unixsocketmon/unixsocketmon.cpp
+sources += unixsocketmon/unixsocketmon.h
+sources += unixsocketmon/private.h
+endif
+
 ###############################################################################
 sources += plugins.cpp plugins.h plugins_ex.cpp plugins_ex.h plugin_utils.cpp plugin_utils.h private.h type_traits_helpers.h hook_helpers.h
 sources += output_format.h output_format/common.h output_format/csvfmt.h output_format/deffmt.h output_format/jsonfmt.h output_format/kvfmt.h

--- a/src/plugins/meson.build
+++ b/src/plugins/meson.build
@@ -189,6 +189,12 @@ if get_option('plugin-ebpfmon')
     config_h.set('ENABLE_PLUGIN_EBPFMON', 1)
 endif
 
+if get_option('plugin-unixsocketmon')
+    plugin_sources += 'unixsocketmon/unixsocketmon.cpp'
+
+    config_h.set('ENABLE_PLUGIN_UNIXSOCKETMON', 1)
+endif
+
 summary({
     'syscalls': get_option('plugin-syscalls'),
     'poolmon': get_option('plugin-poolmon'),
@@ -216,6 +222,7 @@ summary({
     'hidevm': get_option('plugin-hidevm'),
     'ptracemon': get_option('plugin-ptracemon'),
     'ebpfmon' : get_option('plugin-ebpfmon'),
+    'unixsocketmon' : get_option('plugin-unixsocketmon'),
 }, section: 'Plugins (-Dplugin-<x>)')
 
 summary({

--- a/src/plugins/output_format/check.cpp
+++ b/src/plugins/output_format/check.cpp
@@ -195,6 +195,20 @@ START_TEST(test_kvfmt_rstr_basic)
 }
 END_TEST
 
+START_TEST(test_kvfmt_binary_string_basic)
+{
+    std::stringstream ss;
+    bool result = false;
+
+    const char* str = "\x1ftest";
+    size_t str_len = strlen(str);
+
+    result = kvfmt::print_data(ss, fmt::BinaryString(reinterpret_cast<const uint8_t*>(str), str_len), ',');
+    ck_assert_msg(ss.str() == std::string("1f74657374"), nullptr);
+    ck_assert_msg(result == true, nullptr);
+}
+END_TEST
+
 START_TEST(test_kvfmt_xval)
 {
     std::stringstream ss;
@@ -348,6 +362,7 @@ Suite* kvfmt_suite(void)
     tcase_add_test(tc_core, test_kvfmt_qstr_utf_8_multiline);
     tcase_add_test(tc_core, test_kvfmt_qstr_utf_8_binary);
     tcase_add_test(tc_core, test_kvfmt_rstr_basic);
+    tcase_add_test(tc_core, test_kvfmt_binary_string_basic);
     tcase_add_test(tc_core, test_kvfmt_xval);
     tcase_add_test(tc_core, test_kvfmt_nval);
     tcase_add_test(tc_core, test_kvfmt_fval);

--- a/src/plugins/output_format/csvfmt.h
+++ b/src/plugins/output_format/csvfmt.h
@@ -195,6 +195,13 @@ struct DataPrinter
     }
 
     template <class Tv = T>
+    static bool print(std::ostream& os, const fmt::BinaryString<Tv>& data, char)
+    {
+        data.format(os);
+        return true;
+    }
+
+    template <class Tv = T>
     static bool print(std::ostream& os, const std::function<bool(std::ostream&)>& printer, char)
     {
         auto pos = os.tellp();

--- a/src/plugins/output_format/deffmt.h
+++ b/src/plugins/output_format/deffmt.h
@@ -186,6 +186,13 @@ struct DataPrinter
     }
 
     template <class Tv = T>
+    static bool print(std::ostream& os, const fmt::BinaryString<Tv>& data, char)
+    {
+        data.format(os);
+        return true;
+    }
+
+    template <class Tv = T>
     static bool print(std::ostream& os, const fmt::Estr<Tv>& data, char)
     {
         gchar* escaped = drakvuf_escape_str(data.value.c_str());

--- a/src/plugins/output_format/jsonfmt.h
+++ b/src/plugins/output_format/jsonfmt.h
@@ -179,6 +179,15 @@ public:
     }
 
     template <class Tv = T>
+    static bool print(std::ostream& os, const fmt::BinaryString<Tv>& data, char)
+    {
+        os << "\"";
+        data.format(os);
+        os << "\"";
+        return true;
+    }
+
+    template <class Tv = T>
     static bool print(std::ostream& os, const std::function<bool(std::ostream&)>& printer, char)
     {
         auto pos = os.tellp();

--- a/src/plugins/output_format/kvfmt.h
+++ b/src/plugins/output_format/kvfmt.h
@@ -193,6 +193,13 @@ struct DataPrinter
         return print_escaped(os, data.value);
     }
 
+    template <class Tv = T>
+    static bool print(std::ostream& os, const fmt::BinaryString<Tv>& data, char)
+    {
+        data.format(os);
+        return true;
+    }
+
     static bool print_escaped(std::ostream& os, const std::string& value)
     {
         char const* const hexdig = "0123456789ABCDEF";

--- a/src/plugins/plugins.cpp
+++ b/src/plugins/plugins.cpp
@@ -143,6 +143,7 @@
 #include "hidevm/hidevm.h"
 #include "ptracemon/ptracemon.h"
 #include "ebpfmon/ebpfmon.h"
+#include "unixsocketmon/unixsocketmon.h"
 
 drakvuf_plugins::drakvuf_plugins(const drakvuf_t _drakvuf, output_format_t _output, os_t _os)
     : drakvuf{ _drakvuf }, output{ _output }, os{ _os }
@@ -557,6 +558,17 @@ int drakvuf_plugins::start(const drakvuf_plugin_t plugin_id,
                 case PLUGIN_EBPFMON:
                 {
                     this->plugins[plugin_id] = std::make_unique<ebpfmon>(this->drakvuf, this->output);
+                    break;
+                }
+#endif
+#ifdef ENABLE_PLUGIN_UNIXSOCKETMON
+                case PLUGIN_UNIXSOCKETMON:
+                {
+                    unixsocketmon_config config =
+                    {
+                        .print_max_size = options->unixsocketmon_max_size
+                    };
+                    this->plugins[plugin_id] = std::make_unique<unixsocketmon>(this->drakvuf, &config, this->output);
                     break;
                 }
 #endif

--- a/src/plugins/plugins.h
+++ b/src/plugins/plugins.h
@@ -187,6 +187,7 @@ struct plugins_options
     const char* services_profile;       // PLUGIN_DKOMMON
     const char* netio_profile;          // PLUGIN_CALLBACKMON
     uint64_t hidevm_delay;              // PLUGIN_HIDEVM
+    uint64_t unixsocketmon_max_size;    // PLUGIN_UNIXSOCKETMON
 };
 
 typedef enum drakvuf_plugin
@@ -230,6 +231,7 @@ typedef enum drakvuf_plugin
     PLUGIN_HIDEVM,
     PLUGIN_PTRACEMON,
     PLUGIN_EBPFMON,
+    PLUGIN_UNIXSOCKETMON,
     __DRAKVUF_PLUGIN_LIST_MAX
 } drakvuf_plugin_t;
 
@@ -274,6 +276,7 @@ static const char* drakvuf_plugin_names[] =
     [PLUGIN_HIDEVM] = "hidevm",
     [PLUGIN_PTRACEMON] = "ptracemon",
     [PLUGIN_EBPFMON] = "ebpfmon",
+    [PLUGIN_UNIXSOCKETMON] = "unixsocketmon",
 };
 
 static const bool drakvuf_plugin_os_support[__DRAKVUF_PLUGIN_LIST_MAX][VMI_OS_WINDOWS+1] =
@@ -317,6 +320,7 @@ static const bool drakvuf_plugin_os_support[__DRAKVUF_PLUGIN_LIST_MAX][VMI_OS_WI
     [PLUGIN_HIDEVM]       = { [VMI_OS_WINDOWS] = 1, [VMI_OS_LINUX] = 0 },
     [PLUGIN_PTRACEMON]    = { [VMI_OS_WINDOWS] = 0, [VMI_OS_LINUX] = 1 },
     [PLUGIN_EBPFMON]      = { [VMI_OS_WINDOWS] = 0, [VMI_OS_LINUX] = 1 },
+    [PLUGIN_UNIXSOCKETMON]= { [VMI_OS_WINDOWS] = 0, [VMI_OS_LINUX] = 1 },
 };
 
 class plugin

--- a/src/plugins/unixsocketmon/private.h
+++ b/src/plugins/unixsocketmon/private.h
@@ -1,0 +1,255 @@
+/*********************IMPORTANT DRAKVUF LICENSE TERMS***********************
+ *                                                                         *
+ * DRAKVUF (C) 2014-2022 Tamas K Lengyel.                                  *
+ * Tamas K Lengyel is hereinafter referred to as the author.               *
+ * This program is free software; you may redistribute and/or modify it    *
+ * under the terms of the GNU General Public License as published by the   *
+ * Free Software Foundation; Version 2 ("GPL"), BUT ONLY WITH ALL OF THE   *
+ * CLARIFICATIONS AND EXCEPTIONS DESCRIBED HEREIN.  This guarantees your   *
+ * right to use, modify, and redistribute this software under certain      *
+ * conditions.  If you wish to embed DRAKVUF technology into proprietary   *
+ * software, alternative licenses can be acquired from the author.         *
+ *                                                                         *
+ * Note that the GPL places important restrictions on "derivative works",  *
+ * yet it does not provide a detailed definition of that term.  To avoid   *
+ * misunderstandings, we interpret that term as broadly as copyright law   *
+ * allows.  For example, we consider an application to constitute a        *
+ * derivative work for the purpose of this license if it does any of the   *
+ * following with any software or content covered by this license          *
+ * ("Covered Software"):                                                   *
+ *                                                                         *
+ * o Integrates source code from Covered Software.                         *
+ *                                                                         *
+ * o Reads or includes copyrighted data files.                             *
+ *                                                                         *
+ * o Is designed specifically to execute Covered Software and parse the    *
+ * results (as opposed to typical shell or execution-menu apps, which will *
+ * execute anything you tell them to).                                     *
+ *                                                                         *
+ * o Includes Covered Software in a proprietary executable installer.  The *
+ * installers produced by InstallShield are an example of this.  Including *
+ * DRAKVUF with other software in compressed or archival form does not     *
+ * trigger this provision, provided appropriate open source decompression  *
+ * or de-archiving software is widely available for no charge.  For the    *
+ * purposes of this license, an installer is considered to include Covered *
+ * Software even if it actually retrieves a copy of Covered Software from  *
+ * another source during runtime (such as by downloading it from the       *
+ * Internet).                                                              *
+ *                                                                         *
+ * o Links (statically or dynamically) to a library which does any of the  *
+ * above.                                                                  *
+ *                                                                         *
+ * o Executes a helper program, module, or script to do any of the above.  *
+ *                                                                         *
+ * This list is not exclusive, but is meant to clarify our interpretation  *
+ * of derived works with some common examples.  Other people may interpret *
+ * the plain GPL differently, so we consider this a special exception to   *
+ * the GPL that we apply to Covered Software.  Works which meet any of     *
+ * these conditions must conform to all of the terms of this license,      *
+ * particularly including the GPL Section 3 requirements of providing      *
+ * source code and allowing free redistribution of the work as a whole.    *
+ *                                                                         *
+ * Any redistribution of Covered Software, including any derived works,    *
+ * must obey and carry forward all of the terms of this license, including *
+ * obeying all GPL rules and restrictions.  For example, source code of    *
+ * the whole work must be provided and free redistribution must be         *
+ * allowed.  All GPL references to "this License", are to be treated as    *
+ * including the terms and conditions of this license text as well.        *
+ *                                                                         *
+ * Because this license imposes special exceptions to the GPL, Covered     *
+ * Work may not be combined (even as part of a larger work) with plain GPL *
+ * software.  The terms, conditions, and exceptions of this license must   *
+ * be included as well.  This license is incompatible with some other open *
+ * source licenses as well.  In some cases we can relicense portions of    *
+ * DRAKVUF or grant special permissions to use it in other open source     *
+ * software.  Please contact tamas.k.lengyel@gmail.com with any such       *
+ * requests.  Similarly, we don't incorporate incompatible open source     *
+ * software into Covered Software without special permission from the      *
+ * copyright holders.                                                      *
+ *                                                                         *
+ * If you have any questions about the licensing restrictions on using     *
+ * DRAKVUF in other works, are happy to help.  As mentioned above,         *
+ * alternative license can be requested from the author to integrate       *
+ * DRAKVUF into proprietary applications and appliances.  Please email     *
+ * tamas.k.lengyel@gmail.com for further information.                      *
+ *                                                                         *
+ * If you have received a written license agreement or contract for        *
+ * Covered Software stating terms other than these, you may choose to use  *
+ * and redistribute Covered Software under those terms instead of these.   *
+ *                                                                         *
+ * Source is provided to this software because we believe users have a     *
+ * right to know exactly what a program is going to do before they run it. *
+ * This also allows you to audit the software for security holes.          *
+ *                                                                         *
+ * Source code also allows you to port DRAKVUF to new platforms, fix bugs, *
+ * and add new features.  You are highly encouraged to submit your changes *
+ * on https://github.com/tklengyel/drakvuf, or by other methods.           *
+ * By sending these changes, it is understood (unless you specify          *
+ * otherwise) that you are offering unlimited, non-exclusive right to      *
+ * reuse, modify, and relicense the code.  DRAKVUF will always be          *
+ * available Open Source, but this is important because the inability to   *
+ * relicense code has caused devastating problems for other Free Software  *
+ * projects (such as KDE and NASM).                                        *
+ * To specify special license conditions of your contributions, just say   *
+ * so when you send them.                                                  *
+ *                                                                         *
+ * This program is distributed in the hope that it will be useful, but     *
+ * WITHOUT ANY WARRANTY; without even the implied warranty of              *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the DRAKVUF   *
+ * license file for more details (it's in a COPYING file included with     *
+ * DRAKVUF, and also available from                                        *
+ * https://github.com/tklengyel/drakvuf/COPYING)                           *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef UNIXSOCKETMON_PRIVATE_H
+#define UNIXSOCKETMON_PRIVATE_H
+
+typedef enum socket_family
+{
+    AF_LOCAL                = 1,	/* POSIX name for AF_UNIX	*/
+    AF_INET                 = 2,	/* Internet IP Protocol 	*/
+    AF_AX25                 = 3,	/* Amateur Radio AX.25 		*/
+    AF_IPX                  = 4,	/* Novell IPX 			*/
+    AF_APPLETALK            = 5,	/* AppleTalk DDP 		*/
+    AF_NETROM               = 6,	/* Amateur Radio NET/ROM 	*/
+    AF_BRIDGE               = 7,	/* Multiprotocol bridge 	*/
+    AF_ATMPVC               = 8,	/* ATM PVCs			*/
+    AF_X25                  = 9,    /* Reserved for X.25 project 	*/
+    AF_INET6                = 10,	/* IP version 6			*/
+    AF_ROSE                 = 11,	/* Amateur Radio X.25 PLP	*/
+    AF_DECnet               = 12,	/* Reserved for DECnet project	*/
+    AF_NETBEUI              = 13,	/* Reserved for 802.2LLC project*/
+    AF_SECURITY             = 14,	/* Security callback pseudo AF */
+    AF_KEY                  = 15,   /* PF_KEY key management API */
+    AF_NETLINK              = 16,
+    AF_PACKET               = 17,	/* Packet family		*/
+    AF_ASH                  = 18,	/* Ash				*/
+    AF_ECONET               = 19,	/* Acorn Econet			*/
+    AF_ATMSVC               = 20,	/* ATM SVCs			*/
+    AF_RDS                  = 21,	/* RDS sockets 			*/
+    AF_SNA                  = 22,	/* Linux SNA Project (nutters!) */
+    AF_IRDA                 = 23,	/* IRDA sockets			*/
+    AF_PPPOX                = 24,	/* PPPoX sockets		*/
+    AF_WANPIPE              = 25,	/* Wanpipe API Sockets */
+    AF_LLC                  = 26,	/* Linux LLC			*/
+    AF_IB                   = 27,	/* Native InfiniBand address	*/
+    AF_MPLS                 = 28,	/* MPLS */
+    AF_CAN                  = 29,	/* Controller Area Network      */
+    AF_TIPC                 = 30,	/* TIPC sockets			*/
+    AF_BLUETOOTH            = 31,	/* Bluetooth sockets 		*/
+    AF_IUCV                 = 32,	/* IUCV sockets			*/
+    AF_RXRPC                = 33,	/* RxRPC sockets 		*/
+    AF_ISDN                 = 34,	/* mISDN sockets 		*/
+    AF_PHONET               = 35,	/* Phonet sockets		*/
+    AF_IEEE802154           = 36,	/* IEEE802154 sockets		*/
+    AF_CAIF                 = 37,	/* CAIF sockets			*/
+    AF_ALG                  = 38,	/* Algorithm sockets		*/
+    AF_NFC                  = 39,	/* NFC sockets			*/
+    AF_VSOCK                = 40,	/* vSockets			*/
+    AF_KCM                  = 41,	/* Kernel Connection Multiplexor*/
+    AF_QIPCRTR              = 42,	/* Qualcomm IPC Router */
+    AF_SMC                  = 43,	/* smc sockets: reserve number for PF_SMC protocol family that reuses AF_INET address family */
+    AF_XDP                  = 44,	/* XDP sockets */
+    AF_MCTP                 = 45,	/* Management component transport protocol */
+} socket_family_t;
+
+static inline const char* socket_family_to_str(socket_family_t family)
+{
+    switch (family)
+    {
+        case AF_LOCAL:
+            return "AF_LOCAL";
+        case AF_INET:
+            return "AF_INET";
+        case AF_AX25:
+            return "AF_AX25";
+        case AF_IPX:
+            return "AF_IPX";
+        case AF_APPLETALK:
+            return "AF_APPLETALK";
+        case AF_NETROM:
+            return "AF_NETROM";
+        case AF_BRIDGE:
+            return "AF_BRIDGE";
+        case AF_ATMPVC:
+            return "AF_ATMPVC";
+        case AF_X25:
+            return "AF_X25";
+        case AF_INET6:
+            return "AF_INET6";
+        case AF_ROSE:
+            return "AF_ROSE";
+        case AF_DECnet:
+            return "AF_DECnet";
+        case AF_NETBEUI:
+            return "AF_NETBEUI";
+        case AF_SECURITY:
+            return "AF_SECURITY";
+        case AF_KEY:
+            return "AF_KEY";
+        case AF_NETLINK:
+            return "AF_NETLINK";
+        case AF_PACKET:
+            return "AF_PACKET";
+        case AF_ASH:
+            return "AF_ASH";
+        case AF_ECONET:
+            return "AF_ECONET";
+        case AF_ATMSVC:
+            return "AF_ATMSVC";
+        case AF_RDS:
+            return "AF_RDS";
+        case AF_SNA:
+            return "AF_SNA";
+        case AF_IRDA:
+            return "AF_IRDA";
+        case AF_PPPOX:
+            return "AF_PPPOX";
+        case AF_WANPIPE:
+            return "AF_WANPIPE";
+        case AF_LLC:
+            return "AF_LLC";
+        case AF_IB:
+            return "AF_IB";
+        case AF_MPLS:
+            return "AF_MPLS";
+        case AF_CAN:
+            return "AF_CAN";
+        case AF_TIPC:
+            return "AF_TIPC";
+        case AF_BLUETOOTH:
+            return "AF_BLUETOOTH";
+        case AF_IUCV:
+            return "AF_IUCV";
+        case AF_RXRPC:
+            return "AF_RXRPC";
+        case AF_ISDN:
+            return "AF_ISDN";
+        case AF_PHONET:
+            return "AF_PHONET";
+        case AF_IEEE802154:
+            return "AF_IEEE802154";
+        case AF_CAIF:
+            return "AF_CAIF";
+        case AF_ALG:
+            return "AF_ALG";
+        case AF_NFC:
+            return "AF_NFC";
+        case AF_VSOCK:
+            return "AF_VSOCK";
+        case AF_KCM:
+            return "AF_KCM";
+        case AF_QIPCRTR:
+            return "AF_QIPCRTR";
+        case AF_SMC:
+            return "AF_SMC";
+        case AF_XDP:
+            return "AF_XDP";
+        case AF_MCTP:
+            return "AF_MCTP";
+    }
+    return NULL;
+}
+
+#endif

--- a/src/plugins/unixsocketmon/unixsocketmon.cpp
+++ b/src/plugins/unixsocketmon/unixsocketmon.cpp
@@ -1,0 +1,272 @@
+/*********************IMPORTANT DRAKVUF LICENSE TERMS***********************
+ *                                                                         *
+ * DRAKVUF (C) 2014-2022 Tamas K Lengyel.                                  *
+ * Tamas K Lengyel is hereinafter referred to as the author.               *
+ * This program is free software; you may redistribute and/or modify it    *
+ * under the terms of the GNU General Public License as published by the   *
+ * Free Software Foundation; Version 2 ("GPL"), BUT ONLY WITH ALL OF THE   *
+ * CLARIFICATIONS AND EXCEPTIONS DESCRIBED HEREIN.  This guarantees your   *
+ * right to use, modify, and redistribute this software under certain      *
+ * conditions.  If you wish to embed DRAKVUF technology into proprietary   *
+ * software, alternative licenses can be acquired from the author.         *
+ *                                                                         *
+ * Note that the GPL places important restrictions on "derivative works",  *
+ * yet it does not provide a detailed definition of that term.  To avoid   *
+ * misunderstandings, we interpret that term as broadly as copyright law   *
+ * allows.  For example, we consider an application to constitute a        *
+ * derivative work for the purpose of this license if it does any of the   *
+ * following with any software or content covered by this license          *
+ * ("Covered Software"):                                                   *
+ *                                                                         *
+ * o Integrates source code from Covered Software.                         *
+ *                                                                         *
+ * o Reads or includes copyrighted data files.                             *
+ *                                                                         *
+ * o Is designed specifically to execute Covered Software and parse the    *
+ * results (as opposed to typical shell or execution-menu apps, which will *
+ * execute anything you tell them to).                                     *
+ *                                                                         *
+ * o Includes Covered Software in a proprietary executable installer.  The *
+ * installers produced by InstallShield are an example of this.  Including *
+ * DRAKVUF with other software in compressed or archival form does not     *
+ * trigger this provision, provided appropriate open source decompression  *
+ * or de-archiving software is widely available for no charge.  For the    *
+ * purposes of this license, an installer is considered to include Covered *
+ * Software even if it actually retrieves a copy of Covered Software from  *
+ * another source during runtime (such as by downloading it from the       *
+ * Internet).                                                              *
+ *                                                                         *
+ * o Links (statically or dynamically) to a library which does any of the  *
+ * above.                                                                  *
+ *                                                                         *
+ * o Executes a helper program, module, or script to do any of the above.  *
+ *                                                                         *
+ * This list is not exclusive, but is meant to clarify our interpretation  *
+ * of derived works with some common examples.  Other people may interpret *
+ * the plain GPL differently, so we consider this a special exception to   *
+ * the GPL that we apply to Covered Software.  Works which meet any of     *
+ * these conditions must conform to all of the terms of this license,      *
+ * particularly including the GPL Section 3 requirements of providing      *
+ * source code and allowing free redistribution of the work as a whole.    *
+ *                                                                         *
+ * Any redistribution of Covered Software, including any derived works,    *
+ * must obey and carry forward all of the terms of this license, including *
+ * obeying all GPL rules and restrictions.  For example, source code of    *
+ * the whole work must be provided and free redistribution must be         *
+ * allowed.  All GPL references to "this License", are to be treated as    *
+ * including the terms and conditions of this license text as well.        *
+ *                                                                         *
+ * Because this license imposes special exceptions to the GPL, Covered     *
+ * Work may not be combined (even as part of a larger work) with plain GPL *
+ * software.  The terms, conditions, and exceptions of this license must   *
+ * be included as well.  This license is incompatible with some other open *
+ * source licenses as well.  In some cases we can relicense portions of    *
+ * DRAKVUF or grant special permissions to use it in other open source     *
+ * software.  Please contact tamas.k.lengyel@gmail.com with any such       *
+ * requests.  Similarly, we don't incorporate incompatible open source     *
+ * software into Covered Software without special permission from the      *
+ * copyright holders.                                                      *
+ *                                                                         *
+ * If you have any questions about the licensing restrictions on using     *
+ * DRAKVUF in other works, are happy to help.  As mentioned above,         *
+ * alternative license can be requested from the author to integrate       *
+ * DRAKVUF into proprietary applications and appliances.  Please email     *
+ * tamas.k.lengyel@gmail.com for further information.                      *
+ *                                                                         *
+ * If you have received a written license agreement or contract for        *
+ * Covered Software stating terms other than these, you may choose to use  *
+ * and redistribute Covered Software under those terms instead of these.   *
+ *                                                                         *
+ * Source is provided to this software because we believe users have a     *
+ * right to know exactly what a program is going to do before they run it. *
+ * This also allows you to audit the software for security holes.          *
+ *                                                                         *
+ * Source code also allows you to port DRAKVUF to new platforms, fix bugs, *
+ * and add new features.  You are highly encouraged to submit your changes *
+ * on https://github.com/tklengyel/drakvuf, or by other methods.           *
+ * By sending these changes, it is understood (unless you specify          *
+ * otherwise) that you are offering unlimited, non-exclusive right to      *
+ * reuse, modify, and relicense the code.  DRAKVUF will always be          *
+ * available Open Source, but this is important because the inability to   *
+ * relicense code has caused devastating problems for other Free Software  *
+ * projects (such as KDE and NASM).                                        *
+ * To specify special license conditions of your contributions, just say   *
+ * so when you send them.                                                  *
+ *                                                                         *
+ * This program is distributed in the hope that it will be useful, but     *
+ * WITHOUT ANY WARRANTY; without even the implied warranty of              *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the DRAKVUF   *
+ * license file for more details (it's in a COPYING file included with     *
+ * DRAKVUF, and also available from                                        *
+ * https://github.com/tklengyel/drakvuf/COPYING)                           *
+ *                                                                         *
+ ***************************************************************************/
+
+#include <libdrakvuf/libdrakvuf.h>
+#include <libvmi/libvmi.h>
+
+#include "unixsocketmon.h"
+#include "private.h"
+#include "plugins/output_format.h"
+
+bool unixsocketmon::get_socket_family_type(drakvuf_t drakvuf, drakvuf_trap_info_t* info, uint32_t* family_type)
+{
+    addr_t sock = drakvuf_get_function_argument(drakvuf, info, 1);
+
+    auto vmi = vmi_lock_guard(drakvuf);
+    ACCESS_CONTEXT(ctx,
+        .translate_mechanism = VMI_TM_PROCESS_DTB,
+        .dtb = info->regs->cr3,
+        .addr = sock + this->socket_ops
+    );
+
+    addr_t ops;
+    if (VMI_FAILURE == vmi_read_addr(vmi, &ctx, &ops))
+    {
+        PRINT_DEBUG("[UNIXSOCKETMON] Failed to read proto_ops from socket struct\n");
+        return false;
+    }
+
+    ctx.addr = ops + this->proto_ops_family;
+    if (VMI_FAILURE == vmi_read_32(vmi, &ctx, family_type))
+    {
+        PRINT_DEBUG("[UNIXSOCKETMON] Failed to get socket family type\n");
+        return false;
+    }
+
+    return true;
+}
+
+std::vector<uint8_t> unixsocketmon::get_socket_message(drakvuf_t drakvuf, drakvuf_trap_info_t* info, uint64_t* ret_size)
+{
+    addr_t msghdr = drakvuf_get_function_argument(drakvuf, info, 2);
+
+    auto vmi = vmi_lock_guard(drakvuf);
+    ACCESS_CONTEXT(ctx,
+        .translate_mechanism = VMI_TM_PROCESS_DTB,
+        .dtb = info->regs->cr3
+    );
+
+    addr_t iovec;
+    ctx.addr = msghdr + this->msghdr_msg_iter + this->iov_iter_iov;
+    if (VMI_FAILURE == vmi_read_addr(vmi, &ctx, &iovec))
+    {
+        PRINT_DEBUG("[UNIXSOCKETMON] Failed to get iovec from msghdr\n");
+        return {};
+    }
+
+    addr_t buf;
+    ctx.addr = iovec + this->iovec_iov_base;
+    if (VMI_FAILURE == vmi_read_addr(vmi, &ctx, &buf))
+    {
+        PRINT_DEBUG("[UNIXSOCKETMON] Failed to get buffer from iovec struct\n");
+        return {};
+    }
+
+    uint64_t size;
+    ctx.addr = iovec + this->iovec_iov_len;
+    if (VMI_FAILURE == vmi_read_64(vmi, &ctx, &size))
+    {
+        PRINT_DEBUG("[UNIXSOCKETMON] Failed to get size of buffer\n");
+        return {};
+    }
+
+    auto print_size = std::min(size, this->print_max_size);
+
+    std::vector<uint8_t> data(print_size, 0);
+    ctx.addr = buf;
+    size_t bytes_read;
+    if (VMI_FAILURE == vmi_read(vmi, &ctx, print_size, data.data(), &bytes_read))
+    {
+        PRINT_DEBUG("[UNIXSOCKETMON] Failed to read data\n");
+        return {};
+    }
+
+    data.resize(bytes_read);
+    if (ret_size) *ret_size = size;
+    return data;
+}
+
+event_response_t unixsocketmon::sock_send_msg_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
+{
+    uint32_t family_type;
+    if (!get_socket_family_type(drakvuf, info, &family_type))
+        return VMI_EVENT_RESPONSE_NONE;
+    auto socket_family_str = socket_family_to_str((socket_family_t)family_type);
+
+    uint64_t size = 0;
+    auto message = get_socket_message(drakvuf, info, &size);
+
+    unicode_string_t msg =
+    {
+        .length = message.size(),
+        .contents = message.data(),
+        .encoding = "UTF-8"
+    };
+
+    unicode_string_t out;
+    status_t rc = vmi_convert_str_encoding(&msg, &out, "UTF-8");
+
+    if (VMI_FAILURE == rc)
+    {
+        fmt::print(this->m_output_format, "unixsocketmon", drakvuf, info,
+            keyval("Type", fmt::Rstr(socket_family_str)),
+            keyval("Size", fmt::Nval(size)),
+            keyval("Value", fmt::BinaryString(message.data(), message.size()))
+        );
+    }
+    else
+    {
+        fmt::print(this->m_output_format, "unixsocketmon", drakvuf, info,
+            keyval("Type", fmt::Rstr(socket_family_str)),
+            keyval("Size", fmt::Nval(size)),
+            keyval("Value", fmt::Estr(reinterpret_cast<char*>(out.contents)))
+        );
+    }
+
+    g_free(out.contents);
+
+    return VMI_EVENT_RESPONSE_NONE;
+}
+
+unixsocketmon::unixsocketmon(drakvuf_t drakvuf, const unixsocketmon_config* config, output_format_t output)
+    :pluginex(drakvuf, output), print_max_size{config->print_max_size}
+{
+    if (!drakvuf_get_kernel_struct_member_rva(drakvuf, "socket", "ops", &socket_ops))
+    {
+        PRINT_DEBUG("[UNIXSOCKETMON] Failed to get struct member\n");
+        return;
+    }
+
+    if (!drakvuf_get_kernel_struct_member_rva(drakvuf, "proto_ops", "family", &proto_ops_family))
+    {
+        PRINT_DEBUG("[UNIXSOCKETMON] Failed to get proto_ops family\n");
+        return;
+    }
+
+    if (!drakvuf_get_kernel_struct_member_rva(drakvuf, "msghdr", "msg_iter", &msghdr_msg_iter))
+    {
+        PRINT_DEBUG("[UNIXSOCKETMON] Failed to get msg_iter\n");
+        return;
+    }
+
+    if (!drakvuf_get_kernel_struct_member_rva(drakvuf, "iov_iter", "iov", &iov_iter_iov))
+    {
+        PRINT_DEBUG("[UNIXSOCKETMON] Failed to get iov_iter\n");
+        return;
+    }
+
+    if (!drakvuf_get_kernel_struct_member_rva(drakvuf, "iovec", "iov_base", &iovec_iov_base))
+    {
+        PRINT_DEBUG("[UNIXSOCKETMON] Failed to get iov_base\n");
+        return;
+    }
+
+    if (!drakvuf_get_kernel_struct_member_rva(drakvuf, "iovec", "iov_len", &iovec_iov_len))
+    {
+        PRINT_DEBUG("[UNIXSOCKETMON] Failed to get iov_base\n");
+        return;
+    }
+
+    sockethook = createSyscallHook("sock_sendmsg", &unixsocketmon::sock_send_msg_cb);
+}

--- a/src/plugins/unixsocketmon/unixsocketmon.h
+++ b/src/plugins/unixsocketmon/unixsocketmon.h
@@ -1,0 +1,135 @@
+/*********************IMPORTANT DRAKVUF LICENSE TERMS***********************
+ *                                                                         *
+ * DRAKVUF (C) 2014-2022 Tamas K Lengyel.                                  *
+ * Tamas K Lengyel is hereinafter referred to as the author.               *
+ * This program is free software; you may redistribute and/or modify it    *
+ * under the terms of the GNU General Public License as published by the   *
+ * Free Software Foundation; Version 2 ("GPL"), BUT ONLY WITH ALL OF THE   *
+ * CLARIFICATIONS AND EXCEPTIONS DESCRIBED HEREIN.  This guarantees your   *
+ * right to use, modify, and redistribute this software under certain      *
+ * conditions.  If you wish to embed DRAKVUF technology into proprietary   *
+ * software, alternative licenses can be acquired from the author.         *
+ *                                                                         *
+ * Note that the GPL places important restrictions on "derivative works",  *
+ * yet it does not provide a detailed definition of that term.  To avoid   *
+ * misunderstandings, we interpret that term as broadly as copyright law   *
+ * allows.  For example, we consider an application to constitute a        *
+ * derivative work for the purpose of this license if it does any of the   *
+ * following with any software or content covered by this license          *
+ * ("Covered Software"):                                                   *
+ *                                                                         *
+ * o Integrates source code from Covered Software.                         *
+ *                                                                         *
+ * o Reads or includes copyrighted data files.                             *
+ *                                                                         *
+ * o Is designed specifically to execute Covered Software and parse the    *
+ * results (as opposed to typical shell or execution-menu apps, which will *
+ * execute anything you tell them to).                                     *
+ *                                                                         *
+ * o Includes Covered Software in a proprietary executable installer.  The *
+ * installers produced by InstallShield are an example of this.  Including *
+ * DRAKVUF with other software in compressed or archival form does not     *
+ * trigger this provision, provided appropriate open source decompression  *
+ * or de-archiving software is widely available for no charge.  For the    *
+ * purposes of this license, an installer is considered to include Covered *
+ * Software even if it actually retrieves a copy of Covered Software from  *
+ * another source during runtime (such as by downloading it from the       *
+ * Internet).                                                              *
+ *                                                                         *
+ * o Links (statically or dynamically) to a library which does any of the  *
+ * above.                                                                  *
+ *                                                                         *
+ * o Executes a helper program, module, or script to do any of the above.  *
+ *                                                                         *
+ * This list is not exclusive, but is meant to clarify our interpretation  *
+ * of derived works with some common examples.  Other people may interpret *
+ * the plain GPL differently, so we consider this a special exception to   *
+ * the GPL that we apply to Covered Software.  Works which meet any of     *
+ * these conditions must conform to all of the terms of this license,      *
+ * particularly including the GPL Section 3 requirements of providing      *
+ * source code and allowing free redistribution of the work as a whole.    *
+ *                                                                         *
+ * Any redistribution of Covered Software, including any derived works,    *
+ * must obey and carry forward all of the terms of this license, including *
+ * obeying all GPL rules and restrictions.  For example, source code of    *
+ * the whole work must be provided and free redistribution must be         *
+ * allowed.  All GPL references to "this License", are to be treated as    *
+ * including the terms and conditions of this license text as well.        *
+ *                                                                         *
+ * Because this license imposes special exceptions to the GPL, Covered     *
+ * Work may not be combined (even as part of a larger work) with plain GPL *
+ * software.  The terms, conditions, and exceptions of this license must   *
+ * be included as well.  This license is incompatible with some other open *
+ * source licenses as well.  In some cases we can relicense portions of    *
+ * DRAKVUF or grant special permissions to use it in other open source     *
+ * software.  Please contact tamas.k.lengyel@gmail.com with any such       *
+ * requests.  Similarly, we don't incorporate incompatible open source     *
+ * software into Covered Software without special permission from the      *
+ * copyright holders.                                                      *
+ *                                                                         *
+ * If you have any questions about the licensing restrictions on using     *
+ * DRAKVUF in other works, are happy to help.  As mentioned above,         *
+ * alternative license can be requested from the author to integrate       *
+ * DRAKVUF into proprietary applications and appliances.  Please email     *
+ * tamas.k.lengyel@gmail.com for further information.                      *
+ *                                                                         *
+ * If you have received a written license agreement or contract for        *
+ * Covered Software stating terms other than these, you may choose to use  *
+ * and redistribute Covered Software under those terms instead of these.   *
+ *                                                                         *
+ * Source is provided to this software because we believe users have a     *
+ * right to know exactly what a program is going to do before they run it. *
+ * This also allows you to audit the software for security holes.          *
+ *                                                                         *
+ * Source code also allows you to port DRAKVUF to new platforms, fix bugs, *
+ * and add new features.  You are highly encouraged to submit your changes *
+ * on https://github.com/tklengyel/drakvuf, or by other methods.           *
+ * By sending these changes, it is understood (unless you specify          *
+ * otherwise) that you are offering unlimited, non-exclusive right to      *
+ * reuse, modify, and relicense the code.  DRAKVUF will always be          *
+ * available Open Source, but this is important because the inability to   *
+* relicense code has caused devastating problems for other Free Software  *
+ * projects (such as KDE and NASM).                                        *
+ * To specify special license conditions of your contributions, just say   *
+ * so when you send them.                                                  *
+ *                                                                         *
+ * This program is distributed in the hope that it will be useful, but     *
+ * WITHOUT ANY WARRANTY; without even the implied warranty of              *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the DRAKVUF   *
+ * license file for more details (it's in a COPYING file included with     *
+ * DRAKVUF, and also available from                                        *
+ * https://github.com/tklengyel/drakvuf/COPYING)                           *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef UNIXSOCKETMON_H
+#define UNIXSOCKETMON_H
+
+#include "plugins/plugins_ex.h"
+#include "plugins/private.h"
+
+struct unixsocketmon_config
+{
+    uint64_t print_max_size;
+};
+
+class unixsocketmon: public pluginex
+{
+public:
+    uint64_t print_max_size;
+    addr_t socket_ops;
+    addr_t proto_ops_family;
+    addr_t msghdr_msg_iter;
+    addr_t iov_iter_iov;
+    addr_t iovec_iov_base;
+    addr_t iovec_iov_len;
+
+    std::unique_ptr<libhook::SyscallHook> sockethook;
+
+    unixsocketmon(drakvuf_t drakvuf, const unixsocketmon_config* config, output_format_t output);
+    event_response_t sock_send_msg_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
+    std::vector<uint8_t> get_socket_message(drakvuf_t drakvuf, drakvuf_trap_info_t* info, uint64_t* size);
+    bool get_socket_family_type(drakvuf_t drakvuf, drakvuf_trap_info_t* info, uint32_t* family_type);
+};
+
+#endif


### PR DESCRIPTION
Hi, we have prepared the `unixsocketmon` plugin.

The point is to receive events that pass through unix sockets.

This plugin is presented as an independent one, since its logic is slightly different from the one presented in `socketmon`, since there are various sockets, not only network ones.

A special feature is that you can receive events for "free" from the built-in utilities that are sent to the syslog daemon.
For example,
```json
{
    "Plugin": "unixsocketmon",
    "TimeStamp": "1664580052.366219",
    "PID": 1664,
    "PPID": 1396,
    "TID": 1664,
    "UserName": "UID",
    "UserId": 0,
    "ProcessName": "/usr/bin/sudo",
    "Method": "sock_sendmsg",
    "EventUID": "0x19",
    "Type": "AF_LOCAL",
    "Size": 111,
    "Value": "<85>Oct  1 02:20:52 sudo:    ubuntu: TTY=hvc0 ; PWD=/home/astra ; USER=root ; COMMAND=/usr/sbin/useradd -m test"
}
```

Since the plugin does not filter the content depending on the socket type (it is possible for now), we have added `BinaryString` to the output interface, since binary data is transmitted through network devices that can break the text output.

We also added the parameter `--unixsocketmon-max-print-size`, which limits the size of the output characters. It was noticed that sometimes very large data (about 32 KB) is transmitted through the `AF_LOCAL` socket, which has a bad effect on the output. Usually, this is not of interest, binary data.

Since network interaction also occurs through an intercepted function, it is planned to add parsing of `ip`, `port`, etc in the future as in the `socketmon` plugin.

The plugin allows you to receive the sent data for "free". For example:
```json
{
    "Plugin": "unixsocketmon",
    "TimeStamp": "1664580548.709174",
    "PID": 1835,
    "PPID": 1396,
    "TID": 1835,
    "UserName": "UID",
    "UserId": 1000,
    "ProcessName": "/usr/bin/curl",
    "Method": "sock_sendmsg",
    "EventUID": "0x158",
    "Type": "AF_INET",
    "Size": 74,
    "Value": "GET / HTTP/1.1\r\nHost: google.com\r\nUser-Agent: curl/7.52.1\r\nAccept: */*\r\n\r\n"
}
```

Special thanks to @disaykin  for his help with adding parameters to drakvuf, finding edge cases and helping to develop this plugin.
Special thanks to Nikolay Batenkin for his help with adding `BinaryString` formatting.