### PR TITLE
win_get_object_type_index fix

### DIFF
--- a/src/libdrakvuf/win.c
+++ b/src/libdrakvuf/win.c
@@ -490,10 +490,6 @@ bool win_get_object_type_index(drakvuf_t drakvuf, access_context_t* object_heade
     {
         *index = *index ^ ((object_header_addr >> 8) & 0xff) ^ drakvuf->ob_header_cookie;
     }
-    else
-    {
-        return false;
-    }
 
     return true;
 }


### PR DESCRIPTION
`win_get_object_type_index` returned false for Windows version != 10 even when successful.
It corrects the mistake I made in the previous fix #1822.