### PR TITLE
filetracer: fix heap overflow

### DIFF
--- a/src/plugins/filetracer/win_acl.cpp
+++ b/src/plugins/filetracer/win_acl.cpp
@@ -558,7 +558,8 @@ string read_acl(vmi_instance_t vmi, access_context_t* ctx, size_t* offsets, stri
             break;
     }
 
-    while (ace_ptr < aces.get() + aces_size)
+    size_t aces_read = 0;
+    while (ace_ptr < aces.get() + aces_size && aces_read < ace_count)
     {
         auto header = reinterpret_cast<const struct ACE_HEADER*>(ace_ptr);
         auto ace_size = static_cast<size_t>(header->size);
@@ -629,6 +630,7 @@ string read_acl(vmi_instance_t vmi, access_context_t* ctx, size_t* offsets, stri
         }
 
         ace_ptr += ace_size;
+        aces_read += 1;
     }
 
     // manual work done, may arise issues


### PR DESCRIPTION
This fixes heap overflow while reading ACL/ACE structures in filetracer.