### PR TITLE
Remove unused move constructors and assignment operators from libhook

### DIFF
--- a/src/libhook/hooks/base.cpp
+++ b/src/libhook/hooks/base.cpp
@@ -110,17 +110,6 @@ BaseHook::BaseHook(drakvuf_t drakvuf)
     : drakvuf_(drakvuf)
 {}
 
-BaseHook::BaseHook(BaseHook&& rhs) noexcept
-{
-    std::swap(this->drakvuf_, rhs.drakvuf_);
-}
-
-BaseHook& BaseHook::operator=(BaseHook&& rhs) noexcept
-{
-    std::swap(this->drakvuf_, rhs.drakvuf_);
-    return *this;
-}
-
 // don't ask me why C++ has "pure virtual dctors with default implementation"
 BaseHook::~BaseHook()
 {}

--- a/src/libhook/hooks/base.hpp
+++ b/src/libhook/hooks/base.hpp
@@ -127,26 +127,16 @@ public:
     virtual ~BaseHook() = 0;
 
     /**
-     * delete copy ctor, as this class has ownership via RAII
+     * delete copy and move ctors, as this class has ownership via RAII
      */
     BaseHook(const BaseHook&) = delete;
+    BaseHook(BaseHook&&) = delete;
 
     /**
-     * move ctor, required for move semantics to work properly
-     * important to be noexcept, otherwise bad things will happen
-     */
-    BaseHook(BaseHook&&) noexcept;
-
-    /**
-     * delete copy assignment operator, as this class has ownership via RAII
+     * delete copy and move assignment operators, as this class has ownership via RAII
      */
     BaseHook& operator=(const BaseHook&) = delete;
-
-    /**
-     * move assignment operator, required for move semantics to work properly
-     * important to be noexcept, otherwise bad things will happen
-     */
-    BaseHook& operator=(BaseHook&&) noexcept;
+    BaseHook& operator=(BaseHook&&) = delete;
 
     virtual std::shared_ptr<CallResult> params() = 0;
 

--- a/src/libhook/hooks/catchall.cpp
+++ b/src/libhook/hooks/catchall.cpp
@@ -131,20 +131,6 @@ CatchAllHook::~CatchAllHook()
     }
 }
 
-CatchAllHook::CatchAllHook(CatchAllHook&& rhs) noexcept
-    : BaseHook(std::forward<BaseHook>(rhs))
-{
-    std::swap(this->trap_, rhs.trap_);
-    std::swap(this->callback_, rhs.callback_);
-}
-
-CatchAllHook& CatchAllHook::operator=(CatchAllHook&& rhs) noexcept
-{
-    std::swap(this->trap_, rhs.trap_);
-    std::swap(this->callback_, rhs.callback_);
-    return *this;
-}
-
 CatchAllHook::CatchAllHook(drakvuf_t drakvuf, cb_wrapper_t cb)
     : BaseHook(drakvuf),
       callback_(cb)

--- a/src/libhook/hooks/catchall.hpp
+++ b/src/libhook/hooks/catchall.hpp
@@ -127,26 +127,16 @@ public:
     ~CatchAllHook() override;
 
     /**
-     * delete copy ctor, as this class has ownership via RAII
+     * delete copy and move ctors, as this class has ownership via RAII
      */
     CatchAllHook(const CatchAllHook&) = delete;
+    CatchAllHook(CatchAllHook&&) = delete;
 
     /**
-     * move ctor, required for move semantics to work properly
-     * important to be noexcept, otherwise bad things will happen
-     */
-    CatchAllHook(CatchAllHook&&) noexcept;
-
-    /**
-     * delete copy assignment operator, as this class has ownership via RAII
+     * delete copy and move assignment operators, as this class has ownership via RAII
      */
     CatchAllHook& operator=(const CatchAllHook&) = delete;
-
-    /**
-     * move assignment operator, required for move semantics to work properly
-     * important to be noexcept, otherwise bad things will happen
-     */
-    CatchAllHook& operator=(CatchAllHook&&) noexcept;
+    CatchAllHook& operator=(CatchAllHook&&) = delete;
 
     std::shared_ptr<CallResult> params() override;
 

--- a/src/libhook/hooks/cpuid.cpp
+++ b/src/libhook/hooks/cpuid.cpp
@@ -131,20 +131,6 @@ CpuidHook::~CpuidHook()
     }
 }
 
-CpuidHook::CpuidHook(CpuidHook&& rhs) noexcept
-    : BaseHook(std::forward<BaseHook>(rhs))
-{
-    std::swap(this->trap_, rhs.trap_);
-    std::swap(this->callback_, rhs.callback_);
-}
-
-CpuidHook& CpuidHook::operator=(CpuidHook&& rhs) noexcept
-{
-    std::swap(this->trap_, rhs.trap_);
-    std::swap(this->callback_, rhs.callback_);
-    return *this;
-}
-
 CpuidHook::CpuidHook(drakvuf_t drakvuf, cb_wrapper_t cb)
     : BaseHook(drakvuf),
       callback_(cb)

--- a/src/libhook/hooks/cpuid.hpp
+++ b/src/libhook/hooks/cpuid.hpp
@@ -127,26 +127,16 @@ public:
     ~CpuidHook() override;
 
     /**
-     * delete copy ctor, as this class has ownership via RAII
+     * delete copy and move ctors, as this class has ownership via RAII
      */
     CpuidHook(const CpuidHook&) = delete;
+    CpuidHook(CpuidHook&&) = delete;
 
     /**
-     * move ctor, required for move semantics to work properly
-     * important to be noexcept, otherwise bad things will happen
-     */
-    CpuidHook(CpuidHook&&) noexcept;
-
-    /**
-     * delete copy assignment operator, as this class has ownership via RAII
+     * delete copy and move assignment operators, as this class has ownership via RAII
      */
     CpuidHook& operator=(const CpuidHook&) = delete;
-
-    /**
-     * move assignment operator, required for move semantics to work properly
-     * important to be noexcept, otherwise bad things will happen
-     */
-    CpuidHook& operator=(CpuidHook&&) noexcept;
+    CpuidHook& operator=(CpuidHook&&) = delete;
 
     std::shared_ptr<CallResult> params() override;
 

--- a/src/libhook/hooks/cr3.cpp
+++ b/src/libhook/hooks/cr3.cpp
@@ -131,20 +131,6 @@ Cr3Hook::~Cr3Hook()
     }
 }
 
-Cr3Hook::Cr3Hook(Cr3Hook&& rhs) noexcept
-    : BaseHook(std::forward<BaseHook>(rhs))
-{
-    std::swap(this->trap_, rhs.trap_);
-    std::swap(this->callback_, rhs.callback_);
-}
-
-Cr3Hook& Cr3Hook::operator=(Cr3Hook&& rhs) noexcept
-{
-    std::swap(this->trap_, rhs.trap_);
-    std::swap(this->callback_, rhs.callback_);
-    return *this;
-}
-
 Cr3Hook::Cr3Hook(drakvuf_t drakvuf, cb_wrapper_t cb)
     : BaseHook(drakvuf),
       callback_(cb)

--- a/src/libhook/hooks/cr3.hpp
+++ b/src/libhook/hooks/cr3.hpp
@@ -127,26 +127,16 @@ public:
     ~Cr3Hook() override;
 
     /**
-     * delete copy ctor, as this class has ownership via RAII
+     * delete copy and move ctors, as this class has ownership via RAII
      */
     Cr3Hook(const Cr3Hook&) = delete;
+    Cr3Hook(Cr3Hook&&) = delete;
 
     /**
-     * move ctor, required for move semantics to work properly
-     * important to be noexcept, otherwise bad things will happen
-     */
-    Cr3Hook(Cr3Hook&&) noexcept;
-
-    /**
-     * delete copy assignment operator, as this class has ownership via RAII
+     * delete copy and move assignment operators, as this class has ownership via RAII
      */
     Cr3Hook& operator=(const Cr3Hook&) = delete;
-
-    /**
-     * move assignment operator, required for move semantics to work properly
-     * important to be noexcept, otherwise bad things will happen
-     */
-    Cr3Hook& operator=(Cr3Hook&&) noexcept;
+    Cr3Hook& operator=(Cr3Hook&&) = delete;
 
     std::shared_ptr<CallResult> params() override;
 

--- a/src/libhook/hooks/manual.cpp
+++ b/src/libhook/hooks/manual.cpp
@@ -142,20 +142,6 @@ ManualHook::~ManualHook()
     }
 }
 
-ManualHook::ManualHook(ManualHook&& rhs) noexcept
-    : BaseHook(std::forward<ManualHook>(rhs))
-{
-    std::swap(this->trap_, rhs.trap_);
-    std::swap(this->free_routine_, rhs.free_routine_);
-}
-
-ManualHook& ManualHook::operator=(ManualHook&& rhs) noexcept
-{
-    std::swap(this->trap_, rhs.trap_);
-    std::swap(this->free_routine_, rhs.free_routine_);
-    return *this;
-}
-
 std::shared_ptr<CallResult> ManualHook::params()
 {
     return nullptr;

--- a/src/libhook/hooks/manual.hpp
+++ b/src/libhook/hooks/manual.hpp
@@ -137,26 +137,16 @@ public:
     ManualHook() = delete;
 
     /**
-     * delete copy ctor, as this class has ownership via RAII
+     * delete copy and move ctors, as this class has ownership via RAII
      */
     ManualHook(const ManualHook&) = delete;
+    ManualHook(ManualHook&&) = delete;
 
     /**
-     * move ctor, required for move semantics to work properly
-     * important to be noexcept, otherwise bad things will happen
-     */
-    ManualHook(ManualHook&&) noexcept;
-
-    /**
-     * delete copy assignment operator, as this class has ownership via RAII
+     * delete copy and move assignment operators, as this class has ownership via RAII
      */
     ManualHook& operator=(const ManualHook&) = delete;
-
-    /**
-     * move assignment operator, required for move semantics to work properly
-     * important to be noexcept, otherwise bad things will happen
-     */
-    ManualHook& operator=(ManualHook&&) noexcept;
+    ManualHook& operator=(ManualHook&&) = delete;
 
     std::shared_ptr<CallResult> params() override;
 

--- a/src/libhook/hooks/memaccess.cpp
+++ b/src/libhook/hooks/memaccess.cpp
@@ -131,20 +131,6 @@ MemAccessHook::~MemAccessHook()
     }
 }
 
-MemAccessHook::MemAccessHook(MemAccessHook&& rhs) noexcept
-    : BaseHook(std::forward<BaseHook>(rhs))
-{
-    std::swap(this->trap_, rhs.trap_);
-    std::swap(this->callback_, rhs.callback_);
-}
-
-MemAccessHook& MemAccessHook::operator=(MemAccessHook&& rhs) noexcept
-{
-    std::swap(this->trap_, rhs.trap_);
-    std::swap(this->callback_, rhs.callback_);
-    return *this;
-}
-
 MemAccessHook::MemAccessHook(drakvuf_t drakvuf, cb_wrapper_t cb)
     : BaseHook(drakvuf),
       callback_(cb)

--- a/src/libhook/hooks/memaccess.hpp
+++ b/src/libhook/hooks/memaccess.hpp
@@ -127,26 +127,16 @@ public:
     ~MemAccessHook() override;
 
     /**
-     * delete copy ctor, as this class has ownership via RAII
+     * delete copy and move ctors, as this class has ownership via RAII
      */
     MemAccessHook(const MemAccessHook&) = delete;
+    MemAccessHook(MemAccessHook&&) = delete;
 
     /**
-     * move ctor, required for move semantics to work properly
-     * important to be noexcept, otherwise bad things will happen
-     */
-    MemAccessHook(MemAccessHook&&) noexcept;
-
-    /**
-     * delete copy assignment operator, as this class has ownership via RAII
+     * delete copy and move assignment operators, as this class has ownership via RAII
      */
     MemAccessHook& operator=(const MemAccessHook&) = delete;
-
-    /**
-     * move assignment operator, required for move semantics to work properly
-     * important to be noexcept, otherwise bad things will happen
-     */
-    MemAccessHook& operator=(MemAccessHook&&) noexcept;
+    MemAccessHook& operator=(MemAccessHook&&) = delete;
 
     std::shared_ptr<CallResult> params() override;
 

--- a/src/libhook/hooks/return.cpp
+++ b/src/libhook/hooks/return.cpp
@@ -154,22 +154,6 @@ ReturnHook::~ReturnHook()
     }
 }
 
-ReturnHook::ReturnHook(ReturnHook&& rhs) noexcept
-    : BaseHook(std::forward<BaseHook>(rhs))
-{
-    std::swap(this->callback_, rhs.callback_);
-    std::swap(this->trap_, rhs.trap_);
-    std::swap(this->display_name_, rhs.display_name_);
-}
-
-ReturnHook& ReturnHook::operator=(ReturnHook&& rhs) noexcept
-{
-    std::swap(this->callback_, rhs.callback_);
-    std::swap(this->trap_, rhs.trap_);
-    std::swap(this->display_name_, rhs.display_name_);
-    return *this;
-}
-
 std::shared_ptr<CallResult> ReturnHook::params()
 {
     return this->params_;

--- a/src/libhook/hooks/return.hpp
+++ b/src/libhook/hooks/return.hpp
@@ -128,26 +128,16 @@ public:
     ~ReturnHook() override;
 
     /**
-     * delete copy ctor, as this class has ownership via RAII
+     * delete copy and move ctors, as this class has ownership via RAII
      */
     ReturnHook(const ReturnHook&) = delete;
+    ReturnHook(ReturnHook&&) = delete;
 
     /**
-     * move ctor, required for move semantics to work properly
-     * important to be noexcept, otherwise bad things will happen
-     */
-    ReturnHook(ReturnHook&&) noexcept;
-
-    /**
-     * delete copy assignment operator, as this class has ownership via RAII
+     * delete copy and move assignment operators, as this class has ownership via RAII
      */
     ReturnHook& operator=(const ReturnHook&) = delete;
-
-    /**
-     * move assignment operator, required for move semantics to work properly
-     * important to be noexcept, otherwise bad things will happen
-     */
-    ReturnHook& operator=(ReturnHook&&) noexcept;
+    ReturnHook& operator=(ReturnHook&&) = delete;
 
     std::shared_ptr<CallResult> params() override;
 


### PR DESCRIPTION
At first, `clang-tidy-19` static analyzer shows `bugprone-use-after-move` warnings on move constructors in classes, derives `BaseHook`. Also, `params_` members was not transferred at all.
![image](https://github.com/user-attachments/assets/0f988ce4-583e-4cf9-8f7a-da7615cfe8c2)
After that i saw that move semantic for `libhook` hooks is completely not used in actual code, as we use RAII to deal with these hooks and do not transfer ownership of them.
So i delete explicitly move constructors and move operators in base and derived hooks classes, as already been done in `SyscallHook` class. This will prevent porssible errors when working with these hooks,