### PR TITLE
Separate return context for linux and windows hooks

### DIFF
--- a/src/libdrakvuf/libdrakvuf.h
+++ b/src/libdrakvuf/libdrakvuf.h
@@ -566,6 +566,10 @@ bool drakvuf_get_current_thread_id(drakvuf_t drakvuf,
     drakvuf_trap_info_t* info,
     uint32_t* thread_id) NOEXCEPT;
 
+void drakvuf_set_return_context(drakvuf_t drakvuf, drakvuf_trap_info_t* info,
+    vmi_pid_t* target_pid, uint32_t* target_tid,
+    addr_t* target_rsp) NOEXCEPT;
+
 /*
  * To catch the moment of exiting the currently executing function,
  * we put a breakpoint on the instruction located at the function's

--- a/src/libdrakvuf/linux.c
+++ b/src/libdrakvuf/linux.c
@@ -157,6 +157,13 @@ addr_t linux_get_function_return_address(drakvuf_t drakvuf, drakvuf_trap_info_t*
     return ret_addr;
 }
 
+void linux_set_return_context(drakvuf_t drakvuf, drakvuf_trap_info_t* info, vmi_pid_t* pid, uint32_t* tid, addr_t* rsp)
+{
+    *pid = info->proc_data.pid;
+    *tid = info->proc_data.tid;
+    *rsp = linux_get_function_return_address(drakvuf, info);
+}
+
 bool linux_check_return_context(drakvuf_trap_info_t* info, vmi_pid_t pid, uint32_t tid, addr_t rsp)
 {
     return (info->proc_data.pid == pid)
@@ -355,6 +362,7 @@ bool set_os_linux(drakvuf_t drakvuf)
     drakvuf->osi.export_lib_address = get_lib_address;
     drakvuf->osi.get_function_argument = linux_get_function_argument;
     drakvuf->osi.get_function_return_address = linux_get_function_return_address;
+    drakvuf->osi.set_return_context = linux_set_return_context;
     drakvuf->osi.check_return_context = linux_check_return_context;
     drakvuf->osi.enumerate_processes = linux_enumerate_processes;
     drakvuf->osi.get_current_process_environ = linux_get_current_process_environ;

--- a/src/libdrakvuf/linux.h
+++ b/src/libdrakvuf/linux.h
@@ -137,6 +137,8 @@ bool linux_find_eprocess_and_pid(drakvuf_t drakvuf, vmi_pid_t find_pid, char* co
 addr_t linux_get_function_argument(drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t argument_number);
 addr_t linux_get_function_return_address(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
 
+void linux_set_return_context(drakvuf_t drakvuf, drakvuf_trap_info_t* info, vmi_pid_t* pid, uint32_t* tid, addr_t* rsp);
+
 bool linux_check_return_context(drakvuf_trap_info_t* info, vmi_pid_t pid, uint32_t tid, addr_t rsp);
 
 bool linux_find_process_list(drakvuf_t drakvuf, addr_t* list_head);

--- a/src/libdrakvuf/os.c
+++ b/src/libdrakvuf/os.c
@@ -1084,6 +1084,16 @@ addr_t drakvuf_get_wow_peb(drakvuf_t drakvuf, access_context_t* ctx, addr_t epro
     return ret;
 }
 
+void drakvuf_set_return_context(drakvuf_t drakvuf, drakvuf_trap_info_t* info, vmi_pid_t* pid, uint32_t* tid, addr_t* rsp)
+{
+    if ( drakvuf->osi.set_return_context )
+    {
+        drakvuf_lock_and_get_vmi(drakvuf);
+        drakvuf->osi.set_return_context(drakvuf, info, pid, tid, rsp);
+        drakvuf_release_vmi(drakvuf);
+    }
+}
+
 bool drakvuf_check_return_context(drakvuf_t drakvuf, drakvuf_trap_info_t* info, vmi_pid_t pid, uint32_t tid, addr_t rsp)
 {
     bool ret = false;

--- a/src/libdrakvuf/os.h
+++ b/src/libdrakvuf/os.h
@@ -290,6 +290,9 @@ typedef struct os_interface
     addr_t (*get_wow_peb)
     (drakvuf_t drakvuf, access_context_t* ctx, addr_t eprocess);
 
+    void (*set_return_context)
+    (drakvuf_t drakvuf, drakvuf_trap_info_t* info, vmi_pid_t* pid, uint32_t* tid, addr_t* rsp);
+
     bool (*check_return_context)
     (drakvuf_trap_info_t* info, vmi_pid_t pid, uint32_t tid, addr_t rsp);
 

--- a/src/libdrakvuf/win.c
+++ b/src/libdrakvuf/win.c
@@ -500,6 +500,13 @@ bool fill_wow_offsets( drakvuf_t drakvuf, size_t size, const char* names [][2] )
     return 1 ;
 }
 
+void win_set_return_context(drakvuf_t drakvuf __attribute__((unused)), drakvuf_trap_info_t* info, vmi_pid_t* pid, uint32_t* tid, addr_t* rsp)
+{
+    *pid = info->attached_proc_data.pid;
+    *tid = info->attached_proc_data.tid;
+    *rsp = info->regs->rsp;
+}
+
 bool win_check_return_context(drakvuf_trap_info_t* info, vmi_pid_t pid, uint32_t tid, addr_t rsp)
 {
     return (info->attached_proc_data.pid == pid)
@@ -613,6 +620,7 @@ bool set_os_windows(drakvuf_t drakvuf)
     drakvuf->osi.get_user_stack32 = win_get_user_stack32;
     drakvuf->osi.get_user_stack64 = win_get_user_stack64;
     drakvuf->osi.get_wow_peb = win_get_wow_peb;
+    drakvuf->osi.set_return_context = win_set_return_context;
     drakvuf->osi.check_return_context = win_check_return_context;
     drakvuf->osi.get_rspbase = win_get_rspbase;
     drakvuf->osi.get_kernel_symbol_rva = win_get_kernel_symbol_rva;

--- a/src/libdrakvuf/win.h
+++ b/src/libdrakvuf/win.h
@@ -212,6 +212,7 @@ bool win_get_wow_context(drakvuf_t drakvuf, addr_t ethread, addr_t* wow_ctx);
 bool win_get_user_stack32(drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t* stack_ptr, addr_t* frame_ptr);
 bool win_get_user_stack64(drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t* stack_ptr);
 
+void win_set_return_context(drakvuf_t drakvuf, drakvuf_trap_info_t* info, vmi_pid_t* pid, uint32_t* tid, addr_t* rsp);
 bool win_check_return_context(drakvuf_trap_info_t* info, vmi_pid_t pid, uint32_t tid, addr_t rsp);
 
 addr_t win_get_rspbase(drakvuf_t dravkuf, drakvuf_trap_info_t* info);

--- a/src/libhook/call_result.hpp
+++ b/src/libhook/call_result.hpp
@@ -117,11 +117,9 @@ struct CallResult
 
     virtual ~CallResult() = default;
 
-    void setResultCallParams(const drakvuf_trap_info_t* info)
+    void setResultCallParams(drakvuf_t drakvuf, const drakvuf_trap_info_t* info)
     {
-        target_pid = info->attached_proc_data.pid;
-        target_tid = info->attached_proc_data.tid;
-        target_rsp = info->regs->rsp;
+        drakvuf_set_return_context(drakvuf, const_cast<drakvuf_trap_info_t*>(info), &target_pid, &target_tid, &target_rsp);
     }
 
     bool verifyResultCallParams(drakvuf_t drakvuf, drakvuf_trap_info_t* info)

--- a/src/plugins/codemon/codemon.cpp
+++ b/src/plugins/codemon/codemon.cpp
@@ -1010,7 +1010,7 @@ event_response_t codemon::mm_access_fault_hook_cb(drakvuf_t drakvuf, drakvuf_tra
     }
 
     auto params = libhook::GetTrapParams<AccessFaultResult>(this->mmAccessFaultReturnHook->trap_);
-    params->setResultCallParams(trap_info);
+    params->setResultCallParams(drakuf, trap_info);
     params->page_va = fault_va;
 
     return VMI_EVENT_RESPONSE_NONE;

--- a/src/plugins/codemon/codemon.cpp
+++ b/src/plugins/codemon/codemon.cpp
@@ -1010,7 +1010,7 @@ event_response_t codemon::mm_access_fault_hook_cb(drakvuf_t drakvuf, drakvuf_tra
     }
 
     auto params = libhook::GetTrapParams<AccessFaultResult>(this->mmAccessFaultReturnHook->trap_);
-    params->setResultCallParams(drakuf, trap_info);
+    params->setResultCallParams(drakvuf, trap_info);
     params->page_va = fault_va;
 
     return VMI_EVENT_RESPONSE_NONE;

--- a/src/plugins/filetracer/linux.cpp
+++ b/src/plugins/filetracer/linux.cpp
@@ -306,7 +306,7 @@ event_response_t linux_filetracer::open_file_cb(drakvuf_t drakvuf, drakvuf_trap_
     auto params = libhook::GetTrapParams<linux_data>(hook->trap_);
 
     // Save data
-    params->setResultCallParams(info);
+    params->setResultCallParams(drakvuf, info);
 
     this->ret_hooks[hookID] = std::move(hook);
 
@@ -473,7 +473,7 @@ event_response_t linux_filetracer::memfd_create_file_cb(drakvuf_t drakvuf, drakv
     auto params = libhook::GetTrapParams<linux_data>(hook->trap_);
 
     // Save data
-    params->setResultCallParams(info);
+    params->setResultCallParams(drakvuf, info);
 
     char* tmp = read_filename(drakvuf, info, file_name_addr);
     params->filename = tmp ?: "";

--- a/src/plugins/plugins_ex.h
+++ b/src/plugins/plugins_ex.h
@@ -600,7 +600,7 @@ std::unique_ptr<libhook::ReturnHook> pluginex::createReturnHook(drakvuf_trap_inf
     {
         static_cast<Params*>(hook->trap_->data)->plugin_ = this;
         auto params = libhook::GetTrapParams(hook->trap_);
-        params->setResultCallParams(info);
+        params->setResultCallParams(drakvuf, info);
     }
     else
         PRINT_DEBUG("[WARNING] libhook failed to setup a trap, returning nullptr!\n");

--- a/src/plugins/syscalls/linux.cpp
+++ b/src/plugins/syscalls/linux.cpp
@@ -314,7 +314,7 @@ event_response_t linux_syscalls::linux_cb(drakvuf_t drakvuf, drakvuf_trap_info_t
 
     auto hook = this->createReturnHook<linux_syscall_data>(info, &linux_syscalls::linux_ret_cb, info->trap->name);
     auto params = libhook::GetTrapParams<linux_syscall_data>(hook->trap_);
-    params->setResultCallParams(info);
+    params->setResultCallParams(drakvuf, info);
 
     auto hookID = make_hook_id(info);
     this->ret_hooks[hookID] = std::move(hook);


### PR DESCRIPTION
- Add os-specific versions of `set_return_context` methods;
- Method `setResultCallParams` now works correctly for linux hooks.