### PR TITLE
linux: fix garbage in long file names (>32 symbols)

### DIFF
--- a/src/libdrakvuf/linux-processes.c
+++ b/src/libdrakvuf/linux-processes.c
@@ -275,15 +275,23 @@ static void prepend_path(drakvuf_t drakvuf, addr_t path, addr_t root, GString* b
             return;
         }
 
-        // End of cicle
+        // End of cycle
         if (dentry == mnt_mnt_root || dentry == dentry_parent)
             break;
 
-        ctx.addr = dentry + drakvuf->offsets[DENTRY_D_NAME] + drakvuf->offsets[QSTR_NAME] + 16;
+        addr_t qname_addr;
+        ctx.addr = dentry + drakvuf->offsets[DENTRY_D_NAME] + drakvuf->offsets[QSTR_NAME];
+        if (VMI_FAILURE == vmi_read_addr(drakvuf->vmi, &ctx, &qname_addr))
+        {
+            PRINT_DEBUG("Can't read path->dentry->qstr->name pointer\n");
+            return;
+        }
+
+        ctx.addr = qname_addr;
         gchar* res = vmi_read_str(drakvuf->vmi, &ctx);
         if (!res)
         {
-            PRINT_DEBUG("Can't read path->dentry->qstr data\n");
+            PRINT_DEBUG("Can't read path->dentry->qstr->name string\n");
             return;
         }
 

--- a/src/plugins/filetracer/private.h
+++ b/src/plugins/filetracer/private.h
@@ -579,10 +579,7 @@ enum
     _INODE_I_FLAGS,
 
     _PATH_DENTRY,
-    _DENTRY_D_NAME,
     _DENTRY_D_INODE,
-    _DENTRY_D_PARENT,
-    _QSTR_NAME,
     _TIMESPEC64_TV_SEC,
 
     _RENAMEDATA_OLD_DENTRY,
@@ -604,10 +601,7 @@ static const char* linux_offset_names[__LINUX_OFFSET_MAX][2] =
     [_INODE_I_FLAGS] = {"inode", "i_flags"},
 
     [_PATH_DENTRY] = {"path", "dentry"},
-    [_DENTRY_D_NAME] = {"dentry", "d_name"},
     [_DENTRY_D_INODE] = {"dentry", "d_inode"},
-    [_DENTRY_D_PARENT] = {"dentry", "d_parent"},
-    [_QSTR_NAME] = {"qstr", "name"},
     [_TIMESPEC64_TV_SEC] = {"timespec64", "tv_sec"},
 
     [_RENAMEDATA_OLD_DENTRY] = {"renamedata", "old_dentry"},


### PR DESCRIPTION
use dentry->d_name->name instead of dentry->d_iname as file token name

 * 'dentry_addr + offsets[DENTRY_D_NAME] + offsets[QSTR_NAME] + 16' is actually an address of 'dentry_addr->d_iname'
 * 'dentry_addr->d_iname' is just a buffer to save allocations that could be not used for large filenames.
 * this fixes garbage in extracted file names in case of long file names.