### PR TITLE
move token check into PspInsertThread

### DIFF
--- a/src/plugins/exploitmon/exploitmon.cpp
+++ b/src/plugins/exploitmon/exploitmon.cpp
@@ -257,8 +257,6 @@ static event_response_t insert_process_hook_cb(drakvuf_t drakvuf, drakvuf_trap_i
     token = token & plugin->ex_fast_ref_mask;
     plugin->live_processes.push_back(std::make_pair(pid, token));
 
-    plugin->check_created_by_system(drakvuf, process, token);
-
     return VMI_EVENT_RESPONSE_NONE;
 }
 
@@ -364,6 +362,71 @@ static event_response_t check_previous_mode_hook_cb(drakvuf_t drakvuf, drakvuf_t
     return VMI_EVENT_RESPONSE_NONE;
 }
 
+static event_response_t insert_thread_hook_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
+{
+    auto plugin  = get_trap_plugin<exploitmon>(info);
+    auto process = drakvuf_get_function_argument(drakvuf, info, 2);
+    // Read number of active threads. 0 means the process is being created.
+    //
+    vmi_lock_guard vmi(drakvuf);
+    uint32_t active_threads{};
+    if (VMI_FAILURE == vmi_read_32_va(vmi, process + plugin->offsets[EPROCESS_ACTIVE_THREADS], 0, &active_threads))
+    {
+        PRINT_DEBUG("Failed to read active threads count\n");
+        return VMI_EVENT_RESPONSE_NONE;
+    }
+    // 0 active threads - its a new process.
+    //
+    if (active_threads)
+    {
+        return VMI_EVENT_RESPONSE_NONE;
+    }
+    // Check process token.
+    //
+    addr_t token{};
+    if (VMI_FAILURE == vmi_read_addr_va(vmi, process + plugin->offsets[EPROCESS_TOKEN], 0, &token))
+    {
+        PRINT_DEBUG("[EXPLOITMON] Failed to read process token\n");
+        return VMI_EVENT_RESPONSE_NONE;
+    }
+    token = token & plugin->ex_fast_ref_mask;
+
+    addr_t token_name_addr = token
+        + plugin->offsets[EX_FAST_REF_OBJECT]
+        + plugin->offsets[TOKEN_SOURCE]
+        + plugin->offsets[TOKEN_SOURCE_NAME];
+
+    char token_name[8];
+    if (VMI_FAILURE == vmi_read_va(vmi, token_name_addr, 0, sizeof(token_name), token_name, nullptr))
+    {
+        PRINT_DEBUG("[EXPLOITMON] Failed to read token name of created process\n");
+        return VMI_EVENT_RESPONSE_NONE;
+    }
+
+    if (!memcmp(token_name, "*SYSTEM*", sizeof(token_name)))
+    {
+        auto timestamp = g_get_real_time();
+        proc_data_t proc_data{};
+        if (!drakvuf_get_process_data(drakvuf, process, &proc_data))
+        {
+            PRINT_DEBUG("[EXPLOITMON] Failed to get process data\n");
+            return VMI_EVENT_RESPONSE_NONE;
+        }
+
+        fmt::print(plugin->format, "exploitmon", drakvuf, nullptr,
+            keyval("TimeStamp", TimeVal{UNPACK_TIMEVAL(timestamp)}),
+            keyval("PID", fmt::Nval(proc_data.pid)),
+            keyval("PPID", fmt::Nval(proc_data.ppid)),
+            keyval("TID", fmt::Nval(proc_data.tid)),
+            keyval("UserId", fmt::Nval(proc_data.userid)),
+            keyval("ProcessName", fmt::Estr(proc_data.name)),
+            keyval("Reason", fmt::Rstr("Process with SYSTEM privileges started"))
+        );
+        g_free((gpointer)proc_data.name);
+    }
+    return VMI_EVENT_RESPONSE_NONE;
+}
+
 uint64_t exploitmon::get_code_selector(drakvuf_t drakvuf, uint64_t kthread)
 {
     vmi_lock_guard vmi(drakvuf);
@@ -416,6 +479,11 @@ void exploitmon::register_traps(bool enable_k2u)
         PRINT_DEBUG("[EXPLOITMON] Failed to hook NtTerminateProcess or PspInsertProcess\n");
         throw -1;
     }
+    if (!register_trap(nullptr, insert_thread_hook_cb, bp.for_syscall_name("PspInsertThread")))
+    {
+        PRINT_DEBUG("[EXPLOITMON] Failed to hook PspInsertThread\n");
+        throw -1;
+    }
     if (enable_k2u)
     {
         if (!register_trap(nullptr, page_fault_hook_cb, bp.for_syscall_name("MmAccessFault")))
@@ -460,45 +528,6 @@ exploitmon::exploitmon(drakvuf_t drakvuf, struct exploitmon_config* c, output_fo
         throw -1;
     }
     register_traps(c->enable_k2u);
-}
-
-void exploitmon::check_created_by_system(drakvuf_t drakvuf, addr_t process, uint64_t token)
-{
-    addr_t name_addr = token + this->offsets[EX_FAST_REF_OBJECT] + this->offsets[TOKEN_SOURCE] + this->offsets[TOKEN_SOURCE_NAME];
-
-    vmi_lock_guard vmi(drakvuf);
-    addr_t dtb;
-
-    if (!drakvuf_get_process_dtb(drakvuf, process, &dtb))
-    {
-        PRINT_DEBUG("[EXPLOITMON] Failed to get process dtb\n");
-        return;
-    }
-
-    ACCESS_CONTEXT(ctx,
-        .translate_mechanism = VMI_TM_PROCESS_DTB,
-        .dtb = dtb,
-        .addr = name_addr,
-    );
-
-    char token_name[8];
-
-    if (VMI_SUCCESS != vmi_read(vmi, &ctx, sizeof(token_name), token_name, nullptr))
-    {
-        PRINT_DEBUG("[EXPLOITMON] Failed to read token name of created process\n");
-        return;
-    }
-    if (!memcmp(token_name, "*SYSTEM*", sizeof(token_name)))
-    {
-        proc_data_t proc_data;
-        if (!drakvuf_get_process_data(drakvuf, process, &proc_data))
-        {
-            PRINT_DEBUG("[EXPLOITMON] Failed to get process data 2\n");
-            return;
-        }
-        fmt::print_proc_data(this->format, "exploitmon", drakvuf, proc_data, keyval("Reason", fmt::Qstr("Process with SYSTEM privileges started")));
-        g_free((gpointer)proc_data.name);
-    }
 }
 
 exploitmon::~exploitmon()

--- a/src/plugins/exploitmon/exploitmon.h
+++ b/src/plugins/exploitmon/exploitmon.h
@@ -127,7 +127,6 @@ public:
     exploitmon(drakvuf_t drakvuf, struct exploitmon_config* c, output_format_t output);
     exploitmon(const exploitmon&) = delete;
     exploitmon& operator=(const exploitmon&) = delete;
-    void check_created_by_system(drakvuf_t drakvuf, uint64_t token, uint64_t process);
     ~exploitmon();
 
     virtual bool stop_impl() override;

--- a/src/plugins/exploitmon/private.h
+++ b/src/plugins/exploitmon/private.h
@@ -115,6 +115,7 @@ enum offset
 {
     EPROCESS_TOKEN,
     EPROCESS_UNIQUE_PROCESS_ID,
+    EPROCESS_ACTIVE_THREADS,
     TRAP_FRAME,
     PREVIOUS_MODE,
     SEG_CS,
@@ -126,14 +127,15 @@ enum offset
 
 static const char* offset_names[__OFFSET_MAX][2] =
 {
-    [EPROCESS_TOKEN] = {"_EPROCESS", "Token"},
+    [EPROCESS_TOKEN]             = {"_EPROCESS", "Token"},
     [EPROCESS_UNIQUE_PROCESS_ID] = {"_EPROCESS", "UniqueProcessId"},
-    [TRAP_FRAME] = {"_KTHREAD", "TrapFrame"},
-    [PREVIOUS_MODE] = {"_KTHREAD", "PreviousMode"},
-    [SEG_CS] = {"_KTRAP_FRAME", "SegCs"},
-    [TOKEN_SOURCE] = {"_TOKEN", "TokenSource"},
-    [TOKEN_SOURCE_NAME] = {"_TOKEN_SOURCE", "SourceName"},
-    [EX_FAST_REF_OBJECT] = {"_EX_FAST_REF", "Object"},
+    [EPROCESS_ACTIVE_THREADS]    = {"_EPROCESS", "ActiveThreads"},
+    [TRAP_FRAME]                 = {"_KTHREAD", "TrapFrame"},
+    [PREVIOUS_MODE]              = {"_KTHREAD", "PreviousMode"},
+    [SEG_CS]                     = {"_KTRAP_FRAME", "SegCs"},
+    [TOKEN_SOURCE]               = {"_TOKEN", "TokenSource"},
+    [TOKEN_SOURCE_NAME]          = {"_TOKEN_SOURCE", "SourceName"},
+    [EX_FAST_REF_OBJECT]         = {"_EX_FAST_REF", "Object"},
 };
 
 #endif


### PR DESCRIPTION
The process name is trimmed to 15 bytes because the EPROCESS structure is not fully initialized in `PsInsertProcess`. We move callback into `PsInsertThread` and check if thread count is 0 meaning the process is being created.
before:
```
exploitmon Time=1676497247.070258,PID=236,PPID=2332,TID=0,ProcessName="backgroundTask",Reason="Process with SYSTEM privileges started"
```
after:
```
[EXPLOITMON] TimeStamp:1694600082.658729 PID:4136 PPID:948 TID:0 UserId:1 ProcessName:"\\Device\\HarddiskVolume2\\Windows\\System32\\backgroundTaskHost.exe" Reason:Process with SYSTEM privileges started
```
