### PR TITLE
Hidevm string replacement refactor

### DIFF
--- a/src/plugins/Makefile.am
+++ b/src/plugins/Makefile.am
@@ -415,7 +415,7 @@ endif
 sources += plugins.cpp plugins.h plugins_ex.cpp plugins_ex.h plugin_utils.cpp plugin_utils.h
 sources += output_format.h output_format/common.h output_format/csvfmt.h output_format/deffmt.h output_format/jsonfmt.h output_format/kvfmt.h
 sources += output_format/xfmt.h output_format/ostream.h output_format/ostream.cpp
-sources += helpers/type_traits.h helpers/hooks.h helpers/unicode_string.h helpers/vmi_lock_guard.h
+sources += helpers/type_traits.h helpers/hooks.h helpers/unicode_string.h helpers/vmi_lock_guard.h helpers/profile_guard.h
 
 AM_CPPFLAGS = $(CPPFLAGS) -I$(top_srcdir) -I$(top_srcdir)/src -I$(srcdir) -I$(srcdir)/helpers
 AM_CPPFLAGS += $(VMI_CFLAGS)

--- a/src/plugins/helpers/profile_guard.h
+++ b/src/plugins/helpers/profile_guard.h
@@ -1,0 +1,133 @@
+/*********************IMPORTANT DRAKVUF LICENSE TERMS***********************
+ *                                                                         *
+ * DRAKVUF (C) 2014-2023 Tamas K Lengyel.                                  *
+ * Tamas K Lengyel is hereinafter referred to as the author.               *
+ * This program is free software; you may redistribute and/or modify it    *
+ * under the terms of the GNU General Public License as published by the   *
+ * Free Software Foundation; Version 2 ("GPL"), BUT ONLY WITH ALL OF THE   *
+ * CLARIFICATIONS AND EXCEPTIONS DESCRIBED HEREIN.  This guarantees your   *
+ * right to use, modify, and redistribute this software under certain      *
+ * conditions.  If you wish to embed DRAKVUF technology into proprietary   *
+ * software, alternative licenses can be acquired from the author.         *
+ *                                                                         *
+ * Note that the GPL places important restrictions on "derivative works",  *
+ * yet it does not provide a detailed definition of that term.  To avoid   *
+ * misunderstandings, we interpret that term as broadly as copyright law   *
+ * allows.  For example, we consider an application to constitute a        *
+ * derivative work for the purpose of this license if it does any of the   *
+ * following with any software or content covered by this license          *
+ * ("Covered Software"):                                                   *
+ *                                                                         *
+ * o Integrates source code from Covered Software.                         *
+ *                                                                         *
+ * o Reads or includes copyrighted data files.                             *
+ *                                                                         *
+ * o Is designed specifically to execute Covered Software and parse the    *
+ * results (as opposed to typical shell or execution-menu apps, which will *
+ * execute anything you tell them to).                                     *
+ *                                                                         *
+ * o Includes Covered Software in a proprietary executable installer.  The *
+ * installers produced by InstallShield are an example of this.  Including *
+ * DRAKVUF with other software in compressed or archival form does not     *
+ * trigger this provision, provided appropriate open source decompression  *
+ * or de-archiving software is widely available for no charge.  For the    *
+ * purposes of this license, an installer is considered to include Covered *
+ * Software even if it actually retrieves a copy of Covered Software from  *
+ * another source during runtime (such as by downloading it from the       *
+ * Internet).                                                              *
+ *                                                                         *
+ * o Links (statically or dynamically) to a library which does any of the  *
+ * above.                                                                  *
+ *                                                                         *
+ * o Executes a helper program, module, or script to do any of the above.  *
+ *                                                                         *
+ * This list is not exclusive, but is meant to clarify our interpretation  *
+ * of derived works with some common examples.  Other people may interpret *
+ * the plain GPL differently, so we consider this a special exception to   *
+ * the GPL that we apply to Covered Software.  Works which meet any of     *
+ * these conditions must conform to all of the terms of this license,      *
+ * particularly including the GPL Section 3 requirements of providing      *
+ * source code and allowing free redistribution of the work as a whole.    *
+ *                                                                         *
+ * Any redistribution of Covered Software, including any derived works,    *
+ * must obey and carry forward all of the terms of this license, including *
+ * obeying all GPL rules and restrictions.  For example, source code of    *
+ * the whole work must be provided and free redistribution must be         *
+ * allowed.  All GPL references to "this License", are to be treated as    *
+ * including the terms and conditions of this license text as well.        *
+ *                                                                         *
+ * Because this license imposes special exceptions to the GPL, Covered     *
+ * Work may not be combined (even as part of a larger work) with plain GPL *
+ * software.  The terms, conditions, and exceptions of this license must   *
+ * be included as well.  This license is incompatible with some other open *
+ * source licenses as well.  In some cases we can relicense portions of    *
+ * DRAKVUF or grant special permissions to use it in other open source     *
+ * software.  Please contact tamas.k.lengyel@gmail.com with any such       *
+ * requests.  Similarly, we don't incorporate incompatible open source     *
+ * software into Covered Software without special permission from the      *
+ * copyright holders.                                                      *
+ *                                                                         *
+ * If you have any questions about the licensing restrictions on using     *
+ * DRAKVUF in other works, are happy to help.  As mentioned above,         *
+ * alternative license can be requested from the author to integrate       *
+ * DRAKVUF into proprietary applications and appliances.  Please email     *
+ * tamas.k.lengyel@gmail.com for further information.                      *
+ *                                                                         *
+ * If you have received a written license agreement or contract for        *
+ * Covered Software stating terms other than these, you may choose to use  *
+ * and redistribute Covered Software under those terms instead of these.   *
+ *                                                                         *
+ * Source is provided to this software because we believe users have a     *
+ * right to know exactly what a program is going to do before they run it. *
+ * This also allows you to audit the software for security holes.          *
+ *                                                                         *
+ * Source code also allows you to port DRAKVUF to new platforms, fix bugs, *
+ * and add new features.  You are highly encouraged to submit your changes *
+ * on https://github.com/tklengyel/drakvuf, or by other methods.           *
+ * By sending these changes, it is understood (unless you specify          *
+ * otherwise) that you are offering unlimited, non-exclusive right to      *
+ * reuse, modify, and relicense the code.  DRAKVUF will always be          *
+ * available Open Source, but this is important because the inability to   *
+ * relicense code has caused devastating problems for other Free Software  *
+ * projects (such as KDE and NASM).                                        *
+ * To specify special license conditions of your contributions, just say   *
+ * so when you send them.                                                  *
+ *                                                                         *
+ * This program is distributed in the hope that it will be useful, but     *
+ * WITHOUT ANY WARRANTY; without even the implied warranty of              *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the DRAKVUF   *
+ * license file for more details (it's in a COPYING file included with     *
+ * DRAKVUF, and also available from                                        *
+ * https://github.com/tklengyel/drakvuf/COPYING)                           *
+ *                                                                         *
+ ***************************************************************************/
+#pragma once
+#include <libdrakvuf/json-util.h>
+#include <stdexcept>
+
+/**
+ * This is a simple wrapper class for automatic releasing an json_object
+ * at the end of the scope.
+ */
+class profile_guard
+{
+public:
+    explicit profile_guard(const char* profile_file)
+        : obj(json_object_from_file(profile_file))
+    {
+        if (!obj)
+            throw std::runtime_error("Failed to open profile file\n");
+    }
+    ~profile_guard()
+    {
+        json_object_put(obj);
+    }
+
+    operator json_object* () const
+    {
+        return obj;
+    }
+
+private:
+    json_object* obj;
+};

--- a/src/plugins/hidevm/hidevm.cpp
+++ b/src/plugins/hidevm/hidevm.cpp
@@ -607,24 +607,21 @@ static bool replace_object_name(vmi_instance_t vmi, uint64_t cr3, addr_t addr_st
     unicode_string_t replacement_utf16;
     bool result = false;
 
-    const char* replacement_str = "Win32_BIOS";
-    size_t replacement_length = strlen(replacement_str);
-    replacement_utf8.contents = static_cast<uint8_t*>(malloc(replacement_length));
+    replacement_utf8.contents = reinterpret_cast<uint8_t*>(strdup("Win32_BIOS"));
 
     if (replacement_utf8.contents)
     {
         replacement_utf8.encoding = "UTF-8";
-        replacement_utf8.length = strlen(replacement_str);
-        strncpy(reinterpret_cast<char*>(replacement_utf8.contents), replacement_str, replacement_length);
+        replacement_utf8.length = strlen(reinterpret_cast<char*>(replacement_utf8.contents)) + 1;
 
-        if (VMI_SUCCESS == vmi_convert_str_encoding(&replacement_utf8, &replacement_utf16, "UTF-16"))
+        if (VMI_SUCCESS == vmi_convert_str_encoding(&replacement_utf8, &replacement_utf16, "UTF-16LE"))
         {
             ACCESS_CONTEXT(ctx,
                 .translate_mechanism = VMI_TM_PROCESS_DTB,
                 .dtb = cr3,
                 .addr = addr_strQuery + object_name_pos * 2
             );
-            if (VMI_SUCCESS == vmi_write(vmi, &ctx, replacement_utf16.length, replacement_utf16.contents + 2, nullptr))
+            if (VMI_SUCCESS == vmi_write(vmi, &ctx, replacement_utf16.length, replacement_utf16.contents, nullptr))
             {
                 result = true;
             }

--- a/src/plugins/hidevm/hidevm.cpp
+++ b/src/plugins/hidevm/hidevm.cpp
@@ -679,6 +679,7 @@ static void check_and_replace_query_string(drakvuf_t drakvuf, drakvuf_trap_info_
                 );
             }
         }
+        vmi_free_unicode_str(strQuery);
     }
     else
         PRINT_DEBUG("[HIDEVM] IWbemServices::ExecQuery: Failed to read strQuery parameter\n");

--- a/src/plugins/linkmon/linkmon.cpp
+++ b/src/plugins/linkmon/linkmon.cpp
@@ -379,7 +379,7 @@ linkmon::linkmon(drakvuf_t drakvuf,
         return;
     }
 
-    json_object* ole32_profile_json = json_object_from_file(c->ole32_profile);
+    auto ole32_profile_json = profile_guard(c->ole32_profile);
     if (!json_get_struct_members_array_rva(drakvuf, ole32_profile_json,
             offset_names_1, this->offsets.size(), this->offsets.data()))
     {

--- a/src/plugins/plugins.h
+++ b/src/plugins/plugins.h
@@ -121,6 +121,7 @@
 
 #include "helpers/vmi_lock_guard.h"
 #include "helpers/unicode_string.h"
+#include "helpers/profile_guard.h"
 
 #if defined(LIBDRAKVUF_PRIVATE_GUARD)
 #error You should never include libdrakvuf/private.h in a plugin


### PR DESCRIPTION
Use null-terminated strings for `replacenent_utf8` and `replacement_utf16` in `replace_object_name` method.

Use `UTF-16LE` encoding instead of `UTF-16` to get rid of `BOM`.

Fixed memory leak in `check_and_replace_query_string` on `strQuery`