### PR TITLE
filetracer: fix flags parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,7 @@ stamp-h1
 # check unit tests files
 **/*.log
 **/*.trs
-check
+*check
 
 # drakvuf binaries
 drakvuf

--- a/src/plugins/Makefile.am
+++ b/src/plugins/Makefile.am
@@ -449,6 +449,11 @@ AM_DEFAULT_SOURCE_EXT = .cpp
 
 check_PROGRAMS =
 
+check_PROGRAMS += plugin_utils_check
+plugin_utils_check_SOURCES = plugin_utils_check.cpp
+plugin_utils_check_CFLAGS = $(CHECK_CFLAGS)
+plugin_utils_check_LDADD = $(CHECK_LIBS) plugin_utils.lo
+
 if PLUGIN_PROCMON
 check_PROGRAMS += procmon/check
 procmon_check_SOURCES = procmon/check.cpp

--- a/src/plugins/filetracer/win.cpp
+++ b/src/plugins/filetracer/win.cpp
@@ -355,9 +355,9 @@ static void print_basic_file_info(vmi_instance_t vmi, drakvuf_t drakvuf, drakvuf
     if ( VMI_FAILURE == vmi_read_addr(vmi, &ctx, &change) )
         return;
 
-    uint64_t attributes = 0;
+    uint32_t attributes = 0;
     ctx.addr = fileinfo + f->basic_attributes_offset;
-    if ( VMI_FAILURE == vmi_read_addr(vmi, &ctx, &attributes) )
+    if ( VMI_FAILURE == vmi_read_32(vmi, &ctx, &attributes) )
         return;
 
     char* filename_ = drakvuf_get_filename_from_handle(drakvuf, info, src_file_handle);

--- a/src/plugins/plugin_utils_check.cpp
+++ b/src/plugins/plugin_utils_check.cpp
@@ -1,0 +1,182 @@
+/*********************IMPORTANT DRAKVUF LICENSE TERMS***********************
+ *                                                                         *
+ * DRAKVUF (C) 2014-2022 Tamas K Lengyel.                                  *
+ * Tamas K Lengyel is hereinafter referred to as the author.               *
+ * This program is free software; you may redistribute and/or modify it    *
+ * under the terms of the GNU General Public License as published by the   *
+ * Free Software Foundation; Version 2 ("GPL"), BUT ONLY WITH ALL OF THE   *
+ * CLARIFICATIONS AND EXCEPTIONS DESCRIBED HEREIN.  This guarantees your   *
+ * right to use, modify, and redistribute this software under certain      *
+ * conditions.  If you wish to embed DRAKVUF technology into proprietary   *
+ * software, alternative licenses can be acquired from the author.         *
+ *                                                                         *
+ * Note that the GPL places important restrictions on "derivative works",  *
+ * yet it does not provide a detailed definition of that term.  To avoid   *
+ * misunderstandings, we interpret that term as broadly as copyright law   *
+ * allows.  For example, we consider an application to constitute a        *
+ * derivative work for the purpose of this license if it does any of the   *
+ * following with any software or content covered by this license          *
+ * ("Covered Software"):                                                   *
+ *                                                                         *
+ * o Integrates source code from Covered Software.                         *
+ *                                                                         *
+ * o Reads or includes copyrighted data files.                             *
+ *                                                                         *
+ * o Is designed specifically to execute Covered Software and parse the    *
+ * results (as opposed to typical shell or execution-menu apps, which will *
+ * execute anything you tell them to).                                     *
+ *                                                                         *
+ * o Includes Covered Software in a proprietary executable installer.  The *
+ * installers produced by InstallShield are an example of this.  Including *
+ * DRAKVUF with other software in compressed or archival form does not     *
+ * trigger this provision, provided appropriate open source decompression  *
+ * or de-archiving software is widely available for no charge.  For the    *
+ * purposes of this license, an installer is considered to include Covered *
+ * Software even if it actually retrieves a copy of Covered Software from  *
+ * another source during runtime (such as by downloading it from the       *
+ * Internet).                                                              *
+ *                                                                         *
+ * o Links (statically or dynamically) to a library which does any of the  *
+ * above.                                                                  *
+ *                                                                         *
+ * o Executes a helper program, module, or script to do any of the above.  *
+ *                                                                         *
+ * This list is not exclusive, but is meant to clarify our interpretation  *
+ * of derived works with some common examples.  Other people may interpret *
+ * the plain GPL differently, so we consider this a special exception to   *
+ * the GPL that we apply to Covered Software.  Works which meet any of     *
+ * these conditions must conform to all of the terms of this license,      *
+ * particularly including the GPL Section 3 requirements of providing      *
+ * source code and allowing free redistribution of the work as a whole.    *
+ *                                                                         *
+ * Any redistribution of Covered Software, including any derived works,    *
+ * must obey and carry forward all of the terms of this license, including *
+ * obeying all GPL rules and restrictions.  For example, source code of    *
+ * the whole work must be provided and free redistribution must be         *
+ * allowed.  All GPL references to "this License", are to be treated as    *
+ * including the terms and conditions of this license text as well.        *
+ *                                                                         *
+ * Because this license imposes special exceptions to the GPL, Covered     *
+ * Work may not be combined (even as part of a larger work) with plain GPL *
+ * software.  The terms, conditions, and exceptions of this license must   *
+ * be included as well.  This license is incompatible with some other open *
+ * source licenses as well.  In some cases we can relicense portions of    *
+ * DRAKVUF or grant special permissions to use it in other open source     *
+ * software.  Please contact tamas.k.lengyel@gmail.com with any such       *
+ * requests.  Similarly, we don't incorporate incompatible open source     *
+ * software into Covered Software without special permission from the      *
+ * copyright holders.                                                      *
+ *                                                                         *
+ * If you have any questions about the licensing restrictions on using     *
+ * DRAKVUF in other works, are happy to help.  As mentioned above,         *
+ * alternative license can be requested from the author to integrate       *
+ * DRAKVUF into proprietary applications and appliances.  Please email     *
+ * tamas.k.lengyel@gmail.com for further information.                      *
+ *                                                                         *
+ * If you have received a written license agreement or contract for        *
+ * Covered Software stating terms other than these, you may choose to use  *
+ * and redistribute Covered Software under those terms instead of these.   *
+ *                                                                         *
+ * Source is provided to this software because we believe users have a     *
+ * right to know exactly what a program is going to do before they run it. *
+ * This also allows you to audit the software for security holes.          *
+ *                                                                         *
+ * Source code also allows you to port DRAKVUF to new platforms, fix bugs, *
+ * and add new features.  You are highly encouraged to submit your changes *
+ * on https://github.com/tklengyel/drakvuf, or by other methods.           *
+ * By sending these changes, it is understood (unless you specify          *
+ * otherwise) that you are offering unlimited, non-exclusive right to      *
+ * reuse, modify, and relicense the code.  DRAKVUF will always be          *
+ * available Open Source, but this is important because the inability to   *
+ * relicense code has caused devastating problems for other Free Software  *
+ * projects (such as KDE and NASM).                                        *
+ * To specify special license conditions of your contributions, just say   *
+ * so when you send them.                                                  *
+ *                                                                         *
+ * This program is distributed in the hope that it will be useful, but     *
+ * WITHOUT ANY WARRANTY; without even the implied warranty of              *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the DRAKVUF   *
+ * license file for more details (it's in a COPYING file included with     *
+ * DRAKVUF, and also available from                                        *
+ * https://github.com/tklengyel/drakvuf/COPYING)                           *
+ *                                                                         *
+ ***************************************************************************/
+
+#include <check.h>
+
+#include "plugin_utils.h"
+
+enum
+{
+    ATTRIBUTE_1 = 0x00000001,
+    ATTRIBUTE_2 = 0x00000002,
+    ATTRIBUTE_3 = 0x00000004,
+};
+
+static const flags_str_t flags_and_attrs =
+{
+    REGISTER_FLAG(ATTRIBUTE_1),
+    REGISTER_FLAG(ATTRIBUTE_2),
+    REGISTER_FLAG(ATTRIBUTE_3),
+};
+
+START_TEST(test_parse_one_flag)
+{
+    ck_assert(parse_flags(ATTRIBUTE_1, flags_and_attrs, OUTPUT_KV) == std::string("ATTRIBUTE_1=1"));
+    ck_assert(parse_flags(ATTRIBUTE_2, flags_and_attrs, OUTPUT_KV) == std::string("ATTRIBUTE_2=1"));
+    ck_assert(parse_flags(ATTRIBUTE_3, flags_and_attrs, OUTPUT_KV) == std::string("ATTRIBUTE_3=1"));
+}
+END_TEST
+
+START_TEST(test_parse_two_flags)
+{
+    ck_assert(parse_flags(ATTRIBUTE_1 | ATTRIBUTE_2, flags_and_attrs, OUTPUT_KV) == std::string("ATTRIBUTE_1=1,ATTRIBUTE_2=1"));
+}
+END_TEST
+
+START_TEST(test_parse_three_flags)
+{
+    ck_assert(parse_flags(ATTRIBUTE_1 | ATTRIBUTE_2 | ATTRIBUTE_3, flags_and_attrs, OUTPUT_KV) == std::string("ATTRIBUTE_1=1,ATTRIBUTE_2=1,ATTRIBUTE_3=1"));
+}
+END_TEST
+
+START_TEST(test_parse_64bit_flags)
+{
+    uint64_t flags = 0xffffffff00000000 | ATTRIBUTE_1 | ATTRIBUTE_2 | ATTRIBUTE_3;
+    ck_assert(parse_flags(flags, flags_and_attrs, OUTPUT_KV) == std::string("ATTRIBUTE_1=1,ATTRIBUTE_2=1,ATTRIBUTE_3=1"));
+}
+END_TEST
+
+Suite* parse_flags_suite(void)
+{
+    Suite* s;
+    TCase* tc_core;
+
+    s = suite_create("Stringify bit flags");
+
+    /* Core test case */
+    tc_core = tcase_create("Core");
+
+    tcase_add_test(tc_core, test_parse_one_flag);
+    tcase_add_test(tc_core, test_parse_two_flags);
+    tcase_add_test(tc_core, test_parse_three_flags);
+    tcase_add_test(tc_core, test_parse_64bit_flags);
+    suite_add_tcase(s, tc_core);
+
+    return s;
+}
+
+int main(void)
+{
+    int number_failed;
+    Suite* s;
+    SRunner* sr;
+
+    s = parse_flags_suite();
+    sr = srunner_create(s);
+
+    srunner_run_all(sr, CK_NORMAL);
+    number_failed = srunner_ntests_failed(sr);
+    srunner_free(sr);
+    return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}


### PR DESCRIPTION
`FileAttributes` field is `ULONG`. Thus 32 bit only. But with `Windows x64` `vmi_read_addr` reads 64 bit. Thus fix this.

Also add new unit test.