### PR TITLE
libinjector: skip kernel mode trap frame and split wait_for_target_process_cb

### DIFF
--- a/src/libinjector/win/win_injector.c
+++ b/src/libinjector/win/win_injector.c
@@ -292,6 +292,12 @@ static event_response_t wait_for_target_process_cb(drakvuf_t drakvuf, drakvuf_tr
             goto done;
         }
 
+        if (VMI_GET_BIT(bp_addr, 47))
+        {
+            PRINT_DEBUG("Got return address from kernel address space, waiting for another one.\n");
+            goto done;
+        }
+
         if (setup_int3_trap(injector, info, bp_addr))
         {
             PRINT_DEBUG("Got return address 0x%lx from trapframe and it's now trapped!\n",


### PR DESCRIPTION
Following the discussion from https://github.com/tklengyel/drakvuf/pull/1639

- Splitted part of wait_for_target_process_cb into `setup_usermode_trap_x86` and `setup_usermode_trap_x64` to reduce cognitive complexity within that function
- Fixed bug in `setup_usermode_trap_x64` that catched kernel-mode address from trap frame. It was rare case and probably related to page fault inside kernel.
- Added description to `setup_usermode_trap_x86` explaining why we need to use different methods on x64 and x86.
