### PR TITLE
Add a Subkey to output format

### DIFF
--- a/src/plugins/output_format/common.h
+++ b/src/plugins/output_format/common.h
@@ -328,6 +328,8 @@ struct BinaryString<T,
     }
 };
 
+struct Subkey;
+
 /* Any argument type */
 using Aarg = std::variant<
     fmt::Nval<unsigned long>,
@@ -338,7 +340,30 @@ using Aarg = std::variant<
     fmt::Qstr<const char*>,
     fmt::Qstr<std::string>,
     fmt::Estr<const char*>,
-    fmt::Estr<std::string>>;
+    fmt::Estr<std::string>,
+    fmt::Subkey>;
+
+
+struct Subkey
+{
+    std::unordered_map<std::string, Aarg> sub_map;
+    explicit Subkey(const std::unordered_map<std::string, Aarg>& map)
+        : sub_map(map) {}
+
+    explicit Subkey(std::unordered_map<std::string, Aarg>&& map)
+        : sub_map(std::move(map)) {}
+};
+
+
+inline Subkey Skey(const std::unordered_map<std::string, Aarg>& map)
+{
+    return Subkey(map);
+}
+
+inline Subkey Skey(std::unordered_map<std::string, Aarg>&& map)
+{
+    return Subkey(std::move(map));
+}
 
 } // namespace fmt
 

--- a/src/plugins/output_format/common.h
+++ b/src/plugins/output_format/common.h
@@ -346,23 +346,23 @@ using Aarg = std::variant<
 
 struct Subkey
 {
-    std::unordered_map<std::string, Aarg> sub_map;
-    explicit Subkey(const std::unordered_map<std::string, Aarg>& map)
-        : sub_map(map) {}
+    std::vector<std::pair<std::string, Aarg>> sub_data;
+    explicit Subkey(const std::vector<std::pair<std::string, Aarg>>& data)
+        : sub_data(data) {}
 
-    explicit Subkey(std::unordered_map<std::string, Aarg>&& map)
-        : sub_map(std::move(map)) {}
+    explicit Subkey(std::vector<std::pair<std::string, Aarg>>&& data)
+        : sub_data(std::move(data)) {}
 };
 
 
-inline Subkey Skey(const std::unordered_map<std::string, Aarg>& map)
+inline Subkey Skey(const std::vector<std::pair<std::string, Aarg>>& data)
 {
-    return Subkey(map);
+    return Subkey(data);
 }
 
-inline Subkey Skey(std::unordered_map<std::string, Aarg>&& map)
+inline Subkey Skey(std::vector<std::pair<std::string, Aarg>>&& data)
 {
-    return Subkey(std::move(map));
+    return Subkey(std::move(data));
 }
 
 } // namespace fmt

--- a/src/plugins/output_format/csvfmt.h
+++ b/src/plugins/output_format/csvfmt.h
@@ -246,7 +246,7 @@ struct DataPrinter
     static bool print(std::ostream& os, const fmt::Subkey& data, char sep)
     {
         bool printed = false;
-        for (const auto& [key, value] : data.sub_map)
+        for (const auto& [key, value] : data.sub_data)
         {
             bool printed_prev = printed;
             if (printed)

--- a/src/plugins/output_format/csvfmt.h
+++ b/src/plugins/output_format/csvfmt.h
@@ -242,6 +242,21 @@ struct DataPrinter
             return print_data(os, arg, sep);
         }, data);
     }
+
+    static bool print(std::ostream& os, const fmt::Subkey& data, char sep)
+    {
+        bool printed = false;
+        for (const auto& [key, value] : data.sub_map)
+        {
+            bool printed_prev = printed;
+            if (printed)
+                os << sep;
+            printed = print_data(os, value, sep);
+            if (!printed && printed_prev)
+                fmt::unputc(os);
+        }
+        return true;
+    }
 };
 
 template <class T>

--- a/src/plugins/output_format/deffmt.h
+++ b/src/plugins/output_format/deffmt.h
@@ -262,14 +262,14 @@ struct DataPrinter
     // base case for a subkey, probably never called directly but needed by compiler
     static bool print(std::ostream& os, const fmt::Subkey& data, char sep)
     {
-        if (data.sub_map.empty())
+        if (data.sub_data.empty())
         {
             return false;
         }
 
         bool printed = false;
         os << "["; // unnamed object
-        for (const auto& [key, value] : data.sub_map)
+        for (const auto& [key, value] : data.sub_data)
         {
             bool printed_prev = printed;
             if (printed)
@@ -286,13 +286,13 @@ struct DataPrinter
     static bool print(std::ostream& os, const std::pair<Tk, fmt::Subkey>& data, char sep)
     {
         const char* parent_key = data.first;
-        const auto& sub_map = data.second.sub_map;
-        if (sub_map.empty()) return false;
+        const auto& sub_data = data.second.sub_data;
+        if (sub_data.empty()) return false;
 
         bool printed = false;
         os << parent_key << ":[";
 
-        for (const auto& [sub_key, sub_val] : sub_map)
+        for (const auto& [sub_key, sub_val] : sub_data)
         {
             bool printed_prev = printed;
             if (printed)

--- a/src/plugins/output_format/deffmt.h
+++ b/src/plugins/output_format/deffmt.h
@@ -258,6 +258,52 @@ struct DataPrinter
             return print_data(os, arg, sep);
         }, data);
     }
+
+    // base case for a subkey, probably never called directly but needed by compiler
+    static bool print(std::ostream& os, const fmt::Subkey& data, char sep)
+    {
+        if (data.sub_map.empty())
+        {
+            return false;
+        }
+
+        bool printed = false;
+        os << "["; // unnamed object
+        for (const auto& [key, value] : data.sub_map)
+        {
+            bool printed_prev = printed;
+            if (printed)
+                os << sep;
+            printed = print_data(os, keyval(key.c_str(), value), ' ');
+            if (!printed && printed_prev)
+                fmt::unputc(os);
+        }
+        os << "] ";
+        return true;
+    }
+
+    template <class Tk>
+    static bool print(std::ostream& os, const std::pair<Tk, fmt::Subkey>& data, char sep)
+    {
+        const char* parent_key = data.first;
+        const auto& sub_map = data.second.sub_map;
+        if (sub_map.empty()) return false;
+
+        bool printed = false;
+        os << parent_key << ":[";
+
+        for (const auto& [sub_key, sub_val] : sub_map)
+        {
+            bool printed_prev = printed;
+            if (printed)
+                os << sep;
+            printed = print_data(os, keyval(sub_key.c_str(), sub_val), ' ');
+            if (!printed && printed_prev)
+                fmt::unputc(os);
+        }
+        os << "] ";
+        return true;
+    }
 };
 
 template <class T>

--- a/src/plugins/output_format/jsonfmt.h
+++ b/src/plugins/output_format/jsonfmt.h
@@ -245,6 +245,37 @@ public:
         static_assert(always_false<Tv>::value, "Non-printable type");
         return false;
     }
+
+    static bool print(std::ostream& os, const fmt::Subkey& data, char sep)
+    {
+        os << '{';
+        bool first = true;
+        for (const auto& [key, value] : data.sub_map)
+        {
+            if (!first)
+            {
+                os << ',';
+            }
+            first = false;
+
+            DataPrinter<fmt::Qstr<const std::string&>>::print(os, fmt::Qstr(key), ',');
+
+            os << ':';
+
+            DataPrinter<fmt::Aarg>::print(os, value, ',');
+        }
+        os << '}';
+        return true;
+    }
+
+    template <class Tk>
+    static bool print(std::ostream& os, const std::pair<Tk, fmt::Subkey>& data, char sep)
+    {
+        DataPrinter<Tk>::print(os, fmt::Qstr(data.first), sep);
+        os << ':';
+        DataPrinter<fmt::Subkey>::print(os, data.second, sep);
+        return true;
+    }
 };
 
 template <class T>
@@ -381,6 +412,16 @@ private:
             printed = printed || printed_rest;
         }
         return printed;
+    }
+
+    template <class Tv>
+    static bool print_data(std::ostream& os, const std::optional<Tv>& data, char sep)
+    {
+        if (!data)
+        {
+            return false;
+        }
+        return print_data(os, *data, sep);
     }
 
 public:

--- a/src/plugins/output_format/jsonfmt.h
+++ b/src/plugins/output_format/jsonfmt.h
@@ -250,7 +250,7 @@ public:
     {
         os << '{';
         bool first = true;
-        for (const auto& [key, value] : data.sub_map)
+        for (const auto& [key, value] : data.sub_data)
         {
             if (!first)
             {

--- a/src/plugins/output_format/kvfmt.h
+++ b/src/plugins/output_format/kvfmt.h
@@ -292,13 +292,13 @@ struct DataPrinter
     // base case for a subkey, probably never called directly but needed by compiler
     static bool print(std::ostream& os, const fmt::Subkey& data, char sep)
     {
-        if (data.sub_map.empty())
+        if (data.sub_data.empty())
         {
             return false;
         }
 
         bool printed = false;
-        for (const auto& [key, value] : data.sub_map)
+        for (const auto& [key, value] : data.sub_data)
         {
             bool printed_prev = printed;
             if (printed)
@@ -321,11 +321,11 @@ struct DataPrinter
     static bool print(std::ostream& os, const std::pair<Tk, fmt::Subkey>& data, char sep)
     {
         const char* parent_key = data.first;
-        const auto& sub_map = data.second.sub_map;
-        if (sub_map.empty()) return false;
+        const auto& sub_data = data.second.sub_data;
+        if (sub_data.empty()) return false;
 
         bool printed = false;
-        for (const auto& [sub_key, sub_val] : sub_map)
+        for (const auto& [sub_key, sub_val] : sub_data)
         {
             bool printed_prev = printed;
             if (printed) os << sep;


### PR DESCRIPTION
Adds a Subkey output format needed to show syscall arguments in a nested structure, suggested in #1796

It can be used like this (not included in this pr yet):

```diff
index ff940f3..11ab88c 100644
--- a/src/plugins/syscalls/private_2.h
+++ b/src/plugins/syscalls/private_2.h
@@ -131,7 +131,8 @@ public:
     bool disable_sysret;
 
     std::unordered_set<std::string> filter;
-    std::vector<std::pair<char const*, fmt::Aarg>> fmt_args;
+    std::vector<std::pair<std::string, fmt::Aarg>> fmt_args;
```

```diff
index 01dec3e..9ca616f 100644
--- a/src/plugins/syscalls/win.cpp
+++ b/src/plugins/syscalls/win.cpp
@@ -829,7 +829,7 @@ void win_syscalls::print_syscall(
         keyval("PreviousMode", priv_mode_opt),
         keyval("FromModule", from_dll_opt),
         keyval("FromParentModule", from_parent_dll_opt),
-        std::move(fmt_args)
+        keyval("Arguments", fmt::Skey(std::move(fmt_args)))
```

Example outputs:

json:
`{"Plugin":"syscall","TimeStamp":"1758302885.976538","PID":844,"PPID":736,"TID":36,"UserId":0,"ProcessName":"\\Device\\HarddiskVolume2\\Windows\\System32\\svchost.exe","Method":"NtAllocateVirtualMemory","EventUID":"0x20c","Module":"nt","vCPU":1,"CR3":"0x919a1002","Syscall":24,"NArgs":6,"PreviousMode":"Kernel","FromModule":"\\SystemRoot\\system32\\ntoskrnl.exe","FromParentModule":null,"Arguments":{"Protect":"0x104","RegionSize":"0xffffa286498449e0","AllocationType":"0x1000","*BaseAddress":"0x40801f5000","ZeroBits":"0x0","ProcessHandle":"0xffffffffffffffff"}}`

default:
`[SYSCALL] TIME:1758302749.713829 VCPU:1 CR3:0x3ECCE002 "\Device\HarddiskVolume2\Program Files\XenServer\XenTools\xenguestagent.exe":NtAllocateVirtualMemory SessionID:0 PID:3196 PPID:736 Module:"nt" vCPU:1 CR3:0x3ECCE002 Syscall:24 NArgs:6 PreviousMode:Kernel FromModule:"\\SystemRoot\\system32\\ntoskrnl.exe" Arguments:[Protect:0x104 RegionSize:0xFFFFA2864A24C888 AllocationType:0x1000 *BaseAddress:0x7655F3B000 ZeroBits:0x0 ProcessHandle:0xFFFFFFFFFFFFFFFF] 
`

kv:
`syscall Time=1758302922.924422,PID=1368,PPID=736,TID=1460,ProcessName="\Device\HarddiskVolume2\Windows\System32\svchost.exe",Method=NtAllocateVirtualMemory,Module="nt",vCPU=1,CR3=0x1AF56002,Syscall=24,NArgs=6,PreviousMode=User,FromModule="\Windows\System32\KernelBase.dll",Arguments.Protect=0x4,Arguments.RegionSize=0xC1CAFFCDA8,Arguments.AllocationType=0x1000,Arguments.*BaseAddress=0x0,Arguments.ZeroBits=0x0,Arguments.ProcessHandle=0xFFFFFFFFFFFFFFFF
`

csv:
`syscall 1758302962.081038,0,0x3ECCE002,0,3196,736,632,"\Device\HarddiskVolume2\Program Files\XenServer\XenTools\xenguestagent.exe",NtAllocateVirtualMemory,"nt",0,0x3ECCE002,24,6,Kernel,"\\SystemRoot\\system32\\ntoskrnl.exe",0x104;0xFFFFA2864AD40D20;0x1000;0x765603C000;0x0;0xFFFFFFFFFFFFFFFF
`

I'm also working on a refactor of #1824 with dereferenced argument values added in another subkey for example `..."ReturnValue": "0x0", "Arguments": {"Protect": "0x4", "AllocationType": "0x1000", "RegionSize": "0xc540afd1f8", "BaseAddress": "0xc540afd090", "ZeroBits": "0x0", "ProcessHandle": "0x1914"}, "Extra": {"*RegionSize": "0x2000", "*BaseAddress": "0x25797dc0000", "ProcessHandle_PID": 5488}}
`