### PR TITLE
fileextractor: fix BSODs on plugin begin stop

### DIFF
--- a/src/plugins/fileextractor/fileextractor.cpp
+++ b/src/plugins/fileextractor/fileextractor.cpp
@@ -279,10 +279,6 @@ static std::string get_metadata_filename(std::string dump_folder, int task_idx)
 event_response_t fileextractor::setinformation_cb(drakvuf_t,
     drakvuf_trap_info_t* info)
 {
-    if (this->is_stopping())
-        return VMI_EVENT_RESPONSE_NONE;
-
-
     if (drakvuf_lookup_injection(drakvuf, info))
         drakvuf_remove_injection(drakvuf, info);
 


### PR DESCRIPTION
This error could break injection chain if plugin begin stop.

Based on https://github.com/tklengyel/drakvuf/pull/1777