### PR TITLE
Linux plugins update

### DIFF
--- a/src/libhook/hooks/base.hpp
+++ b/src/libhook/hooks/base.hpp
@@ -110,6 +110,8 @@
 namespace libhook
 {
 
+struct CallResult;
+
 using callback_t = event_response_t(*)(drakvuf_t drakvuf, drakvuf_trap_info* info);
 using cb_wrapper_t = std::function<event_response_t(drakvuf_t, drakvuf_trap_info*)>;
 
@@ -145,6 +147,8 @@ public:
      * important to be noexcept, otherwise bad things will happen
      */
     BaseHook& operator=(BaseHook&&) noexcept;
+
+    virtual std::shared_ptr<CallResult> params() = 0;
 
 protected:
     /*

--- a/src/libhook/hooks/catchall.cpp
+++ b/src/libhook/hooks/catchall.cpp
@@ -150,4 +150,9 @@ CatchAllHook::CatchAllHook(drakvuf_t drakvuf, cb_wrapper_t cb)
       callback_(cb)
 {}
 
+std::shared_ptr<CallResult> CatchAllHook::params()
+{
+    return this->params_;
+}
+
 } // namespace libhook

--- a/src/libhook/hooks/catchall.cpp
+++ b/src/libhook/hooks/catchall.cpp
@@ -119,7 +119,7 @@ CatchAllHook::~CatchAllHook()
         };
         drakvuf_remove_trap(this->drakvuf_, this->trap_, [](drakvuf_trap_t* trap)
         {
-            delete static_cast<CallResult*>(trap->data);
+            trap->data = nullptr;
             delete trap;
         });
     }

--- a/src/libhook/hooks/catchall.hpp
+++ b/src/libhook/hooks/catchall.hpp
@@ -148,8 +148,11 @@ public:
      */
     CatchAllHook& operator=(CatchAllHook&&) noexcept;
 
+    std::shared_ptr<CallResult> params() override;
+
     cb_wrapper_t callback_ = nullptr;
     drakvuf_trap_t* trap_ = nullptr;
+    std::shared_ptr<CallResult> params_;
 
 protected:
     /**
@@ -180,17 +183,17 @@ auto CatchAllHook::create(drakvuf_t drakvuf, cb_wrapper_t cb, int ttl)
     static_assert(std::is_default_constructible_v<Params>, "Params must be default constructible");
 
     // populate backref
-    auto* params = new Params();
-    params->hook_ = hook.get();
-    hook->trap_->data = static_cast<void*>(params);
+    hook->params_ = std::make_shared<Params>();
+    hook->params_->hook_ = hook.get();
+    hook->trap_->data = static_cast<void*>(hook->params_.get());
 
     if (!drakvuf_add_trap(drakvuf, hook->trap_))
     {
         PRINT_DEBUG("[LIBHOOK] failed to create CatchAll trap!\n");
-        delete static_cast<CallResult*>(hook->trap_->data);
         hook->trap_->data = nullptr;
         delete hook->trap_;
         hook->trap_ = nullptr;
+        hook->params_.reset();
         return std::unique_ptr<CatchAllHook>();
     }
 

--- a/src/libhook/hooks/cpuid.cpp
+++ b/src/libhook/hooks/cpuid.cpp
@@ -150,4 +150,9 @@ CpuidHook::CpuidHook(drakvuf_t drakvuf, cb_wrapper_t cb)
       callback_(cb)
 {}
 
+std::shared_ptr<CallResult> CpuidHook::params()
+{
+    return this->params_;
+}
+
 } // namespace libhook

--- a/src/libhook/hooks/cpuid.cpp
+++ b/src/libhook/hooks/cpuid.cpp
@@ -119,7 +119,7 @@ CpuidHook::~CpuidHook()
         };
         drakvuf_remove_trap(this->drakvuf_, this->trap_, [](drakvuf_trap_t* trap)
         {
-            delete static_cast<CallResult*>(trap->data);
+            trap->data = nullptr;
             delete trap;
         });
     }

--- a/src/libhook/hooks/cpuid.hpp
+++ b/src/libhook/hooks/cpuid.hpp
@@ -148,8 +148,11 @@ public:
      */
     CpuidHook& operator=(CpuidHook&&) noexcept;
 
+    std::shared_ptr<CallResult> params() override;
+
     cb_wrapper_t callback_ = nullptr;
     drakvuf_trap_t* trap_ = nullptr;
+    std::shared_ptr<CallResult> params_;
 
 protected:
     /**
@@ -180,17 +183,17 @@ auto CpuidHook::create(drakvuf_t drakvuf, cb_wrapper_t cb, int ttl)
     static_assert(std::is_default_constructible_v<Params>, "Params must be default constructible");
 
     // populate backref
-    auto* params = new Params();
-    params->hook_ = hook.get();
-    hook->trap_->data = static_cast<void*>(params);
+    hook->params_ = std::make_shared<Params>();
+    hook->params_->hook_ = hook.get();
+    hook->trap_->data = static_cast<void*>(hook->params_.get());
 
     if (!drakvuf_add_trap(drakvuf, hook->trap_))
     {
         PRINT_DEBUG("[LIBHOOK] failed to create cpuid trap!\n");
-        delete static_cast<CallResult*>(hook->trap_->data);
         hook->trap_->data = nullptr;
         delete hook->trap_;
         hook->trap_ = nullptr;
+        hook->params_.reset();
         return std::unique_ptr<CpuidHook>();
     }
 

--- a/src/libhook/hooks/cr3.cpp
+++ b/src/libhook/hooks/cr3.cpp
@@ -119,7 +119,7 @@ Cr3Hook::~Cr3Hook()
         };
         drakvuf_remove_trap(this->drakvuf_, this->trap_, [](drakvuf_trap_t* trap)
         {
-            delete static_cast<CallResult*>(trap->data);
+            trap->data = nullptr;
             delete trap;
         });
     }

--- a/src/libhook/hooks/cr3.cpp
+++ b/src/libhook/hooks/cr3.cpp
@@ -150,4 +150,9 @@ Cr3Hook::Cr3Hook(drakvuf_t drakvuf, cb_wrapper_t cb)
       callback_(cb)
 {}
 
+std::shared_ptr<CallResult> Cr3Hook::params()
+{
+    return this->params_;
+}
+
 } // namespace libhook

--- a/src/libhook/hooks/manual.cpp
+++ b/src/libhook/hooks/manual.cpp
@@ -156,4 +156,9 @@ ManualHook& ManualHook::operator=(ManualHook&& rhs) noexcept
     return *this;
 }
 
+std::shared_ptr<CallResult> ManualHook::params()
+{
+    return nullptr;
+}
+
 } // namespace libhook

--- a/src/libhook/hooks/manual.hpp
+++ b/src/libhook/hooks/manual.hpp
@@ -158,6 +158,8 @@ public:
      */
     ManualHook& operator=(ManualHook&&) noexcept;
 
+    std::shared_ptr<CallResult> params() override;
+
     drakvuf_trap_t* trap_ = nullptr;
     drakvuf_trap_free_t free_routine_ = nullptr;
 

--- a/src/libhook/hooks/memaccess.cpp
+++ b/src/libhook/hooks/memaccess.cpp
@@ -119,7 +119,7 @@ MemAccessHook::~MemAccessHook()
         };
         drakvuf_remove_trap(this->drakvuf_, this->trap_, [](drakvuf_trap_t* trap)
         {
-            delete static_cast<CallResult*>(trap->data);
+            trap->data = nullptr;
             delete trap;
         });
     }

--- a/src/libhook/hooks/memaccess.cpp
+++ b/src/libhook/hooks/memaccess.cpp
@@ -150,4 +150,9 @@ MemAccessHook::MemAccessHook(drakvuf_t drakvuf, cb_wrapper_t cb)
       callback_(cb)
 {}
 
+std::shared_ptr<CallResult> MemAccessHook::params()
+{
+    return this->params_;
+}
+
 } // namespace libhook

--- a/src/libhook/hooks/memaccess.hpp
+++ b/src/libhook/hooks/memaccess.hpp
@@ -148,8 +148,11 @@ public:
      */
     MemAccessHook& operator=(MemAccessHook&&) noexcept;
 
+    std::shared_ptr<CallResult> params() override;
+
     cb_wrapper_t callback_;
     drakvuf_trap_t* trap_;
+    std::shared_ptr<CallResult> params_;
 
 protected:
     /**
@@ -183,17 +186,17 @@ auto MemAccessHook::create(drakvuf_t drakvuf, cb_wrapper_t cb, addr_t gfn, memac
     static_assert(std::is_default_constructible_v<Params>, "Params must be default constructible");
 
     // populate backref
-    auto* params = new Params();
-    params->hook_ = hook.get();
-    hook->trap_->data = static_cast<void*>(params);
+    hook->params_ = std::make_shared<Params>();
+    hook->params_->hook_ = hook.get();
+    hook->trap_->data = static_cast<void*>(hook->params_.get());
 
     if (!drakvuf_add_trap(drakvuf, hook->trap_))
     {
         PRINT_DEBUG("[LIBHOOK] failed to create MemAccessHook trap!\n");
-        delete static_cast<CallResult*>(hook->trap_->data);
         hook->trap_->data = nullptr;
         delete hook->trap_;
         hook->trap_ = nullptr;
+        hook->params_.reset();
         return std::unique_ptr<MemAccessHook>();
     }
 

--- a/src/libhook/hooks/return.cpp
+++ b/src/libhook/hooks/return.cpp
@@ -124,7 +124,7 @@ ReturnHook::~ReturnHook()
         };
         drakvuf_remove_trap(this->drakvuf_, this->trap_, [](drakvuf_trap_t* trap)
         {
-            delete static_cast<CallResult*>(trap->data);
+            trap->data = nullptr;
             delete trap;
         });
     }

--- a/src/libhook/hooks/return.cpp
+++ b/src/libhook/hooks/return.cpp
@@ -150,4 +150,9 @@ ReturnHook& ReturnHook::operator=(ReturnHook&& rhs) noexcept
     return *this;
 }
 
+std::shared_ptr<CallResult> ReturnHook::params()
+{
+    return this->params_;
+}
+
 } // namespace libhook

--- a/src/libhook/hooks/return.hpp
+++ b/src/libhook/hooks/return.hpp
@@ -202,7 +202,7 @@ auto ReturnHook::create(drakvuf_t drakvuf, drakvuf_trap_info* info, cb_wrapper_t
     // pupulate backref
     hook->params_ = std::make_shared<Params>();
     hook->params_->hook_ = hook.get();
-    hook->trap_->data = static_cast<void*>(hook->params_.get()); 
+    hook->trap_->data = static_cast<void*>(hook->params_.get());
 
     if (!drakvuf_add_trap(drakvuf, hook->trap_))
     {

--- a/src/libhook/hooks/syscall.cpp
+++ b/src/libhook/hooks/syscall.cpp
@@ -193,4 +193,9 @@ drakvuf_trap_t* SyscallHook::createLinuxTrap(drakvuf_t drakvuf, const std::strin
     return trap;
 }
 
+std::shared_ptr<CallResult> SyscallHook::params()
+{
+    return this->params_;
+}
+
 } // namespace libhook

--- a/src/libhook/hooks/syscall.cpp
+++ b/src/libhook/hooks/syscall.cpp
@@ -119,7 +119,7 @@ SyscallHook::~SyscallHook()
         };
         drakvuf_remove_trap(this->drakvuf_, this->trap_, [](drakvuf_trap_t* trap)
         {
-            delete static_cast<CallResult*>(trap->data);
+            trap->data = nullptr;
             delete trap;
         });
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -251,6 +251,10 @@ static void print_usage()
         "\t                           File with list of syscalls for trap in syscalls plugin (trap all if parameter is absent)\n"
         "\t --disable-sysret          Do not monitor syscall results\n"
 #endif
+#ifdef ENABLE_PLUGIN_PROCMON
+        "\t -q, --procmon-envs-list <procmon filter>\n"
+        "\t                           File with list of environment variables for printing in procmon\n"
+#endif
 #ifdef ENABLE_PLUGIN_BSODMON
         "\t -b                        Exit from execution as soon as a BSoD is detected\n"
         "\t --bsodmon-ignore-stop\n"
@@ -623,7 +627,7 @@ int main(int argc, char** argv)
         {"rebootmon-abort-on-power-off", no_argument, NULL, opt_rebootmon_abort_on_power_off},
         {NULL, 0, NULL, 0}
     };
-    const char* opts = "r:d:i:I:e:m:t:D:o:vx:a:f:spT:S:Mc:nblgj:k:w:W:hFC";
+    const char* opts = "r:d:i:I:e:m:t:D:o:vx:a:f:spT:S:q:Mc:nblgj:k:w:W:hFC";
 
     int long_index = 0;
     while ((c = getopt_long (argc, argv, opts, long_opts, &long_index)) != -1)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -581,6 +581,7 @@ int main(int argc, char** argv)
         {"json-clr", required_argument, NULL, opt_json_clr},
         {"json-mscorwks", required_argument, NULL, opt_json_mscorwks},
         {"syscall-hooks-list", required_argument, NULL, 'S'},
+        {"procmon-envs-list", required_argument, NULL, 'q'},
         {"disable-sysret", no_argument, NULL, opt_disable_sysret},
         {"userhook-no-addr", no_argument, NULL, opt_userhook_no_addr},
         {"fast-singlestep", no_argument, NULL, 'F'},
@@ -753,6 +754,16 @@ int main(int argc, char** argv)
                 break;
             case opt_disable_sysret:
                 options.disable_sysret = true;
+                break;
+#endif
+#ifdef ENABLE_PLUGIN_PROCMON
+            case 'q':
+                if (!std::filesystem::exists(optarg))
+                {
+                    fprintf(stderr, "file %s does not exist!\n", optarg);
+                    return drakvuf_exit_code_t::FAIL;
+                }
+                options.procmon_filter_file = optarg;
                 break;
 #endif
 #ifdef ENABLE_PLUGIN_FILEDELETE

--- a/src/plugins/fileextractor/fileextractor.cpp
+++ b/src/plugins/fileextractor/fileextractor.cpp
@@ -774,7 +774,7 @@ event_response_t fileextractor::close_cb(drakvuf_t drakvuf, drakvuf_trap_info_t*
         "\n"
         , info->event_uid
         , info->attached_proc_data.pid, info->attached_proc_data.tid
-        , task->target.ret_pid, task->stage
+        , task->target.ret_pid, (int)task->stage
     );
 
     // check that the file has not been extracted
@@ -1477,7 +1477,7 @@ void fileextractor::check_stack_marker(
                 "expected %#lx, result %#lx\n"
                 , info->event_uid
                 , info->attached_proc_data.pid, info->attached_proc_data.tid
-                , task->target.ret_pid, task->stage
+                , task->target.ret_pid, (int)task->stage
                 , task->stack_marker_va(), task->stack_marker(), stack_marker
             );
         }
@@ -2160,7 +2160,7 @@ bool fileextractor::stop_impl()
                 "pid %d, name '''%s''', stage %d\n"
                 , tasks.size()
                 , i.second->target.ret_pid, i.second->filename.data()
-                , i.second->stage);
+                , (int)i.second->stage);
             return false;
         }
 

--- a/src/plugins/filetracer/linux.cpp
+++ b/src/plugins/filetracer/linux.cpp
@@ -229,9 +229,9 @@ void linux_filetracer::print_info(drakvuf_t drakvuf, drakvuf_trap_info_t* info, 
         extra_args.emplace_back(keyval("Mode", fmt::Rstr(params->modes)));
     if (!params->flags.empty())
         extra_args.emplace_back(keyval("Flag", fmt::Rstr(params->flags)));
-    if (params->uid != -1)
+    if (params->uid)
         extra_args.emplace_back(keyval("UID", fmt::Rstr(std::to_string(*(params->uid)))));
-    if (params->gid != -1)
+    if (params->gid)
         extra_args.emplace_back(keyval("GID", fmt::Rstr(std::to_string(*(params->gid)))));
     if (params->file_handle)
         extra_args.emplace_back(keyval("FileHandle", fmt::Rstr(std::to_string(params->file_handle))));

--- a/src/plugins/filetracer/linux.cpp
+++ b/src/plugins/filetracer/linux.cpp
@@ -229,20 +229,27 @@ void linux_filetracer::print_info(drakvuf_t drakvuf, drakvuf_trap_info_t* info, 
         extra_args.emplace_back(keyval("Mode", fmt::Rstr(params->modes)));
     if (!params->flags.empty())
         extra_args.emplace_back(keyval("Flag", fmt::Rstr(params->flags)));
-    if (params->uid)
+    if (params->uid != -1)
         extra_args.emplace_back(keyval("UID", fmt::Rstr(std::to_string(*(params->uid)))));
-    if (params->gid)
+    if (params->gid != -1)
         extra_args.emplace_back(keyval("GID", fmt::Rstr(std::to_string(*(params->gid)))));
+    if (params->file_handle)
+        extra_args.emplace_back(keyval("FileHandle", fmt::Rstr(std::to_string(params->file_handle))));
     for (auto& arg : params->args)
         extra_args.emplace_back(std::make_pair(arg.first, fmt::Rstr(arg.second)));
 
     addr_t current_process = drakvuf_get_current_process(drakvuf, info);
     const char* thread_name = drakvuf_get_process_name(drakvuf, current_process, false);
 
-    fmt::print(this->m_output_format, "filetracer", drakvuf, info,
+    fmt::print(
+        this->m_output_format,
+        "filetracer",
+        drakvuf,
+        info,
         keyval("Permissions", fmt::Rstr(to_oct_str(params->permissions))),
         keyval("ThreadName", fmt::Rstr(thread_name)),
-        extra_args);
+        std::move(extra_args)
+    );
 
     g_free(const_cast<char*>(thread_name));
 }
@@ -264,7 +271,7 @@ char* linux_filetracer::read_filename(drakvuf_t drakvuf, drakvuf_trap_info_t* in
 event_response_t linux_filetracer::open_file_ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 {
     auto params = libhook::GetTrapParams<linux_data>(info);
-    if (!drakvuf_check_return_context(drakvuf, info, params->pid, params->tid, params->rsp))
+    if (!params->verifyResultCallParams(drakvuf, info))
         return VMI_EVENT_RESPONSE_NONE;
 
     addr_t file_struct = info->regs->rax;
@@ -299,9 +306,7 @@ event_response_t linux_filetracer::open_file_cb(drakvuf_t drakvuf, drakvuf_trap_
     auto params = libhook::GetTrapParams<linux_data>(hook->trap_);
 
     // Save data
-    params->pid = info->proc_data.pid;
-    params->tid = info->proc_data.tid;
-    params->rsp = ret_addr;
+    params->setResultCallParams(info);
 
     hook->trap_->name = info->trap->name;
     this->ret_hooks[hookID] = std::move(hook);
@@ -415,6 +420,22 @@ event_response_t linux_filetracer::llseek_file_cb(drakvuf_t drakvuf, drakvuf_tra
     return VMI_EVENT_RESPONSE_NONE;
 }
 
+event_response_t linux_filetracer::memfd_create_file_ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
+{
+    auto params = libhook::GetTrapParams<linux_data>(info);
+    if (!params->verifyResultCallParams(drakvuf, info))
+        return VMI_EVENT_RESPONSE_NONE;
+
+    params->file_handle = info->regs->rax;
+
+    if (params->file_handle > -1 && !params->filename.empty())
+        print_info(drakvuf, info, params);
+
+    uint64_t hookID = make_hook_id(info);
+    this->ret_hooks.erase(hookID);
+    return VMI_EVENT_RESPONSE_NONE;
+}
+
 event_response_t linux_filetracer::memfd_create_file_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 {
     // int __x64_sys_memfd_create (
@@ -442,14 +463,27 @@ event_response_t linux_filetracer::memfd_create_file_cb(drakvuf_t drakvuf, drakv
         return VMI_EVENT_RESPONSE_NONE;
     }
 
-    linux_data params;
-    char* tmp = read_filename(drakvuf, info, file_name_addr);
-    params.filename = tmp ?: "";
-    g_free(tmp);
-    params.flags = parse_flags(flags, linux_memfd_flags, this->m_output_format);
+    addr_t ret_addr = drakvuf_get_function_return_address(drakvuf, info);
+    if (!ret_addr)
+        return VMI_EVENT_RESPONSE_NONE;
 
-    if (!params.filename.empty())
-        print_info(drakvuf, info, &params);
+
+    // Create new trap for return callback
+    uint64_t hookID = make_hook_id(info);
+    auto hook = this->createReturnHook<linux_data>(info, &linux_filetracer::memfd_create_file_ret_cb);
+    auto params = libhook::GetTrapParams<linux_data>(hook->trap_);
+
+    // Save data
+    params->setResultCallParams(info);
+
+    char* tmp = read_filename(drakvuf, info, file_name_addr);
+    params->filename = tmp ?: "";
+    g_free(tmp);
+
+    params->flags = parse_flags(flags, linux_memfd_flags, this->m_output_format);
+
+    hook->trap_->name = info->trap->name;
+    this->ret_hooks[hookID] = std::move(hook);
 
     return VMI_EVENT_RESPONSE_NONE;
 }

--- a/src/plugins/filetracer/linux.h
+++ b/src/plugins/filetracer/linux.h
@@ -177,6 +177,7 @@ public:
 
     /* Return callbacks */
     event_response_t open_file_ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
+    event_response_t memfd_create_file_ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
 
     /* Helper functions */
     uint64_t make_hook_id(drakvuf_trap_info_t* info);

--- a/src/plugins/filetracer/private.h
+++ b/src/plugins/filetracer/private.h
@@ -187,10 +187,8 @@ struct linux_data : PluginResult
 {
     linux_data()
         : PluginResult()
-        , pid()
-        , tid()
+        , file_handle()
         , permissions()
-        , rsp()
         , filename()
         , flags()
         , modes()
@@ -200,10 +198,8 @@ struct linux_data : PluginResult
     {
     }
 
-    vmi_pid_t pid;
-    uint32_t tid;
+    int file_handle;
     int permissions;
-    addr_t rsp;
 
     std::string filename;
     std::string flags;

--- a/src/plugins/plugins.cpp
+++ b/src/plugins/plugins.cpp
@@ -287,8 +287,14 @@ int drakvuf_plugins::start(const drakvuf_plugin_t plugin_id,
 #endif
 #ifdef ENABLE_PLUGIN_PROCMON
                 case PLUGIN_PROCMON:
-                    this->plugins[plugin_id] = std::make_unique<procmon>(this->drakvuf, this->output);
+                {
+                    procmon_config config =
+                    {
+                        .procmon_filter_file = options->procmon_filter_file,
+                    };
+                    this->plugins[plugin_id] = std::make_unique<procmon>(this->drakvuf, &config, this->output);
                     break;
+                }
 #endif
 #ifdef ENABLE_PLUGIN_BSODMON
                 case PLUGIN_BSODMON:

--- a/src/plugins/plugins.h
+++ b/src/plugins/plugins.h
@@ -198,6 +198,7 @@ struct plugins_options
     const char* services_profile;       // PLUGIN_DKOMMON
     const char* netio_profile;          // PLUGIN_CALLBACKMON
     const char* ndis_profile;           // PLUGIN_CALLBACKMON
+    const char* procmon_filter_file;    // PLUGIN_PROCMON
     uint64_t hidevm_delay;              // PLUGIN_HIDEVM
     uint64_t unixsocketmon_max_size;    // PLUGIN_UNIXSOCKETMON
     bool rebootmon_abort_on_power_off;  // PLUGIN_REBOOTMON

--- a/src/plugins/procmon/linux.cpp
+++ b/src/plugins/procmon/linux.cpp
@@ -713,9 +713,11 @@ linux_procmon::linux_procmon(drakvuf_t drakvuf, const procmon_config* config, ou
         {
             PRINT_DEBUG("[PROCMON] Failed to get symbol of do_open_execat.\n");
             return;
-        } else
+        }
+        else
             do_open_execat_name = "do_open_execat";
-    } else
+    }
+    else
         do_open_execat_name = "__do_open_execat";
 
     exec_hook = createSyscallHook("do_execveat_common", &linux_procmon::do_execveat_common_cb);

--- a/src/plugins/procmon/linux.cpp
+++ b/src/plugins/procmon/linux.cpp
@@ -322,7 +322,6 @@ void linux_procmon::print_info(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 */
 event_response_t linux_procmon::do_open_execat_ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 {
-    PRINT_DEBUG("[testmon] do_open_execat_ret_cb hit\n");
     auto params_ = libhook::GetTrapParams<open_execat_data>(info);
     auto params = static_cast<execve_data*>(params_->data.get());
     if (!drakvuf_check_return_context(drakvuf, info, params->pid, params->tid, params->execat_rsp))
@@ -430,11 +429,9 @@ event_response_t linux_procmon::do_execveat_common_ret_cb(drakvuf_t drakvuf, dra
     if (!drakvuf_check_return_context(drakvuf, info, params->pid, params->tid, params->rsp))
         return VMI_EVENT_RESPONSE_NONE;
 
-    PRINT_DEBUG("[testmon] print info\n");
     if (!params->internal_error)
         linux_procmon::print_info(drakvuf, info);
 
-    PRINT_DEBUG("[testmon] execve_ret_cb erase\n");
     uint64_t hookID = make_hook_id(info);
     ret_hooks.erase(hookID);
 

--- a/src/plugins/procmon/private.h
+++ b/src/plugins/procmon/private.h
@@ -117,13 +117,10 @@ struct execve_data : PluginResult
         : PluginResult()
         , pid()
         , tid()
-        , ppid()
-        , new_pid()
-        , new_tid()
         , rsp()
         , execat_rsp()
         , cr3()
-        , process_name()
+        , fd()
         , thread_name()
         , image_path_name()
         , command_line()
@@ -134,13 +131,12 @@ struct execve_data : PluginResult
 
     vmi_pid_t pid;
     uint32_t tid;
-    vmi_pid_t ppid;
-    vmi_pid_t new_pid;
-    uint32_t new_tid;
+
     addr_t rsp;
     addr_t execat_rsp;
     addr_t cr3;
 
+    int fd;
     std::string process_name;
     std::string thread_name;
     std::string image_path_name;
@@ -150,16 +146,23 @@ struct execve_data : PluginResult
     bool internal_error = false;
 };
 
+struct open_execat_data : PluginResult
+{
+    open_execat_data()
+        : PluginResult()
+    {
+    }
+
+    std::shared_ptr<CallResult> data;
+};
+
 struct send_signal_data : PluginResult
 {
     send_signal_data()
         : PluginResult()
-        , pid()
-        , target_pid()
-        , tid()
-        , target_tid()
-        , target_ppid()
-        , rsp()
+        , target_proc_pid()
+        , target_proc_tid()
+        , target_proc_ppid()
         , target_process_name()
         , thread_name()
         , target_thread_name()
@@ -167,12 +170,9 @@ struct send_signal_data : PluginResult
     {
     }
 
-    vmi_pid_t pid;
-    vmi_pid_t target_pid;
-    uint32_t tid;
-    uint32_t target_tid;
-    vmi_pid_t target_ppid;
-    addr_t rsp;
+    vmi_pid_t target_proc_pid;
+    uint32_t target_proc_tid;
+    vmi_pid_t target_proc_ppid;
 
     std::string target_process_name;
     std::string thread_name;
@@ -475,7 +475,8 @@ static const char* linux_offset_names[__LINUX_OFFSET_MAX][2] =
 
 } // procmon_ns
 
-#define ARG_MAX 131072
-#define MAX_ERRNO 4095
+#define ARG_MAX     131072
+#define MAX_ERRNO   4095
+#define AT_FDCWD    -100
 
 #endif

--- a/src/plugins/procmon/procmon.cpp
+++ b/src/plugins/procmon/procmon.cpp
@@ -106,11 +106,11 @@
 #include "win.h"
 #include "linux.h"
 
-procmon::procmon(drakvuf_t drakvuf, output_format_t output) : pluginex(drakvuf, output)
+procmon::procmon(drakvuf_t drakvuf, const procmon_config* config, output_format_t output) : pluginex(drakvuf, output)
 {
     auto os = drakvuf_get_os_type(drakvuf);
     if (os == VMI_OS_WINDOWS)
         this->wp = std::make_unique<win_procmon>(drakvuf, output);
     else
-        this->lp = std::make_unique<linux_procmon>(drakvuf, output);
+        this->lp = std::make_unique<linux_procmon>(drakvuf, config, output);
 }

--- a/src/plugins/procmon/procmon.h
+++ b/src/plugins/procmon/procmon.h
@@ -117,7 +117,7 @@ public:
     std::unique_ptr<win_procmon> wp;
     std::unique_ptr<linux_procmon> lp;
 
-    procmon(drakvuf_t drakvuf, output_format_t output);
+    procmon(drakvuf_t drakvuf, const procmon_config* config, output_format_t output);
     ~procmon() = default;
 };
 


### PR DESCRIPTION
Hi, updating plugins for Linux.

Changelog:
- procmon: fixed memory leaks and exceptions (thanks for @skvl)
- procmon: added a filter file for Linux environment variables
- procmon: handle program startup by file descriptor (syscall `fexecve`)
- procmon: a small refactoring
- filetracer: printing file descriptor in `memfd` callback
- filetracer: a small refactoring

Possible breaking changes:
- procmon: now `do_execveat_common` is an independent callback without mimicry for the parent process