### PR TITLE
fileextractor: move NtWriteFile to return hook

### DIFF
--- a/src/plugins/fileextractor/private.h
+++ b/src/plugins/fileextractor/private.h
@@ -306,7 +306,6 @@ public:
     addr_t first_len{0};
     addr_t first_offset{0};
     addr_t first_str{0};
-    uint64_t first_cr3{0};
 
     uint64_t new_eof{0};
 

--- a/src/plugins/fileextractor/win.h
+++ b/src/plugins/fileextractor/win.h
@@ -185,6 +185,7 @@ private:
     event_response_t setinformation_cb(drakvuf_t, drakvuf_trap_info_t*);
     event_response_t writefile_cb(drakvuf_t, drakvuf_trap_info_t*);
     event_response_t writefile_ret_cb(drakvuf_t, drakvuf_trap_info_t*);
+    void writefile_cb_impl(drakvuf_t, drakvuf_trap_info_t*, task_t&, uint64_t, uint64_t);
     event_response_t close_cb(drakvuf_t, drakvuf_trap_info_t*);
     event_response_t createsection_cb (drakvuf_t, drakvuf_trap_info_t*);
     event_response_t createfile_cb (drakvuf_t, drakvuf_trap_info_t*);


### PR DESCRIPTION
- First `NtWriteFile` read was moved to return hook (caused errors in extracted file)
- Added `NtWriteFile` error check