### PR TITLE
Modernize usermode hooking using libusermode

### DIFF
--- a/src/plugins/socketmon/socketmon.h
+++ b/src/plugins/socketmon/socketmon.h
@@ -105,6 +105,7 @@
 #ifndef SOCKETMON_H
 #define SOCKETMON_H
 
+#include <libusermode/userhook.hpp>
 #include "plugins/plugins.h"
 #include "private.h"
 
@@ -120,6 +121,7 @@ public:
     output_format_t format;
     win_build_info_t build;
     drakvuf_t drakvuf;
+    wanted_hooks_t wanted_hooks;
 
     drakvuf_trap_t tcpip_trap[2] =
     {


### PR DESCRIPTION
Applies the recommandation of @psrok1 at https://github.com/tklengyel/drakvuf/issues/1613#issuecomment-2248031590 of implementing usermode hooking for socketmon plugin using libusermode.

This allows a user to have basic network and DNS monitoring, even when no process has loaded the `dnsapi.dll` library yet, which should fix issue #1613, assuming that [this comment](https://github.com/tklengyel/drakvuf/issues/1613#issuecomment-1440190721) is highlithing the real issue.