### PR TITLE
libdrakvuf: fix injection manager

### DIFF
--- a/src/libdrakvuf/drakvuf.c
+++ b/src/libdrakvuf/drakvuf.c
@@ -1224,7 +1224,7 @@ bool drakvuf_is_active_callback(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
         return true;
 
     drakvuf_lock_and_get_vmi(drakvuf);
-    void const * const injection_trap = drakvuf_lookup_injection(drakvuf, info);
+    void const* const injection_trap = drakvuf_lookup_injection(drakvuf, info);
     drakvuf_release_vmi(drakvuf);
 
     bool res = false;

--- a/src/libdrakvuf/libdrakvuf.h
+++ b/src/libdrakvuf/libdrakvuf.h
@@ -247,6 +247,10 @@ struct drakvuf_trap
 {
     trap_type_t type;
     event_response_t (*cb)(drakvuf_t, drakvuf_trap_info_t*);
+    // Force 'drakvuf_is_active_callback' check bo be true.
+    // This allows to forcefully execute callback for 'bsodmon' and detect
+    // injections faults.
+    bool cb_force;
     void* data;
 
     union
@@ -793,9 +797,7 @@ bool drakvuf_vmi_response_set_gpr_registers(drakvuf_t drakvuf,
 /* The plug-in is called "active" if it injects function call. */
 bool drakvuf_is_active_callback(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
 void* drakvuf_lookup_injection(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
-void drakvuf_insert_injection(drakvuf_t drakvuf,
-    drakvuf_trap_info_t* info,
-    event_response_t (*cb)(drakvuf_t, drakvuf_trap_info_t*));
+void drakvuf_insert_injection(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
 void drakvuf_remove_injection(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
 
 #define DRAKVUF_IPT_BRANCH_EN (1 << 0)

--- a/src/libinjector/injector_stack.c
+++ b/src/libinjector/injector_stack.c
@@ -768,7 +768,6 @@ bool setup_stack(
 bool inject_function_call(
     drakvuf_t drakvuf,
     drakvuf_trap_info_t* info,
-    event_response_t (*cb)(drakvuf_t, drakvuf_trap_info_t*),
     x86_registers_t* regs,
     struct argument args[],
     int nb_args,
@@ -796,7 +795,7 @@ bool inject_function_call(
         return false;
     }
 
-    drakvuf_insert_injection(drakvuf, info, cb);
+    drakvuf_insert_injection(drakvuf, info);
     drakvuf_release_vmi(drakvuf);
     return true;
 }

--- a/src/libinjector/libinjector.h
+++ b/src/libinjector/libinjector.h
@@ -241,7 +241,6 @@ bool setup_stack_locked(drakvuf_t drakvuf,
 bool inject_function_call(
     drakvuf_t drakvuf,
     drakvuf_trap_info_t* info,
-    event_response_t (*cb)(drakvuf_t, drakvuf_trap_info_t*),
     x86_registers_t* regs,
     struct argument args[],
     int nb_args,

--- a/src/libusermode/userhook_inject.cpp
+++ b/src/libusermode/userhook_inject.cpp
@@ -151,7 +151,7 @@ bool inject_copy_memory(userhook* plugin, drakvuf_t drakvuf,
     init_int_argument(&args[5], 0);
     init_struct_argument(&args[6], read_bytes);
 
-    if (!inject_function_call(drakvuf, info, cb, &regs, args, 7, plugin->copy_virt_mem_va, stack_marker))
+    if (!inject_function_call(drakvuf, info, &regs, args, 7, plugin->copy_virt_mem_va, stack_marker))
     {
         PRINT_DEBUG("[USERHOOK] [%8zu] [%d:%d:%#lx]  "
             "Failed to inject MmCopyVirtualMemory\n"

--- a/src/plugins/bsodmon/bsodmon.h
+++ b/src/plugins/bsodmon/bsodmon.h
@@ -131,6 +131,7 @@ private:
         .breakpoint.addr_type = ADDR_SYMBOL,
         .type = BREAKPOINT,
         .data = (void*)this,
+        .cb_force = true,
     };
 
     void register_trap(drakvuf_t drakvuf, const char* syscall_name,

--- a/src/plugins/fileextractor/fileextractor.cpp
+++ b/src/plugins/fileextractor/fileextractor.cpp
@@ -1239,7 +1239,7 @@ bool fileextractor::inject_queryvolumeinfo(drakvuf_trap_info_t* info,
     init_int_argument(&args[3], sizeof(dev_info));
     init_int_argument(&args[4], FileFsDeviceInformation);
 
-    if (!inject_function_call(drakvuf, info, info->trap->cb, &regs, args.data(), args.size(), this->queryvolumeinfo_va, task.set_stack_marker()))
+    if (!inject_function_call(drakvuf, info, &regs, args.data(), args.size(), this->queryvolumeinfo_va, task.set_stack_marker()))
         return false;
 
     task.target.ret_rsp = regs.rsp;
@@ -1273,7 +1273,7 @@ bool fileextractor::inject_queryinfo(drakvuf_trap_info_t* info,
     init_int_argument(&args[3], sizeof(dev_info));
     init_int_argument(&args[4], FileStandardInformation);
 
-    if (!inject_function_call(drakvuf, info, info->trap->cb, &regs, args.data(), args.size(), this->queryinfo_va, task.set_stack_marker()))
+    if (!inject_function_call(drakvuf, info, &regs, args.data(), args.size(), this->queryinfo_va, task.set_stack_marker()))
         return false;
 
     task.target.ret_rsp = regs.rsp;
@@ -1306,7 +1306,7 @@ bool fileextractor::inject_createsection(drakvuf_trap_info_t* info,
     init_int_argument(&args[5], 0x8000000); // AllocationAttributes = SEC_COMMIT
     init_int_argument(&args[6], task.handle); // FileHandle
 
-    if (!inject_function_call(drakvuf, info, info->trap->cb, &regs, args.data(), args.size(), this->createsection_va, task.set_stack_marker()))
+    if (!inject_function_call(drakvuf, info, &regs, args.data(), args.size(), this->createsection_va, task.set_stack_marker()))
         return false;
 
     task.target.ret_rsp = regs.rsp;
@@ -1343,7 +1343,7 @@ bool fileextractor::inject_mapview(drakvuf_trap_info_t* info,
     init_int_argument   (&args[8], 0); // AllocationType
     init_int_argument   (&args[9], 2); // Win32Protect
 
-    if (!inject_function_call(drakvuf, info, info->trap->cb, &regs, args.data(), args.size(), this->mapview_va, task.set_stack_marker()))
+    if (!inject_function_call(drakvuf, info, &regs, args.data(), args.size(), this->mapview_va, task.set_stack_marker()))
         return false;
 
     task.target.ret_rsp = regs.rsp;
@@ -1369,7 +1369,7 @@ bool fileextractor::inject_allocate_pool(drakvuf_trap_info_t* info,
     init_int_argument(&args[1], BYTES_TO_READ);
     init_int_argument(&args[2], 0);
 
-    if (!inject_function_call(drakvuf, info, info->trap->cb, &regs, args.data(), args.size(), this->exallocatepool_va, task.set_stack_marker()))
+    if (!inject_function_call(drakvuf, info, &regs, args.data(), args.size(), this->exallocatepool_va, task.set_stack_marker()))
         return false;
 
     task.target.ret_rsp = regs.rsp;
@@ -1395,7 +1395,7 @@ bool fileextractor::inject_memcpy(drakvuf_trap_info_t* info,
     init_int_argument(&args[1], task.view_base);
     init_int_argument(&args[2], task.bytes_to_read);
 
-    if (!inject_function_call(drakvuf, info, info->trap->cb, &regs, args.data(), args.size(), this->memcpy_va, task.set_stack_marker()))
+    if (!inject_function_call(drakvuf, info, &regs, args.data(), args.size(), this->memcpy_va, task.set_stack_marker()))
         return false;
 
     task.target.ret_rsp = regs.rsp;
@@ -1419,7 +1419,7 @@ bool fileextractor::inject_unmapview(drakvuf_trap_info_t* info,
     init_int_argument(&args[0], 0xffffffffffffffff); // current process pseudo handle
     init_int_argument(&args[1], task.view_base);
 
-    if (!inject_function_call(drakvuf, info, info->trap->cb, &regs, args.data(), args.size(), this->unmapview_va, task.set_stack_marker()))
+    if (!inject_function_call(drakvuf, info, &regs, args.data(), args.size(), this->unmapview_va, task.set_stack_marker()))
         return false;
 
     task.target.ret_rsp = regs.rsp;
@@ -1442,7 +1442,7 @@ bool fileextractor::inject_close_handle(drakvuf_trap_info_t* info,
 
     init_int_argument(&args[0], task.section_handle);
 
-    if (!inject_function_call(drakvuf, info, info->trap->cb, &regs, args.data(), args.size(), this->close_handle_va, task.set_stack_marker()))
+    if (!inject_function_call(drakvuf, info, &regs, args.data(), args.size(), this->close_handle_va, task.set_stack_marker()))
         return false;
 
     task.target.ret_rsp = regs.rsp;

--- a/src/plugins/procdump2/win.cpp
+++ b/src/plugins/procdump2/win.cpp
@@ -1191,7 +1191,7 @@ void win_procdump2::allocate_pool(
     init_int_argument(&args[1], ctx->POOL_SIZE_IN_PAGES * VMI_PS_4KB);
     init_int_argument(&args[2], 0);
 
-    if (!inject_function_call(drakvuf, info, info->trap->cb, &regs, args.data(), args.size(), malloc_va, ctx->working.set_stack_marker()))
+    if (!inject_function_call(drakvuf, info, &regs, args.data(), args.size(), malloc_va, ctx->working.set_stack_marker()))
     {
         PRINT_DEBUG("[PROCDUMP] [%8zu] [%d:%d] [%d:%d] "
             "Failed to inject ExAllocatePoolWithTag\n"
@@ -1224,7 +1224,7 @@ void win_procdump2::copy_memory(drakvuf_trap_info_t* info,
     init_int_argument(&args[5], 0); // UserMode (TODO Is this correct?)
     init_struct_argument(&args[6], read_bytes);
 
-    if (!inject_function_call(drakvuf, info, info->trap->cb, &regs, args.data(), args.size(), copy_virt_mem_va, ctx->working.set_stack_marker()))
+    if (!inject_function_call(drakvuf, info, &regs, args.data(), args.size(), copy_virt_mem_va, ctx->working.set_stack_marker()))
     {
         PRINT_DEBUG("[PROCDUMP] [%8zu] [%d:%d] [%d:%d] "
             "Failed to inject MmCopyVirtualMemory\n"
@@ -1250,7 +1250,7 @@ void win_procdump2::get_irql(drakvuf_trap_info_t* info, std::shared_ptr<win_proc
     memcpy(&regs, info->regs, sizeof(x86_registers_t));
 
     // TODO We should check if CR8 probing would be sufficient and leave comment here.
-    if (!inject_function_call(drakvuf, info, info->trap->cb, &regs, nullptr, 0, current_irql_va, ctx->working.set_stack_marker()))
+    if (!inject_function_call(drakvuf, info, &regs, nullptr, 0, current_irql_va, ctx->working.set_stack_marker()))
     {
         PRINT_DEBUG("[PROCDUMP] [%8zu] [%d:%d] [%d:%d] "
             "Failed to inject KeGetCurrentIrql\n"
@@ -1275,7 +1275,7 @@ void win_procdump2::resume(drakvuf_trap_info_t* info, std::shared_ptr<win_procdu
     std::array<argument, 1> args{};
     init_int_argument(&args[0], ctx->target_process_base);
 
-    if (!inject_function_call(drakvuf, info, info->trap->cb, &regs, args.data(), args.size(), resume_process_va, ctx->working.set_stack_marker()))
+    if (!inject_function_call(drakvuf, info, &regs, args.data(), args.size(), resume_process_va, ctx->working.set_stack_marker()))
     {
         PRINT_DEBUG("[PROCDUMP] [%8zu] [%d:%d] [%d:%d] "
             "Failed to inject PsResumeProcess\n"
@@ -1307,7 +1307,7 @@ void win_procdump2::suspend(drakvuf_trap_info_t* info, addr_t target_process_bas
     std::array<argument, 1> args{};
     init_int_argument(&args[0], target_process_base);
 
-    if (!inject_function_call(drakvuf, info, info->trap->cb, &regs, args.data(), args.size(), suspend_process_va, ctx.set_stack_marker()))
+    if (!inject_function_call(drakvuf, info, &regs, args.data(), args.size(), suspend_process_va, ctx.set_stack_marker()))
     {
         PRINT_DEBUG("[PROCDUMP] [%8zu] [%d:%d] "
             "Failed to inject PsSuspendProcess\n"
@@ -1336,7 +1336,7 @@ void win_procdump2::delay_execution(drakvuf_trap_info_t* info,
     init_int_argument(&args[1], 1); // Alertable
     init_struct_argument(&args[2], interval);
 
-    if (!inject_function_call(drakvuf, info, info->trap->cb, &regs, args.data(), args.size(), delay_execution_va, ctx.set_stack_marker()))
+    if (!inject_function_call(drakvuf, info, &regs, args.data(), args.size(), delay_execution_va, ctx.set_stack_marker()))
     {
         PRINT_DEBUG("[PROCDUMP] [%8zu] [%d:%d] "
             "Failed to inject KeDelayExecutionThread\n"


### PR DESCRIPTION
Using callback function address to identify injection context is bad idea because of C++ lambda wrappers used in libhook. This result in hard to debug errors in run time.