### PR TITLE
Procdump exclude

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -333,6 +333,8 @@ static void print_usage()
         "\t                           Disables hook on KiDeliverApc\n"
         "\t --procdump-disable-kedelayexecutionthread-hook\n"
         "\t                           Disables hook on KeDelayExecutionThread\n"
+        "\t --procdump-exclude-list <file name filter>\n"
+        "\t                           File with list of process name regexes to exclude from dumping\n"
 #endif
 #ifdef ENABLE_PLUGIN_CODEMON
         "\t --codemon-dump-dir <directory>\n"
@@ -491,6 +493,7 @@ int main(int argc, char** argv)
         opt_procdump_new_processes_on_finish,
         opt_procdump_disable_kideliverapc_hook,
         opt_procdump_disable_kedelayexecutionthread_hook,
+        opt_procdump_exclude_list,
         opt_json_clr,
         opt_json_mscorwks,
         opt_disable_sysret,
@@ -574,6 +577,7 @@ int main(int argc, char** argv)
         {"procdump-new-processes-on-finish", no_argument, NULL, opt_procdump_new_processes_on_finish},
         {"procdump-disable-kideliverapc-hook", no_argument, NULL, opt_procdump_disable_kideliverapc_hook},
         {"procdump-disable-kedelayexecutionthread-hook", no_argument, NULL, opt_procdump_disable_kedelayexecutionthread_hook},
+        {"procdump-exclude-list", required_argument, NULL, opt_procdump_exclude_list},
         {"json-clr", required_argument, NULL, opt_json_clr},
         {"json-mscorwks", required_argument, NULL, opt_json_mscorwks},
         {"syscall-hooks-list", required_argument, NULL, 'S'},
@@ -908,6 +912,13 @@ int main(int argc, char** argv)
                 break;
             case opt_procdump_disable_kedelayexecutionthread_hook:
                 options.procdump_disable_kedelayexecutionthread_hook = true;
+                break;
+            case opt_procdump_exclude_list:
+                if (!std::filesystem::exists(optarg))
+                {
+                    fprintf(stderr, "file %s does not exist!\n", optarg);
+                }
+                options.procdump_exclude_file = optarg;
                 break;
 #endif
 #ifdef ENABLE_PLUGIN_CODEMON

--- a/src/plugins/Makefile.am
+++ b/src/plugins/Makefile.am
@@ -415,7 +415,7 @@ endif
 sources += plugins.cpp plugins.h plugins_ex.cpp plugins_ex.h plugin_utils.cpp plugin_utils.h
 sources += output_format.h output_format/common.h output_format/csvfmt.h output_format/deffmt.h output_format/jsonfmt.h output_format/kvfmt.h
 sources += output_format/xfmt.h output_format/ostream.h output_format/ostream.cpp
-sources += helpers/type_traits.h helpers/hooks.h helpers/unicode_string.h helpers/vmi_lock_guard.h helpers/profile_guard.h
+sources += helpers/type_traits.h helpers/hooks.h helpers/unicode_string.h helpers/vmi_lock_guard.h helpers/profile_guard.h helpers/exclude_matcher.h helpers/exclude_matcher.cpp
 
 AM_CPPFLAGS = $(CPPFLAGS) -I$(top_srcdir) -I$(top_srcdir)/src -I$(srcdir) -I$(srcdir)/helpers
 AM_CPPFLAGS += $(VMI_CFLAGS)

--- a/src/plugins/fileextractor/fileextractor.cpp
+++ b/src/plugins/fileextractor/fileextractor.cpp
@@ -108,7 +108,6 @@
 #include <cassert>
 #include <sstream>
 #include <string>
-#include <fstream>
 #include <algorithm>
 #include <vector>
 #include <iterator>
@@ -223,7 +222,7 @@ event_response_t fileextractor::createfile_ret_cb(drakvuf_t,
             addr_t file = 0;
             auto filename = get_file_name(vmi, info, handle, &file, nullptr);
 
-            if (is_in_exclude_list(filename))
+            if (exclude.match(filename))
             {
                 print_extraction_exclusion(info, filename);
                 return VMI_EVENT_RESPONSE_NONE;
@@ -328,7 +327,7 @@ event_response_t fileextractor::setinformation_cb(drakvuf_t,
                     addr_t file = 0;
                     auto filename = get_file_name(vmi, info, handle, &file, nullptr);
 
-                    if (is_in_exclude_list(filename))
+                    if (exclude.match(filename))
                     {
                         print_extraction_exclusion(info, filename);
                         return VMI_EVENT_RESPONSE_NONE;
@@ -365,7 +364,7 @@ event_response_t fileextractor::setinformation_cb(drakvuf_t,
                     addr_t file = 0;
                     auto filename = get_file_name(vmi, info, handle, &file, nullptr);
 
-                    if (is_in_exclude_list(filename))
+                    if (exclude.match(filename))
                     {
                         print_extraction_exclusion(info, filename);
                         return VMI_EVENT_RESPONSE_NONE;
@@ -550,7 +549,7 @@ event_response_t fileextractor::writefile_cb(drakvuf_t,
             addr_t file = 0;
             auto filename = get_file_name(vmi, info, handle, &file, nullptr);
 
-            if (is_in_exclude_list(filename))
+            if (exclude.match(filename))
             {
                 print_extraction_exclusion(info, filename);
                 return VMI_EVENT_RESPONSE_NONE;
@@ -765,7 +764,7 @@ event_response_t fileextractor::createsection_cb(drakvuf_t,
             addr_t file = 0;
             auto filename = get_file_name(vmi, info, handle, &file, nullptr);
 
-            if (is_in_exclude_list(filename))
+            if (exclude.match(filename))
             {
                 print_extraction_exclusion(info, filename);
                 return VMI_EVENT_RESPONSE_NONE;
@@ -2102,47 +2101,6 @@ bool fileextractor::is_handle_valid(handle_t handle)
     return handle && !VMI_GET_BIT(handle, 31);
 }
 
-bool fileextractor::is_in_exclude_list(const std::string& filename) const
-{
-    for (const auto& re : exclude_list)
-    {
-        if (regex_match(filename, re))
-            return true;
-    }
-    return false;
-}
-
-static std::vector<std::regex> parse_exclude_file(const char* exclude_file)
-{
-    if (!exclude_file)
-        return {};
-
-    std::ifstream fs(exclude_file);
-    if (!fs)
-    {
-        PRINT_DEBUG("[FILEEXTRACTOR] Couldn't open (%s) for reading\n", exclude_file);
-        throw -1;
-    }
-
-    std::vector<std::string> lines;
-    std::copy(std::istream_iterator<std::string>(fs),
-        std::istream_iterator<std::string>(), std::back_inserter(lines));
-
-    std::vector<std::regex> ret;
-    try
-    {
-        auto flags = std::regex::optimize | std::regex::nosubs | std::regex::icase;
-        for (const auto& line : lines)
-            ret.emplace_back(line, flags);
-    }
-    catch (const std::regex_error& e)
-    {
-        PRINT_DEBUG("[FILEEXTRACTOR] Invalid regex: %s\n", e.what());
-        throw;
-    }
-    return ret;
-}
-
 /*****************************************************************************
  *                             Public interface                              *
  *****************************************************************************/
@@ -2155,7 +2113,7 @@ fileextractor::fileextractor(drakvuf_t drakvuf,
     , dump_folder(c->dump_folder)
     , hash_size(c->hash_size)
     , extract_size(c->extract_size)
-    , exclude_list{parse_exclude_file(c->exclude_file)}
+    , exclude{c->exclude_file, "[FILEEXTRACTOR]"}
     , format(output)
     , sequence_number()
 {

--- a/src/plugins/helpers/exclude_matcher.cpp
+++ b/src/plugins/helpers/exclude_matcher.cpp
@@ -102,168 +102,53 @@
  *                                                                         *
  ***************************************************************************/
 
-#ifndef FILEEXTRACTOR_H
-#define FILEEXTRACTOR_H
+#include <fstream>
 
-#include "plugins/plugins.h"
-#include "plugins/plugins_ex.h"
-#include "helpers/exclude_matcher.h"
-#include "private.h"
+#include <libdrakvuf/libdrakvuf.h>
 
-#include <map>
-#include <utility>
-#include <cstdint>
+#include "exclude_matcher.h"
 
-using namespace fileextractor_ns;
-
-struct fileextractor_config
+bool exclude_matcher::match(const std::string& str) const
 {
-    uint32_t timeout;
-    const char* dump_folder;
-    uint64_t hash_size;
-    uint64_t extract_size;
-    const char* exclude_file;
-};
-
-class fileextractor: public pluginex
-{
-public:
-    fileextractor(drakvuf_t drakvuf, const fileextractor_config* config, output_format_t output);
-    fileextractor(const fileextractor&) = delete;
-    fileextractor& operator=(const fileextractor&) = delete;
-    ~fileextractor() = default;
-
-    virtual bool stop_impl() override;
-
-private:
-    enum class error
+    for (const auto& re : exclude_list)
     {
-        success,
-        none,
-        error,
-        zero_size,
-    };
+        if (regex_match(str, re))
+            return true;
+    }
+    return false;
+}
 
-    /* Prevent injections on timeout after stop plugin begin. */
-    uint32_t timeout{0};
-    uint32_t begin_stop_at{0};
-    /* Internal data */
-    std::unordered_map<task_id, std::unique_ptr<task_t>> tasks;
-    bool is32bit{false};
-    // Maps virtual address of buffer to free flag:
-    // * `true` means pools is free;
-    // * `false` otherwise.
-    std::map<addr_t, bool> pools;
+static std::vector<std::regex> parse_exclude_file(const char* exclude_file, const char* plugin)
+{
+    if (!exclude_file)
+        return {};
 
-    std::array<size_t, fileextractor_ns::__OFFSET_MAX> offsets;
-    size_t control_area_size = 0;
-    size_t mmpte_size = 0;
+    std::ifstream fs(exclude_file);
+    if (!fs)
+    {
+        PRINT_DEBUG("%s Couldn't open (%s) for reading\n", plugin, exclude_file);
+        throw -1;
+    }
 
-    const char* dump_folder;
-    uint64_t hash_size{0};
-    uint64_t extract_size{0};
-    const exclude_matcher exclude;
-    output_format_t format;
+    std::vector<std::string> lines;
+    std::copy(std::istream_iterator<std::string>(fs),
+        std::istream_iterator<std::string>(), std::back_inserter(lines));
 
-    int sequence_number = 0;
+    std::vector<std::regex> ret;
+    try
+    {
+        auto flags = std::regex::optimize | std::regex::nosubs | std::regex::icase;
+        for (const auto& line : lines)
+            ret.emplace_back(line, flags);
+    }
+    catch (const std::regex_error& e)
+    {
+        PRINT_DEBUG("%s Invalid regex: %s\n", plugin, e.what());
+        throw;
+    }
+    return ret;
+}
 
-    /* Hooks */
-    std::unique_ptr<libhook::SyscallHook> setinformation_hook;
-    std::unique_ptr<libhook::SyscallHook> writefile_hook;
-    std::unique_ptr<libhook::SyscallHook> close_hook;
-    std::unique_ptr<libhook::SyscallHook> createsection_hook;
-    std::unique_ptr<libhook::SyscallHook> createfile_hook;
-    std::unique_ptr<libhook::SyscallHook> openfile_hook;
-    std::map<uint64_t, std::unique_ptr<libhook::ReturnHook>> createfile_ret_hooks;
-    std::map<uint64_t, std::unique_ptr<libhook::ReturnHook>> writefile_ret_hooks;
-
-    /* VA of functions to be injected */
-    addr_t queryvolumeinfo_va = 0;
-    addr_t queryinfo_va = 0;
-    addr_t createsection_va = 0;
-    addr_t close_handle_va = 0;
-    addr_t mapview_va = 0;
-    addr_t unmapview_va = 0;
-    addr_t readfile_va = 0;
-    addr_t waitobject_va = 0;
-    addr_t exallocatepool_va = 0;
-    addr_t exfreepool_va = 0;
-    addr_t memcpy_va = 0;
-
-    /* Hook handlers */
-    event_response_t setinformation_cb(drakvuf_t, drakvuf_trap_info_t*);
-    event_response_t writefile_cb(drakvuf_t, drakvuf_trap_info_t*);
-    event_response_t writefile_ret_cb(drakvuf_t, drakvuf_trap_info_t*);
-    event_response_t close_cb(drakvuf_t, drakvuf_trap_info_t*);
-    event_response_t createsection_cb (drakvuf_t, drakvuf_trap_info_t*);
-    event_response_t createfile_cb (drakvuf_t, drakvuf_trap_info_t*);
-    event_response_t openfile_cb (drakvuf_t, drakvuf_trap_info_t*);
-    event_response_t createfile_ret_cb(drakvuf_t, drakvuf_trap_info_t*);
-    void createfile_cb_impl(drakvuf_t, drakvuf_trap_info_t*, addr_t handle, bool, bool);
-
-    /* Dispatchers */
-    // TODO Maybe remove "response" in flavor of "error"?
-    error dispatch_pending(vmi_instance_t, drakvuf_trap_info_t*, task_t&);
-    error dispatch_queryvolumeinfo(vmi_instance_t, drakvuf_trap_info_t*, task_t&);
-    error dispatch_queryinfo(vmi_instance_t, drakvuf_trap_info_t*, task_t&);
-    error dispatch_createsection(vmi_instance_t, drakvuf_trap_info_t*, task_t&);
-    error dispatch_mapview(vmi_instance_t, drakvuf_trap_info_t*, task_t&);
-    error dispatch_allocate_pool(vmi_instance_t, drakvuf_trap_info_t*, task_t&);
-    error dispatch_memcpy(vmi_instance_t, drakvuf_trap_info_t*, task_t&);
-    error dispatch_unmapview(vmi_instance_t, drakvuf_trap_info_t*, task_t&);
-    error dispatch_close_handle(vmi_instance_t, drakvuf_trap_info_t*, task_t&);
-
-    /* Injection helpers */
-    bool inject_queryvolumeinfo(drakvuf_trap_info_t*, vmi_instance_t, task_t&);
-    bool inject_queryinfo(drakvuf_trap_info_t*, vmi_instance_t, task_t&);
-    bool inject_createsection(drakvuf_trap_info_t*, vmi_instance_t, task_t&);
-    bool inject_mapview(drakvuf_trap_info_t*, vmi_instance_t, task_t&);
-    bool inject_allocate_pool(drakvuf_trap_info_t*, vmi_instance_t, task_t&);
-    bool inject_memcpy(drakvuf_trap_info_t*, vmi_instance_t, task_t&);
-    bool inject_unmapview(drakvuf_trap_info_t*, vmi_instance_t, task_t&);
-    bool inject_close_handle(drakvuf_trap_info_t*, vmi_instance_t, task_t&);
-
-    /* Routines */
-    bool get_file_object_handle_count(drakvuf_trap_info_t*,
-        handle_t,
-        uint64_t* handle_count);
-
-    bool get_file_object_flags(drakvuf_trap_info_t*,
-        vmi_instance_t,
-        handle_t,
-        uint64_t* flags);
-    std::string get_file_name(vmi_instance_t,
-        drakvuf_trap_info_t*,
-        addr_t handle,
-        addr_t* out_file,
-        addr_t* out_filetype);
-    bool get_file_object_currentbyteoffset(vmi_instance_t, drakvuf_trap_info_t*, handle_t, uint64_t*);
-    bool get_write_offset(vmi_instance_t, drakvuf_trap_info_t*, addr_t, uint64_t*);
-    void calc_checksum(task_t&);
-    void save_file_metadata(drakvuf_trap_info_t*, addr_t control_area, task_t&);
-    void update_file_metadata(drakvuf_trap_info_t*, task_t&);
-    bool save_file_chunk(int file_sequence_number,
-        void* buffer,
-        size_t size);
-    bool save_file_chunk_rb(int file_sequence_number, uint64_t currentoffset,
-        void* buffer,
-        size_t size);
-    void dump_mem_to_file(uint64_t cr3, addr_t str, int idx, uint64_t offset, size_t size);
-    uint64_t make_hook_id(drakvuf_trap_info_t*);
-    uint64_t make_task_id(vmi_pid_t pid, handle_t handle);
-    uint64_t make_task_id(task_t&);
-    void free_pool(addr_t va);
-    addr_t find_pool();
-    void free_resources(drakvuf_trap_info_t*, task_t&);
-    void read_vm(vmi_instance_t, drakvuf_trap_info_t*, task_t&);
-
-    bool is_handle_valid(handle_t);
-    void check_stack_marker(drakvuf_trap_info_t*, vmi_lock_guard&, task_t*);
-
-    void print_file_information(drakvuf_trap_info_t*, task_t&);
-    void print_plugin_close_information(drakvuf_trap_info_t*, task_t&);
-    void print_extraction_failure(drakvuf_trap_info_t* info, const std::string& filename, const std::string& message);
-    void print_extraction_exclusion(drakvuf_trap_info_t* info, const std::string& filename);
-};
-
-#endif
+exclude_matcher::exclude_matcher(const char* file, const char* plugin)
+    : exclude_list{parse_exclude_file(file, plugin)}
+{}

--- a/src/plugins/helpers/exclude_matcher.cpp
+++ b/src/plugins/helpers/exclude_matcher.cpp
@@ -103,6 +103,7 @@
  ***************************************************************************/
 
 #include <fstream>
+#include <iterator>
 
 #include <libdrakvuf/libdrakvuf.h>
 

--- a/src/plugins/helpers/exclude_matcher.h
+++ b/src/plugins/helpers/exclude_matcher.h
@@ -101,169 +101,17 @@
  * https://github.com/tklengyel/drakvuf/COPYING)                           *
  *                                                                         *
  ***************************************************************************/
+#pragma once
+#include <vector>
+#include <regex>
 
-#ifndef FILEEXTRACTOR_H
-#define FILEEXTRACTOR_H
-
-#include "plugins/plugins.h"
-#include "plugins/plugins_ex.h"
-#include "helpers/exclude_matcher.h"
-#include "private.h"
-
-#include <map>
-#include <utility>
-#include <cstdint>
-
-using namespace fileextractor_ns;
-
-struct fileextractor_config
-{
-    uint32_t timeout;
-    const char* dump_folder;
-    uint64_t hash_size;
-    uint64_t extract_size;
-    const char* exclude_file;
-};
-
-class fileextractor: public pluginex
+class exclude_matcher
 {
 public:
-    fileextractor(drakvuf_t drakvuf, const fileextractor_config* config, output_format_t output);
-    fileextractor(const fileextractor&) = delete;
-    fileextractor& operator=(const fileextractor&) = delete;
-    ~fileextractor() = default;
+    exclude_matcher(const char* exclude_file, const char* plugin);
 
-    virtual bool stop_impl() override;
+    bool match(const std::string& str) const;
 
 private:
-    enum class error
-    {
-        success,
-        none,
-        error,
-        zero_size,
-    };
-
-    /* Prevent injections on timeout after stop plugin begin. */
-    uint32_t timeout{0};
-    uint32_t begin_stop_at{0};
-    /* Internal data */
-    std::unordered_map<task_id, std::unique_ptr<task_t>> tasks;
-    bool is32bit{false};
-    // Maps virtual address of buffer to free flag:
-    // * `true` means pools is free;
-    // * `false` otherwise.
-    std::map<addr_t, bool> pools;
-
-    std::array<size_t, fileextractor_ns::__OFFSET_MAX> offsets;
-    size_t control_area_size = 0;
-    size_t mmpte_size = 0;
-
-    const char* dump_folder;
-    uint64_t hash_size{0};
-    uint64_t extract_size{0};
-    const exclude_matcher exclude;
-    output_format_t format;
-
-    int sequence_number = 0;
-
-    /* Hooks */
-    std::unique_ptr<libhook::SyscallHook> setinformation_hook;
-    std::unique_ptr<libhook::SyscallHook> writefile_hook;
-    std::unique_ptr<libhook::SyscallHook> close_hook;
-    std::unique_ptr<libhook::SyscallHook> createsection_hook;
-    std::unique_ptr<libhook::SyscallHook> createfile_hook;
-    std::unique_ptr<libhook::SyscallHook> openfile_hook;
-    std::map<uint64_t, std::unique_ptr<libhook::ReturnHook>> createfile_ret_hooks;
-    std::map<uint64_t, std::unique_ptr<libhook::ReturnHook>> writefile_ret_hooks;
-
-    /* VA of functions to be injected */
-    addr_t queryvolumeinfo_va = 0;
-    addr_t queryinfo_va = 0;
-    addr_t createsection_va = 0;
-    addr_t close_handle_va = 0;
-    addr_t mapview_va = 0;
-    addr_t unmapview_va = 0;
-    addr_t readfile_va = 0;
-    addr_t waitobject_va = 0;
-    addr_t exallocatepool_va = 0;
-    addr_t exfreepool_va = 0;
-    addr_t memcpy_va = 0;
-
-    /* Hook handlers */
-    event_response_t setinformation_cb(drakvuf_t, drakvuf_trap_info_t*);
-    event_response_t writefile_cb(drakvuf_t, drakvuf_trap_info_t*);
-    event_response_t writefile_ret_cb(drakvuf_t, drakvuf_trap_info_t*);
-    event_response_t close_cb(drakvuf_t, drakvuf_trap_info_t*);
-    event_response_t createsection_cb (drakvuf_t, drakvuf_trap_info_t*);
-    event_response_t createfile_cb (drakvuf_t, drakvuf_trap_info_t*);
-    event_response_t openfile_cb (drakvuf_t, drakvuf_trap_info_t*);
-    event_response_t createfile_ret_cb(drakvuf_t, drakvuf_trap_info_t*);
-    void createfile_cb_impl(drakvuf_t, drakvuf_trap_info_t*, addr_t handle, bool, bool);
-
-    /* Dispatchers */
-    // TODO Maybe remove "response" in flavor of "error"?
-    error dispatch_pending(vmi_instance_t, drakvuf_trap_info_t*, task_t&);
-    error dispatch_queryvolumeinfo(vmi_instance_t, drakvuf_trap_info_t*, task_t&);
-    error dispatch_queryinfo(vmi_instance_t, drakvuf_trap_info_t*, task_t&);
-    error dispatch_createsection(vmi_instance_t, drakvuf_trap_info_t*, task_t&);
-    error dispatch_mapview(vmi_instance_t, drakvuf_trap_info_t*, task_t&);
-    error dispatch_allocate_pool(vmi_instance_t, drakvuf_trap_info_t*, task_t&);
-    error dispatch_memcpy(vmi_instance_t, drakvuf_trap_info_t*, task_t&);
-    error dispatch_unmapview(vmi_instance_t, drakvuf_trap_info_t*, task_t&);
-    error dispatch_close_handle(vmi_instance_t, drakvuf_trap_info_t*, task_t&);
-
-    /* Injection helpers */
-    bool inject_queryvolumeinfo(drakvuf_trap_info_t*, vmi_instance_t, task_t&);
-    bool inject_queryinfo(drakvuf_trap_info_t*, vmi_instance_t, task_t&);
-    bool inject_createsection(drakvuf_trap_info_t*, vmi_instance_t, task_t&);
-    bool inject_mapview(drakvuf_trap_info_t*, vmi_instance_t, task_t&);
-    bool inject_allocate_pool(drakvuf_trap_info_t*, vmi_instance_t, task_t&);
-    bool inject_memcpy(drakvuf_trap_info_t*, vmi_instance_t, task_t&);
-    bool inject_unmapview(drakvuf_trap_info_t*, vmi_instance_t, task_t&);
-    bool inject_close_handle(drakvuf_trap_info_t*, vmi_instance_t, task_t&);
-
-    /* Routines */
-    bool get_file_object_handle_count(drakvuf_trap_info_t*,
-        handle_t,
-        uint64_t* handle_count);
-
-    bool get_file_object_flags(drakvuf_trap_info_t*,
-        vmi_instance_t,
-        handle_t,
-        uint64_t* flags);
-    std::string get_file_name(vmi_instance_t,
-        drakvuf_trap_info_t*,
-        addr_t handle,
-        addr_t* out_file,
-        addr_t* out_filetype);
-    bool get_file_object_currentbyteoffset(vmi_instance_t, drakvuf_trap_info_t*, handle_t, uint64_t*);
-    bool get_write_offset(vmi_instance_t, drakvuf_trap_info_t*, addr_t, uint64_t*);
-    void calc_checksum(task_t&);
-    void save_file_metadata(drakvuf_trap_info_t*, addr_t control_area, task_t&);
-    void update_file_metadata(drakvuf_trap_info_t*, task_t&);
-    bool save_file_chunk(int file_sequence_number,
-        void* buffer,
-        size_t size);
-    bool save_file_chunk_rb(int file_sequence_number, uint64_t currentoffset,
-        void* buffer,
-        size_t size);
-    void dump_mem_to_file(uint64_t cr3, addr_t str, int idx, uint64_t offset, size_t size);
-    uint64_t make_hook_id(drakvuf_trap_info_t*);
-    uint64_t make_task_id(vmi_pid_t pid, handle_t handle);
-    uint64_t make_task_id(task_t&);
-    void free_pool(addr_t va);
-    addr_t find_pool();
-    void free_resources(drakvuf_trap_info_t*, task_t&);
-    void read_vm(vmi_instance_t, drakvuf_trap_info_t*, task_t&);
-
-    bool is_handle_valid(handle_t);
-    void check_stack_marker(drakvuf_trap_info_t*, vmi_lock_guard&, task_t*);
-
-    void print_file_information(drakvuf_trap_info_t*, task_t&);
-    void print_plugin_close_information(drakvuf_trap_info_t*, task_t&);
-    void print_extraction_failure(drakvuf_trap_info_t* info, const std::string& filename, const std::string& message);
-    void print_extraction_exclusion(drakvuf_trap_info_t* info, const std::string& filename);
+    const std::vector<std::regex> exclude_list;
 };
-
-#endif

--- a/src/plugins/meson.build
+++ b/src/plugins/meson.build
@@ -4,6 +4,7 @@ plugin_sources = [
     'plugins.cpp',
     'plugins_ex.cpp',
     'plugin_utils.cpp',
+    'helpers/exclude_matcher.cpp',
     'output_format/ostream.cpp'
 ]
 

--- a/src/plugins/plugins.cpp
+++ b/src/plugins/plugins.cpp
@@ -455,7 +455,8 @@ int drakvuf_plugins::start(const drakvuf_plugin_t plugin_id,
                         .dump_new_processes_on_finish = options->procdump_new_processes_on_finish,
                         .hal_profile = options->hal_profile,
                         .disable_kideliverapc_hook = options->procdump_disable_kideliverapc_hook,
-                        .disable_kedelayexecutionthread_hook = options->procdump_disable_kedelayexecutionthread_hook
+                        .disable_kedelayexecutionthread_hook = options->procdump_disable_kedelayexecutionthread_hook,
+                        .exclude_file = options->procdump_exclude_file
                     };
                     this->plugins[plugin_id] =
                         std::make_unique<procdump2>(this->drakvuf, &config, this->output);

--- a/src/plugins/plugins.h
+++ b/src/plugins/plugins.h
@@ -176,6 +176,7 @@ struct plugins_options
     const char* hal_profile;            // PLUGIN_PROCDUMP2
     bool procdump_disable_kideliverapc_hook; // PLUGIN_PROCDUMP2
     bool procdump_disable_kedelayexecutionthread_hook; // PLUGIN_PROCDUMP2
+    const char* procdump_exclude_file; // PLUGIN_PROCDUMP2
     const char* codemon_dump_dir;       // PLUGIN_CODEMON
     const char* codemon_filter_executable;  // PLUGIN_CODEMON
     bool codemon_log_everything;        // PLUGIN_CODEMON

--- a/src/plugins/procdump2/procdump2.h
+++ b/src/plugins/procdump2/procdump2.h
@@ -113,6 +113,7 @@
 #include <libvmi/libvmi.h>
 
 #include "plugins/plugins_ex.h"
+#include "helpers/exclude_matcher.h"
 
 struct procdump2_config
 {
@@ -124,6 +125,7 @@ struct procdump2_config
     const char* hal_profile;
     bool disable_kideliverapc_hook;
     bool disable_kedelayexecutionthread_hook;
+    const char* exclude_file;
 };
 
 struct procdump2_ctx;
@@ -177,6 +179,7 @@ private:
      * Used only with procdump_new_processes_on_finish.
      */
     std::vector<vmi_pid_t> running_processes_on_start;
+    const exclude_matcher exclude;
 
     /* Hooks */
     std::unique_ptr<libhook::SyscallHook> terminate_process_hook;
@@ -232,6 +235,7 @@ private:
      * So be carefull while iterating over it.
      */
     void finish_task(drakvuf_trap_info_t*, std::shared_ptr<procdump2_ctx>);
+    void print_dump_exclusion(drakvuf_trap_info_t*);
     std::pair<addr_t, size_t> get_memory_region(drakvuf_trap_info_t*, std::shared_ptr<procdump2_ctx>);
     bool is_active_process(vmi_pid_t pid);
     bool is_process_handled(vmi_pid_t pid);


### PR DESCRIPTION
- add `--procdump-exclude-list` option to provide file with regexes for not to dump unnecessary processes;
- add common helper `exclude_matcher` class for use in `fileextractor` and `procdump2` plugins.