### PR TITLE
Add the VAD node address to mmvad_info_t struct

### DIFF
--- a/src/libdrakvuf/libdrakvuf.h
+++ b/src/libdrakvuf/libdrakvuf.h
@@ -538,6 +538,7 @@ typedef struct _mmvad_info
     addr_t file_name_ptr;
     uint32_t total_number_of_ptes;
     addr_t prototype_pte;
+    addr_t node_addr;
 } mmvad_info_t;
 
 typedef bool (*mmvad_callback)(drakvuf_t drakvuf, mmvad_info_t* mmvad, void* callback_data);

--- a/src/libdrakvuf/win-processes.c
+++ b/src/libdrakvuf/win-processes.c
@@ -1561,6 +1561,7 @@ bool win_find_mmvad(drakvuf_t drakvuf, addr_t eprocess, addr_t vaddr, mmvad_info
             uint32_t flags1 = 0;
 
             out_mmvad->file_name_ptr = 0;
+            out_mmvad->node_addr = node_addr;
 
             if (is_win7)
             {
@@ -1691,6 +1692,7 @@ static bool win_traverse_mmvad_node(drakvuf_t drakvuf, addr_t node_addr, mmvad_c
     mmvad.file_name_ptr = 0;
     mmvad.total_number_of_ptes = 0;
     mmvad.prototype_pte = 0;
+    mmvad.node_addr = node_addr;
 
     if (is_win7)
     {


### PR DESCRIPTION
Sometimes, plugins need to access information about a VAD node that is not exposed in the `mmvad_info_t` structure (in my own case, subsection address). 

One way to make additional information available without adding every possible attribute as `mmvad_info_t` fields is to make the VAD address public. Then, a plugin can load and parse the VAD node itself.