### PR TITLE
Libhook: default initialize all values

### DIFF
--- a/src/libhook/hooks/catchall.hpp
+++ b/src/libhook/hooks/catchall.hpp
@@ -148,8 +148,8 @@ public:
      */
     CatchAllHook& operator=(CatchAllHook&&) noexcept;
 
-    cb_wrapper_t callback_;
-    drakvuf_trap_t* trap_;
+    cb_wrapper_t callback_ = nullptr;
+    drakvuf_trap_t* trap_ = nullptr;
 
 protected:
     /**

--- a/src/libhook/hooks/cpuid.hpp
+++ b/src/libhook/hooks/cpuid.hpp
@@ -148,8 +148,8 @@ public:
      */
     CpuidHook& operator=(CpuidHook&&) noexcept;
 
-    cb_wrapper_t callback_;
-    drakvuf_trap_t* trap_;
+    cb_wrapper_t callback_ = nullptr;
+    drakvuf_trap_t* trap_ = nullptr;
 
 protected:
     /**

--- a/src/libhook/hooks/cr3.hpp
+++ b/src/libhook/hooks/cr3.hpp
@@ -148,8 +148,8 @@ public:
      */
     Cr3Hook& operator=(Cr3Hook&&) noexcept;
 
-    cb_wrapper_t callback_;
-    drakvuf_trap_t* trap_;
+    cb_wrapper_t callback_ = nullptr;
+    drakvuf_trap_t* trap_ = nullptr;
 
 protected:
     /**

--- a/src/libhook/hooks/return.hpp
+++ b/src/libhook/hooks/return.hpp
@@ -149,7 +149,7 @@ public:
      */
     ReturnHook& operator=(ReturnHook&&) noexcept;
 
-    cb_wrapper_t callback_;
+    cb_wrapper_t callback_ = nullptr;
     drakvuf_trap_t* trap_ = nullptr;
 
 protected:

--- a/src/libhook/hooks/syscall.hpp
+++ b/src/libhook/hooks/syscall.hpp
@@ -139,10 +139,10 @@ public:
     SyscallHook& operator=(const SyscallHook&) = delete;
     SyscallHook& operator=(SyscallHook&&) = delete;
 
-    const std::string syscall_name_;
-    const std::string display_name_;
-    cb_wrapper_t callback_;
-    drakvuf_trap_t* trap_;
+    const std::string syscall_name_ = "";
+    const std::string display_name_ = "";
+    cb_wrapper_t callback_ = nullptr;
+    drakvuf_trap_t* trap_ = nullptr;
 
 private:
     [[nodiscard]]


### PR DESCRIPTION
Should fix `*** CID 404291:  Memory - illegal accesses  (UNINIT)` errors.