### PR TITLE
skip kernel processes in functions with PEB parsing

### DIFF
--- a/src/libdrakvuf/win-exports.c
+++ b/src/libdrakvuf/win-exports.c
@@ -187,7 +187,7 @@ addr_t eprocess_sym2va (drakvuf_t drakvuf, addr_t eprocess_base, const char* mod
 
     if (VMI_FAILURE==vmi_read_addr_va(drakvuf->vmi, eprocess_base + drakvuf->offsets[EPROCESS_PDBASE], 0, &ctx.dtb))
         return 0;
-    if (VMI_FAILURE==vmi_read_addr_va(drakvuf->vmi, eprocess_base + drakvuf->offsets[EPROCESS_PEB], 0, &peb))
+    if (VMI_FAILURE==vmi_read_addr_va(drakvuf->vmi, eprocess_base + drakvuf->offsets[EPROCESS_PEB], 0, &peb) || peb == 0)
         return 0;
 
     ctx.addr = peb + drakvuf->offsets[PEB_LDR];

--- a/src/libdrakvuf/win-processes.c
+++ b/src/libdrakvuf/win-processes.c
@@ -469,7 +469,7 @@ char* win_get_process_commandline(drakvuf_t drakvuf, drakvuf_trap_info_t* info, 
 
     addr_t peb = 0;
     ctx.addr = eprocess_base + drakvuf->offsets[EPROCESS_PEB];
-    if (VMI_SUCCESS != vmi_read_addr(vmi, &ctx, &peb))
+    if (VMI_SUCCESS != vmi_read_addr(vmi, &ctx, &peb) || peb == 0)
         return NULL;
 
     addr_t proc_params = 0;
@@ -514,7 +514,7 @@ int64_t win_get_process_userid(drakvuf_t drakvuf, addr_t eprocess_base)
     if (!eprocess_base)
         return -1;
 
-    if (VMI_FAILURE == vmi_read_addr_va(vmi, eprocess_base + drakvuf->offsets[EPROCESS_PEB], 0, &peb))
+    if (VMI_FAILURE == vmi_read_addr_va(vmi, eprocess_base + drakvuf->offsets[EPROCESS_PEB], 0, &peb) || peb == 0)
         return -1;
 
     if (VMI_FAILURE == vmi_read_addr_va(vmi, eprocess_base + drakvuf->offsets[EPROCESS_PDBASE], 0, &ctx.dtb))
@@ -542,7 +542,7 @@ unicode_string_t* win_get_process_csdversion(drakvuf_t drakvuf, addr_t eprocess_
     if (!eprocess_base)
         return NULL;
 
-    if (VMI_FAILURE == vmi_read_addr_va(vmi, eprocess_base + drakvuf->offsets[EPROCESS_PEB], 0, &peb))
+    if (VMI_FAILURE == vmi_read_addr_va(vmi, eprocess_base + drakvuf->offsets[EPROCESS_PEB], 0, &peb) || peb == 0)
         return NULL;
 
     if (VMI_FAILURE == vmi_read_addr_va(vmi, eprocess_base + drakvuf->offsets[EPROCESS_PDBASE], 0, &ctx.dtb))
@@ -781,7 +781,7 @@ bool win_get_module_list(drakvuf_t drakvuf, addr_t eprocess_base, addr_t* module
     if (VMI_FAILURE == vmi_read_addr_va(vmi, eprocess_base + drakvuf->offsets[EPROCESS_PDBASE], 0, &ctx.dtb))
         return false;
 
-    if (VMI_FAILURE == vmi_read_addr_va(vmi, eprocess_base + drakvuf->offsets[EPROCESS_PEB], 0, &peb))
+    if (VMI_FAILURE == vmi_read_addr_va(vmi, eprocess_base + drakvuf->offsets[EPROCESS_PEB], 0, &peb) || peb == 0)
         return false;
 
     ctx.addr = peb + drakvuf->offsets[PEB_LDR];


### PR DESCRIPTION
While checking cases with invalid address translation, I got an error where some functions try to read information from PEB when PEB address is 0, so `peb + drakvuf->offsets[SOME_PARAMETER]` is just `drakvuf->offsets[SOME_PARAMETER]` offset, but not a valid address. This happens for kernel processes (System, Registry, Memory Compression, ...).

The patch simply interrupts such functions when there is no PEB for the process.