### PR TITLE
filetracer refactor and update

### DIFF
--- a/src/plugins/filetracer/private.h
+++ b/src/plugins/filetracer/private.h
@@ -125,6 +125,26 @@ struct win_objattrs_t
     std::string dacl;
 };
 
+struct file_basic_information_t
+{
+    uint64_t creation_time;
+    uint64_t last_access_time;
+    uint64_t last_write_time;
+    uint64_t change_time;
+    std::string file_attributes;
+};
+
+struct file_network_open_information_t
+{
+    uint64_t creation_time;
+    uint64_t last_access_time;
+    uint64_t last_write_time;
+    uint64_t change_time;
+    uint64_t allocation_size;
+    uint64_t end_of_file;
+    std::string file_attributes;
+};
+
 struct win_data : PluginResult
 {
     win_data()
@@ -138,6 +158,7 @@ struct win_data : PluginResult
         , share_access()
         , create_disposition()
         , create_opts()
+        , open_opts()
         , desired_access()
         , io_status_block()
     {
@@ -154,8 +175,12 @@ struct win_data : PluginResult
     uint64_t share_access;
     uint64_t create_disposition;
     uint64_t create_opts;
+    uint64_t open_opts;
     uint64_t desired_access;
     addr_t io_status_block;
+
+    addr_t file_information;
+    uint32_t file_information_class;
 };
 
 struct linux_data : PluginResult
@@ -237,11 +262,6 @@ enum
     _ACL_AceCount,
     _ACL_AclSize,
     _IO_STATUS_BLOCK_Information,
-    __OFFSET_MAX
-};
-
-enum
-{
     _FILE_RENAME_INFORMATION_RootDirectory,
     _FILE_RENAME_INFORMATION_FileName,
     _FILE_RENAME_INFORMATION_FileNameLength,
@@ -250,7 +270,15 @@ enum
     _FILE_BASIC_INFORMATION_LastWriteTime,
     _FILE_BASIC_INFORMATION_ChangeTime,
     _FILE_BASIC_INFORMATION_FileAttributes,
-    __OLE32_OFFSET_MAX
+    _FILE_NETWORK_OPEN_INFORMATION_CreationTime,
+    _FILE_NETWORK_OPEN_INFORMATION_LastAccessTime,
+    _FILE_NETWORK_OPEN_INFORMATION_LastWriteTime,
+    _FILE_NETWORK_OPEN_INFORMATION_ChangeTime,
+    _FILE_NETWORK_OPEN_INFORMATION_AllocationSize,
+    _FILE_NETWORK_OPEN_INFORMATION_EndOfFile,
+    _FILE_NETWORK_OPEN_INFORMATION_FileAttributes,
+    _FILE_ALL_INFORMATION_BasicInformation,
+    __OFFSET_MAX
 };
 
 enum
@@ -427,10 +455,6 @@ static const char* offset_names[__OFFSET_MAX][2] =
     [_ACL_AceCount] = {"_ACL", "AceCount"},
     [_ACL_AclSize] = {"_ACL", "AclSize"},
     [_IO_STATUS_BLOCK_Information] = {"_IO_STATUS_BLOCK", "Information"},
-};
-
-static const char* ole32_offset_names[__OLE32_OFFSET_MAX][2] =
-{
     [_FILE_RENAME_INFORMATION_RootDirectory] = {"_FILE_RENAME_INFORMATION", "RootDirectory"},
     [_FILE_RENAME_INFORMATION_FileName] = {"_FILE_RENAME_INFORMATION", "FileName"},
     [_FILE_RENAME_INFORMATION_FileNameLength] = {"_FILE_RENAME_INFORMATION", "FileNameLength"},
@@ -439,6 +463,14 @@ static const char* ole32_offset_names[__OLE32_OFFSET_MAX][2] =
     [_FILE_BASIC_INFORMATION_LastWriteTime] = {"_FILE_BASIC_INFORMATION", "LastWriteTime"},
     [_FILE_BASIC_INFORMATION_ChangeTime] = {"_FILE_BASIC_INFORMATION", "ChangeTime"},
     [_FILE_BASIC_INFORMATION_FileAttributes] = {"_FILE_BASIC_INFORMATION", "FileAttributes"},
+    [_FILE_NETWORK_OPEN_INFORMATION_CreationTime] = {"_FILE_NETWORK_OPEN_INFORMATION", "CreationTime"},
+    [_FILE_NETWORK_OPEN_INFORMATION_LastAccessTime] = {"_FILE_NETWORK_OPEN_INFORMATION", "LastAccessTime"},
+    [_FILE_NETWORK_OPEN_INFORMATION_LastWriteTime] = {"_FILE_NETWORK_OPEN_INFORMATION", "LastWriteTime"},
+    [_FILE_NETWORK_OPEN_INFORMATION_ChangeTime] = {"_FILE_NETWORK_OPEN_INFORMATION", "ChangeTime"},
+    [_FILE_NETWORK_OPEN_INFORMATION_AllocationSize] = {"_FILE_NETWORK_OPEN_INFORMATION", "AllocationSize"},
+    [_FILE_NETWORK_OPEN_INFORMATION_EndOfFile] = {"_FILE_NETWORK_OPEN_INFORMATION", "EndOfFile"},
+    [_FILE_NETWORK_OPEN_INFORMATION_FileAttributes] = {"_FILE_NETWORK_OPEN_INFORMATION", "FileAttributes"},
+    [_FILE_ALL_INFORMATION_BasicInformation] = {"_FILE_ALL_INFORMATION", "BasicInformation"},
 };
 
 static const flags_str_t object_attrs =

--- a/src/plugins/filetracer/win.h
+++ b/src/plugins/filetracer/win.h
@@ -119,16 +119,17 @@ class win_filetracer : public pluginex
 {
 public:
     std::array<size_t, __OFFSET_MAX> offsets;
-    std::array<size_t, __OLE32_OFFSET_MAX> ole32_offsets;
 
     /* Hooks */
     std::unique_ptr<libhook::SyscallHook> create_file_hook;
     std::unique_ptr<libhook::SyscallHook> open_file_hook;
     std::unique_ptr<libhook::SyscallHook> open_directory_object_hook;
     std::unique_ptr<libhook::SyscallHook> query_attributes_file_hook;
+    std::unique_ptr<libhook::SyscallHook> query_full_attributes_file_hook;
     std::unique_ptr<libhook::SyscallHook> set_information_file_hook;
     std::unique_ptr<libhook::SyscallHook> read_file_hook;
     std::unique_ptr<libhook::SyscallHook> write_file_hook;
+    std::unique_ptr<libhook::SyscallHook> query_information_file_hook;
 
     /* Return hooks */
     std::unordered_map<uint64_t, std::unique_ptr<libhook::ReturnHook>> ret_hooks;
@@ -138,22 +139,34 @@ public:
     event_response_t open_file_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
     event_response_t open_directory_object_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
     event_response_t query_attributes_file_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
+    event_response_t query_full_attributes_file_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
     event_response_t set_information_file_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
     event_response_t read_file_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
     event_response_t write_file_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
+    event_response_t query_information_file_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
 
     /* Return callbacks */
     event_response_t create_file_ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
+    event_response_t open_file_ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
+    event_response_t query_attributes_file_ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
+    event_response_t query_full_attributes_file_ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
+    event_response_t query_information_file_ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
 
     /* File info parsing */
     std::tuple<bool, win_objattrs_t> objattr_read(drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t attrs);
+    std::tuple<bool, file_basic_information_t> basic_file_info_read(drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t basic_file_info);
+    std::tuple<bool, file_network_open_information_t> net_file_info_read(drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t net_file_info);
 
     /* Helper functions */
     void print_file_obj_info(drakvuf_t drakvuf, drakvuf_trap_info_t* info, const win_objattrs_t& attrs);
-    void print_create_file_obj_info(drakvuf_t drakvuf, drakvuf_trap_info_t* info, uint32_t handle, uint32_t io_information, const win_objattrs_t& attrs, win_data* params, bool is_success);
+    void print_create_file_obj_info(drakvuf_t drakvuf, drakvuf_trap_info_t* info, uint32_t handle, uint32_t io_information, const win_objattrs_t& attrs, win_data* params, uint64_t status);
+    void print_open_file_obj_info(drakvuf_t drakvuf, drakvuf_trap_info_t* info, uint32_t handle, uint32_t io_information, const win_objattrs_t& attrs, win_data* params, uint64_t status);
     void print_file_read_info(drakvuf_t drakvuf, drakvuf_trap_info_t* info, uint32_t handle);
+    void print_file_query_full_attributes(drakvuf_t drakvuf, drakvuf_trap_info_t* info, const win_objattrs_t& attrs, const file_network_open_information_t& file_info, uint64_t status);
+    void print_file_query_attributes(drakvuf_t drakvuf, drakvuf_trap_info_t* info, const win_objattrs_t& attrs, const file_basic_information_t& file_info, uint64_t status);
     void print_delete_file_info(drakvuf_t drakvuf, drakvuf_trap_info_t* info, uint32_t handle, addr_t fileinfo);
-    void print_basic_file_info(vmi_instance_t vmi, drakvuf_t drakvuf, drakvuf_trap_info_t* info, uint32_t src_file_handle, addr_t fileinfo);
+    void print_basic_file_info(drakvuf_t drakvuf, drakvuf_trap_info_t* info, uint32_t src_file_handle, const file_basic_information_t& basic_file_info, uint64_t status);
+    void print_file_net_info(drakvuf_t drakvuf, drakvuf_trap_info_t* info, uint32_t src_file_handle, const file_network_open_information_t& file_info, uint64_t status);
     void print_rename_file_info(vmi_instance_t vmi, drakvuf_t drakvuf, drakvuf_trap_info_t* info, uint32_t src_file_handle, addr_t fileinfo);
     void print_eof_file_info(vmi_instance_t vmi, drakvuf_t drakvuf, drakvuf_trap_info_t* info, uint32_t src_file_handle, addr_t fileinfo);
 


### PR DESCRIPTION
Hello I refactored filetracer again and add some new features:

- All offsets can be extracted from one profile - ole32.json
- NtOpenFile now gets file handle
- Add some functions to get files creation/modification time (from `_FILE_BASIC_INFO` and etc) - it is useful in some cases
- All time converted to unixtime - it is easier to correlate with time in filetracer events 
- "Status" now in hex - [NTSTATUS Values](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-erref/596a1078-e883-4972-9bbc-49e60bebca55) are better