### PR TITLE
Fix: changed make_hook_id to not overwrite return hook when apicall was nested

### DIFF
--- a/src/plugins/apimon/apimon.cpp
+++ b/src/plugins/apimon/apimon.cpp
@@ -123,17 +123,11 @@ struct ApimonReturnHookData : PluginResult
 
 }
 
-static uint64_t make_hook_id(const drakvuf_trap_info_t* info, addr_t target_rsp)
+static std::pair<uint64_t, addr_t> make_hook_id(const drakvuf_trap_info_t* info, addr_t target_rsp)
 {
-    /*
-    This function doesn't have to be exact. We're taking here the low 18-bit part of PID/TID
-    (without 2 LSB that are always zeroed on Windows) and low 32-bit part of target_rsp
-    which identifies the stack pointer at the time when pre-hook was fired.
-    */
-    uint64_t pid_part = (info->attached_proc_data.pid >> 2) & 0xFFFF;
-    uint64_t tid_part = (info->attached_proc_data.tid >> 2) & 0xFFFF;
-    uint64_t u64_target_rsp = static_cast<uint64_t>(target_rsp) & 0xFFFFFFFF;
-    return (u64_target_rsp << 32) | (pid_part << 16) | (tid_part);
+    uint64_t u64_pid = info->attached_proc_data.pid;
+    uint64_t u64_tid = info->attached_proc_data.tid;
+    return std::make_pair((u64_pid << 32) | u64_tid, target_rsp);
 }
 
 static event_response_t delete_process_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
@@ -209,7 +203,7 @@ event_response_t apimon::usermode_return_hook_cb(drakvuf_t drakvuf, drakvuf_trap
 
     usermode_print(info, params->arguments, params->target);
 
-    uint64_t hookID = make_hook_id(info, params->target_rsp);
+    auto hookID = make_hook_id(info, params->target_rsp);
     ret_hooks.erase(hookID);
 
     return VMI_EVENT_RESPONSE_NONE;
@@ -260,7 +254,7 @@ static event_response_t usermode_hook_cb(drakvuf_t drakvuf, drakvuf_trap_info* i
         auto hook = plugin->createReturnHook<ApimonReturnHookData>(info,
                 &apimon::usermode_return_hook_cb, target->target_name.data(), drakvuf_get_limited_traps_ttl(drakvuf));
         auto params = libhook::GetTrapParams<ApimonReturnHookData>(hook->trap_);
-        uint64_t hookID = make_hook_id(info, params->target_rsp);
+        auto hookID = make_hook_id(info, params->target_rsp);
 
         params->arguments = std::move(arguments);
         params->target = target;

--- a/src/plugins/apimon/apimon.cpp
+++ b/src/plugins/apimon/apimon.cpp
@@ -123,11 +123,17 @@ struct ApimonReturnHookData : PluginResult
 
 }
 
-static uint64_t make_hook_id(const drakvuf_trap_info_t* info)
+static uint64_t make_hook_id(const drakvuf_trap_info_t* info, addr_t target_rsp)
 {
-    uint64_t u64_pid = info->attached_proc_data.pid;
-    uint64_t u64_tid = info->attached_proc_data.tid;
-    return (u64_pid << 32) | u64_tid;
+    /*
+    This function doesn't have to be exact. We're taking here the low 18-bit part of PID/TID
+    (without 2 LSB that are always zeroed on Windows) and low 32-bit part of target_rsp
+    which identifies the stack pointer at the time when pre-hook was fired.
+    */
+    uint64_t pid_part = (info->attached_proc_data.pid >> 2) & 0xFFFF;
+    uint64_t tid_part = (info->attached_proc_data.tid >> 2) & 0xFFFF;
+    uint64_t u64_target_rsp = static_cast<uint64_t>(target_rsp) & 0xFFFFFFFF;
+    return (u64_target_rsp << 32) | (pid_part << 16) | (tid_part);
 }
 
 static event_response_t delete_process_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
@@ -203,7 +209,7 @@ event_response_t apimon::usermode_return_hook_cb(drakvuf_t drakvuf, drakvuf_trap
 
     usermode_print(info, params->arguments, params->target);
 
-    uint64_t hookID = make_hook_id(info);
+    uint64_t hookID = make_hook_id(info, params->target_rsp);
     ret_hooks.erase(hookID);
 
     return VMI_EVENT_RESPONSE_NONE;
@@ -251,10 +257,10 @@ static event_response_t usermode_hook_cb(drakvuf_t drakvuf, drakvuf_trap_info* i
     }
     else
     {
-        uint64_t hookID = make_hook_id(info);
         auto hook = plugin->createReturnHook<ApimonReturnHookData>(info,
                 &apimon::usermode_return_hook_cb, target->target_name.data(), drakvuf_get_limited_traps_ttl(drakvuf));
         auto params = libhook::GetTrapParams<ApimonReturnHookData>(hook->trap_);
+        uint64_t hookID = make_hook_id(info, params->target_rsp);
 
         params->arguments = std::move(arguments);
         params->target = target;

--- a/src/plugins/apimon/apimon.h
+++ b/src/plugins/apimon/apimon.h
@@ -145,7 +145,7 @@ public:
 
     void usermode_print(drakvuf_trap_info*, std::vector<uint64_t>&, hook_target_entry_t*);
 
-    std::map<uint64_t, std::unique_ptr<libhook::ReturnHook>> ret_hooks;
+    std::map<std::pair<uint64_t, addr_t>, std::unique_ptr<libhook::ReturnHook>> ret_hooks;
 };
 
 #endif


### PR DESCRIPTION
When hooked API function is called, apimon stores the return (post) hook in `plugin->ret_hooks` hashmap. Unfortunately, the key in that hashmap is composed only from PID and TID, so when hooked function calls another hooked function, the previous return hook reference is overwritten.

When hook reference kept by `plugin->ret_hooks` is overwritten, the previous unique_ptr reference is destroyed, so the return hook is unhooked. Finally, we lose information about the original call and see only the last nested call.

**What's changed**

I changed `make_hook_id` function to include stored target_rsp for pre-hook to actually identify a function call. I have included only 18-bits part of PID/TID (assuming 2 LSB are always zeroed as PID/TID are aligned to 4) and 32-bit part of the RSP. I believe that collision is almost impossible for such composed ID. In addition, we don't even use that ID for actual pre->post-hook correlation, it's used just for keeping the reference to the active return hook.

**Reproduction and tests**

I have noticed this issue while tracking a call to InternetOpenUrlW. Before applying this patch I've observed only InternetOpenUrlA or InternetCrackUrlW - the functions that are called internally by InternetOpenUrlW.

```
{"Plugin":"apimon","TimeStamp":"1753363436.781452","PID":5884,"PPID":3808,"TID":8856,"UserId":1,"ProcessName":"\\Device\\HarddiskVolume2\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe","Method":"InternetOpenW","EventUID":"0xd93ff","Event":"api_called","CLSID":null,"CalledFrom":"0x7ffc5e4f6bca","ReturnValue":"0xcc0004","FromModule":null,"Arguments":["Arg0=0x21899b7142c:\"\"","Arg1=0x0","Arg2=0x21899b7142c:\"\"","Arg3=0x21899b7142c:\"\"","Arg4=0x0"]}
{"Plugin":"apimon","TimeStamp":"1753363439.280075","PID":5884,"PPID":3808,"TID":8856,"UserId":1,"ProcessName":"\\Device\\HarddiskVolume2\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe","Method":"InternetOpenUrlA","EventUID":"0xed347","Event":"api_called","CLSID":null,"CalledFrom":"0x7ffcc02c8dca","ReturnValue":"0xcc000c","FromModule":"wininet.dll","Arguments":["Arg0=0xcc0004","Arg1=0x218b23bae40:\"https://google.com/hello?args=1\"","Arg2=0x218b233b4c0:\"\"","Arg3=0x0","Arg4=0x6700000000","Arg5=0x0"]}
```

After applying this patch, I see all functions that are actually code, including nested ones:

```
{"Plugin":"apimon","TimeStamp":"1753364519.384441","PID":7544,"PPID":3808,"TID":4104,"UserId":1,"ProcessName":"\\Device\\HarddiskVolume2\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe","Method":"InternetOpenW","EventUID":"0x8ef74","Event":"api_called","CLSID":null,"CalledFrom":"0x7ffc5e525f9a","ReturnValue":"0xcc0008","FromModule":null,"Arguments":["Arg0=0x1fc8000142c:\"\"","Arg1=0x0","Arg2=0x1fc8000142c:\"\"","Arg3=0x1fc8000142c:\"\"","Arg4=0x0"]}
{"Plugin":"apimon","TimeStamp":"1753364520.667964","PID":7544,"PPID":3808,"TID":4104,"UserId":1,"ProcessName":"\\Device\\HarddiskVolume2\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe","Method":"InternetOpenUrlA","EventUID":"0x8f531","Event":"api_called","CLSID":null,"CalledFrom":"0x7ffcc02c8dca","ReturnValue":"0xcc0010","FromModule":"wininet.dll","Arguments":["Arg0=0xcc0008","Arg1=0x1fcf39e0440:\"https://shorturl.at/YnXBp\"","Arg2=0x1fcf16f16e0:\"\"","Arg3=0x0","Arg4=0x1400000000","Arg5=0x0"]}
{"Plugin":"apimon","TimeStamp":"1753364520.668910","PID":7544,"PPID":3808,"TID":4104,"UserId":1,"ProcessName":"\\Device\\HarddiskVolume2\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe","Method":"InternetOpenUrlW","EventUID":"0x8f532","Event":"api_called","CLSID":null,"CalledFrom":"0x7ffc5e52721d","ReturnValue":"0xcc0010","FromModule":null,"Arguments":["Arg0=0xcc0008","Arg1=0x1fc80693a44:\"https://shorturl.at/YnXBp\"","Arg2=0x1fc8000142c:\"\"","Arg3=0x0","Arg4=0x0","Arg5=0x0"]}
```
