### PR TITLE
Fix some vmi_read_str memory leaks

### DIFF
--- a/src/libdrakvuf/linux-exports.c
+++ b/src/libdrakvuf/linux-exports.c
@@ -350,10 +350,12 @@ next:
         addr_t symbol_size = strlen(symbol_name);
         if (strcmp(symbol_name, sym) == 0)
         {
+            g_free(symbol_name);
             sym_found = true;
             break;
         }
         symbol_offset += symbol_size+1;
+        g_free(symbol_name);
     }
 
     if (!sym_found)

--- a/src/libdrakvuf/vmi.c
+++ b/src/libdrakvuf/vmi.c
@@ -869,6 +869,8 @@ static event_response_t _cr3_cb(drakvuf_t drakvuf, vmi_event_t* event)
 
             process = process->next;
         }
+
+        g_free(process_name);
     }
 
     free_proc_data_priv_2(&proc_data, &attached_proc_data);

--- a/src/plugins/procmon/linux.cpp
+++ b/src/plugins/procmon/linux.cpp
@@ -651,12 +651,14 @@ event_response_t linux_procmon::execve_cb(drakvuf_t drakvuf, drakvuf_trap_info_t
     params->setResultCallParams(drakvuf, info);
     params->bprm = drakvuf_get_function_argument(drakvuf, info, 1);
     params->process_name = info->proc_data.name;
-    params->thread_name = drakvuf_get_process_name(drakvuf, info->proc_data.base_addr, false);
+    char* thread_name = drakvuf_get_process_name(drakvuf, info->proc_data.base_addr, false);
+    params->thread_name = thread_name ?: "";
     params->old_creds = get_current_credentials(drakvuf, info);
 
     uint64_t hookID = make_hook_id(info);
     this->ret_hooks[hookID] = std::move(hook);
 
+    g_free(thread_name);
     return VMI_EVENT_RESPONSE_NONE;
 }
 


### PR DESCRIPTION
Added memory freeing in several places where a methods derived from `vmi_read_str` was used.