### PR TITLE
Fix fileextractor and other plugins crashing

### DIFF
--- a/src/libdrakvuf/drakvuf.c
+++ b/src/libdrakvuf/drakvuf.c
@@ -1280,7 +1280,7 @@ void drakvuf_remove_injection(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
     gpointer key = GSIZE_TO_POINTER(pid << 32 | tid);
 
     drakvuf_lock_and_get_vmi(drakvuf);
-    
+
     if (drakvuf_lookup_injection(drakvuf, info) == info->trap)
     {
         if (!g_hash_table_remove(drakvuf->injections_in_progress, key))


### PR DESCRIPTION
Removed g_assert for drakvuf_lookup_injection which can cause fileextractor and other code to crash processing when trying to unhook the injection.

In testing multiple samples and multiple OS images (Windows 7,10,11 x64) fileextractor would crash with this error:
Bail out! ERROR:../src/libdrakvuf/drakvuf.c:1284:drakvuf_remove_injection: assertion failed: (drakvuf_lookup_injection(drakvuf, info) == info->trap)

I am guessing this is a race condition with two processes trying to remove the hook at the same time, or the drakvuf_lookup_injection is not returning the correct/unique value. After the update I retested with the same OS and samples and everything ran as expected and completed without error.

As a side note, g_assert should probably be removed from everywhere that is not test code and replaced with better error handling. I didn't want to change more than I needed to in case it caused unexpected errors somewhere else.