### PR TITLE
procmon: fix fexecve handle

### DIFF
--- a/src/plugins/procmon/private.h
+++ b/src/plugins/procmon/private.h
@@ -121,6 +121,8 @@ struct execve_data : PluginResult
         , execat_rsp()
         , cr3()
         , fd()
+        , process_name()
+        , filename()
         , thread_name()
         , image_path_name()
         , command_line()
@@ -138,6 +140,7 @@ struct execve_data : PluginResult
 
     int fd;
     std::string process_name;
+    std::string filename;
     std::string thread_name;
     std::string image_path_name;
     std::string command_line;


### PR DESCRIPTION
Hi, in the last PR (#1688), the correct output of the `ImagePathName` field for `fexecve` was added, however, during testing, some inaccuracies were discovered that this PR corrects