### PR TITLE
Search system DLLs for hooking via VADs (not via PEB)

### DIFF
--- a/src/libusermode/uh-private.hpp
+++ b/src/libusermode/uh-private.hpp
@@ -245,9 +245,17 @@ public:
     std::array<size_t, __OFFSET_MAX> offsets;
 
     std::vector<usermode_cb_registration> plugins;
-    // map pid -> list of hooked dlls
+
+    // map pid -> list of loaded/hooked dlls
     std::map<vmi_pid_t, std::vector<dll_t>> loaded_dlls;
-    std::map<vmi_pid_t, bool> proc_ntdll_hooked;
+
+    struct module_context_t
+    {
+        std::optional<mmvad_info_t> mmvad;
+        bool is_hooked;
+    };
+
+    std::map<vmi_pid_t, module_context_t> proc_ntdll;
 
 #ifndef LIBUSERMODE_USE_INJECTION
     std::set<std::pair<vmi_pid_t, uint32_t /*thread_id*/>> pf_in_progress;
@@ -282,7 +290,7 @@ private:
 
 proc_data_t get_proc_data(drakvuf_t drakvuf, const drakvuf_trap_info_t* info);
 bool make_trap(vmi_instance_t vmi, drakvuf_t drakvuf, drakvuf_trap_info* info, hook_target_entry_t* target, addr_t exec_func);
-event_response_t hook_dll(drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t base_address_ptr);
+event_response_t hook_dll(drakvuf_t drakvuf, drakvuf_trap_info_t* info, mmvad_info_t* mmvad, bool *is_hooked);
 bool is_pagetable_loaded(vmi_instance_t vmi, const drakvuf_trap_info* info, addr_t vaddr);
 event_response_t internal_perform_hooking(drakvuf_t drakvuf, drakvuf_trap_info* info, userhook* plugin, dll_t* dll_meta);
 

--- a/src/libusermode/uh-private.hpp
+++ b/src/libusermode/uh-private.hpp
@@ -290,7 +290,8 @@ private:
 
 proc_data_t get_proc_data(drakvuf_t drakvuf, const drakvuf_trap_info_t* info);
 bool make_trap(vmi_instance_t vmi, drakvuf_t drakvuf, drakvuf_trap_info* info, hook_target_entry_t* target, addr_t exec_func);
-event_response_t hook_dll(drakvuf_t drakvuf, drakvuf_trap_info_t* info, mmvad_info_t* mmvad, bool *is_hooked);
+bool get_module_mmvad(drakvuf_t drakvuf, addr_t eprocess, addr_t base_address, mmvad_info_t* mmvad);
+event_response_t hook_dll(drakvuf_t drakvuf, drakvuf_trap_info_t* info, mmvad_info_t* mmvad, bool* is_hooked);
 bool is_pagetable_loaded(vmi_instance_t vmi, const drakvuf_trap_info* info, addr_t vaddr);
 event_response_t internal_perform_hooking(drakvuf_t drakvuf, drakvuf_trap_info* info, userhook* plugin, dll_t* dll_meta);
 

--- a/src/libusermode/userhook.cpp
+++ b/src/libusermode/userhook.cpp
@@ -409,7 +409,7 @@ static void search_process_system_dlls(drakvuf_t drakvuf, drakvuf_trap_info_t* i
                 if (auto sub = name.find_last_of("/\\"); sub != std::string::npos)
                     name.erase(0, sub + 1);
 
-                auto *vctx = (visitor_context_t*)callback_data;
+                auto* vctx = (visitor_context_t*)callback_data;
 
                 if (name.find(vctx->name) != std::string::npos)
                 {

--- a/src/libusermode/userhook.cpp
+++ b/src/libusermode/userhook.cpp
@@ -353,7 +353,7 @@ static event_response_t perform_hooking(drakvuf_t drakvuf, drakvuf_trap_info* in
     return ret;
 }
 
-event_response_t hook_dll(drakvuf_t drakvuf, drakvuf_trap_info_t* info, mmvad_info_t* mmvad, bool *is_hooked)
+event_response_t hook_dll(drakvuf_t drakvuf, drakvuf_trap_info_t* info, mmvad_info_t* mmvad, bool* is_hooked)
 {
     auto plugin = get_trap_plugin<userhook>(info);
 
@@ -363,7 +363,7 @@ event_response_t hook_dll(drakvuf_t drakvuf, drakvuf_trap_info_t* info, mmvad_in
         dll_meta = create_dll_meta(drakvuf, info, plugin, mmvad);
 
     event_response_t res = VMI_EVENT_RESPONSE_NONE;
-    
+
     if (is_hooked)
         *is_hooked = false;
 
@@ -388,7 +388,7 @@ static void search_process_system_dlls(drakvuf_t drakvuf, drakvuf_trap_info_t* i
     };
 
     userhook::module_context_t* ctx = nullptr;
-    
+
     auto it = plugin->proc_ntdll.find(info->attached_proc_data.pid);
     if (it != plugin->proc_ntdll.end())
     {
@@ -409,7 +409,7 @@ static void search_process_system_dlls(drakvuf_t drakvuf, drakvuf_trap_info_t* i
                 if (auto sub = name.find_last_of("/\\"); sub != std::string::npos)
                     name.erase(0, sub + 1);
 
-                auto *vctx = (visitor_context_t *)callback_data;
+                auto *vctx = (visitor_context_t*)callback_data;
 
                 if (name.find(vctx->name) != std::string::npos)
                 {
@@ -439,7 +439,7 @@ static void search_process_system_dlls(drakvuf_t drakvuf, drakvuf_trap_info_t* i
         hook_dll(drakvuf, info, &ctx->mmvad.value(), &ctx->is_hooked);
 }
 
-static bool get_module_mmvad(drakvuf_t drakvuf, addr_t eprocess, addr_t base_address, mmvad_info_t *mmvad)
+bool get_module_mmvad(drakvuf_t drakvuf, addr_t eprocess, addr_t base_address, mmvad_info_t* mmvad)
 {
     mmvad_info_t mmvad_;
     if (!drakvuf_find_mmvad(drakvuf, eprocess, base_address, &mmvad_))
@@ -447,7 +447,7 @@ static bool get_module_mmvad(drakvuf_t drakvuf, addr_t eprocess, addr_t base_add
 
     if (drakvuf_mmvad_type(drakvuf, &mmvad_) != 2) // VAD_TYPE_DLL
         return false;
-    
+
     *mmvad = mmvad_;
     return true;
 }

--- a/src/libusermode/userhook_inject.cpp
+++ b/src/libusermode/userhook_inject.cpp
@@ -155,7 +155,11 @@ static event_response_t map_view_of_section_ret_cb_2(drakvuf_t drakvuf, drakvuf_
     if (!params->verify_result_call_params(drakvuf, info))
         return VMI_EVENT_RESPONSE_NONE;
 
-    return hook_dll(drakvuf, info, params->base_address_ptr);
+    mmvad_info_t mmvad;
+    if (get_module_mmvad(drakvuf, info->attached_proc_data.base_addr, params->base_address_ptr, &mmvad))
+        return hook_dll(drakvuf, info, &mmvad, 0);
+
+    return VMI_EVENT_RESPONSE_NONE;
 }
 
 static void check_stack_marker(


### PR DESCRIPTION
At the moment, an unreliable algorithm for searching for system DLLs through PEB has been implemented, for at least three reasons:
1) Sometimes PEB's pages are paged out, so reading fails.
2) PEB is user mode memory that is sometimes modified by malware (https://www.cynet.com/attack-techniques-hands-on/defense-evasion-techniques-peb-edition/).
3) Some DLLs (even ntdll) may not be in the PEB list.

The patch implements traverse via VADs.

Also fixed a bug where, after a failed hook attempt, the process is still added to the cache (this is now controlled by the `is_hooked` flag).