### PR TITLE
rebootmon: new plugin for monitoring of system reboot events

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -582,6 +582,16 @@ if test x$plugin_etwmon = xyes; then
   AC_DEFINE_UNQUOTED(ENABLE_PLUGIN_ETWMON, 1, "")
 fi
 
+AC_ARG_ENABLE([plugin_rebootmon],
+  [AS_HELP_STRING([--disable-plugin-rebootmon],
+    [Enable the power off monitoring plugin @<:@yes@:>@])],
+  [plugin_rebootmon="$enableval"],
+  [plugin_rebootmon="yes"])
+AM_CONDITIONAL([PLUGIN_REBOOTMON], [test x$plugin_rebootmon = xyes])
+if test x$plugin_rebootmon = xyes; then
+  AC_DEFINE_UNQUOTED(ENABLE_PLUGIN_REBOOTMON, 1, "")
+fi
+
 #####################################################
 
 AC_ARG_ENABLE([repl],
@@ -898,6 +908,7 @@ HideVM:             $plugin_hidevm
 Etwmon:             $plugin_etwmon
 Memaccessmon:       $plugin_memaccessmon
 Unixsocketmon:      $plugin_unixsocketmon
+Rebootmon:          $plugin_rebootmon
 -------------------------------------------------------------------------------
 Deprecated Plugins
 WMIMon:             $plugin_wmimon

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -43,6 +43,7 @@ option('plugin-memaccessmon', type : 'boolean', value : true)
 option('plugin-unixsocketmon', type : 'boolean', value : true)
 option('plugin-etwmon', type : 'boolean', value : true)
 option('plugin-ipt', type : 'boolean', value : true)
+option('plugin-rebootmon', type : 'boolean', value : true)
 
 # Disabled by default plugins
 option('plugin-libhooktest', type : 'boolean', value : 'false')

--- a/src/libdrakvuf/libdrakvuf.h
+++ b/src/libdrakvuf/libdrakvuf.h
@@ -158,6 +158,7 @@ extern bool verbose;
 #define SIGDRAKVUFTIMEOUT -2
 #define SIGDRAKVUFCRASH   -3
 #define SIGDRAKVUFKERNELPANIC -4 // drakvuf loop interrupted by BSOD or KERNEL PANIC
+#define SIGDRAKVUFPOWEROFF -5 // drakvuf loop interrupted by POWER OFF, HALT or REBOOT
 
 typedef enum lookup_type
 {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -380,6 +380,10 @@ static void print_usage()
         "\t --unixsocketmon-max-size-print <size>\n"
         "\t                           Max message size (in bytes) to print\n"
 #endif
+#ifdef ENABLE_PLUGIN_REBOOTMON
+        "\t --rebootmon-abort-on-power-off\n"
+        "\t                           Exit from execution as soon as we detect power off\n"
+#endif
         "\t --libdrakvuf-not-get-userid\n"
         "\t                           Don't collect user id in get process data\n"
         "\t -h, --help                Show this help\n"
@@ -511,6 +515,7 @@ int main(int argc, char** argv)
         opt_enable_active_callback_check,
         opt_exit_injection_thread,
         opt_unixsocketmon_max_size,
+        opt_rebootmon_abort_on_power_off,
     };
     const option long_opts[] =
     {
@@ -590,6 +595,7 @@ int main(int argc, char** argv)
         {"enable-active-callback-check", no_argument, NULL, opt_enable_active_callback_check},
         {"exit-injection-thread", no_argument, NULL, opt_exit_injection_thread},
         {"unixsocketmon-max-size-print", required_argument, NULL, opt_unixsocketmon_max_size},
+        {"rebootmon-abort-on-power-off", no_argument, NULL, opt_rebootmon_abort_on_power_off},
         {NULL, 0, NULL, 0}
     };
     const char* opts = "r:d:i:I:e:m:t:D:o:vx:a:f:spT:S:Mc:nblgj:k:w:W:hFC";
@@ -947,6 +953,11 @@ int main(int argc, char** argv)
                 options.unixsocketmon_max_size = strtoull(optarg, NULL, 0);
                 break;
 #endif
+#ifdef ENABLE_PLUGIN_REBOOTMON
+            case opt_rebootmon_abort_on_power_off:
+                options.rebootmon_abort_on_power_off = true;
+                break;
+#endif
             case 'h':
                 print_usage();
                 return drakvuf_exit_code_t::SUCCESS;
@@ -1100,6 +1111,9 @@ int main(int argc, char** argv)
     {
         case SIGDRAKVUFKERNELPANIC:
             return drakvuf_exit_code_t::KERNEL_PANIC;
+        case SIGDRAKVUFPOWEROFF:
+            PRINT_DEBUG("Exit on power off\n");
+            return drakvuf_exit_code_t::POWER_OFF;
         default:
             break;
     }

--- a/src/plugins/Makefile.am
+++ b/src/plugins/Makefile.am
@@ -396,6 +396,14 @@ sources += etwmon/etwmon.h
 sources += etwmon/private.h
 endif
 
+if PLUGIN_REBOOTMON
+sources += rebootmon/rebootmon.cpp
+sources += rebootmon/rebootmon.h
+sources += rebootmon/linux.cpp
+sources += rebootmon/linux.h
+sources += rebootmon/linux-private.h
+endif
+
 ###############################################################################
 sources += plugins.cpp plugins.h plugins_ex.cpp plugins_ex.h plugin_utils.cpp plugin_utils.h private.h
 sources += output_format.h output_format/common.h output_format/csvfmt.h output_format/deffmt.h output_format/jsonfmt.h output_format/kvfmt.h

--- a/src/plugins/meson.build
+++ b/src/plugins/meson.build
@@ -213,6 +213,13 @@ if get_option('plugin-ipt')
     config_h.set('ENABLE_PLUGIN_IPT', 1)
 endif
 
+if get_option('plugin-rebootmon')
+    plugin_sources += 'rebootmon/rebootmon.cpp'
+    plugin_sources += 'rebootmon/linux.cpp'
+
+    config_h.set('ENABLE_PLUGIN_REBOOTMON', 1)
+endif
+
 summary({
     'syscalls': get_option('plugin-syscalls'),
     'poolmon': get_option('plugin-poolmon'),
@@ -244,6 +251,7 @@ summary({
     'unixsocketmon' : get_option('plugin-unixsocketmon'),
     'etwmon' : get_option('plugin-etwmon'),
     'ipt' : get_option('plugin-ipt'),
+    'rebootmon' : get_option('plugin-rebootmon'),
 }, section: 'Plugins (-Dplugin-<x>)')
 
 summary({

--- a/src/plugins/plugin_utils.cpp
+++ b/src/plugins/plugin_utils.cpp
@@ -217,3 +217,11 @@ std::string parse_flags(uint64_t flags, const flags_str_t& flags_map, output_for
 
     return output;
 }
+
+std::string parse_enum(uint64_t value, const flags_str_t& enum_map)
+{
+    auto it = enum_map.find(value);
+    if (it != enum_map.end())
+        return it->second;
+    return std::to_string(value);
+}

--- a/src/plugins/plugin_utils.h
+++ b/src/plugins/plugin_utils.h
@@ -132,6 +132,18 @@ std::string parse_flags(uint64_t flags,
     output_format_t format = OUTPUT_DEFAULT,
     std::string empty = std::string());
 
+
+/* Represent enum as string.
+ *
+ * value binary enum value.
+ * enum_map mapping from enum values to names.
+ *
+ * Return string representation for a known enum value.
+ * Return to_string(value) otherwise.
+ */
+std::string parse_enum(uint64_t value,
+    const flags_str_t& enum_map);
+
 /* Dump buffer from VA to stdout.
  *
  * Read count bytes from VA specified in ctx and dumps it to stdout

--- a/src/plugins/plugin_utils_check.cpp
+++ b/src/plugins/plugin_utils_check.cpp
@@ -147,7 +147,22 @@ START_TEST(test_parse_64bit_flags)
 }
 END_TEST
 
-Suite* parse_flags_suite(void)
+
+START_TEST(test_parse_known_enum_value)
+{
+    uint64_t value = ATTRIBUTE_1;
+    ck_assert(parse_enum(value, flags_and_attrs) == std::string("ATTRIBUTE_1"));
+}
+END_TEST
+
+START_TEST(test_parse_unknown_enum_value)
+{
+    uint64_t value = ATTRIBUTE_1 | ATTRIBUTE_2;
+    ck_assert(parse_enum(value, flags_and_attrs) == std::to_string(value));
+}
+END_TEST
+
+static Suite* parse_flags_suite(void)
 {
     Suite* s;
     TCase* tc_core;
@@ -166,6 +181,23 @@ Suite* parse_flags_suite(void)
     return s;
 }
 
+static Suite* parse_enum_suite(void)
+{
+    Suite* s;
+    TCase* tc_core;
+
+    s = suite_create("Stringify enum values");
+
+    /* Core test case */
+    tc_core = tcase_create("Core");
+
+    tcase_add_test(tc_core, test_parse_known_enum_value);
+    tcase_add_test(tc_core, test_parse_unknown_enum_value);
+    suite_add_tcase(s, tc_core);
+
+    return s;
+}
+
 int main(void)
 {
     int number_failed;
@@ -174,6 +206,7 @@ int main(void)
 
     s = parse_flags_suite();
     sr = srunner_create(s);
+    srunner_add_suite(sr, parse_enum_suite());
 
     srunner_run_all(sr, CK_NORMAL);
     number_failed = srunner_ntests_failed(sr);

--- a/src/plugins/plugins.cpp
+++ b/src/plugins/plugins.cpp
@@ -146,6 +146,7 @@
 #include "memaccessmon/memaccessmon.h"
 #include "unixsocketmon/unixsocketmon.h"
 #include "etwmon/etwmon.h"
+#include "rebootmon/rebootmon.h"
 
 drakvuf_plugins::drakvuf_plugins(const drakvuf_t _drakvuf, output_format_t _output, os_t _os)
     : drakvuf{ _drakvuf }, output{ _output }, os{ _os }
@@ -303,6 +304,17 @@ int drakvuf_plugins::start(const drakvuf_plugin_t plugin_id,
                 case PLUGIN_CRASHMON:
                     this->plugins[plugin_id] = std::make_unique<crashmon>(this->drakvuf, this->output);
                     break;
+#endif
+#ifdef ENABLE_PLUGIN_REBOOTMON
+                case PLUGIN_REBOOTMON:
+                {
+                    rebootmon_config config =
+                    {
+                        .abort_on_power_off = options->rebootmon_abort_on_power_off,
+                    };
+                    this->plugins[plugin_id] = std::make_unique<rebootmon>(this->drakvuf, &config, this->output);
+                    break;
+                }
 #endif
 #ifdef ENABLE_PLUGIN_CLIPBOARDMON
                 case PLUGIN_CLIPBOARDMON:

--- a/src/plugins/plugins.h
+++ b/src/plugins/plugins.h
@@ -194,6 +194,7 @@ struct plugins_options
     const char* ndis_profile;           // PLUGIN_CALLBACKMON
     uint64_t hidevm_delay;              // PLUGIN_HIDEVM
     uint64_t unixsocketmon_max_size;    // PLUGIN_UNIXSOCKETMON
+    bool rebootmon_abort_on_power_off;  // PLUGIN_REBOOTMON
 };
 
 typedef enum drakvuf_plugin
@@ -240,6 +241,7 @@ typedef enum drakvuf_plugin
     PLUGIN_MEMACCESSMON,
     PLUGIN_UNIXSOCKETMON,
     PLUGIN_ETWMON,
+    PLUGIN_REBOOTMON,
     __DRAKVUF_PLUGIN_LIST_MAX
 } drakvuf_plugin_t;
 
@@ -287,6 +289,7 @@ static const char* drakvuf_plugin_names[] =
     [PLUGIN_MEMACCESSMON] = "memaccessmon",
     [PLUGIN_UNIXSOCKETMON] = "unixsocketmon",
     [PLUGIN_ETWMON] = "etwmon",
+    [PLUGIN_REBOOTMON] = "rebootmon",
 };
 
 static const bool drakvuf_plugin_os_support[__DRAKVUF_PLUGIN_LIST_MAX][VMI_OS_WINDOWS+1] =
@@ -333,6 +336,7 @@ static const bool drakvuf_plugin_os_support[__DRAKVUF_PLUGIN_LIST_MAX][VMI_OS_WI
     [PLUGIN_MEMACCESSMON] = { [VMI_OS_WINDOWS] = 1, [VMI_OS_LINUX] = 0 },
     [PLUGIN_UNIXSOCKETMON]= { [VMI_OS_WINDOWS] = 0, [VMI_OS_LINUX] = 1 },
     [PLUGIN_ETWMON]       = { [VMI_OS_WINDOWS] = 1, [VMI_OS_LINUX] = 0 },
+    [PLUGIN_REBOOTMON]    = { [VMI_OS_WINDOWS] = 0, [VMI_OS_LINUX] = 1 },
 };
 
 class plugin

--- a/src/plugins/rebootmon/linux-private.h
+++ b/src/plugins/rebootmon/linux-private.h
@@ -104,18 +104,62 @@
 
 #pragma once
 
-enum drakvuf_exit_code_t
+#include "plugin_utils.h"
+
+namespace rebootmon_ns
 {
-    SUCCESS = 0,
-    FAIL = 1,
-    INJECTION_TIMEOUT = 2,
-    INJECTION_ERROR = 3, // Injection failed due to implementation error
-    INJECTION_UNSUCCESSFUL = 4, /* Injection has been done correctly, but
-                                 * the sample could not be started
-                                 * (corrupted, arch mismatch and so on) */
-    WRITE_FILE_TIMEOUT = 5,
-    WRITE_FILE_ERROR = 6,
-    PLUGINS_STOP_TIMEOUT = 7,
-    KERNEL_PANIC = 10,
-    POWER_OFF = 11,
+
+// Magic values required to use _reboot() system call.
+#define	LINUX_REBOOT_MAGIC1  0xfee1dead
+#define	LINUX_REBOOT_MAGIC2  672274793
+#define	LINUX_REBOOT_MAGIC2A 85072278
+#define	LINUX_REBOOT_MAGIC2B 369367448
+#define	LINUX_REBOOT_MAGIC2C 537993216
+
+
+/*
+ * Commands accepted by the _reboot() system call.
+ *
+ * RESTART     Restart system using default command and mode.
+ * HALT        Stop OS and give system control to ROM monitor, if any.
+ * CAD_ON      Ctrl-Alt-Del sequence causes RESTART command.
+ * CAD_OFF     Ctrl-Alt-Del sequence sends SIGINT to init task.
+ * POWER_OFF   Stop OS and remove all power from system, if possible.
+ * RESTART2    Restart system using given command string.
+ * SW_SUSPEND  Suspend system using software suspend if compiled in.
+ * KEXEC       Restart system using a previously loaded Linux kernel
+ */
+enum reboot_command_t
+{
+    LINUX_REBOOT_CMD_RESTART    = 0x01234567,
+    LINUX_REBOOT_CMD_HALT       = 0xCDEF0123,
+    LINUX_REBOOT_CMD_CAD_ON     = 0x89ABCDEF,
+    LINUX_REBOOT_CMD_CAD_OFF    = 0x00000000,
+    LINUX_REBOOT_CMD_POWER_OFF  = 0x4321FEDC,
+    LINUX_REBOOT_CMD_RESTART2   = 0xA1B2C3D4,
+    LINUX_REBOOT_CMD_SW_SUSPEND = 0xD000FCE2,
+    LINUX_REBOOT_CMD_KEXEC      = 0x45584543,
 };
+
+static const flags_str_t reboot_magics =
+{
+    REGISTER_FLAG(LINUX_REBOOT_MAGIC1),
+    REGISTER_FLAG(LINUX_REBOOT_MAGIC2),
+    REGISTER_FLAG(LINUX_REBOOT_MAGIC2A),
+    REGISTER_FLAG(LINUX_REBOOT_MAGIC2B),
+    REGISTER_FLAG(LINUX_REBOOT_MAGIC2C),
+};
+
+static const flags_str_t reboot_commands =
+{
+    REGISTER_FLAG(LINUX_REBOOT_CMD_RESTART),
+    REGISTER_FLAG(LINUX_REBOOT_CMD_HALT),
+    REGISTER_FLAG(LINUX_REBOOT_CMD_CAD_ON),
+    REGISTER_FLAG(LINUX_REBOOT_CMD_CAD_OFF),
+    REGISTER_FLAG(LINUX_REBOOT_CMD_POWER_OFF),
+    REGISTER_FLAG(LINUX_REBOOT_CMD_RESTART2),
+    REGISTER_FLAG(LINUX_REBOOT_CMD_SW_SUSPEND),
+    REGISTER_FLAG(LINUX_REBOOT_CMD_KEXEC),
+};
+
+}

--- a/src/plugins/rebootmon/linux.h
+++ b/src/plugins/rebootmon/linux.h
@@ -104,18 +104,32 @@
 
 #pragma once
 
-enum drakvuf_exit_code_t
+#include "plugins/plugins_ex.h"
+#include "plugins/private.h"
+#include "linux-private.h"
+
+using namespace rebootmon_ns;
+
+struct rebootmon_config;
+
+class linux_rebootmon : public pluginex
 {
-    SUCCESS = 0,
-    FAIL = 1,
-    INJECTION_TIMEOUT = 2,
-    INJECTION_ERROR = 3, // Injection failed due to implementation error
-    INJECTION_UNSUCCESSFUL = 4, /* Injection has been done correctly, but
-                                 * the sample could not be started
-                                 * (corrupted, arch mismatch and so on) */
-    WRITE_FILE_TIMEOUT = 5,
-    WRITE_FILE_ERROR = 6,
-    PLUGINS_STOP_TIMEOUT = 7,
-    KERNEL_PANIC = 10,
-    POWER_OFF = 11,
+private:
+    /* Hooks */
+    std::unique_ptr<libhook::SyscallHook> reboot_hook;
+    std::unique_ptr<libhook::SyscallHook> machine_restart_hook;
+    std::unique_ptr<libhook::SyscallHook> machine_halt_hook;
+    std::unique_ptr<libhook::SyscallHook> machine_power_off_hook;
+
+    /* Callbacks */
+    event_response_t reboot_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
+    event_response_t machine_restart_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
+    event_response_t machine_power_off_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
+
+    const bool abort_on_power_off;
+
+public:
+    linux_rebootmon(drakvuf_t drakvuf, const rebootmon_config* c, output_format_t output);
+    linux_rebootmon(const linux_rebootmon&) = delete;
+    linux_rebootmon& operator=(const linux_rebootmon&) = delete;
 };

--- a/src/plugins/rebootmon/rebootmon.cpp
+++ b/src/plugins/rebootmon/rebootmon.cpp
@@ -102,20 +102,15 @@
  *                                                                         *
  ***************************************************************************/
 
-#pragma once
+#include "rebootmon.h"
+#include "linux.h"
 
-enum drakvuf_exit_code_t
+rebootmon::rebootmon(drakvuf_t drakvuf, const rebootmon_config* c, output_format_t output)
+    : pluginex(drakvuf, output)
 {
-    SUCCESS = 0,
-    FAIL = 1,
-    INJECTION_TIMEOUT = 2,
-    INJECTION_ERROR = 3, // Injection failed due to implementation error
-    INJECTION_UNSUCCESSFUL = 4, /* Injection has been done correctly, but
-                                 * the sample could not be started
-                                 * (corrupted, arch mismatch and so on) */
-    WRITE_FILE_TIMEOUT = 5,
-    WRITE_FILE_ERROR = 6,
-    PLUGINS_STOP_TIMEOUT = 7,
-    KERNEL_PANIC = 10,
-    POWER_OFF = 11,
-};
+    auto os = drakvuf_get_os_type(drakvuf);
+    if (os == VMI_OS_WINDOWS)
+        throw -1;
+    else
+        this->l_impl = std::make_unique<linux_rebootmon>(drakvuf, c, output);
+}

--- a/src/plugins/rebootmon/rebootmon.h
+++ b/src/plugins/rebootmon/rebootmon.h
@@ -88,7 +88,7 @@
  * otherwise) that you are offering unlimited, non-exclusive right to      *
  * reuse, modify, and relicense the code.  DRAKVUF will always be          *
  * available Open Source, but this is important because the inability to   *
- * relicense code has caused devastating problems for other Free Software  *
+* relicense code has caused devastating problems for other Free Software  *
  * projects (such as KDE and NASM).                                        *
  * To specify special license conditions of your contributions, just say   *
  * so when you send them.                                                  *
@@ -104,18 +104,22 @@
 
 #pragma once
 
-enum drakvuf_exit_code_t
+#include "plugins/private.h"
+#include "plugins/plugins_ex.h"
+#include "linux.h"
+
+#include <memory>
+
+struct rebootmon_config
 {
-    SUCCESS = 0,
-    FAIL = 1,
-    INJECTION_TIMEOUT = 2,
-    INJECTION_ERROR = 3, // Injection failed due to implementation error
-    INJECTION_UNSUCCESSFUL = 4, /* Injection has been done correctly, but
-                                 * the sample could not be started
-                                 * (corrupted, arch mismatch and so on) */
-    WRITE_FILE_TIMEOUT = 5,
-    WRITE_FILE_ERROR = 6,
-    PLUGINS_STOP_TIMEOUT = 7,
-    KERNEL_PANIC = 10,
-    POWER_OFF = 11,
+    bool abort_on_power_off;
+};
+
+class rebootmon : public pluginex
+{
+public:
+    std::unique_ptr<linux_rebootmon> l_impl;
+
+    rebootmon(drakvuf_t drakvuf, const rebootmon_config* c, output_format_t output);
+    ~rebootmon() = default;
 };


### PR DESCRIPTION
This plugin allows detect such system reboot events as halt, reboot, power off and can break drakvuf event loop before VM destruction caused by such events.

Use drakvuf command line option "--rebootmon-abort-on-power-off" for enabling loop break mode.