### PR TITLE
Fix injector: drakvuf_set_vcpu_gprs forgot about RSI and RDI

### DIFF
--- a/src/libdrakvuf/drakvuf.c
+++ b/src/libdrakvuf/drakvuf.c
@@ -1146,6 +1146,8 @@ bool drakvuf_set_vcpu_gprs(drakvuf_t drakvuf, unsigned int vcpu, registers_t* re
     ctx.x64.user_regs.rdx = regs->x86.rdx;
     ctx.x64.user_regs.rbp = regs->x86.rbp;
     ctx.x64.user_regs.rsp = regs->x86.rsp;
+    ctx.x64.user_regs.rsi = regs->x86.rsi;
+    ctx.x64.user_regs.rdi = regs->x86.rdi;
     ctx.x64.user_regs.r8 = regs->x86.r8;
     ctx.x64.user_regs.r9 = regs->x86.r9;
     ctx.x64.user_regs.r10 = regs->x86.r10;


### PR DESCRIPTION
Hi!

This fix is addressing issues related with target process crash/hang caused by injector e.g. https://github.com/tklengyel/drakvuf/issues/925, https://github.com/tklengyel/drakvuf/issues/1758

I've spent hours on debugging injector crashes and I found a bit surprising bug: hijacked thread context is incorrectly restored because two registers were missing in `drakvuf_set_vcpu_gprs` function: RSI and RDI.

These registers are crucial because according to [Microsoft x64 ABI convention](https://learn.microsoft.com/en-us/cpp/build/x64-software-conventions?view=msvc-170&redirectedfrom=MSDN#register-volatility-and-preservation), they're non-volatile registers that should be preserved by the callee. Of course the bug leads to the corruption of targeted process, usually followed by a crash.

I found the bug by debugging one of the common places where `explorer.exe` was spotted to crash after injection. In this case, injector traps on the return from `ZwWaitForWorkViaWorkerFactory` where hijacked thread wakes up. The clobbered RSI register is then used in various places as it points to some shared structure with `PSRWLOCK` pointer in `rsi+0x48`. Final result is usually an `EXCEPTION_ACCESS_VIOLATION` crash in `RtlAcquireSRWLockExclusive`.

Other register values are correctly restored excluding RSI and RDI:
![image](https://github.com/user-attachments/assets/e33e2465-245b-4edf-9739-053dd0ea91bf)
![image](https://github.com/user-attachments/assets/42725079-9c12-4e3b-9d57-a7e7c71d7d49)

`RtlAcquireSRWLockExclusive` argument evaluated from `RSI`:
![image](https://github.com/user-attachments/assets/f915a867-0aa3-41c6-90f7-145c2b7346da)
The faulting instruction:
![image](https://github.com/user-attachments/assets/69d52dfb-40b2-40a6-8117-97bb8df870e4)


