### PR TITLE
socketmon: extend Windows builds support

### DIFF
--- a/src/plugins/socketmon/private.h
+++ b/src/plugins/socketmon/private.h
@@ -336,4 +336,24 @@ static const uint16_t win10_1803_tcp_offsets[__TCP_ARRAY_MAX] =
     [REMOTE_ADDR_OFF1]  = 0xf0,
 };
 
+static const uint16_t winserv_2019_tcp_offsets[__TCP_ARRAY_MAX] =
+{
+    [IP_FAMILY_OFF0]    = 0x10,
+    [IP_FAMILY_OFF1]    = 0x18,
+    [LOCAL_PORT]        = 0xC0,
+    [REMOTE_PORT]       = 0xC4,
+    [REMOTE_ADDR_OFF0]  = 0x18,
+    [REMOTE_ADDR_OFF1]  = 0xC0,
+};
+
+static const uint16_t win10_21h2_23h2_tcp_offsets[__TCP_ARRAY_MAX] =
+{
+    [IP_FAMILY_OFF0]    = 0x10,
+    [IP_FAMILY_OFF1]    = 0x18,
+    [LOCAL_PORT]        = 0x70,
+    [REMOTE_PORT]       = 0x72,
+    [REMOTE_ADDR_OFF0]  = 0x18,
+    [REMOTE_ADDR_OFF1]  = 0xC0,
+};
+
 #endif

--- a/src/plugins/socketmon/socketmon.cpp
+++ b/src/plugins/socketmon/socketmon.cpp
@@ -156,6 +156,7 @@ static constexpr uint16_t win_10_1803_ver   = 17134;
 static constexpr uint16_t win_serv_2019_ver = 17763;
 static constexpr uint16_t win_10_21h2_ver   = 19044;
 static constexpr uint16_t win_10_22h2_ver   = 19045;
+static constexpr uint16_t win_10_23h2_ver   = 22631;
 
 static const std::unordered_map<uint16_t, udp_offsets_t> udp_offsets_x86 =
 {
@@ -242,8 +243,31 @@ static const std::unordered_map<uint16_t, udp_offsets_t> udp_offsets_x64 =
             .remote_port = 0x110,
             .remote_addr = 0x120
         }
+    },
+    {
+        win_10_23h2_ver,
+        {
+            .family_1    = 0x20,
+            .family_2    = 0x18,
+            .local_port  = 0xA0,
+            .remote_port = 0x128,
+            .remote_addr = 0x130
+        }
     }
 };
+
+static const uint16_t* get_tcp_offsets(uint16_t buildnumber)
+{
+    if (buildnumber == win_7_sp1_ver)
+        return win7_sp1_tcp_offsets;
+    if (buildnumber == win_10_1803_ver)
+        return win10_1803_tcp_offsets;
+    if (buildnumber == win_serv_2019_ver)
+        return winserv_2019_tcp_offsets;
+    if (buildnumber >= win_10_21h2_ver && buildnumber <= win_10_23h2_ver)
+        return win10_21h2_23h2_tcp_offsets;
+    return nullptr;
+}
 
 static char* ipv4_to_str(uint8_t ipv4[4])
 {
@@ -325,7 +349,7 @@ static char const* tcp_addressfamily_string(int family)
 static void print_udp_info(drakvuf_t drakvuf, drakvuf_trap_info_t* info, socketmon* s, proc_data_t const& owner_proc_data, int addressfamily, char const* lip, int localport, char const* rip, int remoteport)
 {
     fmt::print(s->format, "socketmon", drakvuf, info,
-        keyval("Owner", fmt::Qstr(owner_proc_data.name)),
+        keyval("Owner", fmt::Estr(owner_proc_data.name)),
         keyval("OwnerId", fmt::Nval(owner_proc_data.userid)),
         keyval("OwnerPID", fmt::Nval(owner_proc_data.pid)),
         keyval("OwnerPPID", fmt::Nval(owner_proc_data.ppid)),
@@ -341,7 +365,7 @@ static void print_tcpe(drakvuf_t drakvuf, drakvuf_trap_info_t* info, socketmon* 
     int addressfamily, char const* lip, int localport, char const* rip, int remoteport)
 {
     fmt::print(s->format, "socketmon", drakvuf, info,
-        keyval("Owner", fmt::Qstr(owner_proc_data.name)),
+        keyval("Owner", fmt::Estr(owner_proc_data.name)),
         keyval("OwnerId", fmt::Nval(owner_proc_data.userid)),
         keyval("OwnerPID", fmt::Nval(owner_proc_data.pid)),
         keyval("OwnerPPID", fmt::Nval(owner_proc_data.ppid)),
@@ -428,23 +452,13 @@ static event_response_t tcpe_win10_x64_cb(drakvuf_t drakvuf, drakvuf_trap_info_t
     return tcpe_old_cb<tcp_endpoint_win10_x64, inetaf_win10_x64, addr_info_x64>(drakvuf, info);
 }
 
-static uint16_t tcp_get_family(vmi_instance_t vmi, addr_t rcx, addr_t build)
+static uint16_t tcp_get_family(vmi_instance_t vmi, addr_t rcx, uint16_t buildnumber)
 {
     addr_t ptr = 0;
     uint16_t family = 0;
-    const uint16_t* offsets = nullptr;
-
-    switch (build)
-    {
-        case win_7_sp1_ver:
-            offsets = win7_sp1_tcp_offsets;
-            break;
-        case win_10_1803_ver:
-            offsets = win10_1803_tcp_offsets;
-            break;
-        default:
-            return 0;
-    };
+    const uint16_t* offsets = get_tcp_offsets(buildnumber);
+    if (!offsets)
+        return 0;
 
     if (VMI_SUCCESS != vmi_read_addr_va(vmi, rcx + offsets[IP_FAMILY_OFF0], 0, &ptr))
         return 0;
@@ -454,22 +468,12 @@ static uint16_t tcp_get_family(vmi_instance_t vmi, addr_t rcx, addr_t build)
     return family;
 }
 
-static std::pair<uint16_t, uint16_t> tcp_get_port(vmi_instance_t vmi, addr_t rcx, addr_t build)
+static std::pair<uint16_t, uint16_t> tcp_get_port(vmi_instance_t vmi, addr_t rcx, uint16_t buildnumber)
 {
     uint16_t rport = 0, lport = 0;
-    const uint16_t* offsets = nullptr;
-
-    switch (build)
-    {
-        case win_7_sp1_ver:
-            offsets = win7_sp1_tcp_offsets;
-            break;
-        case win_10_1803_ver:
-            offsets = win10_1803_tcp_offsets;
-            break;
-        default:
-            return std::make_pair(0, 0);
-    };
+    const uint16_t* offsets = get_tcp_offsets(buildnumber);
+    if (!offsets)
+        return std::make_pair(0, 0);
 
     vmi_read_16_va(vmi, rcx + offsets[LOCAL_PORT],  0, &lport);
     vmi_read_16_va(vmi, rcx + offsets[REMOTE_PORT], 0, &rport);
@@ -478,7 +482,7 @@ static std::pair<uint16_t, uint16_t> tcp_get_port(vmi_instance_t vmi, addr_t rcx
     return std::make_pair(lport, rport);
 }
 
-static char* tcp_get_addr(vmi_instance_t vmi, addr_t rcx, addr_t build, uint16_t family)
+static char* tcp_get_addr(vmi_instance_t vmi, addr_t rcx, uint16_t buildnumber, uint16_t family)
 {
     addr_t ptr = 0;
 
@@ -487,20 +491,9 @@ static char* tcp_get_addr(vmi_instance_t vmi, addr_t rcx, addr_t build, uint16_t
         .pid                 = 4
     );
 
-    const uint16_t* offsets = nullptr;
-
-    switch (build)
-    {
-        case win_7_sp1_ver:
-            offsets = win7_sp1_tcp_offsets;
-            break;
-        case win_10_1803_ver:
-            offsets = win10_1803_tcp_offsets;
-            break;
-        default:
-            return nullptr;
-    };
-
+    const uint16_t* offsets = get_tcp_offsets(buildnumber);
+    if (!offsets)
+        return nullptr;
 
     if (VMI_SUCCESS != vmi_read_addr_va(vmi, rcx + offsets[REMOTE_ADDR_OFF0], 0, &ptr))
         return nullptr;
@@ -997,7 +990,7 @@ socketmon::socketmon(drakvuf_t drakvuf_, const socketmon_config* c, output_forma
                 break;
             case VMI_OS_WINDOWS_10:
                 if (this->build.buildnumber < 17134)
-                    // Tested on Windows 10 x64 before 1803
+                    // Tested on Windows 10 x64 before 1803 and on WinServ 2016-1198
                     tcpe_cb = tcpe_win10_x64_cb;
                 break;
             case VMI_OS_WINDOWS_7:
@@ -1024,6 +1017,7 @@ socketmon::socketmon(drakvuf_t drakvuf_, const socketmon_config* c, output_forma
 
 socketmon::~socketmon()
 {
+    stop();
 }
 
 bool socketmon::stop_impl()


### PR DESCRIPTION
* add Windows 11 23H2 x64 TCP and UDP field offsets
* add Windows Server 2019 TCP and UDP field offsets
* stop plugin on destruction