### PR TITLE
libinjector: skip kernel mode trap frame

### DIFF
--- a/src/libinjector/win/win_injector.c
+++ b/src/libinjector/win/win_injector.c
@@ -292,6 +292,11 @@ static event_response_t wait_for_target_process_cb(drakvuf_t drakvuf, drakvuf_tr
             goto done;
         }
 
+        if (bp_addr & (1LL << 63)) {
+            PRINT_DEBUG("Got return address from kernel address space, waiting for another one.\n")
+            goto done;
+        }
+
         if (setup_int3_trap(injector, info, bp_addr))
         {
             PRINT_DEBUG("Got return address 0x%lx from trapframe and it's now trapped!\n",

--- a/src/libinjector/win/win_injector.c
+++ b/src/libinjector/win/win_injector.c
@@ -294,7 +294,7 @@ static event_response_t wait_for_target_process_cb(drakvuf_t drakvuf, drakvuf_tr
 
         if (VMI_GET_BIT(bp_addr, 47))
         {
-            PRINT_DEBUG("Got return address from kernel address space, waiting for another one.\n")
+            PRINT_DEBUG("Got return address from kernel address space, waiting for another one.\n");
             goto done;
         }
 

--- a/src/libinjector/win/win_injector.c
+++ b/src/libinjector/win/win_injector.c
@@ -292,7 +292,8 @@ static event_response_t wait_for_target_process_cb(drakvuf_t drakvuf, drakvuf_tr
             goto done;
         }
 
-        if (bp_addr & (1LL << 63)) {
+        if (bp_addr & (1LL << 63))
+        {
             PRINT_DEBUG("Got return address from kernel address space, waiting for another one.\n")
             goto done;
         }

--- a/src/libinjector/win/win_injector.c
+++ b/src/libinjector/win/win_injector.c
@@ -292,7 +292,7 @@ static event_response_t wait_for_target_process_cb(drakvuf_t drakvuf, drakvuf_tr
             goto done;
         }
 
-        if (bp_addr & (1LL << 63))
+        if (VMI_GET_BIT(bp_addr, 47))
         {
             PRINT_DEBUG("Got return address from kernel address space, waiting for another one.\n")
             goto done;


### PR DESCRIPTION
Refer to https://github.com/CERT-Polska/drakvuf-sandbox/issues/748 for more info why this is an issue.