### PR TITLE
 C++ wrapper to use memory access traps 

### DIFF
--- a/src/plugins/plugins_ex.h
+++ b/src/plugins/plugins_ex.h
@@ -384,9 +384,9 @@ struct memaccess_trap
 
     drakvuf_trap_t* operator()(drakvuf_t drakvuf, drakvuf_trap_info_t* info, drakvuf_trap_t* trap) const
     {
-        if(trap)
+        if (trap)
         {
-            if(access == VMI_MEMACCESS_INVALID)
+            if (access == VMI_MEMACCESS_INVALID)
                 return nullptr;
 
             trap->type = MEMACCESS;


### PR DESCRIPTION
Drakvuf enables the use of breakpoints with the drakvuf_add_breakpoint function. In order to make this function easier to use by C++ plugins, multiple wrappers are available in plugin_ex.h. However, these wrappers lack the possibility of putting traps of type MEMACCESS.
This pull request :
- removes the default trap type value ;
- sets the trap type value inside each existing wrapper ;
- adds a new wrapper that puts a trap with type MEMACCESS to a GFN.