### PR TITLE
Fix regression: Missing "disable-output-buffering" option since meson builds

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -6,6 +6,7 @@ option('xtf', type : 'boolean', value : 'false')
 option('repl', type : 'boolean', value : 'false')
 option('threadsafety', type : 'boolean', value : 'false')
 option('coverage', type : 'boolean', value : 'false')
+option('disable-output-buffering', type : 'boolean', value : 'false')
 
 option('plugin-syscalls', type : 'boolean', value : true)
 option('plugin-poolmon', type : 'boolean', value : true)

--- a/src/plugins/meson.build
+++ b/src/plugins/meson.build
@@ -314,6 +314,10 @@ if get_option('plugin-windowmon')
     config_h.set('ENABLE_PLUGIN_WINDOWMON', 1)
 endif
 
+if get_option('disable-output-buffering')
+    config_h.set('DISABLE_OUTPUT_BUFFERING', 1)
+endif
+
 summary({
     'syscalls': get_option('plugin-syscalls'),
     'poolmon': get_option('plugin-poolmon'),

--- a/src/plugins/output_format/ostream.h
+++ b/src/plugins/output_format/ostream.h
@@ -106,6 +106,10 @@
 #define PLUGINS_OUTPUT_FORMAT_OSTREAM_H
 #pragma once
 
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif /* HAVE_CONFIG_H */
+
 #include <iostream>
 
 namespace fmt


### PR DESCRIPTION
The Meson build system was missing the `disable-output-buffering` option, which is available in the Make build system. This commit adds the `disable-output-buffering` option to the Meson build system.