### PR TITLE
fileextractor: exclude extracted files by config file

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -233,6 +233,8 @@ static void print_usage()
         "\t                           Max file size (in MB) to calculate hash\n"
         "\t --fileextractor-max-size-extract <size>\n"
         "\t                           Max file size (in MB) to extract\n"
+        "\t --fileextractor-exclude-list <file name filter>\n"
+        "\t                           File with list of file name regexps to exclude from extracting\n"
 #endif
 #ifdef ENABLE_PLUGIN_SOCKETMON
         "\t -T, --json-tcpip <path to json>\n"
@@ -481,6 +483,7 @@ int main(int argc, char** argv)
         opt_fileextractor_timeout,
         opt_fileextractor_hash,
         opt_fileextractor_extract,
+        opt_fileextractor_exclude_list,
         opt_procdump_timeout,
         opt_procdump_dir,
         opt_compress_procdumps,
@@ -563,6 +566,7 @@ int main(int argc, char** argv)
         {"fileextractor-timeout", required_argument, NULL, opt_fileextractor_timeout},
         {"fileextractor-max-size-hash", required_argument, NULL, opt_fileextractor_hash},
         {"fileextractor-max-size-extract", required_argument, NULL, opt_fileextractor_extract},
+        {"fileextractor-exclude-list", required_argument, NULL, opt_fileextractor_exclude_list},
         {"procdump-timeout", required_argument, NULL, opt_procdump_timeout},
         {"procdump-dir", required_argument, NULL, opt_procdump_dir},
         {"compress-procdumps", no_argument, NULL, opt_compress_procdumps},
@@ -764,6 +768,14 @@ int main(int argc, char** argv)
                 break;
             case opt_fileextractor_extract:
                 options.fileextractor_extract = strtoul(optarg, NULL, 0);
+                break;
+            case opt_fileextractor_exclude_list:
+                if (!std::filesystem::exists(optarg))
+                {
+                    fprintf(stderr, "file %s does not exist!\n", optarg);
+                    return drakvuf_exit_code_t::FAIL;
+                }
+                options.fileextractor_exclude_file = optarg;
                 break;
 #endif
 #ifdef ENABLE_PLUGIN_BSODMON

--- a/src/plugins/fileextractor/fileextractor.h
+++ b/src/plugins/fileextractor/fileextractor.h
@@ -113,6 +113,8 @@
 #include <map>
 #include <utility>
 #include <cstdint>
+#include <vector>
+#include <regex>
 
 using namespace fileextractor_ns;
 
@@ -122,6 +124,7 @@ struct fileextractor_config
     const char* dump_folder;
     uint64_t hash_size;
     uint64_t extract_size;
+    const char* exclude_file;
 };
 
 class fileextractor: public pluginex
@@ -161,6 +164,7 @@ private:
     const char* dump_folder;
     uint64_t hash_size{0};
     uint64_t extract_size{0};
+    const std::vector<std::regex> exclude_list;
     output_format_t format;
 
     int sequence_number = 0;
@@ -237,12 +241,7 @@ private:
         addr_t* out_filetype);
     bool get_file_object_currentbyteoffset(vmi_instance_t, drakvuf_trap_info_t*, handle_t, uint64_t*);
     bool get_write_offset(vmi_instance_t, drakvuf_trap_info_t*, addr_t, uint64_t*);
-    void print_file_information(drakvuf_trap_info_t*, task_t&);
-    void print_plugin_close_information(drakvuf_trap_info_t*, task_t&);
     void calc_checksum(task_t&);
-    void print_extraction_failure(drakvuf_trap_info_t*,
-        const std::string& filename,
-        const std::string& message);
     void save_file_metadata(drakvuf_trap_info_t*, addr_t control_area, task_t&);
     void update_file_metadata(drakvuf_trap_info_t*, task_t&);
     bool save_file_chunk(int file_sequence_number,
@@ -260,8 +259,15 @@ private:
     void free_resources(drakvuf_trap_info_t*, task_t&);
     void read_vm(vmi_instance_t, drakvuf_trap_info_t*, task_t&);
 
+    bool is_in_exclude_list(const std::string& filename) const;
+
     bool is_handle_valid(handle_t);
     void check_stack_marker(drakvuf_trap_info_t*, vmi_lock_guard&, task_t*);
+
+    void print_file_information(drakvuf_trap_info_t*, task_t&);
+    void print_plugin_close_information(drakvuf_trap_info_t*, task_t&);
+    void print_extraction_failure(drakvuf_trap_info_t* info, const std::string& filename, const std::string& message);
+    void print_extraction_exclusion(drakvuf_trap_info_t* info, const std::string& filename);
 };
 
 #endif

--- a/src/plugins/fileextractor/private.h
+++ b/src/plugins/fileextractor/private.h
@@ -337,7 +337,7 @@ public:
         } readfile;
     };
 
-    addr_t pool;
+    addr_t pool{0};
 
     task_t(handle_t handle_,
         std::string filename_,

--- a/src/plugins/plugins.cpp
+++ b/src/plugins/plugins.cpp
@@ -214,6 +214,7 @@ int drakvuf_plugins::start(const drakvuf_plugin_t plugin_id,
                         .dump_folder = options->dump_folder,
                         .hash_size = options->fileextractor_hash,
                         .extract_size = options->fileextractor_extract,
+                        .exclude_file = options->fileextractor_exclude_file,
                     };
                     this->plugins[plugin_id] = std::make_unique<fileextractor>(this->drakvuf, &config, this->output);
                     break;

--- a/src/plugins/plugins.h
+++ b/src/plugins/plugins.h
@@ -136,6 +136,7 @@ struct plugins_options
     uint32_t fileextractor_timeout;     // PLUGIN_FILEEXTRACTOR
     uint64_t fileextractor_hash;        // PLUGIN_FILEEXTRACTOR
     uint64_t fileextractor_extract;     // PLUGIN_FILEEXTRACTOR
+    const char* fileextractor_exclude_file; // PLUGIN_FILEEXTRACTOR
     bool cpuid_stealth;                 // PLUGIN_CPUIDMON
     const char* tcpip_profile;          // PLUGIN_SOCKETMON
     const char* win32k_profile;         // PLUGIN_CLIPBOARDMON, PLUGIN_WINDOWMON, PLUGIN_SYSCALLS


### PR DESCRIPTION
I add the ability to exclude some files from extraction. Files is excluding by regular expressions on its path.

Regexps must be provided via option `--fileextractor-exlude-list <path to file with regular expressions>`.

Example file content:
```
^.+\.evtx$
^.+\.pf$
^.*\\windows\\system32\\spool\\drivers\\color\\.+\.icm$
```