### PR TITLE
improve memdump dotnet

### DIFF
--- a/src/libdrakvuf/libdrakvuf.h
+++ b/src/libdrakvuf/libdrakvuf.h
@@ -323,6 +323,13 @@ typedef enum privilege_mode
     MAXIMUM_MODE
 } privilege_mode_t ;
 
+typedef enum calling_convention
+{
+    CALLING_CONV_FASTCALL,
+    CALLING_CONV_THISCALL,
+    CALLING_CONV_STDCALL
+} calling_convention_t;
+
 // Confirmed only on Win7 SP1...
 typedef enum object_manager_object
 {
@@ -782,6 +789,10 @@ bool drakvuf_is_wow64(drakvuf_t drakvuf, drakvuf_trap_info_t* info) NOEXCEPT;
 addr_t drakvuf_get_function_argument(drakvuf_t drakvuf,
     drakvuf_trap_info_t* info,
     int argument_number) NOEXCEPT;
+addr_t drakvuf_get_function_argument_ex(drakvuf_t drakvuf,
+    drakvuf_trap_info_t* info,
+    int argument_number,
+    calling_convention_t conv) NOEXCEPT;
 addr_t drakvuf_get_function_return_address(drakvuf_t drakvuf, drakvuf_trap_info_t* info) NOEXCEPT;
 
 bool drakvuf_get_pid_from_handle(drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t handle, vmi_pid_t* pid) NOEXCEPT;

--- a/src/libdrakvuf/os.c
+++ b/src/libdrakvuf/os.c
@@ -329,7 +329,7 @@ static void process_visitor(drakvuf_t drakvuf, addr_t eprocess, void* visitor_ct
 bool drakvuf_get_process_by_handle(drakvuf_t drakvuf, drakvuf_trap_info_t* info, uint64_t handle, addr_t* process, addr_t* dtb)
 {
     // Remote process
-    if (handle != ~0ULL)
+    if (handle != ~0ULL && handle != 0)
     {
         vmi_pid_t pid;
         if (!drakvuf_get_pid_from_handle(drakvuf, info, handle, &pid))
@@ -839,6 +839,20 @@ addr_t drakvuf_get_function_argument(drakvuf_t drakvuf, drakvuf_trap_info_t* inf
     {
         drakvuf_lock_and_get_vmi(drakvuf);
         ret = drakvuf->osi.get_function_argument( drakvuf, info, narg );
+        drakvuf_release_vmi(drakvuf);
+    }
+
+    return ret;
+}
+
+addr_t drakvuf_get_function_argument_ex(drakvuf_t drakvuf, drakvuf_trap_info_t* info, int narg, calling_convention_t conv)
+{
+    addr_t ret = 0;
+
+    if ( drakvuf->osi.get_function_argument_ex )
+    {
+        drakvuf_lock_and_get_vmi(drakvuf);
+        ret = drakvuf->osi.get_function_argument_ex( drakvuf, info, narg, conv );
         drakvuf_release_vmi(drakvuf);
     }
 

--- a/src/libdrakvuf/os.h
+++ b/src/libdrakvuf/os.h
@@ -231,6 +231,9 @@ typedef struct os_interface
     addr_t (*get_function_argument)
     (drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t narg);
 
+    addr_t (*get_function_argument_ex)
+    (drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t narg, calling_convention_t conv);
+
     addr_t (*get_function_return_address)
     (drakvuf_t drakvuf, drakvuf_trap_info_t* info);
 

--- a/src/libdrakvuf/vmi.c
+++ b/src/libdrakvuf/vmi.c
@@ -156,6 +156,7 @@ static void copy_proc_data_from_priv(proc_data_t* proc_data, proc_data_priv_t* p
     proc_data->ppid      = proc_data_priv->ppid;
     proc_data->userid    = proc_data_priv->userid;
     proc_data->tid       = proc_data_priv->tid;
+    proc_data->bitness   = proc_data_priv->bitness;
 }
 
 /*

--- a/src/libdrakvuf/win-processes.c
+++ b/src/libdrakvuf/win-processes.c
@@ -1963,7 +1963,7 @@ bool win_get_pid_from_handle(drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_
     if (handle == 0 || handle == UINT64_MAX)
     {
         *pid = info->proc_data.pid;
-        return false;
+        return true;
     }
 
     if (!info->proc_data.base_addr)
@@ -1986,7 +1986,7 @@ bool win_get_tid_from_handle(drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_
     if (handle == 0 || handle == UINT64_MAX)
     {
         *tid = info->proc_data.tid;
-        return false;
+        return true;
     }
 
     if (!info->proc_data.base_addr)

--- a/src/libdrakvuf/win.c
+++ b/src/libdrakvuf/win.c
@@ -589,11 +589,22 @@ bool win_is_wow64(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 
 addr_t win_get_function_argument(drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t narg)
 {
-    g_assert(narg > 0);
+    return win_get_function_argument_ex(drakvuf, info, narg, CALLING_CONV_STDCALL);
+}
 
+addr_t win_get_function_argument_ex(drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t narg, calling_convention_t x86_conv)
+{
+    if (narg == 0)
+    {
+        PRINT_DEBUG("Invalid argument number\n");
+        return 0;
+    }
+
+    addr_t ret;
     bool is32 = drakvuf_process_is32bit(drakvuf, info);
     if (!is32)
     {
+        // microsoft x64 calling convention
         switch (narg)
         {
             case 1:
@@ -605,18 +616,60 @@ addr_t win_get_function_argument(drakvuf_t drakvuf, drakvuf_trap_info_t* info, a
             case 4:
                 return info->regs->r9;
         }
+        // arguments 5+ are on the stack + 0x20 for shadow space
+        // for some syscall arguments which take 32bits, the upper half of the data might be garbage
+        ACCESS_CONTEXT(ctx,
+            .translate_mechanism = VMI_TM_PROCESS_DTB,
+            .dtb = info->regs->cr3,
+            .addr = info->regs->rsp + 0x20 + (narg - 4) * 8
+        );
+        
+        if (VMI_FAILURE == drakvuf_read_addr(drakvuf, info, &ctx, &ret))
+        {
+            PRINT_DEBUG("x64 argument lookup failed narg %d\n", (int32_t)narg);
+            return 0;
+        }
+        PRINT_DEBUG("x64 argument lookup narg %d, value %lx\n", (int32_t)narg, ret);
+        return ret;
     }
+    else
+    {
+        // x86 calling conventions
+        int32_t reg_args = 0;
+        switch (x86_conv)
+        {
+            case CALLING_CONV_FASTCALL:
+                reg_args = 2;
+                if (narg == 1)
+                    return (uint32_t)info->regs->rcx;
+                if (narg == 2)
+                    return (uint32_t)info->regs->rdx;
+                break;
+            case CALLING_CONV_THISCALL:
+                reg_args = 1;
+                if (narg == 1)
+                    return (uint32_t)info->regs->rcx;
+                break;
+            case CALLING_CONV_STDCALL:
+                break;
+            default:
+                PRINT_DEBUG("Unknown calling convention\n");
+                break;
+        }
 
-    ACCESS_CONTEXT(ctx,
-        .translate_mechanism = VMI_TM_PROCESS_DTB,
-        .dtb = info->regs->cr3,
-        .addr = info->regs->rsp + narg * (is32 ? 4 : 8)
-    );
-
-    addr_t ret;
-    if (VMI_FAILURE == drakvuf_read_addr(drakvuf, info, &ctx, &ret))
-        return 0;
-    return ret;
+        ACCESS_CONTEXT(ctx,
+            .translate_mechanism = VMI_TM_PROCESS_DTB,
+            .dtb = info->regs->cr3,
+            .addr = info->regs->rsp + (narg - reg_args) * 4
+        );
+        if (VMI_FAILURE == drakvuf_read_addr(drakvuf, info, &ctx, &ret))
+        {
+            PRINT_DEBUG("x86 function argument lookup failed narg %d \n", (int32_t)narg);
+            return 0;
+        }
+        PRINT_DEBUG("x86 argument lookup narg %d, value %lx \n", (int32_t)narg, ret);
+        return ret;
+    }
 }
 
 addr_t win_get_function_return_address(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
@@ -764,6 +817,7 @@ bool set_os_windows(drakvuf_t drakvuf)
     drakvuf->osi.get_filename_from_object_attributes = win_get_filename_from_object_attributes;
     drakvuf->osi.is_wow64 = win_is_wow64;
     drakvuf->osi.get_function_argument = win_get_function_argument;
+    drakvuf->osi.get_function_argument_ex = win_get_function_argument_ex;
     drakvuf->osi.get_function_return_address = win_get_function_return_address;
     drakvuf->osi.enumerate_processes = win_enumerate_processes;
     drakvuf->osi.enumerate_processes_with_module = win_enumerate_processes_with_module;

--- a/src/libdrakvuf/win.c
+++ b/src/libdrakvuf/win.c
@@ -623,7 +623,7 @@ addr_t win_get_function_argument_ex(drakvuf_t drakvuf, drakvuf_trap_info_t* info
             .dtb = info->regs->cr3,
             .addr = info->regs->rsp + 0x20 + (narg - 4) * 8
         );
-        
+
         if (VMI_FAILURE == drakvuf_read_addr(drakvuf, info, &ctx, &ret))
         {
             PRINT_DEBUG("x64 argument lookup failed narg %d\n", (int32_t)narg);

--- a/src/libdrakvuf/win.c
+++ b/src/libdrakvuf/win.c
@@ -600,76 +600,88 @@ addr_t win_get_function_argument_ex(drakvuf_t drakvuf, drakvuf_trap_info_t* info
         return 0;
     }
 
-    addr_t ret;
     bool is32 = drakvuf_process_is32bit(drakvuf, info);
     if (!is32)
     {
-        // microsoft x64 calling convention
-        switch (narg)
-        {
-            case 1:
-                return info->regs->rcx;
-            case 2:
-                return info->regs->rdx;
-            case 3:
-                return info->regs->r8;
-            case 4:
-                return info->regs->r9;
-        }
-        // arguments 5+ are on the stack + 0x20 for shadow space
-        // for some syscall arguments which take 32bits, the upper half of the data might be garbage
-        ACCESS_CONTEXT(ctx,
-            .translate_mechanism = VMI_TM_PROCESS_DTB,
-            .dtb = info->regs->cr3,
-            .addr = info->regs->rsp + 0x20 + (narg - 4) * 8
-        );
-
-        if (VMI_FAILURE == drakvuf_read_addr(drakvuf, info, &ctx, &ret))
-        {
-            PRINT_DEBUG("x64 argument lookup failed narg %d\n", (int32_t)narg);
-            return 0;
-        }
-        PRINT_DEBUG("x64 argument lookup narg %d, value %lx\n", (int32_t)narg, ret);
-        return ret;
+        return win_get_function_argument_64(drakvuf, info, narg);
     }
     else
     {
-        // x86 calling conventions
-        int32_t reg_args = 0;
-        switch (x86_conv)
-        {
-            case CALLING_CONV_FASTCALL:
-                reg_args = 2;
-                if (narg == 1)
-                    return (uint32_t)info->regs->rcx;
-                if (narg == 2)
-                    return (uint32_t)info->regs->rdx;
-                break;
-            case CALLING_CONV_THISCALL:
-                reg_args = 1;
-                if (narg == 1)
-                    return (uint32_t)info->regs->rcx;
-                break;
-            case CALLING_CONV_STDCALL:
-                break;
-            default:
-                PRINT_DEBUG("Unknown calling convention\n");
-                break;
-        }
-
-        ACCESS_CONTEXT(ctx,
-            .translate_mechanism = VMI_TM_PROCESS_DTB,
-            .dtb = info->regs->cr3,
-            .addr = info->regs->rsp + (narg - reg_args) * 4
-        );
-        if (VMI_FAILURE == drakvuf_read_addr(drakvuf, info, &ctx, &ret))
-        {
-            PRINT_DEBUG("x86 function argument lookup failed narg %d \n", (int32_t)narg);
-            return 0;
-        }
-        PRINT_DEBUG("x86 argument lookup narg %d, value %lx \n", (int32_t)narg, ret);
-        return ret;
+        return win_get_function_argument_32(drakvuf, info, narg, x86_conv);
     }
+}
+
+addr_t win_get_function_argument_64(drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t narg)
+{
+    // microsoft x64 calling convention
+    switch (narg)
+    {
+        case 1:
+            return info->regs->rcx;
+        case 2:
+            return info->regs->rdx;
+        case 3:
+            return info->regs->r8;
+        case 4:
+            return info->regs->r9;
+    }
+    // arguments 5+ are on the stack + 0x20 for shadow space
+    // for some syscall arguments which take 32bits, the upper half of the data might be garbage
+    ACCESS_CONTEXT(ctx,
+        .translate_mechanism = VMI_TM_PROCESS_DTB,
+        .dtb = info->regs->cr3,
+        .addr = info->regs->rsp + 0x20 + (narg - 4) * 8
+    );
+
+    addr_t ret;
+    if (VMI_FAILURE == drakvuf_read_addr(drakvuf, info, &ctx, &ret))
+    {
+        PRINT_DEBUG("x64 argument lookup failed narg %d\n", (int32_t)narg);
+        return 0;
+    }
+    PRINT_DEBUG("x64 argument lookup narg %d, value %lx\n", (int32_t)narg, ret);
+    return ret;
+}
+
+addr_t win_get_function_argument_32(drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t narg, calling_convention_t x86_conv)
+{
+    // x86 calling conventions
+    int32_t reg_args = 0;
+    switch (x86_conv)
+    {
+        case CALLING_CONV_FASTCALL:
+            reg_args = 2;
+            if (narg == 1)
+                return (uint32_t)info->regs->rcx;
+            if (narg == 2)
+                return (uint32_t)info->regs->rdx;
+            break;
+        case CALLING_CONV_THISCALL:
+            reg_args = 1;
+            if (narg == 1)
+                return (uint32_t)info->regs->rcx;
+            break;
+        case CALLING_CONV_STDCALL:
+            break;
+        default:
+            PRINT_DEBUG("Unknown calling convention\n");
+            break;
+    }
+
+    ACCESS_CONTEXT(ctx,
+        .translate_mechanism = VMI_TM_PROCESS_DTB,
+        .dtb = info->regs->cr3,
+        .addr = info->regs->rsp + (narg - reg_args) * 4
+    );
+
+    addr_t ret;
+    if (VMI_FAILURE == drakvuf_read_addr(drakvuf, info, &ctx, &ret))
+    {
+        PRINT_DEBUG("x86 function argument lookup failed narg %d \n", (int32_t)narg);
+        return 0;
+    }
+    PRINT_DEBUG("x86 argument lookup narg %d, value %lx \n", (int32_t)narg, ret);
+    return ret;
 }
 
 addr_t win_get_function_return_address(drakvuf_t drakvuf, drakvuf_trap_info_t* info)

--- a/src/libdrakvuf/win.h
+++ b/src/libdrakvuf/win.h
@@ -192,6 +192,7 @@ char* win_get_filename_from_object_attributes(drakvuf_t drakvuf, drakvuf_trap_in
 bool win_is_wow64(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
 
 addr_t win_get_function_argument(drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t argument_number);
+addr_t win_get_function_argument_ex(drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t argument_number, calling_convention_t conv);
 addr_t win_get_function_return_address(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
 
 bool win_inject_traps_modules(drakvuf_t drakvuf, drakvuf_trap_t* trap, addr_t list_head, vmi_pid_t pid);

--- a/src/libdrakvuf/win.h
+++ b/src/libdrakvuf/win.h
@@ -193,6 +193,8 @@ bool win_is_wow64(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
 
 addr_t win_get_function_argument(drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t argument_number);
 addr_t win_get_function_argument_ex(drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t argument_number, calling_convention_t conv);
+addr_t win_get_function_argument_32(drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t argument_number, calling_convention_t conv);
+addr_t win_get_function_argument_64(drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t argument_number);
 addr_t win_get_function_return_address(drakvuf_t drakvuf, drakvuf_trap_info_t* info);
 
 bool win_inject_traps_modules(drakvuf_t drakvuf, drakvuf_trap_t* trap, addr_t list_head, vmi_pid_t pid);

--- a/src/libusermode/userhook.cpp
+++ b/src/libusermode/userhook.cpp
@@ -240,7 +240,8 @@ static dll_t* create_dll_meta(drakvuf_t drakvuf, drakvuf_trap_info* info, userho
         .v.tid = proc_data.tid,
         .v.real_dll_base = vad_start,
         .v.mmvad = *mmvad,
-        .v.is_hooked = false
+        .v.is_hooked = false,
+        .v.is_32bit = proc_data.bitness == PROC_TYPE_32
     };
 
     auto dll_name = drakvuf_read_unicode(drakvuf, dll_meta.v.mmvad.file_name_ptr);
@@ -400,10 +401,11 @@ void trap_loaded_dll_targets(drakvuf_t drakvuf, dll_t* dll_meta, addr_t process_
 
             if (target.state == HOOK_OK || target.state == HOOK_FAILED)
             {
-                PRINT_DEBUG("[USERHOOK] Hook %s (vaddr = 0x%llx, dll_base = 0x%llx, result = %s)\n",
+                PRINT_DEBUG("[USERHOOK] Hook %s (vaddr = 0x%llx, dll_base = 0x%llx, %s, result = %s)\n",
                     target.target_name.c_str(),
                     (unsigned long long)exec_func,
                     (unsigned long long)dll_meta->v.real_dll_base,
+                    dll_meta->v.is_32bit == 1 ? "32bit" : "64bit",
                     target.state == HOOK_OK ? "OK" : "FAIL");
             }
         }

--- a/src/libusermode/userhook.hpp
+++ b/src/libusermode/userhook.hpp
@@ -194,6 +194,7 @@ struct dll_view_t
     addr_t real_dll_base;
     mmvad_info_t mmvad;
     bool is_hooked;
+    bool is_32bit;
 };
 
 typedef void (*dll_pre_hook_cb)(drakvuf_t, const std::string&, const dll_view_t*, void*);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -297,7 +297,9 @@ static void print_usage()
         "\t --memdump-dir <directory>\n"
         "\t                           Where to store memory dumps\n"
         "\t --json-clr <path to json>\n"
-        "\t                           The JSON profile for clr.dll\n"
+        "\t                           The JSON profile for 32 bit clr.dll\n"
+        "\t --json-clr-64 <path to json>\n"
+        "\t                           The JSON profile for 64 bit clr.dll\n"
         "\t --json-mscorwks <path to json>\n"
         "\t                           The JSON profile for mscorewks.dll\n"
         "\t --memdump-disable-free-vm\n"
@@ -507,6 +509,7 @@ int main(int argc, char** argv)
         opt_procdump_disable_kedelayexecutionthread_hook,
         opt_procdump_exclude_list,
         opt_json_clr,
+        opt_json_clr_64,
         opt_json_mscorwks,
         opt_disable_sysret,
         opt_userhook_no_addr,
@@ -594,6 +597,7 @@ int main(int argc, char** argv)
         {"procdump-disable-kedelayexecutionthread-hook", no_argument, NULL, opt_procdump_disable_kedelayexecutionthread_hook},
         {"procdump-exclude-list", required_argument, NULL, opt_procdump_exclude_list},
         {"json-clr", required_argument, NULL, opt_json_clr},
+        {"json-clr-64", required_argument, NULL, opt_json_clr_64},
         {"json-mscorwks", required_argument, NULL, opt_json_mscorwks},
         {"syscall-hooks-list", required_argument, NULL, 'S'},
         {"procmon-envs-list", required_argument, NULL, 'q'},
@@ -893,6 +897,9 @@ int main(int argc, char** argv)
                 break;
             case opt_json_clr:
                 options.clr_profile = optarg;
+                break;
+            case opt_json_clr_64:
+                options.clr_profile_64 = optarg;
                 break;
             case opt_json_mscorwks:
                 options.mscorwks_profile = optarg;

--- a/src/plugins/memdump/memdump.cpp
+++ b/src/plugins/memdump/memdump.cpp
@@ -594,10 +594,6 @@ static event_response_t shellcode_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* inf
             }
         }
     }
-    else
-    {
-        PRINT_DEBUG("[MEMDUMP] Shellcode cb: vmi pagetable lookup failed for addr %lx, process %lx, dtb %lx\n", base_address, process, dtb);
-    }
     return VMI_EVENT_RESPONSE_NONE;
 }
 
@@ -965,6 +961,24 @@ bool dotnet_assembly_native_load_image_cb(drakvuf_t drakvuf, drakvuf_trap_info_t
     return true;
 }
 
+void memdump::setup_usermode_dotnet_hooks(const memdump_config* c)
+{
+    if (c->clr_profile)
+        this->setup_dotnet_hooks("clr.dll", c->clr_profile, true);
+    else
+        PRINT_DEBUG("clr.dll 32 profile not found, memdump will proceed without some .NET hooks\n");
+
+    if (c->clr_profile_64)
+        this->setup_dotnet_hooks("clr.dll", c->clr_profile_64, false);
+    else
+        PRINT_DEBUG("clr.dll 64 profile not found, memdump will proceed without some .NET hooks\n");
+
+    if (c->mscorwks_profile)
+        this->setup_dotnet_hooks("mscorwks.dll", c->mscorwks_profile, true);
+    else
+        PRINT_DEBUG("mscorwks.dll profile not found, memdump will proceed without some .NET hooks\n");
+}
+
 memdump::memdump(drakvuf_t drakvuf, const memdump_config* c, output_format_t output)
     : pluginex(drakvuf, output)
     , dumps_count()
@@ -997,20 +1011,7 @@ memdump::memdump(drakvuf_t drakvuf, const memdump_config* c, output_format_t out
         }
     }
 
-    if (c->clr_profile)
-        this->setup_dotnet_hooks("clr.dll", c->clr_profile, true);
-    else
-        PRINT_DEBUG("clr.dll 32 profile not found, memdump will proceed without some .NET hooks\n");
-
-    if (c->clr_profile_64)
-        this->setup_dotnet_hooks("clr.dll", c->clr_profile_64, false);
-    else
-        PRINT_DEBUG("clr.dll 64 profile not found, memdump will proceed without some .NET hooks\n");
-
-    if (c->mscorwks_profile)
-        this->setup_dotnet_hooks("mscorwks.dll", c->mscorwks_profile, true);
-    else
-        PRINT_DEBUG("mscorwks.dll profile not found, memdump will proceed without some .NET hooks\n");
+    setup_usermode_dotnet_hooks(c);
 
     breakpoint_in_system_process_searcher bp;
     if (!c->memdump_disable_free_vm)

--- a/src/plugins/memdump/memdump.cpp
+++ b/src/plugins/memdump/memdump.cpp
@@ -527,7 +527,7 @@ static event_response_t terminate_process_hook_cb(drakvuf_t drakvuf, drakvuf_tra
 
     if (process_handle != ~0ULL)
     {
-        PRINT_DEBUG("[MEMDUMP] Process handle not pointing to self, ignore\n");
+        PRINT_DEBUG("[MEMDUMP] Terminate process handle not pointing to self, ignore %lx\n", process_handle);
         return VMI_EVENT_RESPONSE_NONE;
     }
 
@@ -549,7 +549,7 @@ static event_response_t shellcode_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* inf
 
     if (!drakvuf_get_process_by_handle(drakvuf, info, handle, &process, &dtb))
     {
-        PRINT_DEBUG("[MEMDUMP] Failed to get process by handle\n");
+        PRINT_DEBUG("[MEMDUMP] Shellcode cb: Failed to get process by handle %lx\n", handle);
         return VMI_EVENT_RESPONSE_NONE;
     }
 
@@ -565,14 +565,14 @@ static event_response_t shellcode_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* inf
     addr_t base_address;
     if (VMI_SUCCESS != vmi_read_addr(vmi, &ctx, &base_address))
     {
-        PRINT_DEBUG("[MEMDUMP] Failed to read base address in NtFreeVirtualMemory\n");
+        PRINT_DEBUG("[MEMDUMP] Shellcode cb: Failed to read base address in NtFreeVirtualMemory\n");
         return VMI_EVENT_RESPONSE_NONE;
     }
 
     mmvad_info_t mmvad;
     if (!drakvuf_find_mmvad(drakvuf, process, base_address, &mmvad))
     {
-        PRINT_DEBUG("[MEMDUMP] Failed to find MMVAD for memory passed to NtFreeVirtualMemory\n");
+        PRINT_DEBUG("[MEMDUMP] Shellcode cb: failed to find MMVAD for memory passed to NtFreeVirtualMemory\n");
         return VMI_EVENT_RESPONSE_NONE;
     }
 
@@ -583,7 +583,6 @@ static event_response_t shellcode_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* inf
         bool page_writeable  = (p_info.x86_ia32e.pte_value & (1UL << 1))  != 0;
         bool page_executable = (p_info.x86_ia32e.pte_value & (1UL << 63)) == 0;
         size_t len_bytes     = (mmvad.ending_vpn - mmvad.starting_vpn + 1) * VMI_PS_4KB;
-
         if (pte_valid && page_writeable && page_executable && len_bytes >= 0x1000)
         {
             PRINT_DEBUG("[MEMDUMP] Dumping RWX vad\n");
@@ -594,6 +593,10 @@ static event_response_t shellcode_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* inf
                 PRINT_DEBUG("[MEMDUMP] Failed to store memory dump due to an internal error\n");
             }
         }
+    }
+    else
+    {
+        PRINT_DEBUG("[MEMDUMP] Shellcode cb: vmi pagetable lookup failed for addr %lx, process %lx, dtb %lx\n", base_address, process, dtb);
     }
     return VMI_EVENT_RESPONSE_NONE;
 }
@@ -607,7 +610,7 @@ static event_response_t free_virtual_memory_hook_cb(drakvuf_t drakvuf, drakvuf_t
 
     if (process_handle != ~0ULL)
     {
-        PRINT_DEBUG("[MEMDUMP] Process handle not pointing to self, ignore\n");
+        PRINT_DEBUG("[MEMDUMP] Free process handle not pointing to self, ignore %lx\n", process_handle);
         return VMI_EVENT_RESPONSE_NONE;
     }
 
@@ -644,7 +647,7 @@ static event_response_t free_virtual_memory_hook_cb(drakvuf_t drakvuf, drakvuf_t
 
     if (VMI_SUCCESS != vmi_read_16(vmi, &ctx, &magic))
     {
-        PRINT_DEBUG("[MEMDUMP] Failed to access memory to be used with NtFreeVirtualMemory\n");
+        PRINT_DEBUG("[MEMDUMP] Failed to access memory to be used with NtFreeVirtualMemory %lx\n", ctx.addr);
         drakvuf_release_vmi(drakvuf);
         return VMI_EVENT_RESPONSE_NONE;
     }
@@ -693,7 +696,7 @@ static event_response_t protect_virtual_memory_hook_cb(drakvuf_t drakvuf, drakvu
 
     if (process_handle != ~0ULL)
     {
-        PRINT_DEBUG("[MEMDUMP] Process handle not pointing to self, ignore\n");
+        PRINT_DEBUG("[MEMDUMP] Protect process handle not pointing to self, ignore %lx\n", process_handle);
         return VMI_EVENT_RESPONSE_NONE;
     }
 
@@ -730,7 +733,7 @@ static event_response_t protect_virtual_memory_hook_cb(drakvuf_t drakvuf, drakvu
 
     if (VMI_SUCCESS != vmi_read_16(vmi, &ctx, &magic))
     {
-        PRINT_DEBUG("[MEMDUMP] Failed to access memory to be used with NtProtectVirtualMemory\n");
+        PRINT_DEBUG("[MEMDUMP] Failed to access memory to be used with NtProtectVirtualMemory %lx\n", ctx.addr);
         drakvuf_release_vmi(drakvuf);
         return VMI_EVENT_RESPONSE_NONE;
     }
@@ -821,7 +824,7 @@ static event_response_t create_remote_thread_hook_cb(drakvuf_t drakvuf, drakvuf_
     vmi_pid_t target_process_pid;
     if (!drakvuf_get_pid_from_handle(drakvuf, info, target_process_handle, &target_process_pid))
     {
-        PRINT_DEBUG("[MEMDUMP] Failed to retrieve target process pid\n");
+        PRINT_DEBUG("[MEMDUMP] Failed to retrieve target process pid for handle %lx\n", target_process_handle);
         return VMI_EVENT_RESPONSE_NONE;
     }
 
@@ -934,7 +937,7 @@ bool dotnet_assembly_native_load_image_cb(drakvuf_t drakvuf, drakvuf_trap_info_t
     auto vmi = vmi_lock_guard(drakvuf);
     vmi_v2pcache_flush(vmi, info->regs->cr3);
 
-    addr_t addr = drakvuf_get_function_argument(drakvuf, info, 1) + ptr_size;
+    addr_t addr = drakvuf_get_function_argument_ex(drakvuf, info, 1, CALLING_CONV_FASTCALL) + ptr_size;
 
     ACCESS_CONTEXT(ctx,
         .translate_mechanism = VMI_TM_PROCESS_DTB,
@@ -995,14 +998,19 @@ memdump::memdump(drakvuf_t drakvuf, const memdump_config* c, output_format_t out
     }
 
     if (c->clr_profile)
-        this->setup_dotnet_hooks("clr.dll", c->clr_profile);
+        this->setup_dotnet_hooks("clr.dll", c->clr_profile, true);
     else
-        PRINT_DEBUG("clr.dll profile not found, memdump will proceed without .NET hooks\n");
+        PRINT_DEBUG("clr.dll 32 profile not found, memdump will proceed without some .NET hooks\n");
+
+    if (c->clr_profile_64)
+        this->setup_dotnet_hooks("clr.dll", c->clr_profile_64, false);
+    else
+        PRINT_DEBUG("clr.dll 64 profile not found, memdump will proceed without some .NET hooks\n");
 
     if (c->mscorwks_profile)
-        this->setup_dotnet_hooks("mscorwks.dll", c->mscorwks_profile);
+        this->setup_dotnet_hooks("mscorwks.dll", c->mscorwks_profile, true);
     else
-        PRINT_DEBUG("mscorwks.dll profile not found, memdump will proceed without .NET hooks\n");
+        PRINT_DEBUG("mscorwks.dll profile not found, memdump will proceed without some .NET hooks\n");
 
     breakpoint_in_system_process_searcher bp;
     if (!c->memdump_disable_free_vm)

--- a/src/plugins/memdump/memdump.h
+++ b/src/plugins/memdump/memdump.h
@@ -117,6 +117,7 @@ struct memdump_config
     const char* memdump_dir;
     const char* dll_hooks_list;
     const char* clr_profile;
+    const char* clr_profile_64;
     const char* mscorwks_profile;
     const bool print_no_addr;
     const bool memdump_disable_free_vm;
@@ -140,7 +141,8 @@ public:
     size_t wow64context_eip_rva;
     size_t wow64context_eax_rva;
 
-    wanted_hooks_t wanted_hooks;
+    wanted_hooks_t wanted_hooks_32;
+    wanted_hooks_t wanted_hooks_64;
 
     memdump(drakvuf_t drakvuf, const memdump_config* config, output_format_t output);
     memdump(const memdump&) = delete;
@@ -154,7 +156,7 @@ public:
     bool userhooks_stop();
 
 private:
-    void setup_dotnet_hooks(const char* dll_name, const char* profile);
+    void setup_dotnet_hooks(const char* dll_name, const char* profile, bool is_32bit);
 };
 
 #endif

--- a/src/plugins/memdump/memdump.h
+++ b/src/plugins/memdump/memdump.h
@@ -151,6 +151,7 @@ public:
 
     virtual bool stop_impl() override;
 
+    void setup_usermode_dotnet_hooks(const memdump_config* c);
     void userhook_init(const memdump_config* c, output_format_t output);
     void userhook_destroy();
     bool userhooks_stop();

--- a/src/plugins/memdump/userhook.cpp
+++ b/src/plugins/memdump/userhook.cpp
@@ -146,10 +146,20 @@ static void on_dll_discovered(drakvuf_t drakvuf, std::string const& dll_name, co
 {
     memdump* plugin = (memdump*)extra;
 
-    plugin->wanted_hooks.visit_hooks_for(dll_name, [&](const auto& e)
+    if (dll->is_32bit)
     {
-        drakvuf_request_usermode_hook(drakvuf, dll, &e, usermode_hook_cb, plugin);
-    });
+        plugin->wanted_hooks_32.visit_hooks_for(dll_name, [&](const auto& e)
+        {
+            drakvuf_request_usermode_hook(drakvuf, dll, &e, usermode_hook_cb, plugin);
+        });
+    }
+    else
+    {
+        plugin->wanted_hooks_64.visit_hooks_for(dll_name, [&](const auto& e)
+        {
+            drakvuf_request_usermode_hook(drakvuf, dll, &e, usermode_hook_cb, plugin);
+        });
+    }
 }
 
 static void on_dll_hooked(drakvuf_t drakvuf, const dll_view_t* dll, const std::vector<hook_target_view_t>& targets, void* extra)
@@ -171,7 +181,8 @@ void memdump::userhook_init(const memdump_config* c, output_format_t output)
         {
             return !entry.actions.stack;
         };
-        drakvuf_load_dll_hook_config(drakvuf, c->dll_hooks_list, c->print_no_addr, noStack, this->wanted_hooks);
+        drakvuf_load_dll_hook_config(drakvuf, c->dll_hooks_list, c->print_no_addr, noStack, this->wanted_hooks_32);
+        drakvuf_load_dll_hook_config(drakvuf, c->dll_hooks_list, c->print_no_addr, noStack, this->wanted_hooks_64);
     }
     catch (const std::runtime_error& exc)
     {
@@ -180,7 +191,7 @@ void memdump::userhook_init(const memdump_config* c, output_format_t output)
         throw -1;
     }
 
-    if (this->wanted_hooks.empty())
+    if (this->wanted_hooks_32.empty() && this->wanted_hooks_64.empty())
     {
         // don't load this part of plugin if there is nothing to do
         return;
@@ -195,7 +206,7 @@ void memdump::userhook_init(const memdump_config* c, output_format_t output)
     drakvuf_register_usermode_callback(drakvuf, &reg);
 }
 
-void memdump::setup_dotnet_hooks(const char* dll_name, const char* profile)
+void memdump::setup_dotnet_hooks(const char* dll_name, const char* profile, bool is32_bit)
 {
     PRINT_DEBUG("%s profile found, will setup usermode hooks for .NET\n", dll_name);
 
@@ -219,7 +230,16 @@ void memdump::setup_dotnet_hooks(const char* dll_name, const char* profile)
     }
 
     auto actions = HookActions::empty().set_log().set_stack();
-    this->wanted_hooks.add_hook(dll_name, "AssemblyNative::LoadImage", func_rva, actions, std::vector< std::unique_ptr< ArgumentPrinter > > {});
+    if (is32_bit)
+    {
+        PRINT_DEBUG("[MEMDUMP.NET] hooking 32bit LoadImage\n");
+        this->wanted_hooks_32.add_hook(dll_name, "AssemblyNative::LoadImage", func_rva, actions, std::vector< std::unique_ptr< ArgumentPrinter > > {});
+    }
+    else
+    {
+        PRINT_DEBUG("[MEMDUMP.NET] hooking 64bit LoadImage\n");
+        this->wanted_hooks_64.add_hook(dll_name, "AssemblyNative::LoadImage", func_rva, actions, std::vector< std::unique_ptr< ArgumentPrinter > > {});
+    }
 }
 
 void memdump::userhook_destroy()

--- a/src/plugins/plugins.cpp
+++ b/src/plugins/plugins.cpp
@@ -420,6 +420,7 @@ int drakvuf_plugins::start(const drakvuf_plugin_t plugin_id,
                         .memdump_disable_shellcode_detect = options->memdump_disable_shellcode_detect,
                         .dll_hooks_list = options->dll_hooks_list,
                         .clr_profile = options->clr_profile,
+                        .clr_profile_64 = options->clr_profile_64,
                         .mscorwks_profile = options->mscorwks_profile,
                         .print_no_addr = options->userhook_no_addr,
                     };

--- a/src/plugins/plugins.h
+++ b/src/plugins/plugins.h
@@ -174,6 +174,7 @@ struct plugins_options
     bool userhook_no_addr;              // PLUGIN_MEMDUMP, PLUGIN_APIMON
     bool userhook_injection_mode;       // PLUGIN_MEMDUMP, PLUGIN_APIMON, PLUGIN_RPCMON
     const char* clr_profile;            // PLUGIN_MEMDUMP
+    const char* clr_profile_64;         // PLUGIN_MEMDUMP
     const char* mscorwks_profile;       // PLUGIN_MEMDUMP
     uint32_t procdump_timeout;          // PLUGIN_PROCDUMP
     const char* procdump_dir;           // PLUGIN_PROCDUMP


### PR DESCRIPTION
- adds `drakvuf_get_function_argument_ex` which allows to override 32bit calling convention to fastcall or thiscall
- uses fastcall for memdump `AssemblyNative::LoadImage` hook
- splits memdump wanted_hooks to 32 and 64 bit versions and adds `--json-clr-64` option for 64bit clr.dll profile
- fixes `copy_proc_data_from_priv` not copying bitness field
- fixes `win_get_pid_from_handle` and `win_get_tid_from_handle` returning false when self pseudo handle is resolved to current pid