### PR TITLE
rework hooks in pluginex class

### DIFF
--- a/src/libhook/hooks/cpuid.hpp
+++ b/src/libhook/hooks/cpuid.hpp
@@ -118,8 +118,7 @@ public:
      */
     template<typename Params = CallResult>
     [[nodiscard]]
-    static auto create(drakvuf_t, cb_wrapper_t cb, int ttl)
-    -> std::unique_ptr<CpuidHook>;
+    static CpuidHook* create(drakvuf_t, cb_wrapper_t cb, int ttl);
 
     /**
      * unhook on dctor
@@ -162,13 +161,11 @@ protected:
 };
 
 template<typename Params>
-auto CpuidHook::create(drakvuf_t drakvuf, cb_wrapper_t cb, int ttl)
--> std::unique_ptr<CpuidHook>
+CpuidHook* CpuidHook::create(drakvuf_t drakvuf, cb_wrapper_t cb, int ttl)
 {
     PRINT_DEBUG("[LIBHOOK] creating cpuid hook\n");
 
-    // not using std::make_unique because ctor is private
-    auto hook = std::unique_ptr<CpuidHook>(new CpuidHook(drakvuf, cb));
+    auto hook = new CpuidHook(drakvuf, cb);
     hook->trap_ = new drakvuf_trap_t();
 
     hook->trap_->name = "libhook cpuid";
@@ -184,7 +181,7 @@ auto CpuidHook::create(drakvuf_t drakvuf, cb_wrapper_t cb, int ttl)
 
     // populate backref
     hook->params_ = std::make_shared<Params>();
-    hook->params_->hook_ = hook.get();
+    hook->params_->hook_ = hook;
     hook->trap_->data = static_cast<void*>(hook->params_.get());
 
     if (!drakvuf_add_trap(drakvuf, hook->trap_))
@@ -194,7 +191,8 @@ auto CpuidHook::create(drakvuf_t drakvuf, cb_wrapper_t cb, int ttl)
         delete hook->trap_;
         hook->trap_ = nullptr;
         hook->params_.reset();
-        return std::unique_ptr<CpuidHook>();
+        delete hook;
+        return nullptr;
     }
 
     PRINT_DEBUG("[LIBHOOK] cpuid hook OK\n");

--- a/src/libhook/hooks/cr3.hpp
+++ b/src/libhook/hooks/cr3.hpp
@@ -118,8 +118,7 @@ public:
      */
     template<typename Params = CallResult>
     [[nodiscard]]
-    static auto create(drakvuf_t, cb_wrapper_t cb, int ttl)
-    -> std::unique_ptr<Cr3Hook>;
+    static Cr3Hook* create(drakvuf_t, cb_wrapper_t cb, int ttl);
 
     /**
      * unhook on dctor
@@ -162,13 +161,11 @@ protected:
 };
 
 template<typename Params>
-auto Cr3Hook::create(drakvuf_t drakvuf, cb_wrapper_t cb, int ttl)
--> std::unique_ptr<Cr3Hook>
+Cr3Hook* Cr3Hook::create(drakvuf_t drakvuf, cb_wrapper_t cb, int ttl)
 {
     PRINT_DEBUG("[LIBHOOK] creating cr3 hook\n");
 
-    // not using std::make_unique because ctor is private
-    auto hook = std::unique_ptr<Cr3Hook>(new Cr3Hook(drakvuf, cb));
+    auto hook = new Cr3Hook(drakvuf, cb);
     hook->trap_ = new drakvuf_trap_t();
 
     hook->trap_->name = "libhook cr3";
@@ -185,7 +182,7 @@ auto Cr3Hook::create(drakvuf_t drakvuf, cb_wrapper_t cb, int ttl)
 
     // populate backref
     hook->params_ = std::make_shared<Params>();
-    hook->params_->hook_ = hook.get();
+    hook->params_->hook_ = hook;
     hook->trap_->data = static_cast<void*>(hook->params_.get());
 
     if (!drakvuf_add_trap(drakvuf, hook->trap_))
@@ -195,7 +192,8 @@ auto Cr3Hook::create(drakvuf_t drakvuf, cb_wrapper_t cb, int ttl)
         delete hook->trap_;
         hook->trap_ = nullptr;
         hook->params_.reset();
-        return std::unique_ptr<Cr3Hook>();
+        delete hook;
+        return nullptr;
     }
 
     PRINT_DEBUG("[LIBHOOK] cr3 hook OK\n");

--- a/src/libhook/hooks/manual.cpp
+++ b/src/libhook/hooks/manual.cpp
@@ -106,17 +106,16 @@
 namespace libhook
 {
 
-auto ManualHook::create(drakvuf_t drakvuf, drakvuf_trap_t* trap, drakvuf_trap_free_t free_routine)
--> std::unique_ptr<ManualHook>
+ManualHook* ManualHook::create(drakvuf_t drakvuf, drakvuf_trap_t* trap, drakvuf_trap_free_t free_routine)
 {
     PRINT_DEBUG("[LIBHOOK] creating manual hook\n");
 
-    // not using std::make_unique because ctor is private
-    auto hook = std::unique_ptr<ManualHook>(new ManualHook(drakvuf, trap, free_routine));
+    auto hook = new ManualHook(drakvuf, trap, free_routine);
     if (!drakvuf_add_trap(hook->drakvuf_, hook->trap_))
     {
         PRINT_DEBUG("[LIBHOOK] failed to create trap for manual hook\n");
-        return std::unique_ptr<ManualHook>();
+        delete hook;
+        return nullptr;
     }
 
     PRINT_DEBUG("[LIBHOOK] manual hook OK\n");

--- a/src/libhook/hooks/manual.hpp
+++ b/src/libhook/hooks/manual.hpp
@@ -123,8 +123,7 @@ public:
      * Factory function to create the trap and perform hooking at the same time.
      */
     [[nodiscard]]
-    static auto create(drakvuf_t, drakvuf_trap_t*, drakvuf_trap_free_t)
-    -> std::unique_ptr<ManualHook>;
+    static ManualHook* create(drakvuf_t, drakvuf_trap_t*, drakvuf_trap_free_t);
 
     /**
      * Unhook in dctor

--- a/src/plugins/apimon/apimon.h
+++ b/src/plugins/apimon/apimon.h
@@ -138,11 +138,8 @@ public:
     ~apimon();
 
     std::optional<std::string> resolve_module(drakvuf_t drakvuf, addr_t process, addr_t addr, vmi_pid_t pid);
-    bool stop_impl() override;
 
     event_response_t usermode_return_hook_cb(drakvuf_t drakvuf, drakvuf_trap_info* info);
-
-    std::map<uint64_t, std::unique_ptr<libhook::ReturnHook>> ret_hooks;
 };
 
 #endif

--- a/src/plugins/codemon/codemon.h
+++ b/src/plugins/codemon/codemon.h
@@ -151,23 +151,16 @@ public:
     //Counts how often an actual dump occured
     unsigned int dump_id = 0;
 
-    // hooks and callbacks for MmAccessFault
-    std::unique_ptr<libhook::SyscallHook> mmAccessFaultHook;
-    std::unique_ptr<libhook::ReturnHook> mmAccessFaultReturnHook;
+    // callbacks for MmAccessFault
     event_response_t mm_access_fault_hook_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* trap_info);
     event_response_t mm_access_fault_return_hook_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* trap_info);
 
-    // hooks and callbacks for memory execution/write
-    std::set<std::unique_ptr<libhook::MemAccessHook>> memaccess_hooks;
+    // callbacks for memory execution/write
     event_response_t execute_faulted_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* trap_info);
     event_response_t write_faulted_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* trap_info);
 
-    // responsible for removing traps from memaccess_hooks field based on drakvuf_trap_info_t
-    void remove_memaccess_hook(drakvuf_trap_info_t* trap_info);
-
     // used for forcing windows to load swapped pages
     event_response_t ki_system_service_handler_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
-    std::unique_ptr<libhook::SyscallHook> kiSystemServiceHandlerHook;
     x86_registers_t backup_regs;
     std::set<std::pair<vmi_pid_t, uint32_t /*thread_id*/>> pf_in_progress;
 

--- a/src/plugins/ebpfmon/ebpfmon.cpp
+++ b/src/plugins/ebpfmon/ebpfmon.cpp
@@ -197,7 +197,7 @@ event_response_t ebpfmon::sys_bpf_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* inf
 ebpfmon::ebpfmon(drakvuf_t drakvuf, output_format_t output)
     : pluginex(drakvuf, output)
 {
-    ebpfhook = createSyscallHook("__do_sys_bpf", &ebpfmon::sys_bpf_cb, "bpf");
+    auto ebpfhook = createSyscallHook("__do_sys_bpf", &ebpfmon::sys_bpf_cb, "bpf");
     if (nullptr == ebpfhook)
     {
         PRINT_DEBUG("[EBPFMON] Method __do_sys_bpf not found.\n");

--- a/src/plugins/ebpfmon/ebpfmon.h
+++ b/src/plugins/ebpfmon/ebpfmon.h
@@ -110,8 +110,6 @@
 class ebpfmon: public pluginex
 {
 public:
-    std::unique_ptr<libhook::SyscallHook> ebpfhook;
-
     ebpfmon(drakvuf_t drakvuf, output_format_t output);
     event_response_t sys_bpf_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* trap);
 };

--- a/src/plugins/fileextractor/fileextractor.h
+++ b/src/plugins/fileextractor/fileextractor.h
@@ -167,16 +167,6 @@ private:
 
     int sequence_number = 0;
 
-    /* Hooks */
-    std::unique_ptr<libhook::SyscallHook> setinformation_hook;
-    std::unique_ptr<libhook::SyscallHook> writefile_hook;
-    std::unique_ptr<libhook::SyscallHook> close_hook;
-    std::unique_ptr<libhook::SyscallHook> createsection_hook;
-    std::unique_ptr<libhook::SyscallHook> createfile_hook;
-    std::unique_ptr<libhook::SyscallHook> openfile_hook;
-    std::map<uint64_t, std::unique_ptr<libhook::ReturnHook>> createfile_ret_hooks;
-    std::map<uint64_t, std::unique_ptr<libhook::ReturnHook>> writefile_ret_hooks;
-
     /* VA of functions to be injected */
     addr_t queryvolumeinfo_va = 0;
     addr_t queryinfo_va = 0;
@@ -250,7 +240,6 @@ private:
         void* buffer,
         size_t size);
     void dump_mem_to_file(uint64_t cr3, addr_t str, int idx, uint64_t offset, size_t size);
-    uint64_t make_hook_id(drakvuf_trap_info_t*);
     uint64_t make_task_id(vmi_pid_t pid, handle_t handle);
     uint64_t make_task_id(task_t&);
     void free_pool(addr_t va);

--- a/src/plugins/filetracer/linux.h
+++ b/src/plugins/filetracer/linux.h
@@ -116,37 +116,6 @@ public:
     std::array<size_t, __LINUX_OFFSET_MAX> offsets;
     std::array<size_t, __PT_REGS_MAX> regs;
 
-    /* Hooks */
-    // File operations hooks
-    std::unique_ptr<libhook::SyscallHook> open_file_hook;
-    std::unique_ptr<libhook::SyscallHook> read_file_hook;
-    std::unique_ptr<libhook::SyscallHook> write_file_hook;
-    std::unique_ptr<libhook::SyscallHook> close_file_hook;
-    std::unique_ptr<libhook::SyscallHook> llseek_file_hook;
-    std::unique_ptr<libhook::SyscallHook> memfd_create_file_hook;
-    std::unique_ptr<libhook::SyscallHook> mknod_file_hook;
-    std::unique_ptr<libhook::SyscallHook> rename_file_hook;
-    std::unique_ptr<libhook::SyscallHook> truncate_file_hook;
-    std::unique_ptr<libhook::SyscallHook> allocate_file_hook;
-    // File attributes change hooks
-    std::unique_ptr<libhook::SyscallHook> chmod_file_hook;
-    std::unique_ptr<libhook::SyscallHook> chown_file_hook;
-    std::unique_ptr<libhook::SyscallHook> utimes_file_hook;
-    std::unique_ptr<libhook::SyscallHook> access_file_hook;
-    // Directory operations hooks
-    std::unique_ptr<libhook::SyscallHook> mkdir_hook;
-    std::unique_ptr<libhook::SyscallHook> rmdir_hook;
-    std::unique_ptr<libhook::SyscallHook> chdir_hook;
-    std::unique_ptr<libhook::SyscallHook> chroot_hook;
-    // Link operations hooks
-    std::unique_ptr<libhook::SyscallHook> link_file_hook;
-    std::unique_ptr<libhook::SyscallHook> unlink_file_hook;
-    std::unique_ptr<libhook::SyscallHook> symbolic_link_file_hook;
-    std::unique_ptr<libhook::SyscallHook> read_link_hook;
-
-    /* Return hooks */
-    std::unordered_map<uint64_t, std::unique_ptr<libhook::ReturnHook>> ret_hooks;
-
     /* Callbacks */
     // File operations callbacks
     event_response_t open_file_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
@@ -180,7 +149,6 @@ public:
     event_response_t memfd_create_file_ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
 
     /* Helper functions */
-    uint64_t make_hook_id(drakvuf_trap_info_t* info);
     void print_info(drakvuf_t drakvuf, drakvuf_trap_info_t* info, linux_data* params);
 
     /* File info parsing */

--- a/src/plugins/filetracer/win.h
+++ b/src/plugins/filetracer/win.h
@@ -123,20 +123,6 @@ public:
     bool has_ole32;
     std::array<size_t, __OLE32_OFFSET_MAX> ole32_offsets;
 
-    /* Hooks */
-    std::unique_ptr<libhook::SyscallHook> create_file_hook;
-    std::unique_ptr<libhook::SyscallHook> open_file_hook;
-    std::unique_ptr<libhook::SyscallHook> open_directory_object_hook;
-    std::unique_ptr<libhook::SyscallHook> query_attributes_file_hook;
-    std::unique_ptr<libhook::SyscallHook> query_full_attributes_file_hook;
-    std::unique_ptr<libhook::SyscallHook> set_information_file_hook;
-    std::unique_ptr<libhook::SyscallHook> read_file_hook;
-    std::unique_ptr<libhook::SyscallHook> write_file_hook;
-    std::unique_ptr<libhook::SyscallHook> query_information_file_hook;
-
-    /* Return hooks */
-    std::unordered_map<uint64_t, std::unique_ptr<libhook::ReturnHook>> ret_hooks;
-
     /* Callbacks */
     event_response_t create_file_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
     event_response_t open_file_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info);

--- a/src/plugins/hidevm/hidevm.cpp
+++ b/src/plugins/hidevm/hidevm.cpp
@@ -129,7 +129,7 @@ event_response_t hidevm::NtClose_cb(drakvuf_t, drakvuf_trap_info_t* info)
     uint64_t hook_ID = make_hook_id(info);
 
     // We need to set our fake handle value with 0 to avoid invalid handle exception
-    if (this->NtClose_hook.count(hook_ID))
+    if (this->NtClose_hooked.count(hook_ID))
     {
         uint64_t Handle = drakvuf_get_function_argument(drakvuf, info, 1);
         if (Handle == this->FakeWmiGuidHandle)
@@ -140,7 +140,7 @@ event_response_t hidevm::NtClose_cb(drakvuf_t, drakvuf_trap_info_t* info)
             }
             this->stage = 0;
             this->query_stage = 0;
-            this->NtClose_hook.erase(hook_ID);
+            this->NtClose_hooked.erase(hook_ID);
         }
     }
 
@@ -324,7 +324,8 @@ event_response_t hidevm::ReturnNtDeviceIoControlFile_cb(drakvuf_t, drakvuf_trap_
                             {
                                 this->addr_InputBuffer_Status = 0;
                                 this->addr_IoStatusBlock_Information = 0;
-                                this->NtClose_hook[hook_ID] = std::unique_ptr<libhook::SyscallHook>(this->createSyscallHook("NtClose", &hidevm::NtClose_cb, {}, UNLIMITED_TTL, false));
+                                this->NtClose_hooked.insert(hook_ID);
+                                this->createSyscallHook("NtClose", &hidevm::NtClose_cb);
                                 fmt::print(this->format, "hidevm", drakvuf, info,
                                     keyval("Reason", fmt::Qstr("MSAcpi_ThermalZoneTemperature query spoofed"))
                                 );

--- a/src/plugins/hidevm/hidevm.h
+++ b/src/plugins/hidevm/hidevm.h
@@ -129,7 +129,7 @@ public:
 
     // don't use pluginex::hooks because we need to handle hooks by threads (PID + TID)
     std::unordered_map<uint64_t, std::unique_ptr<libhook::ReturnHook>> ret_hooks;
-    std::unordered_map<uint64_t, std::unique_ptr<libhook::SyscallHook>> NtClose_hook;
+    std::unordered_set<uint64_t> NtClose_hooked;
 
     addr_t objattr_length;
     addr_t objattr_name;

--- a/src/plugins/hidevm/hidevm.h
+++ b/src/plugins/hidevm/hidevm.h
@@ -127,7 +127,7 @@ public:
     uint8_t stage = 0;
     uint8_t query_stage = 0;
 
-    std::unique_ptr<libhook::SyscallHook> NtDeviceIoControlFile_hook;
+    // don't use pluginex::hooks because we need to handle hooks by threads (PID + TID)
     std::unordered_map<uint64_t, std::unique_ptr<libhook::ReturnHook>> ret_hooks;
     std::unordered_map<uint64_t, std::unique_ptr<libhook::SyscallHook>> NtClose_hook;
 

--- a/src/plugins/ipt/ipt.cpp
+++ b/src/plugins/ipt/ipt.cpp
@@ -266,15 +266,15 @@ ipt::ipt(drakvuf_t drakvuf, const ipt_config& config, output_format_t output)
         }
     }
 
-    this->cr3_hook = createCr3Hook(&ipt::cr3_cb);
-    if (!this->cr3_hook)
+    auto cr3_hook = createCr3Hook(&ipt::cr3_cb);
+    if (!cr3_hook)
     {
         PRINT_DEBUG("[IPT] Failed to register CR3 trap");
         throw -1;
     }
 
-    this->catchall_hook = createCatchAllHook(&ipt::catchall_cb);
-    if (!this->catchall_hook)
+    auto catchall_hook = createCatchAllHook(&ipt::catchall_cb);
+    if (!catchall_hook)
     {
         PRINT_DEBUG("[IPT] Failed to register catchall trap");
         throw -1;

--- a/src/plugins/ipt/ipt.h
+++ b/src/plugins/ipt/ipt.h
@@ -164,9 +164,6 @@ private:
     int num_vcpus_ = 0;
     drakvuf_t drakvuf_ = nullptr;
     std::array<ipt_vcpu, MAX_DRAKVUF_VCPU> vcpus;
-
-    std::unique_ptr<libhook::Cr3Hook> cr3_hook;
-    std::unique_ptr<libhook::CatchAllHook> catchall_hook;
 };
 
 #endif

--- a/src/plugins/libhooktest/libhooktest.h
+++ b/src/plugins/libhooktest/libhooktest.h
@@ -116,7 +116,6 @@ public:
     event_response_t protectVirtualMemoryCb(drakvuf_t, drakvuf_trap_info*);
     event_response_t protectVirtualMemoryRetCb(drakvuf_t, drakvuf_trap_info*);
 
-    std::unique_ptr<libhook::Cr3Hook> cr3_hook;
-    std::unique_ptr<libhook::SyscallHook> sys_hook;
-    std::vector<std::unique_ptr<libhook::ReturnHook>> ret_hooks;
+    libhook::Cr3Hook* cr3_hook;
+    std::unordered_set<libhook::ReturnHook*> ret_hooks;
 };

--- a/src/plugins/libhooktest/libhooktest.h
+++ b/src/plugins/libhooktest/libhooktest.h
@@ -116,6 +116,6 @@ public:
     event_response_t protectVirtualMemoryCb(drakvuf_t, drakvuf_trap_info*);
     event_response_t protectVirtualMemoryRetCb(drakvuf_t, drakvuf_trap_info*);
 
-    libhook::Cr3Hook* cr3_hook;
+    libhook::Cr3Hook* cr3_hook = nullptr;
     std::unordered_set<libhook::ReturnHook*> ret_hooks;
 };

--- a/src/plugins/linkmon/linkmon.cpp
+++ b/src/plugins/linkmon/linkmon.cpp
@@ -389,6 +389,6 @@ linkmon::linkmon(drakvuf_t drakvuf,
             throw -1;
     }
 
-    this->ntfscontrolfile_hook = createSyscallHook("NtFsControlFile", &linkmon::ntfscontrolfile_cb);
-    this->setinformation_hook = createSyscallHook("NtSetInformationFile", &linkmon::setinformation_cb);
+    createSyscallHook("NtFsControlFile", &linkmon::ntfscontrolfile_cb);
+    createSyscallHook("NtSetInformationFile", &linkmon::setinformation_cb);
 }

--- a/src/plugins/linkmon/linkmon.h
+++ b/src/plugins/linkmon/linkmon.h
@@ -124,9 +124,6 @@ private:
 
     std::array<size_t, linkmon_ns::__OFFSET_MAX> offsets;
 
-    std::unique_ptr<libhook::SyscallHook> ntfscontrolfile_hook;
-    std::unique_ptr<libhook::SyscallHook> setinformation_hook;
-
     event_response_t ntfscontrolfile_cb(drakvuf_t, drakvuf_trap_info_t*);
     event_response_t setinformation_cb(drakvuf_t, drakvuf_trap_info_t*);
 

--- a/src/plugins/memaccessmon/memaccessmon.cpp
+++ b/src/plugins/memaccessmon/memaccessmon.cpp
@@ -216,7 +216,7 @@ memaccessmon::memaccessmon(drakvuf_t drakvuf, output_format_t output)
     : pluginex(drakvuf, output), format(output)
 {
     PRINT_DEBUG("[MEMACCESSMON] Starting initialization...\n");
-    this->write_hook = createSyscallHook("NtWriteVirtualMemory", &memaccessmon::readwrite_cb);
-    this->read_hook = createSyscallHook("NtReadVirtualMemory", &memaccessmon::readwrite_cb);
-    this->read_ex_hook = createSyscallHook("NtReadVirtualMemoryEx", &memaccessmon::readwrite_cb);
+    createSyscallHook("NtWriteVirtualMemory", &memaccessmon::readwrite_cb);
+    createSyscallHook("NtReadVirtualMemory", &memaccessmon::readwrite_cb);
+    createSyscallHook("NtReadVirtualMemoryEx", &memaccessmon::readwrite_cb);
 }

--- a/src/plugins/memaccessmon/memaccessmon.h
+++ b/src/plugins/memaccessmon/memaccessmon.h
@@ -120,9 +120,6 @@ public:
     event_response_t readwrite_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
 
     output_format_t format;
-    std::unique_ptr<libhook::SyscallHook> write_hook;
-    std::unique_ptr<libhook::SyscallHook> read_hook;
-    std::unique_ptr<libhook::SyscallHook> read_ex_hook;
 
     std::unordered_map<uint32_t, std::vector<mmvad_context>> vads;
 };

--- a/src/plugins/plugins_ex.cpp
+++ b/src/plugins/plugins_ex.cpp
@@ -162,13 +162,14 @@ libhook::ManualHook* pluginex::createManualHook(drakvuf_trap_t* info, drakvuf_tr
 
 void pluginex::destroy_trap(drakvuf_trap_t* target)
 {
-    if (traps.find(target) == traps.end())
+    auto it = traps.find(target);
+    if (it == traps.end())
     {
         PRINT_DEBUG("[PLUGINEX] BUG: attempted to destroy non-existant trap");
         throw -1;
     }
+    traps.erase(it);
     delete_trap(target);
-    traps.erase(target);
 }
 
 void pluginex::delete_trap(drakvuf_trap_t* target)

--- a/src/plugins/plugins_ex.cpp
+++ b/src/plugins/plugins_ex.cpp
@@ -140,10 +140,8 @@ bool pluginex::stop_impl()
 
 void pluginex::destroy_all_traps()
 {
-    for (auto trap : traps)
-        destroy_trap(trap);
-
-    traps.clear();
+    while (!traps.empty())
+        destroy_trap(*traps.begin());
 }
 
 libhook::ManualHook* pluginex::createManualHook(drakvuf_trap_t* info, drakvuf_trap_free_t free_routine, bool save)

--- a/src/plugins/procdump2/procdump2.cpp
+++ b/src/plugins/procdump2/procdump2.cpp
@@ -230,10 +230,16 @@ procdump2::procdump2(drakvuf_t drakvuf, const procdump2_config* config,
     createSyscallHook("MmCleanProcessAddressSpace", &procdump2::clean_process_memory_cb);
 
     if (!config->disable_kedelayexecutionthread_hook)
-        this->delay_execution_hook = createSyscallHook("KeDelayExecutionThread", &procdump2::delay_execution_cb);
+    {
+        createSyscallHook("KeDelayExecutionThread", &procdump2::delay_execution_cb);
+        is_plugin_enabled = true;
+    }
 
     if (!config->disable_kideliverapc_hook)
-        this->deliver_apc_hook = createSyscallHook("KiDeliverApc", &procdump2::deliver_apc_cb);
+    {
+        createSyscallHook("KiDeliverApc", &procdump2::deliver_apc_cb);
+        is_plugin_enabled = true;
+    }
 
     if (config->dump_new_processes_on_finish)
         running_processes_on_start = get_running_processes();
@@ -245,8 +251,6 @@ procdump2::~procdump2()
 
 bool procdump2::stop_impl()
 {
-    bool is_plugin_enabled = this->delay_execution_hook || this->deliver_apc_hook;
-
     if (!begin_stop_at)
         begin_stop_at = g_get_real_time() / G_USEC_PER_SEC;
 

--- a/src/plugins/procdump2/procdump2.cpp
+++ b/src/plugins/procdump2/procdump2.cpp
@@ -226,8 +226,8 @@ procdump2::procdump2(drakvuf_t drakvuf, const procdump2_config* config,
     __cpuid(1, version_information, r0, r1, feature_information);
     __cpuid(0x80000001, r0, amd_extended_cpu_features, r1, r2);
 
-    this->terminate_process_hook = createSyscallHook("NtTerminateProcess", &procdump2::terminate_process_cb);
-    this->clean_process_memory_hook = createSyscallHook("MmCleanProcessAddressSpace", &procdump2::clean_process_memory_cb);
+    createSyscallHook("NtTerminateProcess", &procdump2::terminate_process_cb);
+    createSyscallHook("MmCleanProcessAddressSpace", &procdump2::clean_process_memory_cb);
 
     if (!config->disable_kedelayexecutionthread_hook)
         this->delay_execution_hook = createSyscallHook("KeDelayExecutionThread", &procdump2::delay_execution_cb);

--- a/src/plugins/procdump2/procdump2.h
+++ b/src/plugins/procdump2/procdump2.h
@@ -182,10 +182,8 @@ private:
     const exclude_matcher exclude;
 
     /* Hooks */
-    std::unique_ptr<libhook::SyscallHook> terminate_process_hook;
-    std::unique_ptr<libhook::SyscallHook> deliver_apc_hook;
-    std::unique_ptr<libhook::SyscallHook> delay_execution_hook;
-    std::unique_ptr<libhook::SyscallHook> clean_process_memory_hook;
+    libhook::SyscallHook* deliver_apc_hook;
+    libhook::SyscallHook* delay_execution_hook;
 
     /* VA of functions to be injected */
     addr_t malloc_va{0};

--- a/src/plugins/procdump2/procdump2.h
+++ b/src/plugins/procdump2/procdump2.h
@@ -181,9 +181,7 @@ private:
     std::vector<vmi_pid_t> running_processes_on_start;
     const exclude_matcher exclude;
 
-    /* Hooks */
-    libhook::SyscallHook* deliver_apc_hook;
-    libhook::SyscallHook* delay_execution_hook;
+    bool is_plugin_enabled = false;
 
     /* VA of functions to be injected */
     addr_t malloc_va{0};

--- a/src/plugins/procmon/linux.cpp
+++ b/src/plugins/procmon/linux.cpp
@@ -663,36 +663,27 @@ linux_procmon::linux_procmon(drakvuf_t drakvuf, const procmon_config* config, ou
     else
         do_open_execat_name = "__do_open_execat";
 
-    std::unique_ptr<libhook::SyscallHook> exec_hook(createSyscallHook("do_execveat_common", &linux_procmon::do_execveat_common_cb, std::nullopt, false));
-    if (nullptr == exec_hook)
+    if (!createSyscallHook("do_execveat_common", &linux_procmon::do_execveat_common_cb))
     {
         PRINT_DEBUG("[PROCMON] Method do_execveat_common not found. You are probably using an older kernel version below 5.9\n");
         return;
     }
 
-    std::unique_ptr<libhook::SyscallHook> exit_hook(createSyscallHook("do_exit", &linux_procmon::do_exit_cb, std::nullopt, false));
-    if (nullptr == exit_hook)
+    if (!createSyscallHook("do_exit", &linux_procmon::do_exit_cb))
     {
         PRINT_DEBUG("[PROCMON] Method do_exit not found.\n");
         return;
     }
 
-    std::unique_ptr<libhook::SyscallHook> signal_hook(createSyscallHook("__send_signal", &linux_procmon::send_signal_cb, "send_signal", false));
-    if (nullptr == signal_hook)
+    if (!createSyscallHook("__send_signal", &linux_procmon::send_signal_cb, "send_signal"))
     {
         PRINT_DEBUG("[PROCMON] Method __send_signal not found.\n");
         return;
     }
 
-    std::unique_ptr<libhook::SyscallHook> kernel_clone_hook(createSyscallHook("kernel_clone", &linux_procmon::kernel_clone_cb, std::nullopt, false));
-    if (nullptr == kernel_clone_hook)
+    if (!createSyscallHook("kernel_clone", &linux_procmon::kernel_clone_cb))
     {
         PRINT_DEBUG("[PROCMON] Method kernel_clone not found.\n");
         return;
     }
-
-    this->register_hook(std::move(exec_hook));
-    this->register_hook(std::move(exit_hook));
-    this->register_hook(std::move(signal_hook));
-    this->register_hook(std::move(kernel_clone_hook));
 }

--- a/src/plugins/procmon/linux.cpp
+++ b/src/plugins/procmon/linux.cpp
@@ -379,7 +379,6 @@ event_response_t linux_procmon::do_open_execat_cb(drakvuf_t drakvuf, drakvuf_tra
     ret_hook->trap_->name = "do_open_execat_ret_trap";
     auto ret_params = libhook::GetTrapParams<open_execat_data>(ret_hook->trap_);
     ret_params->data = params_->data;
-    //this->internal_traps.erase(hookID); // wtf
 
     return VMI_EVENT_RESPONSE_NONE;
 }

--- a/src/plugins/procmon/linux.h
+++ b/src/plugins/procmon/linux.h
@@ -123,19 +123,6 @@ public:
     /* Offsets */
     std::array<size_t, procmon_ns::__LINUX_OFFSET_MAX> offsets;
 
-    /* Traps */
-    std::unordered_map<uint64_t, std::unique_ptr<libhook::SyscallHook>> internal_traps;
-    std::unordered_map<uint64_t, std::unique_ptr<libhook::ReturnHook>> internal_ret_traps;
-
-    /* Hooks */
-    std::unique_ptr<libhook::SyscallHook> exec_hook;
-    std::unique_ptr<libhook::SyscallHook> exit_hook;
-    std::unique_ptr<libhook::SyscallHook> signal_hook;
-    std::unique_ptr<libhook::SyscallHook> kernel_clone_hook;
-
-    /* Return hooks */
-    std::unordered_map<uint64_t, std::unique_ptr<libhook::ReturnHook>> ret_hooks;
-
     /* Callbacks */
     event_response_t do_execveat_common_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
     event_response_t do_open_execat_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info);

--- a/src/plugins/ptracemon/ptracemon.cpp
+++ b/src/plugins/ptracemon/ptracemon.cpp
@@ -165,7 +165,7 @@ ptracemon::ptracemon(drakvuf_t drakvuf, output_format_t output) : pluginex(drakv
         return;
     }
 
-    syshook = createSyscallHook("__x64_sys_ptrace", &ptracemon::ptrace_cb, "ptrace");
+    auto syshook = createSyscallHook("__x64_sys_ptrace", &ptracemon::ptrace_cb, "ptrace");
     if (nullptr == syshook)
     {
         PRINT_DEBUG("[PTRACEMON] Method __x64_sys_ptrace not found\n");

--- a/src/plugins/ptracemon/ptracemon.h
+++ b/src/plugins/ptracemon/ptracemon.h
@@ -112,7 +112,6 @@ class ptracemon : public pluginex
 {
 public:
     std::array<size_t, ptracemon_ns::__PT_REGS_MAX> offsets;
-    std::unique_ptr<libhook::SyscallHook> syshook;
 
     ptracemon(drakvuf_t drakuvf, output_format_t output);
     event_response_t ptrace_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info);

--- a/src/plugins/rebootmon/linux.cpp
+++ b/src/plugins/rebootmon/linux.cpp
@@ -179,8 +179,9 @@ event_response_t linux_rebootmon::machine_power_off_cb(drakvuf_t drakvuf, drakvu
 linux_rebootmon::linux_rebootmon(drakvuf_t drakvuf, const rebootmon_config* c, output_format_t output) :
     pluginex(drakvuf, output), abort_on_power_off(c->abort_on_power_off)
 {
+
 #define REGISTER_HOOK_EX(name, syscall, cb, alias) \
-    name ## _hook = createSyscallHook(#syscall, &linux_rebootmon::cb, #alias); \
+    auto name ## _hook = createSyscallHook(#syscall, &linux_rebootmon::cb, #alias); \
     if (!name ## _hook) \
     { \
         PRINT_DEBUG("[REBOOTMON] Method " #syscall " does not found.\n"); \

--- a/src/plugins/rebootmon/linux.cpp
+++ b/src/plugins/rebootmon/linux.cpp
@@ -181,8 +181,7 @@ linux_rebootmon::linux_rebootmon(drakvuf_t drakvuf, const rebootmon_config* c, o
 {
 
 #define REGISTER_HOOK_EX(name, syscall, cb, alias) \
-    auto name ## _hook = createSyscallHook(#syscall, &linux_rebootmon::cb, #alias); \
-    if (!name ## _hook) \
+    if (!createSyscallHook(#syscall, &linux_rebootmon::cb, #alias)) \
     { \
         PRINT_DEBUG("[REBOOTMON] Method " #syscall " does not found.\n"); \
         throw -1; \

--- a/src/plugins/rebootmon/linux.h
+++ b/src/plugins/rebootmon/linux.h
@@ -114,13 +114,6 @@ struct rebootmon_config;
 class linux_rebootmon : public pluginex
 {
 private:
-    /* Hooks */
-    std::unique_ptr<libhook::SyscallHook> reboot_hook;
-    std::unique_ptr<libhook::SyscallHook> machine_restart_hook;
-    std::unique_ptr<libhook::SyscallHook> machine_emergency_restart_hook;
-    std::unique_ptr<libhook::SyscallHook> machine_halt_hook;
-    std::unique_ptr<libhook::SyscallHook> machine_power_off_hook;
-
     /* Callbacks */
     event_response_t reboot_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
     event_response_t machine_restart_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info);

--- a/src/plugins/regmon/regmon.cpp
+++ b/src/plugins/regmon/regmon.cpp
@@ -640,20 +640,20 @@ regmon::regmon(drakvuf_t drakvuf, output_format_t output)
     if ( !drakvuf_get_kernel_struct_member_rva(drakvuf, "_OBJECT_ATTRIBUTES", "RootDirectory", &this->objattr_root) )
         throw -1;
 
-    delete_key_hook = createSyscallHook("NtDeleteKey", &regmon::delete_key_cb);
-    set_value_key_hook = createSyscallHook("NtSetValueKey", &regmon::set_value_key_cb);
-    delete_value_key_hook = createSyscallHook("NtDeleteValueKey", &regmon::delete_value_key_cb);
-    create_key_hook = createSyscallHook("NtCreateKey", &regmon::create_key_cb);
-    create_key_transacted_hook = createSyscallHook("NtCreateKeyTransacted", &regmon::create_key_transacted_cb);
-    enumerate_key_hook = createSyscallHook("NtEnumerateKey", &regmon::enumerate_key_cb);
-    enumerate_value_key_hook = createSyscallHook("NtEnumerateValueKey", &regmon::enumerate_value_key_cb);
-    open_key_hook = createSyscallHook("NtOpenKey", &regmon::open_key_cb);
-    open_key_ex_hook = createSyscallHook("NtOpenKeyEx", &regmon::open_key_ex_cb);
-    open_key_transacted_hook = createSyscallHook("NtOpenKeyTransacted", &regmon::open_key_transacted_cb);
-    open_key_transacted_ex_hook = createSyscallHook("NtOpenKeyTransactedEx", &regmon::open_key_transacted_ex_cb);
-    query_key_hook = createSyscallHook("NtQueryKey", &regmon::query_key_cb);
-    query_multiple_value_key_hook = createSyscallHook("NtQueryMultipleValueKey", &regmon::query_multiple_value_key_cb);
-    query_value_key_hook = createSyscallHook("NtQueryValueKey", &regmon::query_value_key_cb);
+    createSyscallHook("NtDeleteKey", &regmon::delete_key_cb);
+    createSyscallHook("NtSetValueKey", &regmon::set_value_key_cb);
+    createSyscallHook("NtDeleteValueKey", &regmon::delete_value_key_cb);
+    createSyscallHook("NtCreateKey", &regmon::create_key_cb);
+    createSyscallHook("NtCreateKeyTransacted", &regmon::create_key_transacted_cb);
+    createSyscallHook("NtEnumerateKey", &regmon::enumerate_key_cb);
+    createSyscallHook("NtEnumerateValueKey", &regmon::enumerate_value_key_cb);
+    createSyscallHook("NtOpenKey", &regmon::open_key_cb);
+    createSyscallHook("NtOpenKeyEx", &regmon::open_key_ex_cb);
+    createSyscallHook("NtOpenKeyTransacted", &regmon::open_key_transacted_cb);
+    createSyscallHook("NtOpenKeyTransactedEx", &regmon::open_key_transacted_ex_cb);
+    createSyscallHook("NtQueryKey", &regmon::query_key_cb);
+    createSyscallHook("NtQueryMultipleValueKey", &regmon::query_multiple_value_key_cb);
+    createSyscallHook("NtQueryValueKey", &regmon::query_value_key_cb);
 }
 
 regmon::~regmon(void) {}

--- a/src/plugins/regmon/regmon.h
+++ b/src/plugins/regmon/regmon.h
@@ -113,22 +113,6 @@ public:
     addr_t objattr_name;
     addr_t objattr_root;
 
-    /* Hooks */
-    std::unique_ptr<libhook::SyscallHook> delete_key_hook;
-    std::unique_ptr<libhook::SyscallHook> set_value_key_hook;
-    std::unique_ptr<libhook::SyscallHook> delete_value_key_hook;
-    std::unique_ptr<libhook::SyscallHook> create_key_hook;
-    std::unique_ptr<libhook::SyscallHook> create_key_transacted_hook;
-    std::unique_ptr<libhook::SyscallHook> enumerate_key_hook;
-    std::unique_ptr<libhook::SyscallHook> enumerate_value_key_hook;
-    std::unique_ptr<libhook::SyscallHook> open_key_hook;
-    std::unique_ptr<libhook::SyscallHook> open_key_ex_hook;
-    std::unique_ptr<libhook::SyscallHook> open_key_transacted_hook;
-    std::unique_ptr<libhook::SyscallHook> open_key_transacted_ex_hook;
-    std::unique_ptr<libhook::SyscallHook> query_key_hook;
-    std::unique_ptr<libhook::SyscallHook> query_multiple_value_key_hook;
-    std::unique_ptr<libhook::SyscallHook> query_value_key_hook;
-
     /* Callbacks */
     event_response_t delete_key_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
     event_response_t set_value_key_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info);

--- a/src/plugins/rootkitmon/rootkitmon.h
+++ b/src/plugins/rootkitmon/rootkitmon.h
@@ -123,9 +123,9 @@ public:
     rootkitmon& operator=(const rootkitmon&) = delete;
     ~rootkitmon() = default;
 
-    std::unique_ptr<libhook::ManualHook> register_profile_hook(drakvuf_t drakvuf, const char* profile, const char* dll_name,
+    void register_profile_hook(drakvuf_t drakvuf, const char* profile, const char* dll_name,
         const char* func_name, hook_cb_t callback);
-    std::unique_ptr<libhook::ManualHook> register_mem_hook(hook_cb_t callback, addr_t pa, vmi_mem_access_t access);
+    void register_mem_hook(hook_cb_t callback, addr_t pa, vmi_mem_access_t access);
 
     std::set<rootkitmon_ns::driver_t> enumerate_object_directory(vmi_instance_t vmi, const char* name);
     unicode_string_t* get_object_type_name(vmi_instance_t vmi, addr_t object);
@@ -183,9 +183,6 @@ public:
     std::unordered_map<unsigned int, rootkitmon_ns::descriptors_t> descriptors;
     // VCPU -> MSR_LSTAR
     std::unordered_map<unsigned int, addr_t> msr_lstar;
-    std::vector<std::unique_ptr<libhook::ManualHook>> manual_hooks;
-    std::vector<std::unique_ptr<libhook::SyscallHook>> syscall_hooks;
-    std::unique_ptr<libhook::ManualHook> msr_hook;
-    std::map<uint64_t, std::unique_ptr<libhook::ManualHook>> rop_hooks;
-    std::unique_ptr<libhook::ManualHook> cr4_hook;
+
+    std::unordered_map<uint64_t, libhook::ManualHook*> rop_hooks;
 };

--- a/src/plugins/rpcmon/rpcmon.h
+++ b/src/plugins/rpcmon/rpcmon.h
@@ -120,11 +120,7 @@ public:
     rpcmon(drakvuf_t drakvuf, output_format_t output);
     ~rpcmon();
 
-    bool stop_impl() override;
-
     event_response_t usermode_return_hook_cb(drakvuf_t drakvuf, drakvuf_trap_info* info);
-
-    std::map<uint64_t, std::unique_ptr<libhook::ReturnHook>> ret_hooks;
 };
 
 #endif

--- a/src/plugins/spraymon/spraymon.cpp
+++ b/src/plugins/spraymon/spraymon.cpp
@@ -263,7 +263,7 @@ spraymon::spraymon(drakvuf_t drakvuf, const spraymon_config* config,
         PRINT_DEBUG("[SPRAYMON] Failed to get kernel struct member offsets.\n");
         throw -1;
     }
-    syscall = createSyscallHook("PsSetProcessWin32Process", &spraymon::hook_setwin32process_cb);
+    createSyscallHook("PsSetProcessWin32Process", &spraymon::hook_setwin32process_cb);
     PRINT_DEBUG("[SPRAYMON]  PLUGIN STARTED\n");
 }
 

--- a/src/plugins/spraymon/spraymon.h
+++ b/src/plugins/spraymon/spraymon.h
@@ -123,7 +123,6 @@ public:
     bool stop_impl() override;
 
 private:
-    std::unique_ptr<libhook::SyscallHook> syscall;
     addr_t eprocess_win32process;
     //_W32PROCESS offsets
     size_t gdihandlecountpeak;

--- a/src/plugins/ssdtmon/ssdtmon.cpp
+++ b/src/plugins/ssdtmon/ssdtmon.cpp
@@ -247,7 +247,7 @@ static bool get_driver_base(drakvuf_t drakvuf, ssdtmon* plugin, const char* driv
     return false;
 }
 
-std::unique_ptr<libhook::ManualHook> ssdtmon::register_mem_hook(hook_cb_t callback, addr_t pa)
+void ssdtmon::register_mem_hook(hook_cb_t callback, addr_t pa)
 {
     auto trap = new drakvuf_trap_t
     {
@@ -271,8 +271,6 @@ std::unique_ptr<libhook::ManualHook> ssdtmon::register_mem_hook(hook_cb_t callba
         PRINT_DEBUG("[SSDTMON] Failed to hook 0x%lx\n", pa >> 12);
         throw -1;
     }
-
-    return hook;
 }
 
 /* ----------------------------------------------------- */
@@ -361,7 +359,7 @@ ssdtmon::ssdtmon(drakvuf_t drakvuf, const ssdtmon_config* config, output_format_
                     throw -1;
                 }
 
-                this->ssdt_traps.push_back(register_mem_hook(write_cb, page_paddr));
+                register_mem_hook(write_cb, page_paddr);
                 this->w32p_ssdt.emplace_back(page_paddr, page_payload_len);
 
                 if (page == 0)
@@ -414,7 +412,7 @@ ssdtmon::ssdtmon(drakvuf_t drakvuf, const ssdtmon_config* config, output_format_
         this->kiservicelimit,
         sizeof(uint32_t)*this->kiservicelimit);
 
-    this->ssdt_traps.push_back(register_mem_hook(write_cb, kiservicetable));
+    register_mem_hook(write_cb, kiservicetable);
 
     addr_t sdt_rva, sdt_shadow_rva;
 

--- a/src/plugins/ssdtmon/ssdtmon.h
+++ b/src/plugins/ssdtmon/ssdtmon.h
@@ -115,7 +115,7 @@ struct ssdtmon_config
 class ssdtmon: public pluginex
 {
 private:
-    std::unique_ptr<libhook::ManualHook> register_mem_hook(hook_cb_t callback, addr_t pa);
+    void register_mem_hook(hook_cb_t callback, addr_t pa);
 
 public:
     output_format_t format;
@@ -129,8 +129,6 @@ public:
 
     addr_t sdt_va, sdt_shadow_va;
     std::array<uint8_t, 32> sdt_crc, sdt_shadow_crc;
-
-    std::vector<std::unique_ptr<libhook::ManualHook>> ssdt_traps;
 
     ssdtmon(drakvuf_t drakvuf, const ssdtmon_config* config, output_format_t output);
     ~ssdtmon();

--- a/src/plugins/syscalls/linux.h
+++ b/src/plugins/syscalls/linux.h
@@ -111,8 +111,6 @@ class linux_syscalls : public syscalls_base
 {
 public:
     std::array<size_t, syscalls_ns::__PT_REGS_MAX> regs;
-    std::unordered_map<uint64_t, std::unique_ptr<libhook::SyscallHook>> hooks;
-    std::unordered_map<uint64_t, std::unique_ptr<libhook::ReturnHook>> ret_hooks;
 
     // Helpers
     std::vector<uint64_t> build_arguments_buffer(drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t pt_regs_addr, addr_t nr);

--- a/src/plugins/syscalls/win.cpp
+++ b/src/plugins/syscalls/win.cpp
@@ -686,10 +686,10 @@ event_response_t win_syscalls::load_driver_cb(drakvuf_t drakvuf, drakvuf_trap_in
     {
         if (strstr(service_name_casefold, "win32k.sys"))
         {
-            this->load_driver_hook = {};
+            this->remove_hook(this->load_driver_hook);
 
             if (setup_win32k_syscalls(drakvuf))
-                this->create_process_hook = {};
+                this->remove_hook(this->create_process_hook);
         }
         g_free(service_name_casefold);
     }
@@ -714,10 +714,8 @@ event_response_t win_syscalls::create_process_cb(drakvuf_t drakvuf, drakvuf_trap
     {
         if (strstr(image_path_casefold, "explorer.exe"))
         {
-            this->create_process_hook = {};
-
-            auto hook = createReturnHook<PluginResult>(info, &win_syscalls::create_process_ret_cb);
-            this->wait_process_creation_hook = std::move(hook);
+            this->remove_hook(this->create_process_hook);
+            createReturnHook<PluginResult>(info, &win_syscalls::create_process_ret_cb);
         }
         g_free(image_path_casefold);
     }
@@ -731,10 +729,10 @@ event_response_t win_syscalls::create_process_ret_cb(drakvuf_t drakvuf, drakvuf_
     if (!params->verifyResultCallParams(drakvuf, info))
         return VMI_EVENT_RESPONSE_NONE;
 
-    this->wait_process_creation_hook = {};
+    this->remove_hook(params->hook_);
 
     if (setup_win32k_syscalls(drakvuf))
-        this->load_driver_hook = {};
+        this->remove_hook(this->load_driver_hook);
 
     return VMI_EVENT_RESPONSE_NONE;
 }

--- a/src/plugins/syscalls/win.h
+++ b/src/plugins/syscalls/win.h
@@ -124,8 +124,8 @@ public:
     std::string win32k_profile;
     bool win32k_initialized;
 
-    libhook::SyscallHook* load_driver_hook;
-    libhook::SyscallHook* create_process_hook;
+    libhook::SyscallHook* load_driver_hook = nullptr;
+    libhook::SyscallHook* create_process_hook = nullptr;
 
     bool setup_win32k_syscalls(drakvuf_t drakvuf);
 

--- a/src/plugins/syscalls/win.h
+++ b/src/plugins/syscalls/win.h
@@ -124,9 +124,8 @@ public:
     std::string win32k_profile;
     bool win32k_initialized;
 
-    std::unique_ptr<libhook::SyscallHook> load_driver_hook;
-    std::unique_ptr<libhook::SyscallHook> create_process_hook;
-    std::unique_ptr<libhook::ReturnHook> wait_process_creation_hook;
+    libhook::SyscallHook* load_driver_hook;
+    libhook::SyscallHook* create_process_hook;
 
     bool setup_win32k_syscalls(drakvuf_t drakvuf);
 

--- a/src/plugins/unixsocketmon/unixsocketmon.cpp
+++ b/src/plugins/unixsocketmon/unixsocketmon.cpp
@@ -289,5 +289,5 @@ unixsocketmon::unixsocketmon(drakvuf_t drakvuf, const unixsocketmon_config* conf
         return;
     }
 
-    sockethook = createSyscallHook("sock_sendmsg", &unixsocketmon::sock_send_msg_cb);
+    createSyscallHook("sock_sendmsg", &unixsocketmon::sock_send_msg_cb);
 }

--- a/src/plugins/unixsocketmon/unixsocketmon.h
+++ b/src/plugins/unixsocketmon/unixsocketmon.h
@@ -123,8 +123,6 @@ public:
     addr_t iovec_iov_base;
     addr_t iovec_iov_len;
 
-    std::unique_ptr<libhook::SyscallHook> sockethook;
-
     unixsocketmon(drakvuf_t drakvuf, const unixsocketmon_config* config, output_format_t output);
     event_response_t sock_send_msg_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
     std::vector<uint8_t> get_socket_message(drakvuf_t drakvuf, drakvuf_trap_info_t* info, uint64_t* size);


### PR DESCRIPTION
This improvement implements storing hooks in the pluginex base class, so that almost all plugins no longer need to store hook objects (inherited from BaseHook) in their own containers.

Hooks were typically stored in plugin members in two ways:
- separate pointers (`std::unique_ptr<libhook::SyscallHook> some_func_hook;`)
- map (`std::map<uint64_t, std::unique_ptr<libhook::ReturnHook>> ret_hooks` with the key calculated by the `make_hook_id()`), which also breaks some plugins (#1712)

Hooks are now by default saved in the `pluginex::hooks` map with a unique key (hook address), so there are additional methods to remove or register (i.e. take ownership of an existing hook previously created with the `save = false` flag) hook.

So, the key changes:
- `pluginex` methods for creating hooks (eg `createReturnHook()`) now return raw pointers (instead of 'std::unique_ptr') and have a `bool save` flag (`true` by default).
- removed custom maps and `std::unique_ptr`s in varoius plugins.
- now return hooks are removed from their callbacks (`*_ret_cb()`) using the backward reference in `params` (`this->remove_hook(params->hook_);`).
- if the plugin needs to perform more complex manipulations with the hook, it can store the raw pointer during creation to later delete it (by passing the pointer to `plugin->remove_hook()`) or just read the information via dereference.
- the plugin can pass the `bool = false` flag, then it is responsible for storing/deleting the hook (usually in this case the raw pointer is instantly wrapped in `std::unique_ptr`).

Also made a small refactoring related to containers in different classes (`std::map` -> `std::unordered_map`, `std::vector` -> `std::unordered_set`, etc.).