### PR TITLE
FILE_DISPOSITION_INFORMATION_EX class support added to filetracer

### DIFF
--- a/src/plugins/filetracer/private.h
+++ b/src/plugins/filetracer/private.h
@@ -134,6 +134,11 @@ struct file_basic_information_t
     std::string file_attributes;
 };
 
+struct file_disposition_information_ex_t
+{
+    std::string flags;
+};
+
 struct file_network_open_information_t
 {
     uint64_t creation_time;
@@ -317,6 +322,17 @@ enum
     FILE_ATTRIBUTE_NO_SCRUB_DATA = 0x00020000,
     FILE_ATTRIBUTE_RECALL_ON_OPEN = 0x00040000,
     FILE_ATTRIBUTE_RECALL_ON_DATA_ACCESS = 0x00400000,
+};
+
+// FILE_DISPOSITION_EX class flags
+enum
+{
+    FILE_DISPOSITION_DO_NOT_DELETE = 0x00000000,
+    FILE_DISPOSITION_DELETE = 0x00000001,
+    FILE_DISPOSITION_POSIX_SEMANTICS = 0x00000002,
+    FILE_DISPOSITION_FORCE_IMAGE_SECTION_CHECK = 0x00000004,
+    FILE_DISPOSITION_ON_CLOSE = 0x00000008,
+    FILE_DISPOSITION_IGNORE_READONLY_ATTRIBUTE = 0x00000010,
 };
 
 // Flags
@@ -522,6 +538,15 @@ static const flags_str_t file_flags_and_attrs =
     REGISTER_FLAG(FILE_FLAG_NO_BUFFERING),
     REGISTER_FLAG(FILE_FLAG_OVERLAPPED),
     REGISTER_FLAG(FILE_FLAG_WRITE_THROUGH),
+};
+
+const flags_str_t file_disposition_flags =
+{
+    REGISTER_FLAG(FILE_DISPOSITION_DELETE),
+    REGISTER_FLAG(FILE_DISPOSITION_POSIX_SEMANTICS),
+    REGISTER_FLAG(FILE_DISPOSITION_FORCE_IMAGE_SECTION_CHECK),
+    REGISTER_FLAG(FILE_DISPOSITION_ON_CLOSE),
+    REGISTER_FLAG(FILE_DISPOSITION_IGNORE_READONLY_ATTRIBUTE),
 };
 
 const flags_str_t generic_ar =

--- a/src/plugins/filetracer/win.cpp
+++ b/src/plugins/filetracer/win.cpp
@@ -341,6 +341,33 @@ std::tuple<bool, file_basic_information_t> win_filetracer::basic_file_info_read(
     return std::make_tuple(true, std::move(ret));
 }
 
+std::tuple<bool, file_disposition_information_ex_t> win_filetracer::file_disposition_information_ex_read(drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t disposition_info)
+{
+    if (!disposition_info)
+    {
+        return {};
+    }
+
+    auto vmi = vmi_lock_guard(drakvuf);
+
+    ACCESS_CONTEXT(ctx,
+                   .translate_mechanism = VMI_TM_PROCESS_DTB,
+                   .dtb = info->regs->cr3
+                  );
+
+    uint32_t flags = 0;
+    ctx.addr = disposition_info;
+    if ( VMI_FAILURE == vmi_read_32(vmi, &ctx, &flags) )
+    {
+        PRINT_DEBUG("[FILETRACER] failed to read FILE_DISPOSITION_INFORMATION_EX\n");
+        return {};
+    }
+    auto str_disposition_flags = parse_flags(flags, file_disposition_flags, this->m_output_format, "flags=0");
+    file_disposition_information_ex_t ret {str_disposition_flags};
+
+    return std::make_tuple(true, std::move(ret));
+}
+
 std::tuple<bool, file_network_open_information_t> win_filetracer::net_file_info_read(drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t net_file_info)
 {
     if (!net_file_info) return {};
@@ -439,6 +466,23 @@ void win_filetracer::print_delete_file_info(drakvuf_t drakvuf, drakvuf_trap_info
         keyval("FileName", fmt::Qstr(file)),
         keyval("FileHandle", fmt::Xval(handle))
     );
+
+    g_free(file);
+}
+
+void win_filetracer::print_delete_file_info_ex(drakvuf_t drakvuf, drakvuf_trap_info_t* info, uint32_t handle, file_disposition_information_ex_t& fileinfo)
+{
+    const char* operation_name = "FileDispositionInformationEx";
+    char* file = drakvuf_get_filename_from_handle(drakvuf, info, handle);
+    if ( !file )
+        return;
+
+    fmt::print(this->m_output_format, "filetracer", drakvuf, info,
+               keyval("Operation", fmt::Rstr(operation_name)),
+               keyval("FileName", fmt::Qstr(file)),
+               keyval("FileHandle", fmt::Xval(handle)),
+               flagsval("Flags", fileinfo.flags)
+              );
 
     g_free(file);
 }
@@ -958,6 +1002,7 @@ event_response_t win_filetracer::query_full_attributes_file_cb(drakvuf_t drakvuf
 #define FILE_BASIC_INFORMATION 4
 #define FILE_RENAME_INFORMATION 10
 #define FILE_DISPOSITION_INFORMATION 13
+#define FILE_DISPOSITION_INFORMATION_EX 64
 #define FILE_END_OF_FILE_INFORMATION 20
 
 event_response_t win_filetracer::set_information_file_cb(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
@@ -988,6 +1033,16 @@ event_response_t win_filetracer::set_information_file_cb(drakvuf_t drakvuf, drak
         case FILE_DISPOSITION_INFORMATION:
         {
             print_delete_file_info(drakvuf, info, handle, fileinfo);
+        }
+        break;
+
+        case FILE_DISPOSITION_INFORMATION_EX:
+        {
+            auto [succ, file_info] = file_disposition_information_ex_read(drakvuf, info, fileinfo);
+            if (succ) 
+            {
+                print_delete_file_info_ex(drakvuf, info, handle, file_info);
+            }
         }
         break;
 

--- a/src/plugins/filetracer/win.cpp
+++ b/src/plugins/filetracer/win.cpp
@@ -351,9 +351,9 @@ std::tuple<bool, file_disposition_information_ex_t> win_filetracer::file_disposi
     auto vmi = vmi_lock_guard(drakvuf);
 
     ACCESS_CONTEXT(ctx,
-                   .translate_mechanism = VMI_TM_PROCESS_DTB,
-                   .dtb = info->regs->cr3
-                  );
+        .translate_mechanism = VMI_TM_PROCESS_DTB,
+        .dtb = info->regs->cr3
+    );
 
     uint32_t flags = 0;
     ctx.addr = disposition_info;
@@ -478,11 +478,11 @@ void win_filetracer::print_delete_file_info_ex(drakvuf_t drakvuf, drakvuf_trap_i
         return;
 
     fmt::print(this->m_output_format, "filetracer", drakvuf, info,
-               keyval("Operation", fmt::Rstr(operation_name)),
-               keyval("FileName", fmt::Qstr(file)),
-               keyval("FileHandle", fmt::Xval(handle)),
-               flagsval("Flags", fileinfo.flags)
-              );
+        keyval("Operation", fmt::Rstr(operation_name)),
+        keyval("FileName", fmt::Qstr(file)),
+        keyval("FileHandle", fmt::Xval(handle)),
+        flagsval("Flags", fileinfo.flags)
+    );
 
     g_free(file);
 }
@@ -1039,7 +1039,7 @@ event_response_t win_filetracer::set_information_file_cb(drakvuf_t drakvuf, drak
         case FILE_DISPOSITION_INFORMATION_EX:
         {
             auto [succ, file_info] = file_disposition_information_ex_read(drakvuf, info, fileinfo);
-            if (succ) 
+            if (succ)
             {
                 print_delete_file_info_ex(drakvuf, info, handle, file_info);
             }

--- a/src/plugins/filetracer/win.h
+++ b/src/plugins/filetracer/win.h
@@ -159,6 +159,7 @@ public:
     std::tuple<bool, win_objattrs_t> objattr_read(drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t attrs);
     std::tuple<bool, file_basic_information_t> basic_file_info_read(drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t basic_file_info);
     std::tuple<bool, file_network_open_information_t> net_file_info_read(drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t net_file_info);
+    std::tuple<bool, file_disposition_information_ex_t> file_disposition_information_ex_read(drakvuf_t drakvuf, drakvuf_trap_info_t* info, addr_t disposition_info);
 
     /* Helper functions */
     void print_file_obj_info(drakvuf_t drakvuf, drakvuf_trap_info_t* info, const win_objattrs_t& attrs);
@@ -168,6 +169,7 @@ public:
     void print_file_query_full_attributes(drakvuf_t drakvuf, drakvuf_trap_info_t* info, const win_objattrs_t& attrs, const file_network_open_information_t& file_info, uint64_t status);
     void print_file_query_attributes(drakvuf_t drakvuf, drakvuf_trap_info_t* info, const win_objattrs_t& attrs, const file_basic_information_t& file_info, uint64_t status);
     void print_delete_file_info(drakvuf_t drakvuf, drakvuf_trap_info_t* info, uint32_t handle, addr_t fileinfo);
+    void print_delete_file_info_ex(drakvuf_t drakvuf, drakvuf_trap_info_t* info, uint32_t handle, file_disposition_information_ex_t& fileinfo);
     void print_basic_file_info(drakvuf_t drakvuf, drakvuf_trap_info_t* info, uint32_t src_file_handle, const file_basic_information_t& basic_file_info, uint64_t status);
     void print_file_net_info(drakvuf_t drakvuf, drakvuf_trap_info_t* info, uint32_t src_file_handle, const file_network_open_information_t& file_info, uint64_t status);
     void print_rename_file_info(vmi_instance_t vmi, drakvuf_t drakvuf, drakvuf_trap_info_t* info, uint32_t src_file_handle, addr_t fileinfo);


### PR DESCRIPTION
Hi!
I've found out that some delete events don't show up in filetracer plugin in my Windows 10 22H2 test environment. The reason is that it handles FILE_DISPOSITION_INFORMATION (13), but does not process FILE_DISPOSITION_INFORMATION_EX (64). So I added support for it.

This information class is set via NtSetInformationFile inside DeleteFileW. Apparently, in newer Windows versions, Microsoft disabled the "compatibility" flag checked before NtSetInformationFile call of the function for processes such as explorer.exe, causing the API to use FILE_DISPOSITION_INFORMATION_EX instead of the legacy FILE_DISPOSITION_INFORMATION.

```
...
v2 = NtCurrentPeb()->AppCompatFlags.QuadPart & 0x100000000LL;
...
if ( v2
      || (v23 = 7,
          v14 = NtSetInformationFile(FileHandle, &IoStatusBlock, &v23, 4u, (FILE_INFORMATION_CLASS)64),
          (int)(v14 + 0x80000000) >= 0)
      && v14 != 0xC0000121)
    {
      v22 = 1;
      v14 = NtSetInformationFile(FileHandle, &IoStatusBlock, &v22, 1u, FileDispositionInformation);
    }
```

Output example for FILE_DISPOSITION_INFORMATION_EX:
```
{
    "Plugin": "filetracer",
    "TimeStamp": "1779200675.094673",
    "PID": 5128,
    "PPID": 2616,
    "TID": 5576,
    "UserId": 2,
    "ProcessName": "\\Device\\HarddiskVolume2\\Windows\\System32\\cmd.exe",
    "Method": "NtSetInformationFile",
    "EventUID": "0xf03",
    "Operation": "FileDispositionInformationEx",
    "FileName": "\\test\\APPCOM~1\\APPRAI~1\\TELEME~1",
    "FileHandle": "0x184",
    "Flags": "FILE_DISPOSITION_DELETE | FILE_DISPOSITION_POSIX_SEMANTICS | FILE_DISPOSITION_FORCE_IMAGE_SECTION_CHECK"
}

```