### PR TITLE
cppcheck: fix some defects found by new cppcheck

### DIFF
--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -4,11 +4,12 @@ on:
     branches: [ master ]
 jobs:
   cppcheck:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: cppcheck
         run: |
           sudo apt-get update -q
           sudo apt-get install -y cppcheck
-          cppcheck --error-exitcode=1 --force --language=c++ ./src
+          git submodule update --init --recursive libvmi
+          cppcheck --error-exitcode=1 --force -Ilibvmi --include=libvmi/libvmi/libvmi.h ./src

--- a/src/drakvuf.cpp
+++ b/src/drakvuf.cpp
@@ -253,7 +253,7 @@ drakvuf_c::~drakvuf_c()
     if ( !interrupted )
         interrupt(SIGDRAKVUFERROR);
 
-    injector_free(drakvuf, injector_to_be_freed);
+    injector_free_win(injector_to_be_freed);
 
     delete plugins;
 

--- a/src/libdrakvuf/linux-exports.c
+++ b/src/libdrakvuf/linux-exports.c
@@ -355,7 +355,6 @@ next:
 
     // Mapping symbol name to address in dynsym table
 
-    addr_t value;
     offset = dynsym_offset;
     while (true)
     {
@@ -364,16 +363,16 @@ next:
         if (VMI_FAILURE == vmi_read_32(vmi, &ctx, &key))
             return -1;
 
+        addr_t value = 0;
         ctx.addr =  offset + drakvuf->offsets[ELF64SYM_VALUE];
         if (VMI_FAILURE == vmi_read_addr(vmi, &ctx, &value))
             return -1;
 
         if (key == symbol_offset)
-            break;
+            return text_segment_address + value;
 
         offset += dynsym_entry_size;
     }
-    return text_segment_address + value;
 }
 
 addr_t get_lib_address(drakvuf_t drakvuf, addr_t eprocess_base, const char* lib)

--- a/src/libinjector/Makefile.am
+++ b/src/libinjector/Makefile.am
@@ -106,7 +106,7 @@ h_sources = libinjector.h private.h debug_helpers.h injector_utils.h \
 	win/win_private.h win/win_injector.h win/win_utils.h win/win_functions.h \
 	win/method_helpers.h win/methods/win_read_file.h win/methods/win_write_file.h win/methods/win_createproc.h \
 	win/methods/win_shellexec.h win/methods/win_shellcode.h win/methods/win_terminate.h win/methods/win_exitthread.h \
-	linux/linux_injector.h linux/linux_utils.h linux/linux_syscalls.h \
+	linux/linux_private.h linux/linux_injector.h linux/linux_utils.h linux/linux_syscalls.h \
 	linux/methods/linux_shellcode.h linux/methods/linux_write_file.h linux/methods/linux_read_file.h linux/methods/linux_execve.h
 c_sources = injector.c  injector_stack.c debug_helpers.c injector_utils.c \
 	win/win_injector.c win/win_utils.c win/win_functions.c \

--- a/src/libinjector/injector_utils.c
+++ b/src/libinjector/injector_utils.c
@@ -106,24 +106,14 @@
 
 #include <assert.h>
 
-// a dummy stub which should be compatible with the extended definitions of win_injector as well as linux_injector
-// since c doesn't support inheritance, this is how it is being done for now ¯\_(ツ)_/¯
-// NOTE: sync the variables with linux and windows injector if this stub is updated
-struct injector
-{
-    injector_step_t step;
-    bool step_override;
-    bool set_gprs_only;
-};
-
-event_response_t override_step(injector_t injector, const injector_step_t step, event_response_t event)
+event_response_t override_step(base_injector_t injector, const injector_step_t step, event_response_t event)
 {
     injector->step_override = true;
     injector->step = step;
     return event;
 }
 
-void fall_through_step(injector_t injector, const injector_step_t step)
+void fall_through_step(base_injector_t injector, const injector_step_t step)
 {
     injector->step = step;
 }
@@ -135,10 +125,8 @@ void fall_through_step(injector_t injector, const injector_step_t step)
 // would point to KPCR of vCPU0.
 // Hence, the safe way is to only modify the general purpose registers
 // which won't affect the kernel structures
-event_response_t handle_gprs_registers(drakvuf_t drakvuf, drakvuf_trap_info_t* info, event_response_t event)
+event_response_t handle_gprs_registers(drakvuf_t drakvuf, drakvuf_trap_info_t* info, base_injector_t injector, event_response_t event)
 {
-    injector_t injector = info->trap->data;
-
     if (injector->set_gprs_only && event == VMI_EVENT_RESPONSE_SET_REGISTERS)
     {
         vmi_instance_t vmi = drakvuf_lock_and_get_vmi(drakvuf);

--- a/src/libinjector/injector_utils.h
+++ b/src/libinjector/injector_utils.h
@@ -108,7 +108,15 @@
 #include <libdrakvuf/libdrakvuf.h>
 #include <libinjector/private.h>
 
-event_response_t override_step(injector_t injector, const injector_step_t step, event_response_t event);
-void fall_through_step(injector_t injector, const injector_step_t step);
-event_response_t handle_gprs_registers(drakvuf_t drakvuf, drakvuf_trap_info_t* info, event_response_t event);
+struct base_injector
+{
+    injector_step_t step;
+    bool step_override;
+    bool set_gprs_only;
+};
+typedef struct base_injector* base_injector_t;
+
+event_response_t override_step(base_injector_t injector, const injector_step_t step, event_response_t event);
+void fall_through_step(base_injector_t injector, const injector_step_t step);
+event_response_t handle_gprs_registers(drakvuf_t drakvuf, drakvuf_trap_info_t* info, base_injector_t injector, event_response_t event);
 #endif

--- a/src/libinjector/libinjector.h
+++ b/src/libinjector/libinjector.h
@@ -275,7 +275,7 @@ void injector_exitthread(drakvuf_t drakvuf,
     uint32_t injection_tid);
 
 
-void injector_free(drakvuf_t drakvuf, injector_t injector);
+void injector_free_win(injector_t injector);
 
 const char* injection_method_name(injection_method_t method);
 

--- a/src/libinjector/linux/linux_private.h
+++ b/src/libinjector/linux/linux_private.h
@@ -102,112 +102,12 @@
  *                                                                         *
  ***************************************************************************/
 
-#include "libinjector.h"
-#include "private.h"
-#include "win/win_utils.h"
-#include "linux/linux_utils.h"
 
-injector_status_t injector_start_app(
-    drakvuf_t drakvuf,
-    vmi_pid_t pid,
-    uint32_t tid,
-    const char* app,
-    const char* cwd,
-    injection_method_t method,
-    output_format_t format,
-    const char* binary_path,
-    const char* target_process,
-    bool break_loop_on_detection,
-    injector_t* injector_to_be_freed,
-    bool global_search,
-    bool wait_for_exit,
-    int args_count,
-    const char* args[],
-    vmi_pid_t* injected_pid)
-{
-    if (drakvuf_get_os_type(drakvuf) == VMI_OS_WINDOWS)
-    {
-        return injector_start_app_on_win(drakvuf,
-                pid,
-                tid,
-                app,
-                cwd,
-                method,
-                format,
-                binary_path,
-                target_process,
-                break_loop_on_detection,
-                injector_to_be_freed,
-                global_search,
-                wait_for_exit,
-                injected_pid);
-    }
-    else if (drakvuf_get_os_type(drakvuf) == VMI_OS_LINUX)
-    {
-        if (!tid)
-            tid = pid;
+#ifndef LINUX_PRIVATE_H
+#define LINUX_PRIVATE_H
 
-        return injector_start_app_on_linux(drakvuf,
-                pid,
-                tid,
-                app,
-                method,
-                format,
-                binary_path,
-                args_count,
-                args,
-                injected_pid);
-    }
-    else
-    {
-        PRINT_DEBUG("WARNING Unsupported OS!\n");
-        return 0;
-    }
-}
+// syscall limit for error codes
+#define MAX_ERRNO 4096UL
+#define FILE_BUF_SIZE 65536UL
 
-void injector_terminate(drakvuf_t drakvuf,
-    vmi_pid_t injection_pid,
-    uint32_t injection_tid,
-    vmi_pid_t pid)
-{
-    if (drakvuf_get_os_type(drakvuf) == VMI_OS_WINDOWS)
-        injector_terminate_on_win(drakvuf, injection_pid, injection_tid, pid);
-    else
-        PRINT_DEBUG("WARNING Unsupported OS!\n");
-}
-
-void injector_exitthread(drakvuf_t drakvuf,
-    vmi_pid_t injection_pid,
-    uint32_t injection_tid)
-{
-    if (drakvuf_get_os_type(drakvuf) == VMI_OS_WINDOWS)
-        injector_exitthread_on_win(drakvuf, injection_pid, injection_tid);
-    else
-        PRINT_DEBUG("WARNING Unsupported OS!\n");
-}
-
-const char* injection_method_name(injection_method_t method)
-{
-    switch (method)
-    {
-        case INJECT_METHOD_CREATEPROC:
-            return "CreateProc";
-        case INJECT_METHOD_TERMINATEPROC:
-            return "TerminateProc";
-        case INJECT_METHOD_EXITTHREAD:
-            return "ExitThread";
-        case INJECT_METHOD_SHELLEXEC:
-            return "ShellExec";
-        case INJECT_METHOD_SHELLCODE:
-            return "Shellcode";
-        case INJECT_METHOD_READ_FILE:
-            return "ReadFile";
-        case INJECT_METHOD_WRITE_FILE:
-            return "WriteFile";
-        case INJECT_METHOD_EXECPROC:
-            return "ExecProc";
-        case __INJECT_METHOD_MAX:
-            break;
-    }
-    return "Unknown";
-}
+#endif

--- a/src/libinjector/linux/linux_syscalls.h
+++ b/src/libinjector/linux/linux_syscalls.h
@@ -113,23 +113,23 @@
 // use this in STEP1 for initializing the syscalls
 bool init_syscalls(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
 
-bool setup_mmap_syscall(injector_t injector, x86_registers_t* regs, size_t size);
-bool setup_open_syscall(injector_t injector, x86_registers_t* regs,
+bool setup_mmap_syscall(linux_injector_t injector, x86_registers_t* regs, size_t size);
+bool setup_open_syscall(linux_injector_t injector, x86_registers_t* regs,
     const char* target_file, int flags, int mode);
-bool setup_close_syscall(injector_t injector, x86_registers_t* regs, int fd);
-bool setup_write_syscall(injector_t injector, x86_registers_t* regs,
+bool setup_close_syscall(linux_injector_t injector, x86_registers_t* regs, int fd);
+bool setup_write_syscall(linux_injector_t injector, x86_registers_t* regs,
     int fd, addr_t buffer_addr, size_t amount);
-bool setup_read_syscall(injector_t injector, x86_registers_t* regs,
+bool setup_read_syscall(linux_injector_t injector, x86_registers_t* regs,
     int fd, addr_t buffer_addr, size_t amount);
-bool setup_exit_syscall(injector_t injector, x86_registers_t* regs, uint64_t rc);
+bool setup_exit_syscall(linux_injector_t injector, x86_registers_t* regs, uint64_t rc);
 // note: void return type for vfork syscall
-void setup_vfork_syscall(injector_t injector, x86_registers_t* regs, char* proc_name, vmi_pid_t parent_pid);
-bool setup_execve_syscall(injector_t injector, x86_registers_t* regs, const char* binary_file, const GHashTable* environ);
+void setup_vfork_syscall(linux_injector_t injector, x86_registers_t* regs, char* proc_name, vmi_pid_t parent_pid);
+bool setup_execve_syscall(linux_injector_t injector, x86_registers_t* regs, const char* binary_file, const GHashTable* environ);
 
-bool call_read_syscall_cb(injector_t injector, x86_registers_t* regs);
-bool call_vfork_syscall_cb(injector_t injector, x86_registers_t* regs, vmi_pid_t pid, uint32_t tid);
-bool call_write_syscall_cb(injector_t injector, x86_registers_t* regs);
-bool call_open_syscall_cb(injector_t injector, x86_registers_t* regs);
-bool call_mmap_syscall_cb(injector_t injector, x86_registers_t* regs, size_t size);
+bool call_read_syscall_cb(linux_injector_t injector, x86_registers_t* regs);
+bool call_vfork_syscall_cb(linux_injector_t injector, x86_registers_t* regs, vmi_pid_t pid, uint32_t tid);
+bool call_write_syscall_cb(linux_injector_t injector, x86_registers_t* regs);
+bool call_open_syscall_cb(linux_injector_t injector, x86_registers_t* regs);
+bool call_mmap_syscall_cb(linux_injector_t injector, x86_registers_t* regs, size_t size);
 
 #endif

--- a/src/libinjector/linux/linux_utils.c
+++ b/src/libinjector/linux/linux_utils.c
@@ -109,6 +109,7 @@
 #include <libinjector/debug_helpers.h>
 
 #include "linux_injector.h"
+#include "linux_private.h"
 #include <sys/mman.h>
 #include <fcntl.h>
 
@@ -209,7 +210,7 @@ addr_t find_syscall(drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t vdso)
         return 0;
     }
     syscall_offset = syscall_substring_address - vdso_memory;
-    injector_t injector = info->trap->data;
+    linux_injector_t injector = info->trap->data;
     injector->syscall_addr = vdso + syscall_offset;
 
     PRINT_DEBUG("syscall offset: %d\n", syscall_offset);
@@ -221,7 +222,7 @@ addr_t find_syscall(drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t vdso)
 
 bool setup_post_syscall_trap(drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t syscall_addr)
 {
-    injector_t injector = info->trap->data;
+    linux_injector_t injector = info->trap->data;
 
     injector->bp = g_malloc0(sizeof(drakvuf_trap_t));
 
@@ -271,13 +272,13 @@ bool save_rip_for_ret(drakvuf_t drakvuf, x86_registers_t* regs)
     return success;
 }
 
-void free_bp_trap(drakvuf_t drakvuf, injector_t injector, drakvuf_trap_t* trap)
+void free_bp_trap(drakvuf_t drakvuf, linux_injector_t injector, drakvuf_trap_t* trap)
 {
     drakvuf_remove_trap(drakvuf, trap, (drakvuf_trap_free_t)g_free);
     injector->bp = NULL;
 }
 
-void injector_free_linux(injector_t injector)
+void injector_free_linux(linux_injector_t injector)
 {
     if (!injector) return;
 
@@ -307,7 +308,7 @@ bool is_syscall_error(addr_t rax, const char* err)
     return false;
 }
 
-void print_linux_injection_info(output_format_t format, injector_t injector)
+void print_linux_injection_info(output_format_t format, linux_injector_t injector)
 {
     const char* process_name = injector->host_file;
     gchar* arguments = g_strjoinv(" ", (gchar**)injector->args);
@@ -320,7 +321,7 @@ void print_linux_injection_info(output_format_t format, injector_t injector)
     g_free(arguments);
 }
 
-GHashTable* get_injection_environ(injector_t injector, drakvuf_trap_info_t* info)
+GHashTable* get_injection_environ(linux_injector_t injector, drakvuf_trap_info_t* info)
 {
     GHashTable* env = NULL; // process "__environ" contents
 

--- a/src/libinjector/linux/linux_utils.h
+++ b/src/libinjector/linux/linux_utils.h
@@ -125,10 +125,6 @@
 #include <libinjector/private.h>
 #include "injector_utils.h"
 
-// syscall limit for error codes
-#define MAX_ERRNO 4096UL
-#define FILE_BUF_SIZE 65536UL
-
 typedef enum
 {
     sys_read = 0,
@@ -145,13 +141,9 @@ typedef enum
     sys_kill = 62,
 } syscall_t;
 
-struct injector
+struct linux_injector
 {
-    // common in win and linux
-    // KEEP THESE IN TOP and in sync with the order in injector_utils.c
-    injector_step_t step;
-    bool step_override; // set this as true for jumping to some arbitrary step
-    bool dummy; // set_gprs_only
+    struct base_injector base_injector;
 
     // Inputs:
     vmi_pid_t target_pid;
@@ -204,17 +196,17 @@ struct injector
 
     uint32_t pid, tid;
 };
+typedef struct linux_injector* linux_injector_t;
 
-void free_bp_trap(drakvuf_t drakvuf, injector_t injector, drakvuf_trap_t* trap);
-void injector_free_linux(injector_t injector);
+void free_bp_trap(drakvuf_t drakvuf, linux_injector_t injector, drakvuf_trap_t* trap);
+void injector_free_linux(linux_injector_t injector);
 bool save_rip_for_ret(drakvuf_t drakvuf, x86_registers_t* regs);
 addr_t find_vdso(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
 addr_t find_syscall(drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t vdso);
 bool setup_post_syscall_trap(drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t syscall_addr);
-event_response_t override_step(injector_t injector, const injector_step_t step, event_response_t event);
 bool is_syscall_error(addr_t rax, const char* err);
-void print_linux_injection_info(output_format_t format, injector_t injector);
+void print_linux_injection_info(output_format_t format, linux_injector_t injector);
 
-GHashTable* get_injection_environ(injector_t injector, drakvuf_trap_info_t* info);
+GHashTable* get_injection_environ(linux_injector_t injector, drakvuf_trap_info_t* info);
 
 #endif

--- a/src/libinjector/linux/methods/linux_read_file.c
+++ b/src/libinjector/linux/methods/linux_read_file.c
@@ -111,11 +111,12 @@
 
 #include "linux_read_file.h"
 #include "linux_syscalls.h"
+#include "linux_private.h"
 
 static event_response_t cleanup(drakvuf_t drakvuf, drakvuf_trap_info_t* info, bool clear_trap);
 static bool write_buffer_to_file(drakvuf_t drakvuf, drakvuf_trap_info_t* info, int amount);
 
-bool init_read_file_method(injector_t injector, const char* file)
+bool init_read_file_method(linux_injector_t injector, const char* file)
 {
     FILE* fp = fopen(file, "wb");
     if (!fp)
@@ -167,11 +168,10 @@ bool init_read_file_method(injector_t injector, const char* file)
  */
 event_response_t handle_read_file(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 {
-    injector_t injector = (injector_t)info->trap->data;
+    linux_injector_t injector = (linux_injector_t)info->trap->data;
+    base_injector_t base_injector = &injector->base_injector;
 
-    event_response_t event;
-
-    switch (injector->step)
+    switch (base_injector->step)
     {
         case STEP1: // Finds vdso and sets up mmap
         {
@@ -186,9 +186,7 @@ event_response_t handle_read_file(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
             if (!setup_mmap_syscall(injector, info->regs, FILE_BUF_SIZE))
                 return cleanup(drakvuf, info, false);
 
-            event = VMI_EVENT_RESPONSE_SET_REGISTERS;
-
-            break;
+            return VMI_EVENT_RESPONSE_SET_REGISTERS;
         }
         case STEP2: // open file handle
         {
@@ -201,8 +199,7 @@ event_response_t handle_read_file(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
                     O_RDONLY, S_IRWXU | S_IRWXG | S_IRWXO))
                 return cleanup(drakvuf, info, true);
 
-            event = VMI_EVENT_RESPONSE_SET_REGISTERS;
-            break;
+            return VMI_EVENT_RESPONSE_SET_REGISTERS;
         }
         case STEP3: // verify fd and setups first read syscall
         {
@@ -213,8 +210,7 @@ event_response_t handle_read_file(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
                     injector->virtual_memory_addr, injector->buffer.len))
                 return cleanup(drakvuf, info, true);
 
-            event = VMI_EVENT_RESPONSE_SET_REGISTERS;
-            break;
+            return VMI_EVENT_RESPONSE_SET_REGISTERS;
         }
         case STEP4: // loop till all chunks are written and then close the fd
         {
@@ -228,6 +224,8 @@ event_response_t handle_read_file(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 
                 if (!setup_close_syscall(injector, info->regs, injector->fd))
                     return cleanup(drakvuf, info, true);
+
+                return VMI_EVENT_RESPONSE_SET_REGISTERS;
             }
             else
             {
@@ -240,12 +238,8 @@ event_response_t handle_read_file(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
                         injector->virtual_memory_addr, injector->buffer.len))
                     return cleanup(drakvuf, info, true);
 
-                injector->step_override = true;
-                injector->step = STEP4;
+                return override_step(base_injector, STEP4, VMI_EVENT_RESPONSE_SET_REGISTERS);
             }
-
-            event = VMI_EVENT_RESPONSE_SET_REGISTERS;
-            break;
         }
         case STEP5: // restore the registers
         {
@@ -259,8 +253,7 @@ event_response_t handle_read_file(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
             // restore regs
             copy_gprs(info->regs, &injector->saved_regs);
 
-            event = VMI_EVENT_RESPONSE_SET_REGISTERS;
-            break;
+            return VMI_EVENT_RESPONSE_SET_REGISTERS;
         }
         case STEP6: // cleanup
         {
@@ -270,8 +263,7 @@ event_response_t handle_read_file(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
             free_bp_trap(drakvuf, injector, info->trap);
             drakvuf_interrupt(drakvuf, SIGINT);
 
-            event = VMI_EVENT_RESPONSE_NONE;
-            break;
+            return VMI_EVENT_RESPONSE_NONE;
         }
         default:
         {
@@ -280,13 +272,14 @@ event_response_t handle_read_file(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
         }
     }
 
-    return event;
+    return VMI_EVENT_RESPONSE_NONE;
 }
 
 static event_response_t cleanup(drakvuf_t drakvuf, drakvuf_trap_info_t* info, bool clear_trap)
 {
     PRINT_DEBUG("Doing premature cleanup\n");
-    injector_t injector = (injector_t)info->trap->data;
+    linux_injector_t injector = (linux_injector_t)info->trap->data;
+    base_injector_t base_injector = &injector->base_injector;
 
     // restore regs
     copy_gprs(info->regs, &injector->saved_regs);
@@ -295,17 +288,13 @@ static event_response_t cleanup(drakvuf_t drakvuf, drakvuf_trap_info_t* info, bo
         free_bp_trap(drakvuf, injector, info->trap);
 
     // since we are jumping to some arbitrary step, we will set this
-    injector->step_override = true;
-
     // give the last step for cleanup
-    injector->step = STEP6;
-
-    return VMI_EVENT_RESPONSE_SET_REGISTERS;
+    return override_step(base_injector, STEP6, VMI_EVENT_RESPONSE_SET_REGISTERS);
 }
 
 static bool write_buffer_to_file(drakvuf_t drakvuf, drakvuf_trap_info_t* info, int size)
 {
-    injector_t injector = (injector_t)info->trap->data;
+    linux_injector_t injector = (linux_injector_t)info->trap->data;
 
     ACCESS_CONTEXT(ctx,
         .translate_mechanism = VMI_TM_PROCESS_DTB,

--- a/src/libinjector/linux/methods/linux_read_file.h
+++ b/src/libinjector/linux/methods/linux_read_file.h
@@ -109,6 +109,6 @@
 #define LINUX_READ_FILE_H
 #include "linux_utils.h"
 
-bool init_read_file_method(injector_t injector, const char* file);
+bool init_read_file_method(linux_injector_t injector, const char* file);
 event_response_t handle_read_file(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
 #endif

--- a/src/libinjector/linux/methods/linux_shellcode.h
+++ b/src/libinjector/linux/methods/linux_shellcode.h
@@ -110,5 +110,5 @@
 #include "linux_injector.h"
 
 event_response_t handle_shellcode(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
-bool load_shellcode_from_file(injector_t injector, const char* file);
+bool load_shellcode_from_file(linux_injector_t injector, const char* file);
 #endif

--- a/src/libinjector/linux/methods/linux_write_file.h
+++ b/src/libinjector/linux/methods/linux_write_file.h
@@ -109,6 +109,6 @@
 #define LINUX_WRITE_FILE_H
 #include "linux_utils.h"
 
-bool init_write_file_method(injector_t injector, const char* file);
+bool init_write_file_method(linux_injector_t injector, const char* file);
 event_response_t handle_write_file(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
 #endif

--- a/src/libinjector/private.h
+++ b/src/libinjector/private.h
@@ -166,9 +166,6 @@ void injector_exitthread_on_win(drakvuf_t drakvuf,
     vmi_pid_t injection_pid,
     uint32_t injection_tid);
 
-void injector_free_win(injector_t injector);
-void injector_free_linux(injector_t injector);
-
 void print_injection_info(
     output_format_t format,
     injection_method_t method,

--- a/src/libinjector/win/methods/win_exitthread.c
+++ b/src/libinjector/win/methods/win_exitthread.c
@@ -142,9 +142,10 @@ static event_response_t wait_for_thread_exit_cb(drakvuf_t drakvuf, drakvuf_trap_
 event_response_t handle_win_exitthread(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 {
     injector_t injector = info->trap->data;
+    base_injector_t base_injector = &injector->base_injector;
     event_response_t event;
 
-    if (injector->step == STEP1)
+    if (base_injector->step == STEP1)
     {
         // save registers
         PRINT_DEBUG("Saving registers\n");

--- a/src/libinjector/win/methods/win_shellexec.c
+++ b/src/libinjector/win/methods/win_shellexec.c
@@ -111,9 +111,9 @@ static event_response_t cleanup(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
 event_response_t handle_shellexec(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 {
     injector_t injector = info->trap->data;
-    event_response_t event;
+    base_injector_t base_injector = &injector->base_injector;
 
-    switch (injector->step)
+    switch (base_injector->step)
     {
         case STEP1:
         {
@@ -128,8 +128,7 @@ event_response_t handle_shellexec(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
             }
 
             info->regs->rip = injector->exec_func;
-            event = VMI_EVENT_RESPONSE_SET_REGISTERS;
-            break;
+            return VMI_EVENT_RESPONSE_SET_REGISTERS;
         }
         case STEP2:
         {
@@ -146,8 +145,7 @@ event_response_t handle_shellexec(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
             drakvuf_interrupt(drakvuf, SIGINT);
 
             memcpy(info->regs, &injector->x86_saved_regs, sizeof(x86_registers_t));
-            event = VMI_EVENT_RESPONSE_SET_REGISTERS;
-            break;
+            return VMI_EVENT_RESPONSE_SET_REGISTERS;
         }
         default:
         {
@@ -156,7 +154,7 @@ event_response_t handle_shellexec(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
         }
     }
 
-    return event;
+    return VMI_EVENT_RESPONSE_NONE;
 }
 
 static event_response_t cleanup(drakvuf_t drakvuf, drakvuf_trap_info_t* info)

--- a/src/libinjector/win/methods/win_terminate.c
+++ b/src/libinjector/win/methods/win_terminate.c
@@ -60,9 +60,9 @@ static bool setup_create_remote_thread_stack(injector_t injector, x86_registers_
 event_response_t handle_win_terminate(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 {
     injector_t injector = info->trap->data;
-    event_response_t event;
+    base_injector_t base_injector = &injector->base_injector;
 
-    switch (injector->step)
+    switch (base_injector->step)
     {
         case STEP1:
         {
@@ -77,8 +77,7 @@ event_response_t handle_win_terminate(drakvuf_t drakvuf, drakvuf_trap_info_t* in
                 return cleanup(drakvuf, info);
 
             info->regs->rip = injector->open_process;
-            event = VMI_EVENT_RESPONSE_SET_REGISTERS;
-            break;
+            return VMI_EVENT_RESPONSE_SET_REGISTERS;
         }
         case STEP2:
         {
@@ -91,8 +90,7 @@ event_response_t handle_win_terminate(drakvuf_t drakvuf, drakvuf_trap_info_t* in
                 return cleanup(drakvuf, info);
 
             info->regs->rip = injector->exec_func;
-            event = VMI_EVENT_RESPONSE_SET_REGISTERS;
-            break;
+            return VMI_EVENT_RESPONSE_SET_REGISTERS;
         }
         case STEP3:
         {
@@ -105,8 +103,7 @@ event_response_t handle_win_terminate(drakvuf_t drakvuf, drakvuf_trap_info_t* in
             drakvuf_interrupt(drakvuf, SIGINT);
 
             memcpy(info->regs, &injector->x86_saved_regs, sizeof(x86_registers_t));
-            event = VMI_EVENT_RESPONSE_SET_REGISTERS;
-            break;
+            return VMI_EVENT_RESPONSE_SET_REGISTERS;
         }
         default:
         {
@@ -114,7 +111,7 @@ event_response_t handle_win_terminate(drakvuf_t drakvuf, drakvuf_trap_info_t* in
             assert(false);
         }
     }
-    return event;
+    return VMI_EVENT_RESPONSE_NONE;
 }
 
 static event_response_t cleanup(drakvuf_t drakvuf, drakvuf_trap_info_t* info)

--- a/src/libinjector/win/win_injector.c
+++ b/src/libinjector/win/win_injector.c
@@ -148,6 +148,7 @@ static event_response_t mem_callback(drakvuf_t drakvuf, drakvuf_trap_info_t* inf
 {
     (void)drakvuf;
     injector_t injector = info->trap->data;
+    base_injector_t base_injector = &injector->base_injector;
 
     if ( info->proc_data.pid != injector->target_pid || ( injector->target_tid && (uint32_t)info->proc_data.tid != injector->target_tid ))
     {
@@ -207,11 +208,11 @@ static event_response_t mem_callback(drakvuf_t drakvuf, drakvuf_trap_info_t* inf
         }
     }
 
-    if (!injector->step_override)
-        injector->step+=1;
+    if (!base_injector->step_override)
+        base_injector->step+=1;
 
-    injector->step_override = false;
-    return handle_gprs_registers(drakvuf, info, event);
+    base_injector->step_override = false;
+    return handle_gprs_registers(drakvuf, info, base_injector, event);
 }
 
 static event_response_t wait_for_crash_of_target_process(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
@@ -383,6 +384,7 @@ bool check_int3_trap(injector_t injector, drakvuf_trap_info_t* info)
 event_response_t injector_int3_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 {
     injector_t injector = info->trap->data;
+    base_injector_t base_injector = &injector->base_injector;
 
     if (!check_int3_trap(injector, info))
         return VMI_EVENT_RESPONSE_NONE;
@@ -441,11 +443,11 @@ event_response_t injector_int3_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
     if (!injector->hijacked)
         return 0;
 
-    if (!injector->step_override)
-        injector->step+=1;
+    if (!base_injector->step_override)
+        base_injector->step+=1;
 
-    injector->step_override = false;
-    return handle_gprs_registers(drakvuf, info, event);
+    base_injector->step_override = false;
+    return handle_gprs_registers(drakvuf, info, base_injector, event);
 
 }
 
@@ -662,9 +664,9 @@ injector_status_t injector_start_app_on_win(
     injector->error_code.valid = false;
     injector->error_code.code = -1;
     injector->error_code.string = "<UNKNOWN>";
-    injector->step = STEP1;
-    injector->step_override = false;
-    injector->set_gprs_only = true;
+    injector->base_injector.step = STEP1;
+    injector->base_injector.step_override = false;
+    injector->base_injector.set_gprs_only = true;
 
     if (!initialize_injector_functions(drakvuf, injector, file))
     {
@@ -754,8 +756,8 @@ void injector_terminate_on_win(drakvuf_t drakvuf,
     injector->target_tid = injection_tid;
     injector->is32bit = (drakvuf_get_page_mode(drakvuf) != VMI_PM_IA32E);
     injector->terminate_pid = pid;
-    injector->step_override = false;
-    injector->step = STEP1;
+    injector->base_injector.step_override = false;
+    injector->base_injector.step = STEP1;
 
     if (!initialize_injector_functions(drakvuf, injector, NULL))
     {
@@ -784,8 +786,8 @@ void injector_exitthread_on_win(drakvuf_t drakvuf,
     injector->target_pid = injection_pid;
     injector->target_tid = injection_tid;
     injector->is32bit = (drakvuf_get_page_mode(drakvuf) != VMI_PM_IA32E);
-    injector->step_override = false;
-    injector->step = STEP1;
+    injector->base_injector.step_override = false;
+    injector->base_injector.step = STEP1;
 
     if (!initialize_injector_functions(drakvuf, injector, NULL))
     {

--- a/src/libinjector/win/win_utils.h
+++ b/src/libinjector/win/win_utils.h
@@ -137,11 +137,7 @@
 
 struct injector
 {
-    // common in win and linux
-    // KEEP THESE IN TOP and in sync with the order in injector_utils.c
-    injector_step_t step;
-    bool step_override; // set this as true for jumping to some arbitrary step
-    bool set_gprs_only;
+    struct base_injector base_injector;
 
     // Inputs:
     unicode_string_t* target_file_us;
@@ -201,6 +197,7 @@ struct injector
     uint32_t pid, tid;
     uint64_t hProc, hThr;
 };
+typedef struct injector* injector_t;
 
 
 struct startup_info_32

--- a/src/plugins/procdump2/minidump2.h
+++ b/src/plugins/procdump2/minidump2.h
@@ -124,6 +124,9 @@ using rva64_t = uint64_t;
 #define MDMP_MAX_MEMORY_RANGES 256
 #define MDMP_MAX_THREADS 1
 
+namespace procdump2_ns
+{
+
 enum mdmp_type
 {
     MiniDumpNormal         = 0,
@@ -684,4 +687,6 @@ struct __attribute__ ((packed, aligned(4))) minidump
     }
 };
 
-#endif // PROCDUMP_MINIDUMP_H
+}
+
+#endif // PROCDUMP2_MINIDUMP_H

--- a/src/plugins/procdump2/private2.h
+++ b/src/plugins/procdump2/private2.h
@@ -108,6 +108,7 @@
 #include "writer.h"
 
 using namespace std::string_literals;
+using namespace procdump2_ns;
 
 using std::string;
 

--- a/src/plugins/procdump2/procdump2.cpp
+++ b/src/plugins/procdump2/procdump2.cpp
@@ -121,6 +121,8 @@
 #include "minidump2.h"
 #include "plugins/output_format.h"
 
+using namespace procdump2_ns;
+
 /*****************************************************************************
  *                             Public interface                              *
  *****************************************************************************/
@@ -1031,6 +1033,7 @@ bool procdump2::dispatch_host_wakeup(
             delay_execution(info, ctx->host, 500);
             return true;
     }
+    return true;
 }
 
 bool procdump2::dispatch_target_wakeup(
@@ -1131,6 +1134,7 @@ bool procdump2::dispatch_target_wakeup(
             }
             return true;
     }
+    return true;
 }
 
 /*****************************************************************************

--- a/src/plugins/procdump2/writer.cpp
+++ b/src/plugins/procdump2/writer.cpp
@@ -115,6 +115,8 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 
+using namespace procdump2_ns;
+
 namespace
 {
 

--- a/src/plugins/procdump2/writer.h
+++ b/src/plugins/procdump2/writer.h
@@ -106,6 +106,9 @@
 
 #include <memory>
 
+namespace procdump2_ns
+{
+
 class ProcdumpWriter
 {
 public:
@@ -120,3 +123,5 @@ class ProcdumpWriterFactory
 public:
     static std::unique_ptr<ProcdumpWriter> build(std::string const& path, bool use_compression);
 };
+
+}


### PR DESCRIPTION
 * The one definition rule is violated, different classes/structs have the same name 'injector'
 * src/plugins/procdump/minidump.h and src/plugins/procdump2/minidump2.h code duplication
 * src/plugins/procdump/writer.cpp and src/plugins/procdump2/writer.cpp code duplication