### PR TITLE
socketmon: extend Windows builds support for Win10 1909

### DIFF
--- a/src/plugins/socketmon/private.h
+++ b/src/plugins/socketmon/private.h
@@ -346,6 +346,16 @@ static const uint16_t winserv_2019_tcp_offsets[__TCP_ARRAY_MAX] =
     [REMOTE_ADDR_OFF1]  = 0xC0,
 };
 
+static const uint16_t win10_1909_tcp_offsets[__TCP_ARRAY_MAX] =
+{
+    [IP_FAMILY_OFF0]    = 0x10,
+    [IP_FAMILY_OFF1]    = 0x18,
+    [LOCAL_PORT]        = 0x70,
+    [REMOTE_PORT]       = 0x72,
+    [REMOTE_ADDR_OFF0]  = 0x18,
+    [REMOTE_ADDR_OFF1]  = 0xb8,
+};
+
 static const uint16_t win10_21h2_23h2_tcp_offsets[__TCP_ARRAY_MAX] =
 {
     [IP_FAMILY_OFF0]    = 0x10,

--- a/src/plugins/socketmon/socketmon.cpp
+++ b/src/plugins/socketmon/socketmon.cpp
@@ -154,6 +154,7 @@ static constexpr uint16_t win_8_1_ver       = 9600;
 static constexpr uint16_t win_serv_2016_ver = 14393;
 static constexpr uint16_t win_10_1803_ver   = 17134;
 static constexpr uint16_t win_serv_2019_ver = 17763;
+static constexpr uint16_t win_10_1909_ver   = 18362;
 static constexpr uint16_t win_10_21h2_ver   = 19044;
 static constexpr uint16_t win_10_22h2_ver   = 19045;
 static constexpr uint16_t win_10_23h2_ver   = 22631;
@@ -225,6 +226,16 @@ static const std::unordered_map<uint16_t, udp_offsets_t> udp_offsets_x64 =
         }
     },
     {
+        win_10_1909_ver,
+        {
+            .family_1    = 0x20,
+            .family_2    = 0x18,
+            .local_port  = 0x78,
+            .remote_port = 0xE8,
+            .remote_addr = 0xF0
+        }
+    },
+    {
         win_10_21h2_ver,
         {
             .family_1    = 0x20,
@@ -262,6 +273,8 @@ static const uint16_t* get_tcp_offsets(uint16_t buildnumber)
         return win7_sp1_tcp_offsets;
     if (buildnumber == win_10_1803_ver)
         return win10_1803_tcp_offsets;
+    if (buildnumber == win_10_1909_ver)
+        return win10_1909_tcp_offsets;
     if (buildnumber == win_serv_2019_ver)
         return winserv_2019_tcp_offsets;
     if (buildnumber >= win_10_21h2_ver && buildnumber <= win_10_23h2_ver)


### PR DESCRIPTION
Adds offsets for TCP and UDP for socketmon on Windows 10 1909.