### PR TITLE
Fix EXITTHREAD injector method used by --exit-injection-thread

### DIFF
--- a/src/libinjector/win/methods/win_exitthread.c
+++ b/src/libinjector/win/methods/win_exitthread.c
@@ -154,7 +154,7 @@ event_response_t handle_win_exitthread(drakvuf_t drakvuf, drakvuf_trap_info_t* i
         if (!setup_exitthread_stack(injector, info->regs))
             return cleanup(injector, info);
 
-        info->regs->rip = injector->exit_thread;
+        info->regs->rip = injector->exec_func;
         drakvuf_remove_trap(drakvuf, info->trap, NULL);
         event = VMI_EVENT_RESPONSE_SET_REGISTERS;
 

--- a/src/libinjector/win/win_injector.c
+++ b/src/libinjector/win/win_injector.c
@@ -570,8 +570,7 @@ static bool initialize_injector_functions(drakvuf_t drakvuf, injector_t injector
         }
         case INJECT_METHOD_EXITTHREAD:
         {
-            injector->exit_thread = get_function_va(drakvuf, eprocess_base, "ntdll.dll", "RtlExitUserThread", injector->global_search);
-            if (!injector->exit_thread) return false;
+            injector->exec_func = get_function_va(drakvuf, eprocess_base, "ntdll.dll", "RtlExitUserThread", injector->global_search);
             break;
         }
         case INJECT_METHOD_SHELLEXEC:

--- a/src/libinjector/win/win_utils.h
+++ b/src/libinjector/win/win_utils.h
@@ -162,7 +162,6 @@ struct injector
     vmi_pid_t terminate_pid;
     addr_t open_process;
     addr_t exit_process;
-    addr_t exit_thread;
 
     // For shellcode execution
     addr_t payload, payload_addr, memset;


### PR DESCRIPTION
Exit thread injection method and related `--exit-injection-thread` Drakvuf parameter doesn't work because `initialize_injector_functions` returns successfully only when `injector->exec_func` is set. 

INJECT_METHOD_EXITTHREAD used dedicated `exit_thread` pointer instead which is incorrect regarding the convention followed by other injection methods.

This PR changes the `RtlExitUserThread` pointer assignment to `injector::exec_func` and removes unused `injector::exit_thread`