### PR TITLE
xen_helper: fix handling of invalid domain name

### DIFF
--- a/src/libdrakvuf/drakvuf.c
+++ b/src/libdrakvuf/drakvuf.c
@@ -233,10 +233,11 @@ bool drakvuf_init(
     drakvuf_event_fd_add(drakvuf, xen_get_evtchn_fd(drakvuf->xen), drakvuf_vmi_event_callback, drakvuf);
     PRINT_DEBUG("drakvuf_init: adding event_fd done\n");
 
-    xen_get_dom_info(drakvuf->xen, domain, &drakvuf->domID, &drakvuf->dom_name);
-    domid_t test = ~0;
-    if ( drakvuf->domID == test )
+    if ( !xen_get_dom_info(drakvuf->xen, domain, &drakvuf->domID, &drakvuf->dom_name) )
+    {
+        fprintf(stderr, "Failed to get domain info\n");
         goto err;
+    }
 
     xen_pause(drakvuf->xen, drakvuf->domID);
 

--- a/src/xen_helper/xen_helper.h
+++ b/src/xen_helper/xen_helper.h
@@ -133,7 +133,7 @@ typedef struct ipt_state
 bool xen_init_interface(xen_interface_t** xen);
 void xen_free_interface(xen_interface_t* xen);
 
-int xen_get_dom_info(xen_interface_t* xen, const char* input, domid_t* domID, char** name);
+bool xen_get_dom_info(xen_interface_t* xen, const char* input, domid_t* domID, char** name);
 xc_evtchn* xen_get_evtchn(xen_interface_t* xen);
 int xen_get_evtchn_fd(xen_interface_t* xen);
 


### PR DESCRIPTION
Got the problem with name of inactive domain:

![Screenshot_2024-09-11_15-35-38](https://github.com/user-attachments/assets/6afe7e08-ae9a-4827-b511-d089c034a5b2)

 Fix incorrect error handling after `libxl_name_to_domid()` and additional improvements in **xen_helper.c** bool logic. 