### PR TITLE
Fix potential use-after-free in trap->name set by userhook on running process

### DIFF
--- a/src/libusermode/running.cpp
+++ b/src/libusermode/running.cpp
@@ -322,16 +322,17 @@ event_response_t hook_process_cb(
 
     // We have managed to resolve the physical address. Place the trap.
     drakvuf_trap_t* trap = new drakvuf_trap_t();
+    auto trap_rh_data = new rh_data_t(*rh_data);
     trap->type = BREAKPOINT;
-    trap->name = rh_data->func_name.c_str();
+    trap->name = trap_rh_data->func_name.c_str();
     trap->cb = rh_data->cb;
-    trap->data = rh_data->extra;
+    trap->data = trap_rh_data;
     trap->breakpoint.lookup_type = LOOKUP_NONE;
     trap->breakpoint.addr_type = ADDR_PA;
     trap->breakpoint.addr = func_pa;
     trap->ttl = drakvuf_get_limited_traps_ttl(drakvuf);
     if (!userhook_plugin->add_running_trap(drakvuf, trap))
-        delete trap;
+        rh_data_t::free_trap(trap);
 
     userhook_plugin->remove_running_rh_trap(drakvuf, info->trap);
     return VMI_EVENT_RESPONSE_NONE;

--- a/src/plugins/tlsmon/tlsmon.cpp
+++ b/src/plugins/tlsmon/tlsmon.cpp
@@ -114,6 +114,7 @@
 #include "private.h"
 #include "tlsmon.h"
 
+#include "libusermode/uh-private.hpp"
 
 
 struct ssl_generate_master_key_result_t: public call_result_t
@@ -246,8 +247,8 @@ event_response_t ssl_generate_master_key_ret_cb(drakvuf_t drakvuf, drakvuf_trap_
 static
 event_response_t ssl_generate_master_key_cb(drakvuf_t drakvuf, drakvuf_trap_info* info)
 {
-    tlsmon* plugin = static_cast<tlsmon*>(info->trap->data);
-
+    auto rh_data = static_cast<rh_data_t *>(info->trap->data);
+    auto plugin = static_cast<tlsmon *>(rh_data->extra);
     auto trap = plugin->register_trap<ssl_generate_master_key_result_t>(
             info,
             ssl_generate_master_key_ret_cb,


### PR DESCRIPTION
When I tried to log an WinAPI function call trapped by `drakvuf_request_userhook_on_running_process`, I noticed that I'm getting some junk in "Method" key. It was caused by use-after-free bug.

The usual pattern in the `running.cpp` code is to keep rh_data object in `trap->data`. This object keeps additional context information about requested trap. `trap->data` is owned by `drakvuf_trap_t` and freed along with the trap using `rh_data_t::free_trap` method.

https://github.com/tklengyel/drakvuf/blob/22d35c37403aeef61135ddc0ddd11a207f9b05c4/src/libusermode/running.cpp#L383

Unfortunately, in the final callback (that is actually setting a trap on a target function), someone took a shortcut and passed `rh_data->extra` to the trap. In the same time, pointer from rh_data is used in `trap->name` (`trap->name = rh_data->func_name.c_str();`). As soon as trap is set: rh_data is freed by call to `free_trap` or `remove_running_rh_trap`

To fix that, I've followed the pattern from previous traps and made a copy of rh_data that is attached to `trap->data`. Then `trap->name` can safely refer to the `trap->data->func_name`. This type of trap should be freed using `remove_running_rh_trap` as the previous traps.