### PR TITLE
syscalls: support multiple symbols for one RVA

### DIFF
--- a/src/plugins/syscalls/win.cpp
+++ b/src/plugins/syscalls/win.cpp
@@ -529,7 +529,7 @@ void win_syscalls::trap_syscalls(addr_t syscall_num, addr_t syscall_va, addr_t c
     }
 }
 
-bool win_syscalls::trap_syscall_table_entries(drakvuf_t drakvuf, vmi_instance_t vmi, addr_t cr3, bool ntos, addr_t base, addr_t _sst[2], json_object* json)
+bool win_syscalls::trap_syscall_table_entries(drakvuf_t drakvuf, vmi_instance_t vmi, addr_t cr3, bool ntos, addr_t base, std::array<addr_t, 2> _sst, json_object* json)
 {
     symbols_t* symbols = json ? json_get_symbols(json) : NULL;
 

--- a/src/plugins/syscalls/win.h
+++ b/src/plugins/syscalls/win.h
@@ -140,6 +140,9 @@ public:
 
     win_syscalls(drakvuf_t drakvuf, const syscalls_config* config, output_format_t output);
     ~win_syscalls();
+    
+    std::vector<std::pair<const syscalls_ns::syscall_t*, const char*>> get_symbols_for_rva(addr_t rva, addr_t syscall_va, addr_t cr3, symbols_t* symbols, bool ntos);
+    void trap_syscalls(addr_t syscall_num, addr_t syscall_va, addr_t cr3, std::vector<std::pair<const syscalls_ns::syscall_t*, const char*>>& matching_symbols, bool ntos);
 };
 
 namespace syscalls_ns

--- a/src/plugins/syscalls/win.h
+++ b/src/plugins/syscalls/win.h
@@ -140,7 +140,7 @@ public:
 
     win_syscalls(drakvuf_t drakvuf, const syscalls_config* config, output_format_t output);
     ~win_syscalls();
-    
+
     std::vector<std::pair<const syscalls_ns::syscall_t*, const char*>> get_symbols_for_rva(addr_t rva, addr_t syscall_va, addr_t cr3, symbols_t* symbols, bool ntos);
     void trap_syscalls(addr_t syscall_num, addr_t syscall_va, addr_t cr3, std::vector<std::pair<const syscalls_ns::syscall_t*, const char*>>& matching_symbols, bool ntos);
 };


### PR DESCRIPTION
ArbPreprocessEntry, NtFlushInstructionCache, NtCompleteConnectPort and many other symbols are pointing to the same RVA.
It leads to the following scenario:
1) NtFlushInstructionCache() hook is requested
2) Drakvuf parses ssdt, finds the first symbol for this shared RVA (ArbPreprocessEntry) and skips this RVA entry
3) NtFlushInstructionCache() calls are not logged
It will happen in all cases when two or more symbols are pointing to the same RVA.

This PR adds code to find all symbols, related to the RVA, store them in a vector and then set traps for all requested syscalls.