### PR TITLE
Support for Windows Vista: skip ObTypeIndexTable and ObpInfoMaskToOffset for Vista

### DIFF
--- a/src/libdrakvuf/win.c
+++ b/src/libdrakvuf/win.c
@@ -681,10 +681,13 @@ bool set_os_windows(drakvuf_t drakvuf)
         return 0;
     }
 
-    if (VMI_FAILURE == vmi_translate_ksym2v(drakvuf->vmi, "ObpInfoMaskToOffset", &drakvuf->ob_infomask2off) ||
-        VMI_FAILURE == vmi_translate_ksym2v(drakvuf->vmi, "ObTypeIndexTable",    &drakvuf->ob_type_table))
+    if (vmi_get_winver(drakvuf->vmi) != VMI_OS_WINDOWS_VISTA)
     {
-        return 0;
+        if (VMI_FAILURE == vmi_translate_ksym2v(drakvuf->vmi, "ObpInfoMaskToOffset", &drakvuf->ob_infomask2off) ||
+            VMI_FAILURE == vmi_translate_ksym2v(drakvuf->vmi, "ObTypeIndexTable",    &drakvuf->ob_type_table))
+        {
+            return 0;
+        }
     }
 
     if (vmi_get_winver(drakvuf->vmi) == VMI_OS_WINDOWS_10 && VMI_FAILURE == vmi_read_8_ksym(drakvuf->vmi, "ObHeaderCookie", &drakvuf->ob_header_cookie))


### PR DESCRIPTION
This PR ensures that DRAKVUF doesn't try to resolve `ObTypeIndexTable` and `ObpInfoMaskToOffset` kernel symbols on Windows Vista, as those are not present in that OS version.

This small change allows several plugins such as `regmon`, `objmon`, and others to work under Windows Vista SP2 x64 and x86 (see issue [#1831](https://github.com/tklengyel/drakvuf/issues/1831) for more information). 

Further adjustments to plugin behavior for Vista support may follow in a later PR - for instance for `callbackmon` that fails at startup.
