### PR TITLE
remove explicit CXXFLAGS assignment

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -120,7 +120,6 @@ AC_PROG_CXX(clang++)
 
 AX_REQUIRE_DEFINED([AX_CXX_COMPILE_STDCXX])
 AX_CXX_COMPILE_STDCXX([17], [ext], [mandatory])
-CXXFLAGS="-std=gnu++17"
 
 ######################################################
 


### PR DESCRIPTION
Remove explicit CXXFLAGS assignment in configure.ac, as `gnu++17` standard  is determined by line `AX_CXX_COMPILE_STDCXX([17], [ext], [mandatory])` (`[17]` and `[ext]`, https://www.gnu.org/software/autoconf-archive/ax_cxx_compile_stdcxx.html); and if flag is described here - it overlaps CXXFLAGS flag, that you can pass to `configure` script.