### PR TITLE
Syscalls improvements

### DIFF
--- a/src/plugins/Makefile.am
+++ b/src/plugins/Makefile.am
@@ -114,6 +114,7 @@ sources += syscalls/linux.h
 sources += syscalls/win.cpp
 sources += syscalls/win.h
 sources += syscalls/private.h
+sources += syscalls/private_2.h
 endif
 
 if PLUGIN_POOLMON

--- a/src/plugins/syscalls/linux.cpp
+++ b/src/plugins/syscalls/linux.cpp
@@ -196,7 +196,8 @@ std::vector<uint64_t> linux_syscalls::build_arguments_buffer(drakvuf_t drakvuf, 
             // The order of the arguments is different when processing x32 syscalls
             // https://elixir.bootlin.com/linux/v5.10.166/source/arch/x86/include/asm/syscall_wrapper.h#L24
             // Assume if it is not x32 syscall, then we will use the standard convention for x64
-            if ( params->type == SYSCALL_TYPE_LINUX_X32 ) {
+            if ( params->type == SYSCALL_TYPE_LINUX_X32 )
+            {
                 if ( nargs > 0 )
                     arguments.push_back(pt_regs[PT_REGS_RBX]);
                 if ( nargs > 1 )
@@ -209,7 +210,9 @@ std::vector<uint64_t> linux_syscalls::build_arguments_buffer(drakvuf_t drakvuf, 
                     arguments.push_back(pt_regs[PT_REGS_RDI]);
                 if ( nargs > 5 )
                     arguments.push_back(pt_regs[PT_REGS_RBP]);
-            } else {
+            }
+            else
+            {
                 if ( nargs > 0 )
                     arguments.push_back(pt_regs[PT_REGS_RDI]);
                 if ( nargs > 1 )
@@ -250,13 +253,15 @@ void linux_syscalls::print_syscall(drakvuf_t drakvuf, drakvuf_trap_info_t* info,
     auto params = libhook::GetTrapParams<linux_syscall_data>(info);
 
     this->fmt_args.clear();
-    if (arguments.size() > 0) {
+    if (arguments.size() > 0)
+    {
         for (size_t i = 0; i < arguments.size(); i++)
         {
             auto str = this->parse_argument(drakvuf, info, params->sc->args[i], arguments[i]);
             if (!str.empty())
                 this->fmt_args.push_back(keyval(params->sc->args[i].name, fmt::Estr(str)));
-            else {
+            else
+            {
                 uint64_t value = this->transform_value(drakvuf, info, params->sc->args[i], arguments[i]);
                 this->fmt_args.push_back(keyval(params->sc->args[i].name, fmt::Xval(value)));
             }
@@ -273,7 +278,7 @@ void linux_syscalls::print_syscall(drakvuf_t drakvuf, drakvuf_trap_info_t* info,
         keyval("vCPU", fmt::Nval(info->vcpu)),
         keyval("CR3", fmt::Xval(info->regs->cr3)),
         keyval("Syscall", fmt::Nval((uint64_t)(params->num))),
-        keyval("NArgs", fmt::Nval(params->sc->num_args)), 
+        keyval("NArgs", fmt::Nval(params->sc->num_args)),
         keyval("Type", fmt::Estr(params->type)),
         this->fmt_args
     );
@@ -282,7 +287,7 @@ void linux_syscalls::print_syscall(drakvuf_t drakvuf, drakvuf_trap_info_t* info,
 event_response_t linux_syscalls::linux_ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 {
     auto params = libhook::GetTrapParams<linux_syscall_data>(info);
-    if(!drakvuf_check_return_context(drakvuf, info, params->pid, params->tid, params->rsp))
+    if (!drakvuf_check_return_context(drakvuf, info, params->pid, params->tid, params->rsp))
         return VMI_EVENT_RESPONSE_NONE;
 
     this->print_sysret(drakvuf, info, (uint64_t)params->num);
@@ -317,7 +322,7 @@ event_response_t linux_syscalls::linux_cb(drakvuf_t drakvuf, drakvuf_trap_info_t
     params->tid = info->proc_data.tid;
 
     hook->trap_->name = info->trap->name;
-    
+
     auto hookID = make_hook_id(info);
     this->ret_hooks[hookID] = std::move(hook);
 
@@ -357,7 +362,7 @@ bool linux_syscalls::trap_syscall_table_entries(drakvuf_t drakvuf)
         // Setup filter
         if (!this->filter.empty() && (this->filter.find(syscall_defintion->name) == this->filter.end()))
             continue;
-        
+
         // x32 syscall breakpoint
         snprintf(syscall_name, sizeof(syscall_name), "__ia32_sys_%s", syscall_defintion->name);
         if (!this->register_hook(syscall_name, syscall_number, syscall_defintion, false))
@@ -385,6 +390,6 @@ linux_syscalls::linux_syscalls(drakvuf_t drakvuf, const syscalls_config* config,
         return;
     }
 
-    if(!this->trap_syscall_table_entries(drakvuf))
+    if (!this->trap_syscall_table_entries(drakvuf))
         PRINT_DEBUG("[SYSCALLS] Failed to set breakpoints on some syscalls.\n");
 }

--- a/src/plugins/syscalls/linux.h
+++ b/src/plugins/syscalls/linux.h
@@ -101,84 +101,40 @@
  * https://github.com/tklengyel/drakvuf/COPYING)                           *
  *                                                                         *
  ***************************************************************************/
-
 #ifndef SYSCALLS_LINUX_H
 #define SYSCALLS_LINUX_H
 
 #include "private.h"
+#include "private_2.h"
 
+class linux_syscalls : public syscalls_base
+{
+public:
+    std::array<size_t, syscalls_ns::__PT_REGS_MAX> regs;
+    std::unordered_map<uint64_t, std::unique_ptr<libhook::SyscallHook>> hooks;
+    std::unordered_map<uint64_t, std::unique_ptr<libhook::ReturnHook>> ret_hooks;
+
+    // Helpers
+    std::vector<uint64_t> build_arguments_buffer(drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t pt_regs_addr, addr_t nr);
+    bool get_pt_regs_addr(drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t* pt_regs_addr, addr_t* nr);
+    bool register_hook(char* syscall_name, uint64_t syscall_number, const syscalls_ns::syscall_t* syscall_definition, bool is_x64);
+
+    // Print information
+    void print_syscall(drakvuf_t drakvuf, drakvuf_trap_info_t* info, std::vector<uint64_t> arguments);
+
+    // Callbacks
+    event_response_t linux_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
+    event_response_t linux_ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
+
+    bool trap_syscall_table_entries(drakvuf_t drakvuf);
+
+    linux_syscalls(drakvuf_t drakvuf, const syscalls_config* config, output_format_t output);
+};
 namespace syscalls_ns
 {
 
-void setup_linux(drakvuf_t drakvuf, syscalls* s);
-
-/**
- * Older Linux kernels pass the arguments to the syscall functions via
- * registers, per the ABI. Newer kernels pass the arguments via a
- * struct pt_regs. This change was made Apr 2018 in/near commit
- * fa697140f9a20119a9ec8fd7460cc4314fbdaff3.
- *
- * See kernel: arch/x86/include/asm/syscall_wrapper.h
- *             arch/x86/entry/entry_64.S
- *             arch/x86/include/uapi/asm/ptrace.h
- */
-enum linux_pt_regs
-{
-    PT_REGS_R15,
-    PT_REGS_R14,
-    PT_REGS_R13,
-    PT_REGS_R12,
-    PT_REGS_RBP,
-    PT_REGS_RBX,
-
-    PT_REGS_R11,
-    PT_REGS_R10,
-    PT_REGS_R9,
-    PT_REGS_R8,
-    PT_REGS_RAX,
-    PT_REGS_RCX,
-    PT_REGS_RDX,
-    PT_REGS_RSI,
-    PT_REGS_RDI,
-
-    PT_REGS_ORIG_RAX,
-
-    PT_REGS_RIP,
-    PT_REGS_CS,
-    PT_REGS_EFLAGS,
-    PT_REGS_RSP,
-    PT_REGS_SS,
-
-    __PT_REGS_MAX
-};
-
-static const char* linux_pt_regs_names[__PT_REGS_MAX] =
-{
-    [PT_REGS_R15] = "r15",
-    [PT_REGS_R14] = "r14",
-    [PT_REGS_R13] = "r13",
-    [PT_REGS_R12] = "r12",
-    [PT_REGS_RBP] = "bp",
-    [PT_REGS_RBX] = "bx",
-
-    [PT_REGS_R11] = "r11",
-    [PT_REGS_R10] = "r10",
-    [PT_REGS_R9] = "r9",
-    [PT_REGS_R8] = "r8",
-    [PT_REGS_RAX] = "ax",
-    [PT_REGS_RCX] = "cx",
-    [PT_REGS_RDX] = "dx",
-    [PT_REGS_RSI] = "si",
-    [PT_REGS_RDI] = "di",
-
-    [PT_REGS_ORIG_RAX] = "orig_ax",
-
-    [PT_REGS_RIP] = "ip",
-    [PT_REGS_CS] = "cs",
-    [PT_REGS_EFLAGS] = "flags",
-    [PT_REGS_RSP] = "sp",
-    [PT_REGS_SS] = "ss",
-};
+#define SYSCALL_TYPE_LINUX_X32 "x32"
+#define SYSCALL_TYPE_LINUX_X64 "x64"
 
 namespace linuxsc
 {
@@ -210,224 +166,742 @@ SYSCALL(openat, LONG,
     "flags",    "", DIR_IN, ULONG,
     "mode",     "", DIR_IN, ULONG,
 );
-
-// TODO: fill in missing ret & argument info
-SYSCALL(stat, VOID);
-SYSCALL(fstat, VOID);
-SYSCALL(lstat, VOID);
-SYSCALL(poll, VOID);
-SYSCALL(lseek, VOID);
-SYSCALL(mmap, VOID);
-SYSCALL(mprotect, VOID);
-SYSCALL(munmap, VOID);
-SYSCALL(brk, VOID);
-SYSCALL(rt_sigaction, VOID);
-SYSCALL(rt_sigprocmask, VOID);
-SYSCALL(rt_sigreturn, VOID);
-SYSCALL(ioctl, VOID);
-SYSCALL(pread64, VOID);
-SYSCALL(pwrite64, VOID);
-SYSCALL(readv, VOID);
-SYSCALL(writev, VOID);
-SYSCALL(access, VOID);
-SYSCALL(pipe, VOID);
-SYSCALL(select, VOID);
+SYSCALL(stat, LONG,
+    "pathname", "", DIR_IN, PCHAR,
+    "statbuf",  "", DIR_IN, PVOID,
+);
+SYSCALL(fstat, LONG,
+    "fd",      "", DIR_IN, ULONG,
+    "statbuf", "", DIR_IN, VOID,
+);
+SYSCALL(lstat, LONG,
+    "filename", "", DIR_IN, PCHAR,
+    "statbuf",  "", DIR_IN, VOID,
+);
+SYSCALL(poll, LONG,
+    "fds",     "", DIR_IN, PVOID,
+    "nfds",    "", DIR_IN, ULONG,
+    "timeout", "", DIR_IN, LONG,
+);
+SYSCALL(lseek, LONG,
+    "fd",     "", DIR_IN, ULONG,
+    "offset", "", DIR_IN, LONG,
+    "whence", "", DIR_IN, ULONG,
+);
+SYSCALL(mmap, PVOID,
+    "addr",   "", DIR_IN, PVOID,
+    "length", "", DIR_IN, ULONG,
+    "prot",   "", DIR_IN, MMAP_PROT,
+    "flags",  "", DIR_IN, LONG,
+    "fd",     "", DIR_IN, ULONG,
+    "offset", "", DIR_IN, ULONG,
+);
+SYSCALL(mprotect, LONG,
+    "start", "", DIR_IN, ULONG,
+    "len",   "", DIR_IN, ULONG,
+    "prot",  "", DIR_IN, MMAP_PROT,
+);
+SYSCALL(munmap, LONG,
+    "addr",   "", DIR_IN, PVOID,
+    "length", "", DIR_IN, ULONG,
+);
+SYSCALL(brk, LONG,
+    "brk", "", DIR_IN, ULONG,
+);
+SYSCALL(rt_sigaction, LONG,
+    "signum", "", DIR_IN, LONG,
+    "act",    "", DIR_IN, PVOID,
+    "oldact", "", DIR_IN, PVOID,
+);
+SYSCALL(rt_sigprocmask, LONG,
+    "how",    "", DIR_IN, LONG,
+    "set",    "", DIR_IN, PVOID,
+    "oldset", "", DIR_IN, PVOID,
+);
+SYSCALL(rt_sigreturn, LONG);
+SYSCALL(ioctl, LONG,
+    "fd",      "", DIR_IN, LONG,
+    "request", "", DIR_IN, ULONG,
+);
+SYSCALL(pread64, ULONG,
+    "fd",     "", DIR_IN, LONG,
+    "buf",    "", DIR_IN, PVOID,
+    "count",  "", DIR_IN, ULONG,
+    "offset", "", DIR_IN, ULONG,
+);
+SYSCALL(pwrite64, ULONG,
+    "fd",     "", DIR_IN, LONG,
+    "buf",    "", DIR_IN, PVOID,
+    "count",  "", DIR_IN, ULONG,
+    "offset", "", DIR_IN, ULONG,
+);
+SYSCALL(readv, ULONG,
+    "fd",     "", DIR_IN, LONG,
+    "iov",    "", DIR_IN, PVOID,
+    "iovcnt", "", DIR_IN, LONG,
+);
+SYSCALL(writev, ULONG,
+    "fd",     "", DIR_IN, LONG,
+    "iov",    "", DIR_IN, PVOID,
+    "iovcnt", "", DIR_IN, LONG,
+);
+SYSCALL(access, LONG,
+    "pathname", "", DIR_IN, PCHAR,
+    "mode", "", DIR_IN, LONG,
+);
+SYSCALL(pipe, LONG,
+    "pipefd", "", DIR_IN, PVOID,
+);
+SYSCALL(select, LONG,
+    "nfds",      "", DIR_IN, LONG,
+    "readfds",   "", DIR_IN, PVOID,
+    "writefds",  "", DIR_IN, PVOID,
+    "exceptfds", "", DIR_IN, PVOID,
+    "timeout",   "", DIR_IN, PVOID,
+);
 SYSCALL(sched_yield, VOID);
-SYSCALL(mremap, VOID);
-SYSCALL(msync, VOID);
-SYSCALL(mincore, VOID);
-SYSCALL(madvise, VOID);
-SYSCALL(shmget, VOID);
-SYSCALL(shmat, VOID);
-SYSCALL(shmctl, VOID);
-SYSCALL(dup, VOID);
-SYSCALL(dup2, VOID);
-SYSCALL(pause, VOID);
-SYSCALL(nanosleep, VOID);
-SYSCALL(getitimer, VOID);
-SYSCALL(alarm, VOID);
-SYSCALL(setitimer, VOID);
-SYSCALL(getpid, VOID);
-SYSCALL(sendfile64, VOID);
-SYSCALL(socket, VOID);
-SYSCALL(connect, VOID);
-SYSCALL(accept, VOID);
-SYSCALL(sendto, VOID);
-SYSCALL(recvfrom, VOID);
-SYSCALL(sendmsg, VOID);
-SYSCALL(recvmsg, VOID);
-SYSCALL(shutdown, VOID);
-SYSCALL(bind, VOID);
-SYSCALL(listen, VOID);
-SYSCALL(getsockname, VOID);
-SYSCALL(getpeername, VOID);
-SYSCALL(socketpair, VOID);
-SYSCALL(setsockopt, VOID);
-SYSCALL(getsockopt, VOID);
+SYSCALL(mremap, PVOID,
+    "old_address", "", DIR_IN, PVOID,
+    "old_size",    "", DIR_IN, ULONG,
+    "new_size",    "", DIR_IN, ULONG,
+    "flags",       "", DIR_IN, LONG,
+);
+SYSCALL(msync, LONG,
+    "addr",   "", DIR_IN, PVOID,
+    "length", "", DIR_IN, ULONG,
+    "flags",  "", DIR_IN, LONG,
+);
+SYSCALL(mincore, LONG,
+    "addr",   "", DIR_IN, PVOID,
+    "length", "", DIR_IN, ULONG,
+    "vec",    "", DIR_IN, PCHAR,
+);
+SYSCALL(madvise, LONG,
+    "addr",   "", DIR_IN, PVOID,
+    "length", "", DIR_IN, ULONG,
+    "advice", "", DIR_IN, LONG,
+);
+SYSCALL(shmget, LONG,
+    "key",    "", DIR_IN, VOID,
+    "size",   "", DIR_IN, ULONG,
+    "shmflg", "", DIR_IN, LONG,
+);
+SYSCALL(shmat, VOID,
+    "shmid",   "", DIR_IN, LONG,
+    "shmaddr", "", DIR_IN, PVOID,
+    "shmflg",  "", DIR_IN, LONG,
+);
+SYSCALL(shmctl, LONG,
+    "shmid", "", DIR_IN, LONG,
+    "cmd",   "", DIR_IN, LONG,
+    "buf",   "", DIR_IN, PVOID,
+);
+SYSCALL(dup, LONG,
+    "oldfd", "", DIR_IN, LONG
+);
+SYSCALL(dup2, LONG,
+    "oldfd", "", DIR_IN, LONG,
+    "newfd", "", DIR_IN, LONG,
+);
+SYSCALL(pause, LONG);
+// A very expensive syscall, the interception of which will greatly slow down the guest
+// It is recommended to exclude it using the filter file
+SYSCALL(nanosleep, LONG,
+    "req", "", DIR_IN, PVOID,
+    "rem", "", DIR_IN, PVOID,
+);
+SYSCALL(getitimer, LONG,
+    "which",      "", DIR_IN, LONG,
+    "curr_value", "", DIR_IN, PVOID,
+);
+SYSCALL(alarm, ULONG,
+    "seconds", "", DIR_IN, ULONG,
+);
+SYSCALL(setitimer, LONG,
+    "which",     "", DIR_IN, LONG,
+    "new_value", "", DIR_IN, PVOID,
+    "old_value", "", DIR_IN, PVOID,
+);
+SYSCALL(getpid, LONG);
+SYSCALL(sendfile64, LONG,
+    "out_fd", "", DIR_IN, LONG,
+    "in_fd",  "", DIR_IN, LONG,
+    "offset", "", DIR_IN, ULONG,
+    "count",  "", DIR_IN, ULONG,
+);
+SYSCALL(socket, LONG,
+    "domain",   "", DIR_IN, LONG,
+    "type",     "", DIR_IN, LONG,
+    "protocol", "", DIR_IN, LONG,
+);
+SYSCALL(connect, LONG,
+    "sockfd",  "", DIR_IN, LONG,
+    "addr",    "", DIR_IN, PVOID,
+    "addrlen", "", DIR_IN, ULONG,
+);
+SYSCALL(accept, LONG,
+    "sockfd",  "", DIR_IN, LONG,
+    "addr",    "", DIR_IN, PVOID,
+    "addrlen", "", DIR_IN, ULONG,
+);
+SYSCALL(sendto, LONG,
+    "sockfd",    "", DIR_IN, LONG,
+    "buf",       "", DIR_IN, PVOID,
+    "len",       "", DIR_IN, ULONG,
+    "flags",     "", DIR_IN, LONG,
+    "dest_addr", "", DIR_IN, PVOID,
+    "addrlen",   "", DIR_IN, VOID,
+);
+SYSCALL(recvfrom, LONG,
+    "sockfd",   "", DIR_IN, LONG,
+    "buf",      "", DIR_IN, PVOID,
+    "len",      "", DIR_IN, ULONG,
+    "flags",    "", DIR_IN, LONG,
+    "src_addr", "", DIR_IN, PVOID,
+    "addrlen",  "", DIR_IN, VOID,
+);
+SYSCALL(sendmsg, LONG,
+    "sockfd", "", DIR_IN, LONG,
+    "msg",    "", DIR_IN, PVOID,
+    "flags",  "", DIR_IN, LONG,
+);
+SYSCALL(recvmsg, LONG,
+    "sockfd", "", DIR_IN, LONG,
+    "msg",    "", DIR_IN, PVOID,
+    "flags",  "", DIR_IN, LONG,
+);
+SYSCALL(shutdown, LONG,
+    "sockfd", "", DIR_IN, LONG,
+    "how",    "", DIR_IN, LONG,
+);
+SYSCALL(bind, LONG,
+    "sockfd",  "", DIR_IN, LONG,
+    "addr",    "", DIR_IN, PVOID,
+    "addrlen", "", DIR_IN, ULONG,
+);
+SYSCALL(listen, LONG,
+    "sockfd",  "", DIR_IN, LONG,
+    "backlog", "", DIR_IN, LONG,
+);
+SYSCALL(getsockname, LONG,
+    "sockfd",  "", DIR_IN, LONG,
+    "addr",    "", DIR_IN, PVOID,
+    "addrlen", "", DIR_IN, ULONG,
+);
+SYSCALL(getpeername, LONG,
+    "sockfd",  "", DIR_IN, LONG,
+    "addr",    "", DIR_IN, PVOID,
+    "addrlen", "", DIR_IN, ULONG,
+);
+SYSCALL(socketpair, LONG,
+    "domain",   "", DIR_IN, LONG,
+    "type",     "", DIR_IN, LONG,
+    "protocol", "", DIR_IN, LONG,
+    "sv",       "", DIR_IN, PVOID,
+);
+SYSCALL(setsockopt, LONG,
+    "sockfd",  "", DIR_IN, LONG,
+    "level",   "", DIR_IN, LONG,
+    "optname", "", DIR_IN, LONG,
+    "optval",  "", DIR_IN, PVOID,
+    "optlen",  "", DIR_IN, ULONG,
+);
+SYSCALL(getsockopt, LONG,
+    "sockfd",  "", DIR_IN, LONG,
+    "level",   "", DIR_IN, LONG,
+    "optname", "", DIR_IN, LONG,
+    "optval",  "", DIR_IN, PVOID,
+    "optlen",  "", DIR_IN, ULONG,
+);
+// We can ignore these syscalls because there is a better interpretation going on in the procmon plugin
+// procmon
 SYSCALL(clone, VOID);
 SYSCALL(fork, VOID);
 SYSCALL(vfork, VOID);
 SYSCALL(execve, VOID);
 SYSCALL(exit, VOID);
-SYSCALL(wait4, VOID);
-SYSCALL(kill, VOID);
-SYSCALL(uname, VOID);
-SYSCALL(semget, VOID);
-SYSCALL(semop, VOID);
-SYSCALL(semctl, VOID);
+// end procmon
+SYSCALL(wait4, ULONG,
+    "pid",     "", DIR_IN, LONG,
+    "wstatus", "", DIR_IN, PLONG,
+    "options", "", DIR_IN, LONG,
+    "rusage",  "", DIR_IN, PVOID,
+);
+SYSCALL(kill, LONG,
+    "pid", "", DIR_IN, LONG,
+    "sig", "", DIR_IN, LONG,
+);
+SYSCALL(uname, LONG);
+SYSCALL(semget, LONG,
+    "key",    "", DIR_IN, ULONG,
+    "nsems",  "", DIR_IN, LONG,
+    "semflg", "", DIR_IN, LONG,
+);
+SYSCALL(semop, LONG,
+    "semid", "", DIR_IN, LONG,
+    "sops",  "", DIR_IN, PVOID,
+    "nsops", "", DIR_IN, LONG,
+);
+SYSCALL(semctl, LONG,
+    "semid",  "", DIR_IN, LONG,
+    "semnum", "", DIR_IN, LONG,
+    "cmd",    "", DIR_IN, LONG,
+);
 SYSCALL(shmdt, VOID);
 SYSCALL(msgget, VOID);
 SYSCALL(msgsnd, VOID);
 SYSCALL(msgrcv, VOID);
 SYSCALL(msgctl, VOID);
-SYSCALL(fcntl, VOID);
-SYSCALL(flock, VOID);
-SYSCALL(fsync, VOID);
-SYSCALL(fdatasync, VOID);
-SYSCALL(truncate, VOID);
-SYSCALL(ftruncate, VOID);
-SYSCALL(getdents, VOID);
-SYSCALL(getcwd, VOID);
-SYSCALL(chdir, VOID);
-SYSCALL(fchdir, VOID);
-SYSCALL(rename, VOID);
-SYSCALL(mkdir, VOID);
-SYSCALL(rmdir, VOID);
-SYSCALL(creat, VOID);
-SYSCALL(link, VOID);
-SYSCALL(unlink, VOID);
-SYSCALL(symlink, VOID);
-SYSCALL(readlink, VOID);
-SYSCALL(chmod, VOID);
-SYSCALL(fchmod, VOID);
-SYSCALL(chown, VOID);
-SYSCALL(fchown, VOID);
-SYSCALL(lchown, VOID);
-SYSCALL(umask, VOID);
-SYSCALL(gettimeofday, VOID);
-SYSCALL(getrlimit, VOID);
-SYSCALL(getrusage, VOID);
-SYSCALL(sysinfo, VOID);
-SYSCALL(times, VOID);
-SYSCALL(ptrace, VOID);
-SYSCALL(getuid, VOID);
-SYSCALL(syslog, VOID);
-SYSCALL(getgid, VOID);
-SYSCALL(setuid, VOID);
-SYSCALL(setgid, VOID);
-SYSCALL(geteuid, VOID);
-SYSCALL(getegid, VOID);
-SYSCALL(setpgid, VOID);
-SYSCALL(getppid, VOID);
-SYSCALL(getpgrp, VOID);
-SYSCALL(setsid, VOID);
-SYSCALL(setreuid, VOID);
-SYSCALL(setregid, VOID);
-SYSCALL(getgroups, VOID);
-SYSCALL(setgroups, VOID);
-SYSCALL(setresuid, VOID);
-SYSCALL(getresuid, VOID);
-SYSCALL(setresgid, VOID);
-SYSCALL(getresgid, VOID);
-SYSCALL(getpgid, VOID);
-SYSCALL(setfsuid, VOID);
-SYSCALL(setfsgid, VOID);
-SYSCALL(getsid, VOID);
-SYSCALL(capget, VOID);
-SYSCALL(capset, VOID);
-SYSCALL(rt_sigpending, VOID);
-SYSCALL(rt_sigtimedwait, VOID);
-SYSCALL(rt_sigqueueinfo, VOID);
-SYSCALL(rt_sigsuspend, VOID);
-SYSCALL(sigaltstack, VOID);
-SYSCALL(utime, VOID);
-SYSCALL(mknod, VOID);
-SYSCALL(uselib, VOID);
-SYSCALL(personality, VOID);
-SYSCALL(ustat, VOID);
-SYSCALL(statfs, VOID);
-SYSCALL(fstatfs, VOID);
-SYSCALL(sysfs, VOID);
-SYSCALL(getpriority, VOID);
-SYSCALL(setpriority, VOID);
-SYSCALL(sched_setparam, VOID);
-SYSCALL(sched_getparam, VOID);
-SYSCALL(sched_setscheduler, VOID);
-SYSCALL(sched_getscheduler, VOID);
-SYSCALL(sched_get_priority_max, VOID);
-SYSCALL(sched_get_priority_min, VOID);
-SYSCALL(sched_rr_get_interval, VOID);
-SYSCALL(mlock, VOID);
-SYSCALL(munlock, VOID);
-SYSCALL(mlockall, VOID);
-SYSCALL(munlockall, VOID);
-SYSCALL(vhangup, VOID);
-SYSCALL(modify_ldt, VOID);
-SYSCALL(pivot_root, VOID);
-SYSCALL(_sysctl, VOID);
-SYSCALL(prctl, VOID);
-SYSCALL(arch_prctl, VOID);
-SYSCALL(adjtimex, VOID);
-SYSCALL(setrlimit, VOID);
-SYSCALL(chroot, VOID);
+SYSCALL(fcntl, LONG,
+    "fd",  "", DIR_IN, LONG,
+    "cmd", "", DIR_IN, LONG,
+);
+SYSCALL(flock, LONG,
+    "fd",  "", DIR_IN, LONG,
+    "operation", "", DIR_IN, LONG,
+);
+SYSCALL(fsync, LONG,
+    "fd",  "", DIR_IN, LONG,
+);
+SYSCALL(fdatasync, LONG,
+    "fd",  "", DIR_IN, LONG,
+);
+SYSCALL(truncate, LONG,
+    "pathname", "", DIR_IN, PCHAR,
+    "length",   "", DIR_IN, ULONG,
+);
+SYSCALL(ftruncate, LONG,
+    "fd",     "", DIR_IN, LONG,
+    "length", "", DIR_IN, ULONG,
+);
+SYSCALL(getdents, LONG,
+    "fd",    "", DIR_IN, LONG,
+    "dirp",  "", DIR_IN, PVOID,
+    "count", "", DIR_IN, LONG,
+);
+SYSCALL(getcwd, PCHAR);
+SYSCALL(chdir, LONG,
+    "path", "", DIR_IN, PCHAR,
+);
+SYSCALL(fchdir, LONG,
+    "fd", "", DIR_IN, LONG,
+);
+// filetracer
+SYSCALL(rename, LONG,
+    "oldpath", "", DIR_IN, PCHAR,
+    "newpath", "", DIR_IN, PCHAR,
+);
+SYSCALL(mkdir, LONG,
+    "pathname", "", DIR_IN, PCHAR,
+    "mode",     "", DIR_IN, LONG,
+);
+SYSCALL(rmdir, LONG,
+    "pathname", "", DIR_IN, PCHAR,
+);
+SYSCALL(creat, LONG,
+    "pathname", "", DIR_IN, PCHAR,
+    "flags",    "", DIR_IN, LONG,
+);
+SYSCALL(link, LONG,
+    "oldpath", "", DIR_IN, PCHAR,
+    "newpath", "", DIR_IN, PCHAR,
+);
+SYSCALL(unlink, LONG,
+    "pathname", "", DIR_IN, PCHAR,
+);
+SYSCALL(symlink, LONG,
+    "target",   "", DIR_IN, PCHAR,
+    "linkpath", "", DIR_IN, PCHAR,
+);
+SYSCALL(readlink, LONG,
+    "pathname", "", DIR_IN, PCHAR,
+);
+SYSCALL(chmod, LONG,
+    "pathname", "", DIR_IN, PCHAR,
+    "mode",     "", DIR_IN, LONG,
+);
+SYSCALL(fchmod, LONG,
+    "fd",   "", DIR_IN, LONG,
+    "mode", "", DIR_IN, LONG,
+);
+SYSCALL(chown, LONG,
+    "pathname", "", DIR_IN, PCHAR,
+    "owner",    "", DIR_IN, ULONG,
+    "group",    "", DIR_IN, ULONG,
+);
+SYSCALL(fchown, LONG,
+    "fd",    "", DIR_IN, LONG,
+    "owner", "", DIR_IN, ULONG,
+    "group", "", DIR_IN, ULONG,
+);
+SYSCALL(lchown, LONG,
+    "pathname", "", DIR_IN, PCHAR,
+    "owner",    "", DIR_IN, ULONG,
+    "group",    "", DIR_IN, ULONG,
+);
+// end filetracer
+SYSCALL(umask, LONG,
+    "mask", "", DIR_IN, LONG,
+);
+SYSCALL(gettimeofday, LONG);
+SYSCALL(getrlimit, LONG);
+SYSCALL(getrusage, LONG);
+SYSCALL(sysinfo, LONG);
+SYSCALL(times, LONG);
+// ptracemon
+SYSCALL(ptrace, LONG,
+    "request", "", DIR_IN, LONG,
+    "pid",     "", DIR_IN, LONG,
+    "addr",    "", DIR_IN, PVOID,
+    "data",    "", DIR_IN, PVOID,
+);
+// end ptracemon
+SYSCALL(getuid, ULONG);
+SYSCALL(syslog, LONG,
+    "type", "", DIR_IN, LONG,
+    "bufp", "", DIR_IN, PCHAR,
+    "len",  "", DIR_IN, LONG,
+);
+SYSCALL(getgid, ULONG);
+SYSCALL(setuid, LONG,
+    "uid", "", DIR_IN, ULONG,
+);
+SYSCALL(setgid, LONG,
+    "gid", "", DIR_IN, ULONG,
+);
+SYSCALL(geteuid, ULONG);
+SYSCALL(getegid, ULONG);
+SYSCALL(setpgid, LONG,
+    "pid",  "", DIR_IN, LONG,
+    "pgid", "", DIR_IN, ULONG,
+);
+SYSCALL(getppid, ULONG);
+SYSCALL(getpgrp, ULONG);
+SYSCALL(setsid, ULONG);
+SYSCALL(setreuid, LONG,
+    "ruid", "", DIR_IN, ULONG,
+    "euid", "", DIR_IN, ULONG,
+);
+SYSCALL(setregid, LONG,
+    "rgid", "", DIR_IN, ULONG,
+    "egid", "", DIR_IN, ULONG,
+);
+SYSCALL(getgroups, LONG);
+SYSCALL(setgroups, LONG);
+SYSCALL(setresuid, LONG,
+    "ruid", "", DIR_IN, ULONG,
+    "euid", "", DIR_IN, ULONG,
+    "suid", "", DIR_IN, ULONG,
+);
+SYSCALL(getresuid, LONG);
+SYSCALL(setresgid, LONG,
+    "rgid", "", DIR_IN, ULONG,
+    "egid", "", DIR_IN, ULONG,
+    "sgid", "", DIR_IN, ULONG,
+);
+SYSCALL(getresgid, LONG);
+SYSCALL(getpgid, ULONG);
+SYSCALL(setfsuid, LONG,
+    "fsuid", "", DIR_IN, ULONG,
+);
+SYSCALL(setfsgid, LONG,
+    "fsgid", "", DIR_IN, ULONG,
+);
+SYSCALL(getsid, ULONG);
+SYSCALL(capget, LONG);
+SYSCALL(capset, LONG);
+SYSCALL(rt_sigpending, LONG);
+SYSCALL(rt_sigtimedwait, LONG);
+SYSCALL(rt_sigqueueinfo, LONG);
+SYSCALL(rt_sigsuspend, LONG);
+SYSCALL(sigaltstack, LONG);
+SYSCALL(utime, LONG,
+    "filename", "", DIR_IN, PCHAR,
+    "times",    "", DIR_IN, PVOID,
+);
+// filetracer
+SYSCALL(mknod, LONG,
+    "pathname", "", DIR_IN, PCHAR,
+    "mode",     "", DIR_IN, LONG,
+    "dev",      "", DIR_IN, LONG,
+);
+// end filetracer
+SYSCALL(uselib, LONG,
+    "library", "", DIR_IN, PCHAR,
+);
+SYSCALL(personality, LONG,
+    "persona", "", DIR_IN, ULONG,
+);
+SYSCALL(ustat, LONG);
+SYSCALL(statfs, LONG,
+    "path", "", DIR_IN, PCHAR,
+    "buf",  "", DIR_IN, PVOID,
+);
+SYSCALL(fstatfs, LONG,
+    "fd",  "", DIR_IN, LONG,
+    "buf", "", DIR_IN, PVOID,
+);
+SYSCALL(sysfs, LONG);
+SYSCALL(getpriority, LONG,
+    "which", "", DIR_IN, LONG,
+    "who",   "", DIR_IN, LONG,
+);
+SYSCALL(setpriority, LONG,
+    "which", "", DIR_IN, LONG,
+    "who",   "", DIR_IN, LONG,
+    "prio",  "", DIR_IN, LONG,
+);
+SYSCALL(sched_setparam, LONG,
+    "pid",   "", DIR_IN, ULONG,
+    "param", "", DIR_IN, PVOID,
+);
+SYSCALL(sched_getparam, LONG,
+    "pid",   "", DIR_IN, ULONG,
+    "param", "", DIR_IN, PVOID,
+);
+SYSCALL(sched_setscheduler, LONG,
+    "pid",    "", DIR_IN, ULONG,
+    "policy", "", DIR_IN, LONG,
+    "param",  "", DIR_IN, PVOID,
+);
+SYSCALL(sched_getscheduler, LONG,
+    "pid", "", DIR_IN, ULONG,
+);
+SYSCALL(sched_get_priority_max, LONG,
+    "policy", "", DIR_IN, LONG,
+);
+SYSCALL(sched_get_priority_min, LONG,
+    "policy", "", DIR_IN, LONG,
+);
+SYSCALL(sched_rr_get_interval, LONG,
+    "pid", "", DIR_IN, ULONG,
+    "tp",  "", DIR_IN, PVOID,
+);
+SYSCALL(mlock, LONG,
+    "addr", "", DIR_IN, PVOID,
+    "len",  "", DIR_IN, ULONG,
+);
+SYSCALL(munlock, LONG,
+    "addr", "", DIR_IN, PVOID,
+    "len",  "", DIR_IN, ULONG,
+);
+SYSCALL(mlockall, LONG,
+    "flags", "", DIR_IN, LONG,
+);
+SYSCALL(munlockall, LONG);
+SYSCALL(vhangup, LONG);
+SYSCALL(modify_ldt, LONG);
+SYSCALL(pivot_root, LONG,
+    "new_root", "", DIR_IN, PCHAR,
+    "put_old",  "", DIR_IN, PCHAR,
+);
+SYSCALL(_sysctl, LONG,
+    "args", "", DIR_IN, PVOID,
+);
+SYSCALL(prctl, LONG,
+    "option", "", DIR_IN, PRCTL_OPTION,
+    "arg2",   "", DIR_IN, ULONG,
+    "arg3",   "", DIR_IN, ULONG,
+    "arg4",   "", DIR_IN, ULONG,
+    "arg5",   "", DIR_IN, ULONG,
+);
+SYSCALL(arch_prctl, LONG,
+    "code", "", DIR_IN, ARCH_PRCTL_CODE,
+    "addr", "", DIR_IN, LONG,
+);
+SYSCALL(adjtimex, LONG,
+    "buf", "", DIR_IN, PVOID,
+);
+SYSCALL(setrlimit, LONG,
+    "resource", "", DIR_IN, LONG,
+    "rlim",     "", DIR_IN, PVOID,
+);
+// filetracer
+SYSCALL(chroot, LONG,
+    "path", "", DIR_IN, PCHAR,
+);
+// end filetracer
 SYSCALL(sync, VOID);
-SYSCALL(acct, VOID);
-SYSCALL(settimeofday, VOID);
-SYSCALL(mount, VOID);
-SYSCALL(umount2, VOID);
-SYSCALL(swapon, VOID);
-SYSCALL(swapoff, VOID);
-SYSCALL(reboot, VOID);
-SYSCALL(sethostname, VOID);
-SYSCALL(setdomainname, VOID);
-SYSCALL(iopl, VOID);
-SYSCALL(ioperm, VOID);
-SYSCALL(create_module, VOID);
-SYSCALL(init_module, VOID);
-SYSCALL(delete_module, VOID);
-SYSCALL(get_kernel_syms, VOID);
-SYSCALL(query_module, VOID);
-SYSCALL(quotactl, VOID);
-SYSCALL(nfsservctl, VOID);
+SYSCALL(acct, LONG,
+    "filename", "", DIR_IN, PCHAR,
+);
+SYSCALL(settimeofday, LONG); // useless information
+SYSCALL(mount, LONG,
+    "source",         "", DIR_IN, PCHAR,
+    "target",         "", DIR_IN, PCHAR,
+    "filesystemtype", "", DIR_IN, PCHAR,
+    "mountflags",     "", DIR_IN, ULONG,
+    "data",           "", DIR_IN, PVOID,
+);
+SYSCALL(umount2, LONG,
+    "target", "", DIR_IN, PCHAR,
+    "flags",  "", DIR_IN, LONG,
+);
+SYSCALL(swapon, LONG,
+    "path",      "", DIR_IN, PCHAR,
+    "swapflags", "", DIR_IN, LONG,
+);
+SYSCALL(swapoff, LONG,
+    "path", "", DIR_IN, PCHAR,
+);
+SYSCALL(reboot, LONG,
+    "magic",  "", DIR_IN, LONG,
+    "magic2", "", DIR_IN, LONG,
+    "cmd",    "", DIR_IN, LONG,
+    "arg",    "", DIR_IN, PVOID,
+);
+SYSCALL(sethostname, LONG,
+    "name", "", DIR_IN, PCHAR,
+    "len",  "", DIR_IN, ULONG,
+);
+SYSCALL(setdomainname, LONG,
+    "name", "", DIR_IN, PCHAR,
+    "len",  "", DIR_IN, ULONG,
+);
+SYSCALL(iopl, LONG,
+    "level", "", DIR_IN, LONG,
+);
+SYSCALL(ioperm, LONG,
+    "from",    "", DIR_IN, ULONG,
+    "num",     "", DIR_IN, ULONG,
+    "turn_on", "", DIR_IN, LONG,
+);
+SYSCALL(create_module, LONG,
+    "name", "", DIR_IN, PCHAR,
+    "size", "", DIR_IN, ULONG,
+);
+SYSCALL(init_module, LONG,
+    "module_image", "", DIR_IN, PVOID,
+    "len",          "", DIR_IN, ULONG,
+    "param_values", "", DIR_IN, PCHAR,
+);
+SYSCALL(delete_module, LONG,
+    "name",  "", DIR_IN, PCHAR,
+    "flags", "", DIR_IN, ULONG,
+);
+SYSCALL(get_kernel_syms, LONG);
+SYSCALL(query_module, LONG,
+    "name",    "", DIR_IN, PCHAR,
+    "wchich",  "", DIR_IN, LONG,
+    "buf",     "", DIR_IN, PVOID,
+    "bufsize", "", DIR_IN, ULONG,
+    "ret",     "", DIR_IN, PULONG,
+);
+SYSCALL(quotactl, LONG,
+    "cmd",     "", DIR_IN, LONG,
+    "special", "", DIR_IN, PCHAR,
+    "id",      "", DIR_IN, LONG,
+    "addr",    "", DIR_IN, VOID,
+);
+SYSCALL(nfsservctl, LONG,
+    "cmd",  "", DIR_IN, LONG,
+    "argp", "", DIR_IN, PVOID,
+    "resp", "", DIR_IN, PVOID,
+);
 SYSCALL(getpmsg, VOID);
 SYSCALL(putpmsg, VOID);
 SYSCALL(afs_syscall, VOID);
 SYSCALL(tuxcall, VOID);
 SYSCALL(security, VOID);
-SYSCALL(gettid, VOID);
-SYSCALL(readahead, VOID);
-SYSCALL(setxattr, VOID);
-SYSCALL(lsetxattr, VOID);
-SYSCALL(fsetxattr, VOID);
-SYSCALL(getxattr, VOID);
-SYSCALL(lgetxattr, VOID);
-SYSCALL(fgetxattr, VOID);
-SYSCALL(listxattr, VOID);
-SYSCALL(llistxattr, VOID);
-SYSCALL(flistxattr, VOID);
-SYSCALL(removexattr, VOID);
-SYSCALL(lremovexattr, VOID);
-SYSCALL(fremovexattr, VOID);
-SYSCALL(tkill, VOID);
+SYSCALL(gettid, LONG);
+SYSCALL(readahead, LONG,
+    "fd",     "", DIR_IN, LONG,
+    "offset", "", DIR_IN, LONG,
+    "count",  "", DIR_IN, ULONG,
+);
+SYSCALL(setxattr, LONG,
+    "path",  "", DIR_IN, PCHAR,
+    "name",  "", DIR_IN, PCHAR,
+    "value", "", DIR_IN, PVOID,
+    "size",  "", DIR_IN, ULONG,
+    "flags", "", DIR_IN, LONG,
+);
+SYSCALL(lsetxattr, LONG,
+    "path",  "", DIR_IN, PCHAR,
+    "name",  "", DIR_IN, PCHAR,
+    "value", "", DIR_IN, PVOID,
+    "size",  "", DIR_IN, ULONG,
+    "flags", "", DIR_IN, LONG,
+);
+SYSCALL(fsetxattr, LONG,
+    "fd",    "", DIR_IN, PCHAR,
+    "name",  "", DIR_IN, PCHAR,
+    "value", "", DIR_IN, PVOID,
+    "size",  "", DIR_IN, ULONG,
+    "flags", "", DIR_IN, LONG,
+);
+SYSCALL(getxattr, LONG,
+    "path",  "", DIR_IN, PCHAR,
+    "name",  "", DIR_IN, PCHAR,
+    "value", "", DIR_IN, PVOID,
+    "size",  "", DIR_IN, ULONG,
+);
+SYSCALL(lgetxattr, LONG,
+    "path",  "", DIR_IN, PCHAR,
+    "name",  "", DIR_IN, PCHAR,
+    "value", "", DIR_IN, PVOID,
+    "size",  "", DIR_IN, ULONG,
+);
+SYSCALL(fgetxattr, LONG,
+    "fd",    "", DIR_IN, PCHAR,
+    "name",  "", DIR_IN, PCHAR,
+    "value", "", DIR_IN, PVOID,
+    "size",  "", DIR_IN, ULONG,
+);
+SYSCALL(listxattr, LONG,
+    "path", "", DIR_IN, PCHAR,
+    "list", "", DIR_INOUT, PCHAR,
+    "size", "", DIR_IN, ULONG,
+);
+SYSCALL(llistxattr, LONG,
+    "path", "", DIR_IN, PCHAR,
+    "list", "", DIR_INOUT, PCHAR,
+    "size", "", DIR_IN, ULONG,
+);
+SYSCALL(flistxattr, LONG,
+    "fd",   "", DIR_IN, PCHAR,
+    "list", "", DIR_INOUT, PCHAR,
+    "size", "", DIR_IN, ULONG,
+);
+SYSCALL(removexattr, LONG,
+    "path", "", DIR_IN, PCHAR,
+    "name", "", DIR_IN, PCHAR,
+);
+SYSCALL(lremovexattr, LONG,
+    "path", "", DIR_IN, PCHAR,
+    "name", "", DIR_IN, PCHAR,
+);
+SYSCALL(fremovexattr, LONG,
+    "fd",   "", DIR_IN, PCHAR,
+    "name", "", DIR_IN, PCHAR,
+);
+SYSCALL(tkill, LONG,
+    "pid", "", DIR_IN, LONG,
+    "sig", "", DIR_IN, LONG,
+);
 SYSCALL(time, VOID);
 SYSCALL(futex, VOID);
-SYSCALL(sched_setaffinity, VOID);
-SYSCALL(sched_getaffinity, VOID);
-SYSCALL(set_thread_area, VOID);
-SYSCALL(io_setup, VOID);
-SYSCALL(io_destroy, VOID);
-SYSCALL(io_getevents, VOID);
-SYSCALL(io_submit, VOID);
-SYSCALL(io_cancel, VOID);
-SYSCALL(get_thread_area, VOID);
-SYSCALL(lookup_dcookie, VOID);
-SYSCALL(epoll_create, VOID);
+SYSCALL(sched_setaffinity, LONG);
+SYSCALL(sched_getaffinity, LONG);
+SYSCALL(set_thread_area, LONG);
+SYSCALL(io_setup, LONG);
+SYSCALL(io_destroy, LONG);
+SYSCALL(io_getevents, LONG);
+SYSCALL(io_submit, LONG);
+SYSCALL(io_cancel, LONG);
+SYSCALL(get_thread_area, LONG);
+SYSCALL(lookup_dcookie, LONG);
+SYSCALL(epoll_create, LONG);
 SYSCALL(epoll_ctl_old, VOID);
 SYSCALL(epoll_wait_old, VOID);
 SYSCALL(remap_file_pages, VOID);
-SYSCALL(getdents64, VOID);
-SYSCALL(set_tid_address, VOID);
-SYSCALL(restart_syscall, VOID);
+SYSCALL(getdents64, LONG,
+    "fd",    "", DIR_IN, LONG,
+    "dirp",  "", DIR_IN, PVOID,
+    "count", "", DIR_IN, ULONG,
+);
+SYSCALL(set_tid_address, LONG);
+SYSCALL(restart_syscall, LONG);
 SYSCALL(semtimedop, VOID);
 SYSCALL(fadvise64, VOID);
 SYSCALL(timer_create, VOID);
@@ -439,92 +913,358 @@ SYSCALL(clock_settime, VOID);
 SYSCALL(clock_gettime, VOID);
 SYSCALL(clock_getres, VOID);
 SYSCALL(clock_nanosleep, VOID);
-SYSCALL(exit_group, VOID);
+SYSCALL(exit_group, VOID,
+    "status", "", DIR_IN, LONG,
+);
 SYSCALL(epoll_wait, VOID);
 SYSCALL(epoll_ctl, VOID);
-SYSCALL(tgkill, VOID);
-SYSCALL(utimes, VOID);
+SYSCALL(tgkill, LONG,
+    "tgid", "", DIR_IN, LONG,
+    "pid",  "", DIR_IN, LONG,
+    "sig",  "", DIR_IN, LONG,
+);
+SYSCALL(utimes, LONG,
+    "filename", "", DIR_IN, PCHAR,
+    "times",    "", DIR_IN, PVOID,
+);
 SYSCALL(vserver, VOID);
 SYSCALL(mbind, VOID);
 SYSCALL(set_mempolicy, VOID);
 SYSCALL(get_mempolicy, VOID);
-SYSCALL(mq_open, VOID);
-SYSCALL(mq_unlink, VOID);
+SYSCALL(mq_open, VOID,
+    "name",  "", DIR_IN, PCHAR,
+    "oflag", "", DIR_IN, LONG,
+);
+SYSCALL(mq_unlink, LONG,
+    "name",  "", DIR_IN, PCHAR,
+);
 SYSCALL(mq_timedsend, VOID);
 SYSCALL(mq_timedreceive, VOID);
 SYSCALL(mq_notify, VOID);
 SYSCALL(mq_getsetattr, VOID);
 SYSCALL(kexec_load, VOID);
 SYSCALL(waitid, VOID);
-SYSCALL(add_key, VOID);
-SYSCALL(request_key, VOID);
-SYSCALL(keyctl, VOID);
+SYSCALL(add_key, VOID,
+    "type",        "", DIR_IN, PCHAR,
+    "description", "", DIR_IN, PCHAR,
+    "payload",     "", DIR_IN, PVOID,
+    "plen",        "", DIR_IN, ULONG,
+    "keyring",     "", DIR_IN, LONG,
+);
+SYSCALL(request_key, VOID,
+    "type",         "", DIR_IN, PCHAR,
+    "description",  "", DIR_IN, PCHAR,
+    "callout_info", "", DIR_IN, PCHAR,
+    "dest_keyring", "", DIR_IN, LONG,
+);
+SYSCALL(keyctl, LONG,
+    "operation", "", DIR_IN, LONG,
+    "arg2",      "", DIR_IN, ULONG,
+    "arg3",      "", DIR_IN, ULONG,
+    "arg4",      "", DIR_IN, ULONG,
+    "arg5",      "", DIR_IN, ULONG,
+);
 SYSCALL(ioprio_set, VOID);
 SYSCALL(ioprio_get, VOID);
 SYSCALL(inotify_init, VOID);
-SYSCALL(inotify_add_watch, VOID);
-SYSCALL(inotify_rm_watch, VOID);
-SYSCALL(migrate_pages, VOID);
-SYSCALL(mkdirat, VOID);
-SYSCALL(mknodat, VOID);
-SYSCALL(fchownat, VOID);
-SYSCALL(futimesat, VOID);
-SYSCALL(newfstatat, VOID);
-SYSCALL(unlinkat, VOID);
-SYSCALL(renameat, VOID);
-SYSCALL(linkat, VOID);
-SYSCALL(symlinkat, VOID);
-SYSCALL(readlinkat, VOID);
-SYSCALL(fchmodat, VOID);
-SYSCALL(faccessat, VOID);
-SYSCALL(pselect6, VOID);
-SYSCALL(ppoll, VOID);
-SYSCALL(unshare, VOID);
+SYSCALL(inotify_add_watch, LONG,
+    "fd",       "", DIR_IN, LONG,
+    "pathname", "", DIR_IN, PCHAR,
+    "mask",     "", DIR_IN, UINT,
+);
+SYSCALL(inotify_rm_watch, LONG,
+    "fd", "", DIR_IN, LONG,
+    "wd", "", DIR_IN, LONG,
+);
+SYSCALL(migrate_pages, LONG,
+    "pid",       "", DIR_IN, LONG,
+    "maxnode",   "", DIR_IN, ULONG,
+    "old_nodes", "", DIR_IN, PULONG,
+    "new_nodes", "", DIR_IN, PULONG,
+);
+SYSCALL(mkdirat, LONG,
+    "dirfd",    "", DIR_IN, LONG,
+    "pathname", "", DIR_IN, PCHAR,
+    "mode",     "", DIR_IN, ULONG,
+);
+SYSCALL(mknodat, LONG,
+    "dirfd",     "", DIR_IN, LONG,
+    "pathname", "", DIR_IN, PCHAR,
+    "mode",     "", DIR_IN, ULONG,
+    "dev",      "", DIR_IN, ULONG,
+);
+SYSCALL(fchownat, LONG,
+    "dirfd",    "", DIR_IN, LONG,
+    "pathname", "", DIR_IN, PCHAR,
+    "owner",    "", DIR_IN, ULONG,
+    "group",    "", DIR_IN, ULONG,
+    "flags",    "", DIR_IN, LONG,
+);
+SYSCALL(futimesat, LONG,
+    "dirfd",    "", DIR_IN, LONG,
+    "pathname", "", DIR_IN, PCHAR,
+    "times",    "", DIR_IN, PVOID,
+);
+SYSCALL(newfstatat, LONG,
+    "dirfd",    "", DIR_IN, LONG,
+    "pathname", "", DIR_IN, PCHAR,
+    "statbuf",  "", DIR_IN, PVOID,
+    "flags",    "", DIR_IN, LONG,
+);
+SYSCALL(unlinkat, LONG,
+    "dirfd",    "", DIR_IN, LONG,
+    "pathname", "", DIR_IN, PCHAR,
+    "flags",    "", DIR_IN, ULONG,
+);
+SYSCALL(renameat, LONG,
+    "olddirfd", "", DIR_IN, LONG,
+    "oldpath",  "", DIR_IN, PCHAR,
+    "newdirfd", "", DIR_IN, LONG,
+    "newpath",  "", DIR_IN, PCHAR,
+);
+SYSCALL(linkat, LONG,
+    "olddirfd", "", DIR_IN, LONG,
+    "oldpath",  "", DIR_IN, PCHAR,
+    "newdirfd", "", DIR_IN, LONG,
+    "newpath",  "", DIR_IN, PCHAR,
+    "flags",    "", DIR_IN, LONG,
+);
+SYSCALL(symlinkat, LONG,
+    "target",   "", DIR_IN, PCHAR,
+    "newdirfd", "", DIR_IN, LONG,
+    "linkpath", "", DIR_IN, PCHAR,
+);
+SYSCALL(readlinkat, LONG,
+    "dirfd",    "", DIR_IN, LONG,
+    "pathname", "", DIR_IN, PCHAR,
+    "buf",      "", DIR_INOUT, PCHAR,
+    "bufsize",  "", DIR_IN, ULONG,
+);
+SYSCALL(fchmodat, LONG,
+    "dirfd",    "", DIR_IN, LONG,
+    "pathname", "", DIR_IN, PCHAR,
+    "mode",     "", DIR_IN, ULONG,
+    "flags",    "", DIR_IN, LONG,
+);
+SYSCALL(faccessat, LONG,
+    "dirfd",    "", DIR_IN, LONG,
+    "pathname", "", DIR_IN, PCHAR,
+    "mode",     "", DIR_IN, LONG,
+    "flags",    "", DIR_IN, LONG,
+);
+SYSCALL(pselect6, LONG);
+SYSCALL(ppoll, LONG);
+SYSCALL(unshare, LONG,
+    "flags", "", DIR_IN, LONG,
+);
 SYSCALL(set_robust_list, VOID);
 SYSCALL(get_robust_list, VOID);
 SYSCALL(splice, VOID);
-SYSCALL(tee, VOID);
+SYSCALL(tee, LONG,
+    "fd_in",  "", DIR_IN, LONG,
+    "fd_out", "", DIR_IN, LONG,
+    "len",    "", DIR_IN, ULONG,
+    "flags",  "", DIR_IN, ULONG,
+);
 SYSCALL(sync_file_range, VOID);
 SYSCALL(vmsplice, VOID);
 SYSCALL(move_pages, VOID);
-SYSCALL(utimensat, VOID);
+SYSCALL(utimensat, LONG,
+    "dirfd",    "", DIR_IN, LONG,
+    "pathname", "", DIR_IN, PCHAR,
+    "times",    "", DIR_IN, PVOID,
+    "flags",    "", DIR_IN, LONG,
+);
 SYSCALL(epoll_pwait, VOID);
 SYSCALL(signalfd, VOID);
-SYSCALL(timerfd_create, VOID);
-SYSCALL(eventfd, VOID);
-SYSCALL(fallocate, VOID);
-SYSCALL(timerfd_settime, VOID);
-SYSCALL(timerfd_gettime, VOID);
-SYSCALL(accept4, VOID);
-SYSCALL(signalfd4, VOID);
-SYSCALL(eventfd2, VOID);
-SYSCALL(epoll_create1, VOID);
-SYSCALL(dup3, VOID);
-SYSCALL(pipe2, VOID);
-SYSCALL(inotify_init1, VOID);
-SYSCALL(preadv, VOID);
-SYSCALL(pwritev, VOID);
-SYSCALL(rt_tgsigqueueinfo, VOID);
-SYSCALL(perf_event_open, VOID);
-SYSCALL(recvmmsg, VOID);
-SYSCALL(fanotify_init, VOID);
-SYSCALL(fanotify_mark, VOID);
-SYSCALL(prlimit64, VOID);
-SYSCALL(name_to_handle_at, VOID);
-SYSCALL(open_by_handle_at, VOID);
-SYSCALL(clock_adjtime, VOID);
-SYSCALL(syncfs, VOID);
-SYSCALL(sendmmsg, VOID);
-SYSCALL(setns, VOID);
-SYSCALL(getcpu, VOID);
-SYSCALL(process_vm_readv, VOID);
-SYSCALL(process_vm_writev, VOID);
-SYSCALL(kcmp, VOID);
-SYSCALL(finit_module, VOID);
+SYSCALL(timerfd_create, LONG,
+    "clockid", "", DIR_IN, LONG,
+    "flags",   "", DIR_IN, LONG,
+);
+SYSCALL(eventfd, LONG,
+    "initval", "", DIR_IN, ULONG,
+    "flags",   "", DIR_IN, LONG,
+);
+SYSCALL(fallocate, LONG,
+    "fd",     "", DIR_IN, LONG,
+    "mode",   "", DIR_IN, LONG,
+    "offset", "", DIR_IN, ULONG,
+    "len",    "", DIR_IN, ULONG,
+);
+SYSCALL(timerfd_settime, LONG,
+    "fd",        "", DIR_IN, LONG,
+    "flags",     "", DIR_IN, LONG,
+    "new_value", "", DIR_IN, PVOID,
+    "old_value", "", DIR_IN, PVOID,
+);
+SYSCALL(timerfd_gettime, LONG,
+    "fd",         "", DIR_IN, LONG,
+    "curr_value", "", DIR_IN, PVOID,
+);
+SYSCALL(accept4, LONG,
+    "sockfd",  "", DIR_IN, LONG,
+    "addr",    "", DIR_IN, PVOID,
+    "addrlen", "", DIR_IN, PVOID,
+    "flags",   "", DIR_IN, LONG,
+);
+SYSCALL(signalfd4, LONG);
+SYSCALL(eventfd2, LONG,
+    "initval", "", DIR_IN, LONG,
+    "flags",   "", DIR_IN, LONG,
+);
+SYSCALL(epoll_create1, LONG,
+    "flags", "", DIR_IN, LONG,
+);
+SYSCALL(dup3, LONG,
+    "oldfd", "", DIR_IN, LONG,
+    "newfd", "", DIR_IN, LONG,
+    "flags", "", DIR_IN, LONG,
+);
+SYSCALL(pipe2, LONG);
+SYSCALL(inotify_init1, LONG,
+    "flags", "", DIR_IN, LONG,
+);
+SYSCALL(preadv, LONG);
+SYSCALL(pwritev, LONG);
+SYSCALL(rt_tgsigqueueinfo, LONG);
+SYSCALL(perf_event_open, LONG);
+SYSCALL(recvmmsg, LONG);
+SYSCALL(fanotify_init, LONG,
+    "flags",         "", DIR_IN, ULONG,
+    "event_f_flags", "", DIR_IN, ULONG,
+);
+SYSCALL(fanotify_mark, LONG,
+    "fanotify_id", "", DIR_IN, LONG,
+    "flags",       "", DIR_IN, ULONG,
+    "mask",        "", DIR_IN, ULONG,
+    "dirfd",       "", DIR_IN, LONG,
+    "pathname",    "", DIR_IN, PCHAR,
+);
+SYSCALL(prlimit64, LONG);
+SYSCALL(name_to_handle_at, LONG,
+    "dirfd",    "", DIR_IN, LONG,
+    "pathname", "", DIR_IN, PCHAR,
+    "handle",   "", DIR_IN, PVOID,
+    "mount_id", "", DIR_IN, PLONG,
+    "flags",    "", DIR_IN, LONG,
+);
+SYSCALL(open_by_handle_at, LONG,
+    "mount_fd", "", DIR_IN, LONG,
+    "handle",   "", DIR_IN, PVOID,
+    "flags",    "", DIR_IN, LONG,
+);
+SYSCALL(clock_adjtime, LONG);
+SYSCALL(syncfs, LONG,
+    "fd", "", DIR_IN, LONG,
+);
+SYSCALL(sendmmsg, LONG,
+    "sockfd", "", DIR_IN, LONG,
+    "msgvec", "", DIR_IN, PVOID,
+    "vlen",   "", DIR_IN, ULONG,
+    "flags",  "", DIR_IN, LONG,
+);
+SYSCALL(setns, LONG,
+    "fd",     "", DIR_IN, LONG,
+    "nstype", "", DIR_IN, LONG,
+);
+SYSCALL(getcpu, LONG);
+SYSCALL(process_vm_readv, LONG,
+    "pid", "", DIR_IN, LONG,
+);
+SYSCALL(process_vm_writev, LONG,
+    "pid", "", DIR_IN, LONG,
+);
+SYSCALL(kcmp, LONG,
+    "pid1", "", DIR_IN, LONG,
+    "pid2", "", DIR_IN, LONG,
+    "type", "", DIR_IN, LONG,
+    "idx1", "", DIR_IN, ULONG,
+    "idx2", "", DIR_IN, ULONG,
+);
+SYSCALL(finit_module, LONG,
+    "fd",           "", DIR_IN, LONG,
+    "param_values", "", DIR_IN, PCHAR,
+    "flags",        "", DIR_IN, LONG,
+);
+SYSCALL(sched_setattr, LONG,
+    "pid",   "", DIR_IN, LONG,
+    "attr",  "", DIR_IN, PVOID,
+    "flags", "", DIR_IN, ULONG,
+);
+SYSCALL(sched_getattr, LONG,
+    "pid",   "", DIR_IN, LONG,
+    "attr",  "", DIR_IN, PVOID,
+    "size",  "", DIR_IN, ULONG,
+    "flags", "", DIR_IN, ULONG,
+);
+// filetracer
+SYSCALL(renameat2, LONG,
+    "olddirfd", "", DIR_IN, LONG,
+    "oldpath",  "", DIR_IN, PCHAR,
+    "newdirfd", "", DIR_IN, LONG,
+    "newpath",  "", DIR_IN, PCHAR,
+    "flags",    "", DIR_IN, ULONG,
+);
+// end filetracer
+SYSCALL(seccomp, LONG,
+    "operation", "", DIR_IN, ULONG,
+    "flags",     "", DIR_IN, ULONG,
+    "args",      "", DIR_IN, PVOID,
+);
+SYSCALL(getrandom, VOID);
+// filetracer
+SYSCALL(memfd_create, LONG,
+    "name",  "", DIR_IN, PCHAR,
+    "flags", "", DIR_IN, ULONG,
+);
+// end filetracer
+SYSCALL(kexec_file_load, LONG,
+    "kernel_fd",   "", DIR_IN, LONG,
+    "initrd_fd",   "", DIR_IN, LONG,
+    "cmdline_len", "", DIR_IN, ULONG,
+    "cmdline",     "", DIR_IN, PCHAR,
+    "flags",       "",  DIR_IN, ULONG,
+);
+// ebpfmon
+SYSCALL(bpf, LONG,
+    "cmd",  "", DIR_IN, LONG,
+    "attr", "", DIR_IN, PVOID,
+    "size", "", DIR_IN, ULONG,
+);
+// ebpfmon
+SYSCALL(execveat, VOID);
+SYSCALL(userfaultfd, LONG,
+    "flags", "", DIR_IN, LONG,
+);
+SYSCALL(membarrier, LONG);
+SYSCALL(mlock2, LONG);
+SYSCALL(copy_file_range, LONG);
+SYSCALL(preadv2, LONG);
+SYSCALL(pwritev2, LONG);
+SYSCALL(pkey_mprotect, LONG,
+    "addr", "", DIR_IN, PVOID,
+    "len",  "", DIR_IN, ULONG,
+    "prot", "", DIR_IN, LONG,
+    "pkey", "", DIR_IN, LONG,
+);
+SYSCALL(pkey_alloc, LONG,
+    "flags",         "", DIR_IN, ULONG,
+    "access_rights", "", DIR_IN, ULONG,
+);
+SYSCALL(pkey_free, LONG,
+    "pkey", "", DIR_IN, LONG,
+);
+SYSCALL(statx, LONG,
+    "dirfd",    "", DIR_IN, LONG,
+    "pathname", "", DIR_IN, PCHAR,
+    "flags",    "", DIR_IN, ULONG,
+    "mask",     "", DIR_IN, ULONG,
+    "statxbuf", "", DIR_IN, PVOID,
+);
 
 #pragma clang diagnostic pop
 
-static const syscall_t* linux_syscalls[] =
+static const syscall_t* linux_syscalls_table[] =
 {
     [0] = &read,
     [1] = &write,
@@ -840,10 +1580,29 @@ static const syscall_t* linux_syscalls[] =
     [311] = &process_vm_writev,
     [312] = &kcmp,
     [313] = &finit_module,
+    [314] = &sched_setattr,
+    [315] = &sched_getattr,
+    [316] = &renameat2,
+    [317] = &seccomp,
+    [318] = &getrandom,
+    [319] = &memfd_create,
+    [320] = &kexec_file_load,
+    [321] = &bpf,
+    [322] = &execveat,
+    [323] = &userfaultfd,
+    [324] = &membarrier,
+    [325] = &mlock2,
+    [326] = &copy_file_range,
+    [327] = &preadv2,
+    [328] = &pwritev2,
+    [329] = &pkey_mprotect,
+    [330] = &pkey_alloc,
+    [331] = &pkey_free,
+    [332] = &statx,
 };
 
 // The actual max depends on the arch and actual kernel version
-#define NUM_SYSCALLS_LINUX sizeof(linuxsc::linux_syscalls)/sizeof(syscall_t*)
+#define NUM_SYSCALLS_LINUX sizeof(linuxsc::linux_syscalls_table)/sizeof(syscall_t*)
 
 }
 

--- a/src/plugins/syscalls/private.h
+++ b/src/plugins/syscalls/private.h
@@ -534,7 +534,7 @@ struct linux_syscall_data : PluginResult
 
 #define ENUM(name, number) { number, #name }
 
-static inline std::unordered_map<uint64_t, std::string> prctl_option = 
+static inline std::unordered_map<uint64_t, std::string> prctl_option =
 {
     ENUM(PR_SET_PDEATHSIG, 1),
     ENUM(PR_GET_PDEATHSIG, 2),
@@ -612,7 +612,7 @@ static inline std::unordered_map<uint64_t, std::string> arch_prctl_code =
     ENUM(ARCH_MAP_VDSO_64, 0x2003),
 };
 
-static const flags_str_t mmap_prot = 
+static const flags_str_t mmap_prot =
 {
     REGISTER_FLAG(PROT_READ),
     REGISTER_FLAG(PROT_WRITE),

--- a/src/plugins/syscalls/private_2.h
+++ b/src/plugins/syscalls/private_2.h
@@ -140,7 +140,10 @@ public:
     uint64_t transform_value(drakvuf_t drakvuf, drakvuf_trap_info_t* info, const syscalls_ns::arg_t& arg, uint64_t val);
     bool read_syscalls_filter(const char* filter_file);
 
-    virtual char* win_extract_string(drakvuf_t drakvuf, drakvuf_trap_info_t* info, const syscalls_ns::arg_t& arg, addr_t val) { return NULL; };
+    virtual char* win_extract_string(drakvuf_t drakvuf, drakvuf_trap_info_t* info, const syscalls_ns::arg_t& arg, addr_t val)
+    {
+        return NULL;
+    };
 
     syscalls_base(drakvuf_t drakvuf, const syscalls_config* config, output_format_t output);
     syscalls_base(const syscalls_base&) = delete;

--- a/src/plugins/syscalls/syscalls.cpp
+++ b/src/plugins/syscalls/syscalls.cpp
@@ -243,8 +243,10 @@ syscalls_base::syscalls_base(drakvuf_t drakvuf, const syscalls_config* config, o
     this->is32bit = (drakvuf_get_page_mode(drakvuf) != VMI_PM_IA32E);
     this->disable_sysret = config->disable_sysret;
 
-    if (config->syscalls_filter_file) {
-        if (!this->read_syscalls_filter(config->syscalls_filter_file)) {
+    if (config->syscalls_filter_file)
+    {
+        if (!this->read_syscalls_filter(config->syscalls_filter_file))
+        {
             PRINT_DEBUG("[SYSCALLS] Failed to read given file\n");
             throw -1;
         }

--- a/src/plugins/syscalls/syscalls.h
+++ b/src/plugins/syscalls/syscalls.h
@@ -105,56 +105,22 @@
 #ifndef SYSCALLS_H
 #define SYSCALLS_H
 
-#include "plugins/plugins.h"
-#include "plugins/plugins_ex.h"
 #include "plugins/private.h"
-#include "plugins/output_format.h"
+#include "plugins/plugins_ex.h"
 
-struct syscalls_config
-{
-    const char* syscalls_filter_file;
-    const char* win32k_profile;
-    bool disable_sysret;
-};
+#include "linux.h"
+#include "win.h"
 
-class syscalls: public pluginex
+// external syscalls class
+class syscalls : public pluginex
 {
 public:
-    GSList* traps; // NOTE Non "pluginex" support for linux
-    GSList* strings_to_free;
-    GHashTable* filter;
-
-    uint8_t reg_size;
-    bool is32bit;
-    output_format_t format;
-    os_t os;
-    bool disable_sysret;
-
-    size_t* offsets;
-
-    addr_t sst[2][2]; // [0=nt][base, limit],[1=win32k][base,limit]
-    addr_t ntdll_base, ntdll_size, wow64cpu_base, wow64cpu_size;
-
-    addr_t kernel_base, kernel_size;
-    addr_t image_path_name;
-    std::string win32k_profile;
-
-    std::unique_ptr<libhook::SyscallHook> load_driver_hook;
-    std::unique_ptr<libhook::SyscallHook> create_process_hook;
-    std::unique_ptr<libhook::ReturnHook> wait_process_creation_hook;
-
-    std::vector<std::pair<char const*, fmt::Aarg>> fmt_args; // cache
+    std::unique_ptr<linux_syscalls> _linux_syscalls;
+    std::unique_ptr<win_syscalls> _win_syscalls;
 
     syscalls(drakvuf_t drakvuf, const syscalls_config* config, output_format_t output);
     syscalls(const syscalls&) = delete;
     syscalls& operator=(const syscalls&) = delete;
-    ~syscalls();
-
-    bool setup_win32k_syscalls(drakvuf_t drakvuf);
-
-    event_response_t load_driver_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
-    event_response_t create_process_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
-    event_response_t create_process_ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
 };
 
 #endif

--- a/src/plugins/syscalls/win.cpp
+++ b/src/plugins/syscalls/win.cpp
@@ -456,7 +456,7 @@ bool win_syscalls::trap_syscall_table_entries(drakvuf_t drakvuf, vmi_instance_t 
     return true;
 }
 
-win_syscalls::win_syscalls(drakvuf_t drakvuf, const syscalls_config* config, output_format_t output) 
+win_syscalls::win_syscalls(drakvuf_t drakvuf, const syscalls_config* config, output_format_t output)
     : syscalls_base(drakvuf, config, output)
     , ntdll_base   { 0 }
     , wow64cpu_base{ 0 }


### PR DESCRIPTION
Changelog:
1. Changed the architecture of the syscall plugin; Added support for `pluginex` for the Linux part; Each OS is separated by its semantic classes;
2. Added a description of all syscalls with their arguments that were already in the plugin + also added new syscalls;
3. Added support for installing hooks in Linux using a filter file, similar to Windows;
4. Added support for x86 syscalls (Linux part);
5. The hook installation system has been redesigned and optimized;

Initially, I only needed improvements on the arguments in syscalls, but the plugin architecture seemed to me absolutely terrible and unsuitable for development, so I decided to fix it.
Also during testing, I noticed that the plugin doesn't intercept x86 syscalls, which was also fixed.
Most of the improvements affect Linux, because I don't really understand the Windows part of the plugin, so there are only minimal changes.

Example of a filter file:
```
execve
prctl
getpid
```