### PR TITLE
filetracer update

### DIFF
--- a/src/plugins/filetracer/private.h
+++ b/src/plugins/filetracer/private.h
@@ -142,6 +142,7 @@ struct wrapper
     uint64_t create_disposition;
     uint64_t create_opts;
     uint64_t desired_access;
+    addr_t io_status_block;
 };
 
 struct linux_data : PluginResult
@@ -222,6 +223,7 @@ enum
     _SID_SubAuthority,
     _ACL_AceCount,
     _ACL_AclSize,
+    _IO_STATUS_BLOCK_Information,
     __OFFSET_MAX
 };
 
@@ -398,6 +400,7 @@ static const char* offset_names[__OFFSET_MAX][2] =
     [_SID_SubAuthority] = {"_SID", "SubAuthority"},
     [_ACL_AceCount] = {"_ACL", "AceCount"},
     [_ACL_AclSize] = {"_ACL", "AclSize"},
+    [_IO_STATUS_BLOCK_Information] = {"_IO_STATUS_BLOCK", "Information"},
 };
 
 static const flags_str_t object_attrs =


### PR DESCRIPTION
filetracer update to get more information about system calls:

- [NtSetInformationFile](https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/ntifs/nf-ntifs-ntsetinformationfile) with `FileEndOfFileInformation` flag to get new size of a file
- [NtCreateFile](https://learn.microsoft.com/en-us/windows/win32/api/winternl/nf-winternl-ntcreatefile) `IoStatusBlock` to get final completion status (the status is correct only when the function returns success, otherwise not) - `FILE_SUPERSEDED` (0), `FILE_OPENED` (1) and etc.


