### PR TITLE
remove "c++-compat" flag in xen_helper build

### DIFF
--- a/src/xen_helper/Makefile.am
+++ b/src/xen_helper/Makefile.am
@@ -118,8 +118,7 @@ AM_CFLAGS += -Wcast-qual -Wcast-align -Wstrict-aliasing \
              -Wpointer-arith -Winit-self -Wshadow \
              -Wswitch-enum -Wstrict-prototypes \
              -Wmissing-prototypes -Wredundant-decls \
-             -Wfloat-equal -Wundef -Wvla \
-             -Wc++-compat
+             -Wfloat-equal -Wundef -Wvla
 endif
 
 if HARDENING


### PR DESCRIPTION
Fix implicit cast errors on clang11:
```
xen_helper.c:184:38: error: request for implicit conversion from ‘void *’ to ‘int (*)(xenforeignmemory_handle *)’ not permitted in C++ [-Werror=c++-compat]
  184 |     _xen->xlw.xenforeignmemory_close = dlsym(_xen->xlw.xfm_handle, "xenforeignmemory_close");
```

Fixes the same build error as #1668, but in the suggested way.