### PR TITLE
Fix/refactor usage of make_hook_id in pulgins

### DIFF
--- a/src/libhook/libhook.hpp
+++ b/src/libhook/libhook.hpp
@@ -152,4 +152,3 @@
  *  - get hook from trap
  *  - call callback stored in hook
  */
-

--- a/src/libhook/libhook.hpp
+++ b/src/libhook/libhook.hpp
@@ -152,3 +152,11 @@
  *  - get hook from trap
  *  - call callback stored in hook
  */
+
+ 
+static std::pair<uint64_t, addr_t> make_hook_id(const drakvuf_trap_info_t* info, addr_t target_rsp)
+{
+    uint64_t u64_pid = info->attached_proc_data.pid;
+    uint64_t u64_tid = info->attached_proc_data.tid;
+    return std::make_pair((u64_pid << 32) | u64_tid, target_rsp);
+}

--- a/src/libhook/libhook.hpp
+++ b/src/libhook/libhook.hpp
@@ -153,10 +153,3 @@
  *  - call callback stored in hook
  */
 
- 
-static std::pair<uint64_t, addr_t> make_hook_id(const drakvuf_trap_info_t* info, addr_t target_rsp)
-{
-    uint64_t u64_pid = info->attached_proc_data.pid;
-    uint64_t u64_tid = info->attached_proc_data.tid;
-    return std::make_pair((u64_pid << 32) | u64_tid, target_rsp);
-}

--- a/src/plugins/apimon/apimon.cpp
+++ b/src/plugins/apimon/apimon.cpp
@@ -123,12 +123,6 @@ struct ApimonReturnHookData : PluginResult
 
 }
 
-static std::pair<uint64_t, addr_t> make_hook_id(const drakvuf_trap_info_t* info, addr_t target_rsp)
-{
-    uint64_t u64_pid = info->attached_proc_data.pid;
-    uint64_t u64_tid = info->attached_proc_data.tid;
-    return std::make_pair((u64_pid << 32) | u64_tid, target_rsp);
-}
 
 static event_response_t delete_process_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 {

--- a/src/plugins/fileextractor/win.cpp
+++ b/src/plugins/fileextractor/win.cpp
@@ -189,7 +189,7 @@ event_response_t win_fileextractor::createfile_ret_cb(drakvuf_t,
     if (!params_copy.verifyResultCallParams(drakvuf, info))
         return VMI_EVENT_RESPONSE_NONE;
 
-    auto hook_id = make_hook_id(info, params_copy->target_rsp);
+    auto hook_id = make_hook_id(info, params_copy.target_rsp);
     createfile_ret_hooks.erase(hook_id);
 
     // Return if NtCreateFile/NtOpenFile failed
@@ -515,7 +515,7 @@ event_response_t win_fileextractor::writefile_ret_cb(drakvuf_t drakvuf,
     if (!params_copy.verifyResultCallParams(drakvuf, info))
         return VMI_EVENT_RESPONSE_NONE;
 
-    auto hook_id = make_hook_id(info, params_copy->target_rsp);
+    auto hook_id = make_hook_id(info, params_copy.target_rsp);
     writefile_ret_hooks.erase(hook_id);
 
     // Return if NtWriteFile failed

--- a/src/plugins/fileextractor/win.cpp
+++ b/src/plugins/fileextractor/win.cpp
@@ -171,7 +171,6 @@ void win_fileextractor::createfile_cb_impl(drakvuf_t,
     drakvuf_trap_info_t* info,
     addr_t handle, bool del, bool append)
 {
-    auto hook_id = make_hook_id(info);
     auto hook = createReturnHook<createfile_result_t>(info,
             &win_fileextractor::createfile_ret_cb);
     auto params = libhook::GetTrapParams<createfile_result_t>(hook->trap_);
@@ -179,6 +178,7 @@ void win_fileextractor::createfile_cb_impl(drakvuf_t,
     params->append = append;
     params->del = del;
 
+    auto hook_id = make_hook_id(info, params->target_rsp);
     createfile_ret_hooks[hook_id] = std::move(hook);
 }
 
@@ -189,7 +189,7 @@ event_response_t win_fileextractor::createfile_ret_cb(drakvuf_t,
     if (!params_copy.verifyResultCallParams(drakvuf, info))
         return VMI_EVENT_RESPONSE_NONE;
 
-    auto hook_id = make_hook_id(info);
+    auto hook_id = make_hook_id(info, params_copy->target_rsp);
     createfile_ret_hooks.erase(hook_id);
 
     // Return if NtCreateFile/NtOpenFile failed
@@ -479,7 +479,6 @@ void win_fileextractor::writefile_cb_impl(drakvuf_t,
     task_t& task, uint64_t str, uint64_t len)
 {
     // return hook setup
-    auto hook_id = make_hook_id(info);
     auto hook = createReturnHook<writefile_result_t>(info,
             &win_fileextractor::writefile_ret_cb);
     auto params = libhook::GetTrapParams<writefile_result_t>(hook->trap_);
@@ -499,6 +498,7 @@ void win_fileextractor::writefile_cb_impl(drakvuf_t,
     else
         params->byteoffset = FILE_WRITE_TO_END_OF_FILE;
 
+    auto hook_id = make_hook_id(info, params->target_rsp);
     writefile_ret_hooks[hook_id] = std::move(hook);
 }
 
@@ -515,7 +515,7 @@ event_response_t win_fileextractor::writefile_ret_cb(drakvuf_t drakvuf,
     if (!params_copy.verifyResultCallParams(drakvuf, info))
         return VMI_EVENT_RESPONSE_NONE;
 
-    auto hook_id = make_hook_id(info);
+    auto hook_id = make_hook_id(info, params_copy->target_rsp);
     writefile_ret_hooks.erase(hook_id);
 
     // Return if NtWriteFile failed
@@ -1712,13 +1712,6 @@ void win_fileextractor::dump_mem_to_file(uint64_t cr3, addr_t str, int idx, uint
     }
 
     return;
-}
-
-uint64_t win_fileextractor::make_hook_id(drakvuf_trap_info_t* info)
-{
-    uint64_t u64_pid = info->attached_proc_data.pid;
-    uint64_t u64_tid = info->attached_proc_data.tid;
-    return (u64_pid << 32) | u64_tid;
 }
 
 uint64_t win_fileextractor::make_task_id(vmi_pid_t pid, handle_t handle)

--- a/src/plugins/fileextractor/win.h
+++ b/src/plugins/fileextractor/win.h
@@ -242,7 +242,6 @@ private:
         void* buffer,
         size_t size);
     void dump_mem_to_file(uint64_t cr3, addr_t str, int idx, uint64_t offset, size_t size);
-    uint64_t make_hook_id(drakvuf_trap_info_t*);
     uint64_t make_task_id(vmi_pid_t pid, handle_t handle);
     uint64_t make_task_id(task_t&);
     void free_pool(addr_t va);

--- a/src/plugins/fileextractor/win.h
+++ b/src/plugins/fileextractor/win.h
@@ -165,8 +165,8 @@ private:
     std::unique_ptr<libhook::SyscallHook> createsection_hook;
     std::unique_ptr<libhook::SyscallHook> createfile_hook;
     std::unique_ptr<libhook::SyscallHook> openfile_hook;
-    std::map<uint64_t, std::unique_ptr<libhook::ReturnHook>> createfile_ret_hooks;
-    std::map<uint64_t, std::unique_ptr<libhook::ReturnHook>> writefile_ret_hooks;
+    std::map<std::pair<uint64_t, addr_t>, std::unique_ptr<libhook::ReturnHook>> createfile_ret_hooks;
+    std::map<std::pair<uint64_t, addr_t>, std::unique_ptr<libhook::ReturnHook>> writefile_ret_hooks;
 
     /* VA of functions to be injected */
     addr_t queryvolumeinfo_va = 0;

--- a/src/plugins/filetracer/linux.cpp
+++ b/src/plugins/filetracer/linux.cpp
@@ -273,7 +273,7 @@ event_response_t linux_filetracer::open_file_ret_cb(drakvuf_t drakvuf, drakvuf_t
         if (get_file_info(drakvuf, info, params, file_struct))
             print_info(drakvuf, info, params);
 
-    uint64_t hookID = make_hook_id(info, params->target_rsp);
+    auto hookID = make_hook_id(info, params->target_rsp);
     this->ret_hooks.erase(hookID);
     return VMI_EVENT_RESPONSE_NONE;
 }
@@ -300,7 +300,7 @@ event_response_t linux_filetracer::open_file_cb(drakvuf_t drakvuf, drakvuf_trap_
     // Save data
     params->setResultCallParams(drakvuf, info);
 
-    uint64_t hookID = make_hook_id(info, params->target_rsp);
+    auto hookID = make_hook_id(info, params->target_rsp);
     this->ret_hooks[hookID] = std::move(hook);
 
     return VMI_EVENT_RESPONSE_NONE;
@@ -423,7 +423,7 @@ event_response_t linux_filetracer::memfd_create_file_ret_cb(drakvuf_t drakvuf, d
     if (params->file_handle > -1 && !params->filename.empty())
         print_info(drakvuf, info, params);
 
-    uint64_t hookID = make_hook_id(info, params->target_rsp);
+    auto hookID = make_hook_id(info, params->target_rsp);
     this->ret_hooks.erase(hookID);
     return VMI_EVENT_RESPONSE_NONE;
 }
@@ -473,7 +473,7 @@ event_response_t linux_filetracer::memfd_create_file_cb(drakvuf_t drakvuf, drakv
 
     params->flags = parse_flags(flags, linux_memfd_flags, this->m_output_format);
 
-    uint64_t hookID = make_hook_id(info, params->target_rsp);
+    auto hookID = make_hook_id(info, params->target_rsp);
     this->ret_hooks[hookID] = std::move(hook);
 
     return VMI_EVENT_RESPONSE_NONE;

--- a/src/plugins/filetracer/linux.cpp
+++ b/src/plugins/filetracer/linux.cpp
@@ -125,13 +125,6 @@ static std::string to_oct_str(uint64_t n)
     return ss.str();
 }
 
-uint64_t linux_filetracer::make_hook_id(drakvuf_trap_info_t* info)
-{
-    uint64_t u64_pid = info->proc_data.pid;
-    uint64_t u64_tid = info->proc_data.tid;
-    return (u64_pid << 32) | u64_tid;
-}
-
 /* -----------------FILE INFO PARSING------------------ */
 
 bool linux_filetracer::get_file_info(drakvuf_t drakvuf, drakvuf_trap_info_t* info, linux_data* params, addr_t file_addr)
@@ -280,7 +273,7 @@ event_response_t linux_filetracer::open_file_ret_cb(drakvuf_t drakvuf, drakvuf_t
         if (get_file_info(drakvuf, info, params, file_struct))
             print_info(drakvuf, info, params);
 
-    uint64_t hookID = make_hook_id(info);
+    uint64_t hookID = make_hook_id(info, params->target_rsp);
     this->ret_hooks.erase(hookID);
     return VMI_EVENT_RESPONSE_NONE;
 }
@@ -301,13 +294,13 @@ event_response_t linux_filetracer::open_file_cb(drakvuf_t drakvuf, drakvuf_trap_
         return VMI_EVENT_RESPONSE_NONE;
 
     // Create new trap for return callback
-    uint64_t hookID = make_hook_id(info);
     auto hook = this->createReturnHook<linux_data>(info, &linux_filetracer::open_file_ret_cb, info->trap->name);
     auto params = libhook::GetTrapParams<linux_data>(hook->trap_);
 
     // Save data
     params->setResultCallParams(drakvuf, info);
 
+    uint64_t hookID = make_hook_id(info, params->target_rsp);
     this->ret_hooks[hookID] = std::move(hook);
 
     return VMI_EVENT_RESPONSE_NONE;
@@ -430,7 +423,7 @@ event_response_t linux_filetracer::memfd_create_file_ret_cb(drakvuf_t drakvuf, d
     if (params->file_handle > -1 && !params->filename.empty())
         print_info(drakvuf, info, params);
 
-    uint64_t hookID = make_hook_id(info);
+    uint64_t hookID = make_hook_id(info, params->target_rsp);
     this->ret_hooks.erase(hookID);
     return VMI_EVENT_RESPONSE_NONE;
 }
@@ -468,7 +461,6 @@ event_response_t linux_filetracer::memfd_create_file_cb(drakvuf_t drakvuf, drakv
 
 
     // Create new trap for return callback
-    uint64_t hookID = make_hook_id(info);
     auto hook = this->createReturnHook<linux_data>(info, &linux_filetracer::memfd_create_file_ret_cb, info->trap->name);
     auto params = libhook::GetTrapParams<linux_data>(hook->trap_);
 
@@ -481,6 +473,7 @@ event_response_t linux_filetracer::memfd_create_file_cb(drakvuf_t drakvuf, drakv
 
     params->flags = parse_flags(flags, linux_memfd_flags, this->m_output_format);
 
+    uint64_t hookID = make_hook_id(info, params->target_rsp);
     this->ret_hooks[hookID] = std::move(hook);
 
     return VMI_EVENT_RESPONSE_NONE;

--- a/src/plugins/filetracer/linux.h
+++ b/src/plugins/filetracer/linux.h
@@ -145,7 +145,7 @@ public:
     std::unique_ptr<libhook::SyscallHook> read_link_hook;
 
     /* Return hooks */
-    std::unordered_map<uint64_t, std::unique_ptr<libhook::ReturnHook>> ret_hooks;
+    std::map<std::pair<uint64_t, addr_t>, std::unique_ptr<libhook::ReturnHook>> ret_hooks;
 
     /* Callbacks */
     // File operations callbacks

--- a/src/plugins/filetracer/linux.h
+++ b/src/plugins/filetracer/linux.h
@@ -180,7 +180,6 @@ public:
     event_response_t memfd_create_file_ret_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
 
     /* Helper functions */
-    uint64_t make_hook_id(drakvuf_trap_info_t* info);
     void print_info(drakvuf_t drakvuf, drakvuf_trap_info_t* info, linux_data* params);
 
     /* File info parsing */

--- a/src/plugins/filetracer/win.cpp
+++ b/src/plugins/filetracer/win.cpp
@@ -901,7 +901,7 @@ event_response_t win_filetracer::query_attributes_file_cb(drakvuf_t drakvuf, dra
     params->file_information = file_information;
     params->rsp = ret_addr;
 
-        auto hookID = make_hook_id(info, params->target_rsp);
+    auto hookID = make_hook_id(info, params->target_rsp);
     this->ret_hooks[hookID] = std::move(hook);
 
     return VMI_EVENT_RESPONSE_NONE;

--- a/src/plugins/filetracer/win.cpp
+++ b/src/plugins/filetracer/win.cpp
@@ -112,13 +112,6 @@ using namespace filetracer_ns;
 
 extern const flags_str_t generic_ar;
 
-static uint64_t make_hook_id(const drakvuf_trap_info_t* info)
-{
-    uint64_t u64_pid = info->attached_proc_data.pid;
-    uint64_t u64_tid = info->attached_proc_data.tid;
-    return (u64_pid << 32) | u64_tid;
-}
-
 static uint64_t windows_tick_to_unix(long long windowsTicks)
 {
     uint64_t windows_tick = 10000000UL;
@@ -698,7 +691,7 @@ event_response_t win_filetracer::create_file_ret_cb(drakvuf_t drakvuf, drakvuf_t
     if (succ)
         print_create_file_obj_info(drakvuf, info, handle, io_information, file_attrs, params, info->regs->rax);
 
-    uint64_t hookID = make_hook_id(info);
+    uint64_t hookID = make_hook_id(info, params->target_rsp);
     this->ret_hooks.erase(hookID);
     return VMI_EVENT_RESPONSE_NONE;
 }
@@ -739,7 +732,6 @@ event_response_t win_filetracer::create_file_cb(drakvuf_t drakvuf, drakvuf_trap_
     }
 
     // Create new trap for return callback
-    uint64_t hookID = make_hook_id(info);
     auto hook = this->createReturnHook<win_data>(info, &win_filetracer::create_file_ret_cb, info->trap->name);
     auto params = libhook::GetTrapParams<win_data>(hook->trap_);
 
@@ -756,6 +748,7 @@ event_response_t win_filetracer::create_file_cb(drakvuf_t drakvuf, drakvuf_trap_
     params->desired_access = desired_access;
     params->rsp = ret_addr;
 
+    uint64_t hookID = make_hook_id(info, params->target_rsp);
     this->ret_hooks[hookID] = std::move(hook);
 
     return VMI_EVENT_RESPONSE_NONE;
@@ -797,7 +790,7 @@ event_response_t win_filetracer::open_file_ret_cb(drakvuf_t drakvuf, drakvuf_tra
     if (succ)
         print_open_file_obj_info(drakvuf, info, handle, io_information, file_attrs, params, info->regs->rax);
 
-    uint64_t hookID = make_hook_id(info);
+    uint64_t hookID = make_hook_id(info, params->target_rsp);
     this->ret_hooks.erase(hookID);
     return VMI_EVENT_RESPONSE_NONE;
 }
@@ -829,7 +822,6 @@ event_response_t win_filetracer::open_file_cb(drakvuf_t drakvuf, drakvuf_trap_in
         return VMI_EVENT_RESPONSE_NONE;
     }
 
-    uint64_t hookID = make_hook_id(info);
     auto hook = this->createReturnHook<win_data>(info, &win_filetracer::open_file_ret_cb, info->trap->name);
     auto params = libhook::GetTrapParams<win_data>(hook->trap_);
 
@@ -844,6 +836,7 @@ event_response_t win_filetracer::open_file_cb(drakvuf_t drakvuf, drakvuf_trap_in
     params->desired_access = desired_access;
     params->rsp = ret_addr;
 
+    uint64_t hookID = make_hook_id(info, prarms->target_rsp);
     this->ret_hooks[hookID] = std::move(hook);
 
     return VMI_EVENT_RESPONSE_NONE;
@@ -880,7 +873,7 @@ event_response_t win_filetracer::query_attributes_file_ret_cb(drakvuf_t drakvuf,
     if (succ_1 && succ_2)
         print_file_query_attributes(drakvuf, info, file_attrs, file_info, info->regs->rax);
 
-    uint64_t hookID = make_hook_id(info);
+    uint64_t hookID = make_hook_id(info, params->target_rsp);
     this->ret_hooks.erase(hookID);
     return VMI_EVENT_RESPONSE_NONE;
 }
@@ -898,7 +891,6 @@ event_response_t win_filetracer::query_attributes_file_cb(drakvuf_t drakvuf, dra
 
     addr_t ret_addr = drakvuf_get_function_return_address(drakvuf, info);
 
-    uint64_t hookID = make_hook_id(info);
     auto hook = this->createReturnHook<win_data>(info, &win_filetracer::query_attributes_file_ret_cb, info->trap->name);
     auto params = libhook::GetTrapParams<win_data>(hook->trap_);
 
@@ -909,6 +901,7 @@ event_response_t win_filetracer::query_attributes_file_cb(drakvuf_t drakvuf, dra
     params->file_information = file_information;
     params->rsp = ret_addr;
 
+        uint64_t hookID = make_hook_id(info, params->target_rsp);
     this->ret_hooks[hookID] = std::move(hook);
 
     return VMI_EVENT_RESPONSE_NONE;
@@ -927,7 +920,7 @@ event_response_t win_filetracer::query_full_attributes_file_ret_cb(drakvuf_t dra
     if (succ_1 && succ_2)
         print_file_query_full_attributes(drakvuf, info, file_attrs, file_info, info->regs->rax);
 
-    uint64_t hookID = make_hook_id(info);
+    uint64_t hookID = make_hook_id(info, params->target_rsp);
     this->ret_hooks.erase(hookID);
     return VMI_EVENT_RESPONSE_NONE;
 }
@@ -945,7 +938,6 @@ event_response_t win_filetracer::query_full_attributes_file_cb(drakvuf_t drakvuf
 
     addr_t ret_addr = drakvuf_get_function_return_address(drakvuf, info);
 
-    uint64_t hookID = make_hook_id(info);
     auto hook = this->createReturnHook<win_data>(info, &win_filetracer::query_attributes_file_ret_cb, info->trap->name);
     auto params = libhook::GetTrapParams<win_data>(hook->trap_);
 
@@ -956,6 +948,7 @@ event_response_t win_filetracer::query_full_attributes_file_cb(drakvuf_t drakvuf
     params->file_information = file_information;
     params->rsp = ret_addr;
 
+    uint64_t hookID = make_hook_id(info, params->target_rsp);
     this->ret_hooks[hookID] = std::move(hook);
 
     return VMI_EVENT_RESPONSE_NONE;
@@ -1092,7 +1085,7 @@ event_response_t win_filetracer::query_information_file_ret_cb(drakvuf_t drakvuf
             break;
     };
 
-    uint64_t hookID = make_hook_id(info);
+    uint64_t hookID = make_hook_id(info, params->target_rsp);
     this->ret_hooks.erase(hookID);
     return VMI_EVENT_RESPONSE_NONE;
 }
@@ -1117,7 +1110,6 @@ event_response_t win_filetracer::query_information_file_cb(drakvuf_t drakvuf, dr
         addr_t ret_addr = drakvuf_get_function_return_address(drakvuf, info);
 
         // Create new trap for return callback
-        uint64_t hookID = make_hook_id(info);
         auto hook = this->createReturnHook<win_data>(info, &win_filetracer::query_information_file_ret_cb, info->trap->name);
         auto params = libhook::GetTrapParams<win_data>(hook->trap_);
 
@@ -1129,6 +1121,7 @@ event_response_t win_filetracer::query_information_file_cb(drakvuf_t drakvuf, dr
         params->file_information = fileinfo;
         params->file_information_class = fileinfoclass;
 
+        uint64_t hookID = make_hook_id(info, params->target_rsp);
         this->ret_hooks[hookID] = std::move(hook);
     }
 

--- a/src/plugins/filetracer/win.cpp
+++ b/src/plugins/filetracer/win.cpp
@@ -691,7 +691,7 @@ event_response_t win_filetracer::create_file_ret_cb(drakvuf_t drakvuf, drakvuf_t
     if (succ)
         print_create_file_obj_info(drakvuf, info, handle, io_information, file_attrs, params, info->regs->rax);
 
-    uint64_t hookID = make_hook_id(info, params->target_rsp);
+    auto hookID = make_hook_id(info, params->target_rsp);
     this->ret_hooks.erase(hookID);
     return VMI_EVENT_RESPONSE_NONE;
 }
@@ -748,7 +748,7 @@ event_response_t win_filetracer::create_file_cb(drakvuf_t drakvuf, drakvuf_trap_
     params->desired_access = desired_access;
     params->rsp = ret_addr;
 
-    uint64_t hookID = make_hook_id(info, params->target_rsp);
+    auto hookID = make_hook_id(info, params->target_rsp);
     this->ret_hooks[hookID] = std::move(hook);
 
     return VMI_EVENT_RESPONSE_NONE;
@@ -790,7 +790,7 @@ event_response_t win_filetracer::open_file_ret_cb(drakvuf_t drakvuf, drakvuf_tra
     if (succ)
         print_open_file_obj_info(drakvuf, info, handle, io_information, file_attrs, params, info->regs->rax);
 
-    uint64_t hookID = make_hook_id(info, params->target_rsp);
+    auto hookID = make_hook_id(info, params->target_rsp);
     this->ret_hooks.erase(hookID);
     return VMI_EVENT_RESPONSE_NONE;
 }
@@ -836,7 +836,7 @@ event_response_t win_filetracer::open_file_cb(drakvuf_t drakvuf, drakvuf_trap_in
     params->desired_access = desired_access;
     params->rsp = ret_addr;
 
-    uint64_t hookID = make_hook_id(info, prarms->target_rsp);
+    auto hookID = make_hook_id(info, params->target_rsp);
     this->ret_hooks[hookID] = std::move(hook);
 
     return VMI_EVENT_RESPONSE_NONE;
@@ -873,7 +873,7 @@ event_response_t win_filetracer::query_attributes_file_ret_cb(drakvuf_t drakvuf,
     if (succ_1 && succ_2)
         print_file_query_attributes(drakvuf, info, file_attrs, file_info, info->regs->rax);
 
-    uint64_t hookID = make_hook_id(info, params->target_rsp);
+    auto hookID = make_hook_id(info, params->target_rsp);
     this->ret_hooks.erase(hookID);
     return VMI_EVENT_RESPONSE_NONE;
 }
@@ -901,7 +901,7 @@ event_response_t win_filetracer::query_attributes_file_cb(drakvuf_t drakvuf, dra
     params->file_information = file_information;
     params->rsp = ret_addr;
 
-        uint64_t hookID = make_hook_id(info, params->target_rsp);
+        auto hookID = make_hook_id(info, params->target_rsp);
     this->ret_hooks[hookID] = std::move(hook);
 
     return VMI_EVENT_RESPONSE_NONE;
@@ -920,7 +920,7 @@ event_response_t win_filetracer::query_full_attributes_file_ret_cb(drakvuf_t dra
     if (succ_1 && succ_2)
         print_file_query_full_attributes(drakvuf, info, file_attrs, file_info, info->regs->rax);
 
-    uint64_t hookID = make_hook_id(info, params->target_rsp);
+    auto hookID = make_hook_id(info, params->target_rsp);
     this->ret_hooks.erase(hookID);
     return VMI_EVENT_RESPONSE_NONE;
 }
@@ -948,7 +948,7 @@ event_response_t win_filetracer::query_full_attributes_file_cb(drakvuf_t drakvuf
     params->file_information = file_information;
     params->rsp = ret_addr;
 
-    uint64_t hookID = make_hook_id(info, params->target_rsp);
+    auto hookID = make_hook_id(info, params->target_rsp);
     this->ret_hooks[hookID] = std::move(hook);
 
     return VMI_EVENT_RESPONSE_NONE;
@@ -1085,7 +1085,7 @@ event_response_t win_filetracer::query_information_file_ret_cb(drakvuf_t drakvuf
             break;
     };
 
-    uint64_t hookID = make_hook_id(info, params->target_rsp);
+    auto hookID = make_hook_id(info, params->target_rsp);
     this->ret_hooks.erase(hookID);
     return VMI_EVENT_RESPONSE_NONE;
 }
@@ -1121,7 +1121,7 @@ event_response_t win_filetracer::query_information_file_cb(drakvuf_t drakvuf, dr
         params->file_information = fileinfo;
         params->file_information_class = fileinfoclass;
 
-        uint64_t hookID = make_hook_id(info, params->target_rsp);
+        auto hookID = make_hook_id(info, params->target_rsp);
         this->ret_hooks[hookID] = std::move(hook);
     }
 

--- a/src/plugins/filetracer/win.h
+++ b/src/plugins/filetracer/win.h
@@ -135,7 +135,7 @@ public:
     std::unique_ptr<libhook::SyscallHook> query_information_file_hook;
 
     /* Return hooks */
-    std::unordered_map<uint64_t, std::unique_ptr<libhook::ReturnHook>> ret_hooks;
+    std::map<std::pair<uint64_t, addr_t>, std::unique_ptr<libhook::ReturnHook>> ret_hooks;
 
     /* Callbacks */
     event_response_t create_file_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info);

--- a/src/plugins/helpers/hooks.h
+++ b/src/plugins/helpers/hooks.h
@@ -141,3 +141,10 @@ Plugin* GetTrapPlugin(const drakvuf_trap_info_t* info)
     static_assert(std::is_base_of_v<pluginex, Plugin>, "Plugin must derive from pluginex");
     return dynamic_cast<Plugin*>(libhook::GetTrapParams<PluginResult>(info)->plugin_);
 }
+
+inline std::pair<uint64_t, addr_t> make_hook_id(const drakvuf_trap_info_t* info, addr_t target_rsp)
+{
+    uint64_t u64_pid = info->attached_proc_data.pid;
+    uint64_t u64_tid = info->attached_proc_data.tid;
+    return std::make_pair((u64_pid << 32) | u64_tid, target_rsp);
+}

--- a/src/plugins/hidevm/hidevm.cpp
+++ b/src/plugins/hidevm/hidevm.cpp
@@ -121,7 +121,7 @@ event_response_t hidevm::NtClose_cb(drakvuf_t, drakvuf_trap_info_t* info)
     auto vmi = vmi_lock_guard(drakvuf);
     auto params = libhook::GetTrapParams(info);
     
-    uint64_t hook_ID = make_hook_id(info, params->target_rsp);
+    auto hook_ID = make_hook_id(info, params->target_rsp);
 
     // We need to set our fake handle value with 0 to avoid invalid handle exception
     if (this->NtClose_hook.count(hook_ID))
@@ -147,7 +147,7 @@ event_response_t hidevm::ReturnNtDeviceIoControlFile_cb(drakvuf_t, drakvuf_trap_
     auto vmi = vmi_lock_guard(drakvuf);
     auto params = libhook::GetTrapParams(info);
 
-    uint64_t hook_ID = make_hook_id(info, params->target_rsp);
+    auto hook_ID = make_hook_id(info, params->target_rsp);
 
     // Verify that hook for this thread was created
     if (this->ret_hooks.count(hook_ID))
@@ -369,7 +369,7 @@ event_response_t hidevm::NtDeviceIoControlFile_cb(drakvuf_t, drakvuf_trap_info_t
     uint64_t IoControlCode = drakvuf_get_function_argument(drakvuf, info, 6) & 0xFFFFFFFF;
     // Hook ID is needed to validate, that syscall return hook is in the same context as our hook chain
     auto params = libhook::GetTrapParams(info);
-    uint64_t hook_ID = make_hook_id(info, params->target_rsp);
+    auto hook_ID = make_hook_id(info, params->target_rsp);
 
     // First NtDeviceIoControlFile call with IoControlCode IOCTL_WMI_OPEN_GUID_BLOCK should return WmiGuid handle
     if (IoControlCode == IOCTL_WMI_OPEN_GUID_BLOCK)
@@ -449,7 +449,7 @@ event_response_t hidevm::NtDeviceIoControlFile_cb(drakvuf_t, drakvuf_trap_info_t
                     this->stage = STAGE_WMI_OPEN_BLOCK;
                     auto hook = this->createReturnHook(info, &hidevm::ReturnNtDeviceIoControlFile_cb);
                     // Save original PID and TID to validate that next steps are in the same chain
-                    this->pid_tid = hook_ID;
+                    this->prev_hook_ID = hook_ID;
                     this->ret_hooks[hook_ID] = std::move(hook);
                 }
                 vmi_free_unicode_str(guid_object_name);
@@ -458,7 +458,7 @@ event_response_t hidevm::NtDeviceIoControlFile_cb(drakvuf_t, drakvuf_trap_info_t
         }
     }
     // Second stage of getting data is checking the status of WmiGuid
-    else if (IoControlCode == IOCTL_WMI_QUERY_GUID_INFORMATION && hook_ID == this->pid_tid)
+    else if (IoControlCode == IOCTL_WMI_QUERY_GUID_INFORMATION && hook_ID == this->prev_hook_ID)
     {
         if (check_process_is_wmiprvse(info))
         {
@@ -509,7 +509,7 @@ event_response_t hidevm::NtDeviceIoControlFile_cb(drakvuf_t, drakvuf_trap_info_t
         }
     }
     // Third stage of getting data consists of 2 steps: 1) Get data size 2) Get data
-    else if (IoControlCode == IOCTL_WMI_QUERY_ALL_DATA && hook_ID == this->pid_tid)
+    else if (IoControlCode == IOCTL_WMI_QUERY_ALL_DATA && hook_ID == this->prev_hook_ID)
     {
         if (check_process_is_wmiprvse(info))
         {

--- a/src/plugins/hidevm/hidevm.h
+++ b/src/plugins/hidevm/hidevm.h
@@ -128,14 +128,14 @@ public:
     uint8_t query_stage = 0;
 
     std::unique_ptr<libhook::SyscallHook> NtDeviceIoControlFile_hook;
-    std::unordered_map<uint64_t, std::unique_ptr<libhook::ReturnHook>> ret_hooks;
-    std::unordered_map<uint64_t, std::unique_ptr<libhook::SyscallHook>> NtClose_hook;
+    std::map<std::pair<uint64_t, addr_t>, std::unique_ptr<libhook::ReturnHook>> ret_hooks;
+    std::map<std::pair<uint64_t, addr_t>, std::unique_ptr<libhook::SyscallHook>> NtClose_hook;
 
     addr_t objattr_length;
     addr_t objattr_name;
     addr_t iostatusblock_information;
 
-    uint64_t pid_tid;
+    std::pair<uint64_t, addr_t> prev_hook_ID;
 
     // Stage 1
     // Address of WMI_KM_REQUEST_OPEN_BLOCK.Handle field, where WmiGuid handle should be stored on return of NtDeviceIoControlFile(IOCTL_WMI_OPEN_GUID_BLOCK)

--- a/src/plugins/procmon/linux.cpp
+++ b/src/plugins/procmon/linux.cpp
@@ -352,7 +352,7 @@ event_response_t linux_procmon::send_signal_ret_cb(drakvuf_t drakvuf, drakvuf_tr
         keyval("SignalStr", fmt::Rstr(signal_str))
     );
 
-    uint64_t hookID = make_hook_id(info, params->target_rsp);
+    auto hookID = make_hook_id(info, params->target_rsp);
     this->ret_hooks.erase(hookID);
     return VMI_EVENT_RESPONSE_NONE;
 }
@@ -416,7 +416,7 @@ event_response_t linux_procmon::send_signal_cb(drakvuf_t drakvuf, drakvuf_trap_i
     params->target_proc_ppid = target_proc_data.ppid;
     params->signal = signal;
 
-    uint64_t hookID = make_hook_id(info, params->target_rsp);
+    auto hookID = make_hook_id(info, params->target_rsp);
     this->ret_hooks[hookID] = std::move(hook);
 
     g_free(const_cast<char*>(target_proc_data.name));
@@ -444,7 +444,7 @@ event_response_t linux_procmon::kernel_clone_ret_cb(drakvuf_t drakvuf, drakvuf_t
         keyval("NewPid", fmt::Nval(new_pid))
     );
 
-    uint64_t hookID = make_hook_id(info, params->target_rsp);
+    auto hookID = make_hook_id(info, params->target_rsp);
     this->ret_hooks.erase(hookID);
     return VMI_EVENT_RESPONSE_NONE;
 }
@@ -491,7 +491,7 @@ event_response_t linux_procmon::kernel_clone_cb(drakvuf_t drakvuf, drakvuf_trap_
     params->flags = flags;
     params->exit_signal = exit_signal;
 
-    uint64_t hookID = make_hook_id(info, params->target_rsp);
+    auto hookID = make_hook_id(info, params->target_rsp);
     this->ret_hooks[hookID] = std::move(hook);
     return VMI_EVENT_RESPONSE_NONE;
 }
@@ -611,7 +611,7 @@ event_response_t linux_procmon::execve_ret_cb(drakvuf_t drakvuf, drakvuf_trap_in
 
     print_info(drakvuf, info, extra_args);
 
-    uint64_t hookID = make_hook_id(info, params->target_rsp);
+    auto hookID = make_hook_id(info, params->target_rsp);
     this->ret_hooks.erase(hookID);
 
     return VMI_EVENT_RESPONSE_NONE;
@@ -648,7 +648,7 @@ event_response_t linux_procmon::execve_cb(drakvuf_t drakvuf, drakvuf_trap_info_t
     params->thread_name = thread_name ?: "";
     params->old_creds = get_current_credentials(drakvuf, info);
 
-    uint64_t hookID = make_hook_id(info, params->target_rsp);
+    auto hookID = make_hook_id(info, params->target_rsp);
     this->ret_hooks[hookID] = std::move(hook);
 
     g_free(thread_name);

--- a/src/plugins/procmon/linux.cpp
+++ b/src/plugins/procmon/linux.cpp
@@ -147,13 +147,6 @@ void process_visitor(drakvuf_t drakvuf, addr_t process, void* visitor_ctx)
 
 } // namespace
 
-uint64_t make_hook_id(drakvuf_trap_info_t* info)
-{
-    uint64_t u64_pid = info->proc_data.pid;
-    uint64_t u64_tid = info->proc_data.tid;
-    return (u64_pid << 32) | u64_tid;
-}
-
 bool linux_procmon::get_struct_field_pointer(drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t struct_addr, int offset_field, addr_t* value)
 {
     auto vmi = vmi_lock_guard(drakvuf);
@@ -359,7 +352,7 @@ event_response_t linux_procmon::send_signal_ret_cb(drakvuf_t drakvuf, drakvuf_tr
         keyval("SignalStr", fmt::Rstr(signal_str))
     );
 
-    uint64_t hookID = make_hook_id(info);
+    uint64_t hookID = make_hook_id(info, params->target_rsp);
     this->ret_hooks.erase(hookID);
     return VMI_EVENT_RESPONSE_NONE;
 }
@@ -409,7 +402,6 @@ event_response_t linux_procmon::send_signal_cb(drakvuf_t drakvuf, drakvuf_trap_i
     char* current_thread_name = drakvuf_get_process_name(drakvuf, process_base_of_current_process, false);
 
     // Create new trap for return callback
-    uint64_t hookID = make_hook_id(info);
     auto hook = this->createReturnHook<send_signal_data>(info, &linux_procmon::send_signal_ret_cb, info->trap->name);
     auto params = libhook::GetTrapParams<send_signal_data>(hook->trap_);
 
@@ -424,6 +416,7 @@ event_response_t linux_procmon::send_signal_cb(drakvuf_t drakvuf, drakvuf_trap_i
     params->target_proc_ppid = target_proc_data.ppid;
     params->signal = signal;
 
+    uint64_t hookID = make_hook_id(info, params->target_rsp);
     this->ret_hooks[hookID] = std::move(hook);
 
     g_free(const_cast<char*>(target_proc_data.name));
@@ -451,7 +444,7 @@ event_response_t linux_procmon::kernel_clone_ret_cb(drakvuf_t drakvuf, drakvuf_t
         keyval("NewPid", fmt::Nval(new_pid))
     );
 
-    uint64_t hookID = make_hook_id(info);
+    uint64_t hookID = make_hook_id(info, params->target_rsp);
     this->ret_hooks.erase(hookID);
     return VMI_EVENT_RESPONSE_NONE;
 }
@@ -492,13 +485,13 @@ event_response_t linux_procmon::kernel_clone_cb(drakvuf_t drakvuf, drakvuf_trap_
         return VMI_EVENT_RESPONSE_NONE;
     }
 
-    uint64_t hookID = make_hook_id(info);
     auto hook = this->createReturnHook<kernel_clone_data>(info, &linux_procmon::kernel_clone_ret_cb, info->trap->name);
     auto params = libhook::GetTrapParams<kernel_clone_data>(hook->trap_);
 
     params->flags = flags;
     params->exit_signal = exit_signal;
 
+    uint64_t hookID = make_hook_id(info, params->target_rsp);
     this->ret_hooks[hookID] = std::move(hook);
     return VMI_EVENT_RESPONSE_NONE;
 }
@@ -618,7 +611,7 @@ event_response_t linux_procmon::execve_ret_cb(drakvuf_t drakvuf, drakvuf_trap_in
 
     print_info(drakvuf, info, extra_args);
 
-    uint64_t hookID = make_hook_id(info);
+    uint64_t hookID = make_hook_id(info, params->target_rsp);
     this->ret_hooks.erase(hookID);
 
     return VMI_EVENT_RESPONSE_NONE;
@@ -655,7 +648,7 @@ event_response_t linux_procmon::execve_cb(drakvuf_t drakvuf, drakvuf_trap_info_t
     params->thread_name = thread_name ?: "";
     params->old_creds = get_current_credentials(drakvuf, info);
 
-    uint64_t hookID = make_hook_id(info);
+    uint64_t hookID = make_hook_id(info, params->target_rsp);
     this->ret_hooks[hookID] = std::move(hook);
 
     g_free(thread_name);

--- a/src/plugins/procmon/linux.h
+++ b/src/plugins/procmon/linux.h
@@ -133,7 +133,7 @@ public:
     std::unique_ptr<libhook::SyscallHook> kernel_clone_hook;
 
     /* Return hooks */
-    std::unordered_map<uint64_t, std::unique_ptr<libhook::ReturnHook>> ret_hooks;
+    std::map<std::pair<uint64_t, addr_t>, std::unique_ptr<libhook::ReturnHook>> ret_hooks;
 
     /* Callbacks */
     event_response_t execve_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info);

--- a/src/plugins/rpcmon/rpcmon.cpp
+++ b/src/plugins/rpcmon/rpcmon.cpp
@@ -402,7 +402,7 @@ event_response_t rpcmon::usermode_return_hook_cb(drakvuf_t drakvuf, drakvuf_trap
         keyval("ExtraNum", fmt_extra_num)
     );
 
-    uint64_t hookID = make_hook_id(info, params->target_rsp);
+    auto hookID = make_hook_id(info, params->target_rsp);
     ret_hooks.erase(hookID);
 
     return VMI_EVENT_RESPONSE_NONE;
@@ -451,7 +451,7 @@ static event_response_t usermode_hook_cb(drakvuf_t drakvuf, drakvuf_trap_info* i
     params->arguments = std::move(arguments);
     params->target = target;
 
-    uint64_t hookID = make_hook_id(info, params->target_rsp);
+    auto hookID = make_hook_id(info, params->target_rsp);
     plugin->ret_hooks[hookID] = std::move(hook);
 
     return VMI_EVENT_RESPONSE_NONE;

--- a/src/plugins/rpcmon/rpcmon.h
+++ b/src/plugins/rpcmon/rpcmon.h
@@ -124,7 +124,7 @@ public:
 
     event_response_t usermode_return_hook_cb(drakvuf_t drakvuf, drakvuf_trap_info* info);
 
-    std::map<uint64_t, std::unique_ptr<libhook::ReturnHook>> ret_hooks;
+    std::map<std::pair<uint64_t, addr_t>, std::unique_ptr<libhook::ReturnHook>> ret_hooks;
 };
 
 #endif

--- a/src/plugins/syscalls/linux.cpp
+++ b/src/plugins/syscalls/linux.cpp
@@ -113,12 +113,6 @@
 
 using namespace syscalls_ns;
 
-static uint64_t make_hook_id(drakvuf_trap_info_t* info)
-{
-    uint64_t u64_pid = info->proc_data.pid;
-    uint64_t u64_tid = info->proc_data.tid;
-    return (u64_pid << 32) | u64_tid;
-}
 
 bool linux_syscalls::get_pt_regs_addr(drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t* pt_regs_addr, addr_t* nr)
 {
@@ -289,7 +283,7 @@ event_response_t linux_syscalls::linux_ret_cb(drakvuf_t drakvuf, drakvuf_trap_in
 
     this->print_sysret(drakvuf, info, (uint64_t)params->num);
 
-    auto hookID = make_hook_id(info);
+    auto hookID = make_hook_id(info, params->target_rsp);
     this->ret_hooks.erase(hookID);
 
     return VMI_EVENT_RESPONSE_NONE;
@@ -316,7 +310,7 @@ event_response_t linux_syscalls::linux_cb(drakvuf_t drakvuf, drakvuf_trap_info_t
     auto params = libhook::GetTrapParams<linux_syscall_data>(hook->trap_);
     params->setResultCallParams(drakvuf, info);
 
-    auto hookID = make_hook_id(info);
+    auto hookID = make_hook_id(info, params->target_rsp);
     this->ret_hooks[hookID] = std::move(hook);
 
     return VMI_EVENT_RESPONSE_NONE;

--- a/src/plugins/syscalls/linux.h
+++ b/src/plugins/syscalls/linux.h
@@ -112,7 +112,7 @@ class linux_syscalls : public syscalls_base
 public:
     std::array<size_t, syscalls_ns::__PT_REGS_MAX> regs;
     std::unordered_map<uint64_t, std::unique_ptr<libhook::SyscallHook>> hooks;
-    std::unordered_map<uint64_t, std::unique_ptr<libhook::ReturnHook>> ret_hooks;
+    std::map<std::pair<uint64_t, addr_t>, std::unique_ptr<libhook::ReturnHook>> ret_hooks;
 
     // Helpers
     std::vector<uint64_t> build_arguments_buffer(drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t pt_regs_addr, addr_t nr);


### PR DESCRIPTION
While debugging rpcmon i noticed that some return hooks were never hit (specifically NdrClientCall3 inside taskschd.dll RpcSession::RegisterTask when calling Register-ScheduledTask from powershell)

In #1845 make_hook_id in apimon was changed to fix missing hooks on nested calls. I copied this solution to rpcmon and it fixed the problem.

make_hook_id is used in more plugins, so I extracted it to helpers/hooks.h and made all plugins use the updated version from there

potential issues:
- I changed std::unordered_map to std::map in some plugins, otherwise hash for `std::pair<int64_t, addr_t>` would be needed,
- I didn't run drakvuf with the affected linux plugins