### PR TITLE
memdump: Get stack pointer from registers instead of trapframe for usermode hooks

### DIFF
--- a/src/plugins/memdump/memdump.cpp
+++ b/src/plugins/memdump/memdump.cpp
@@ -492,7 +492,7 @@ bool dump_from_stack(drakvuf_t drakvuf, drakvuf_trap_info_t* info, memdump* plug
     addr_t stack_ptr;
     addr_t frame_ptr;
 
-    if (is_kernel_addr(drakvuf, info->regs->rsp) || is_kernel_addr(drakvuf, info->regs->rip))
+    if (is_kernel_addr(drakvuf, info->regs->rip))
     {
         // We're in kernel context, we need to get stack from trap frame (syscall hook)
         bool result = false;

--- a/src/plugins/memdump/memdump.cpp
+++ b/src/plugins/memdump/memdump.cpp
@@ -480,7 +480,8 @@ bool inspect_stack_ptr(drakvuf_t drakvuf, drakvuf_trap_info_t* info, memdump* pl
     return VMI_EVENT_RESPONSE_NONE;
 }
 
-bool is_kernel_addr(drakvuf_t drakvuf, addr_t addr) {
+bool is_kernel_addr(drakvuf_t drakvuf, addr_t addr)
+{
     bool const is_os_64bit = (drakvuf_get_page_mode(drakvuf) == VMI_PM_IA32E);
     return is_os_64bit ? VMI_GET_BIT(addr, 47) : VMI_GET_BIT(addr, 31);
 }
@@ -491,7 +492,7 @@ bool dump_from_stack(drakvuf_t drakvuf, drakvuf_trap_info_t* info, memdump* plug
     addr_t stack_ptr;
     addr_t frame_ptr;
 
-    if(is_kernel_addr(drakvuf, info->regs->rsp) || is_kernel_addr(drakvuf, info->regs->rip))
+    if (is_kernel_addr(drakvuf, info->regs->rsp) || is_kernel_addr(drakvuf, info->regs->rip))
     {
         // We're in kernel context, we need to get stack from trap frame (syscall hook)
         bool result = false;
@@ -503,12 +504,14 @@ bool dump_from_stack(drakvuf_t drakvuf, drakvuf_trap_info_t* info, memdump* plug
         {
             result = drakvuf_get_user_stack64(drakvuf, info, &stack_ptr);
         }
-        if(!result)
+        if (!result)
         {
             PRINT_DEBUG("[MEMDUMP] Failed to get stack pointer\n");
             return VMI_EVENT_RESPONSE_NONE;
         }
-    } else {
+    }
+    else
+    {
         // We're in user context, so we can get stack directly from registers (usermode hook)
         stack_ptr = info->regs->rsp;
     }


### PR DESCRIPTION
I found that memdump plugin always gets RSP from trap frame even if stack traversal is triggered by usermode trap. This lead to incorrect dumping because kernel trap frame doesn't have correct usermode stack pointer while we're trapped in usermode. In this case drakvuf fails to find the real caller of the hooked function.

After adding some debug logs to the failed dumping attempt:

```
1717157477.234616 [MEMDUMP DEBUG] Inspecting stack (is_32bit=1, stack_ptr=5dfd800)
1717157477.234627 [MEMDUMP DEBUG] current rsp=5dfd508, current rip=77124141
```

we can see that dumping failed because real stack pointer from vCPU context was at 5dfd508, but stack was read starting from 5dfd800 that was address left in trap frame after some previous syscall.

This PR checks if current RSP/RIP is in user/kernel space and gets stack pointer from correct place.