### PR TITLE
Fix/memdump off by one

### DIFF
--- a/src/plugins/memdump/memdump.cpp
+++ b/src/plugins/memdump/memdump.cpp
@@ -187,6 +187,7 @@ bool dump_memory_region(
 
     const gchar* chk_str = nullptr;
 
+    addr_t dump_addr = ctx->addr;
     addr_t aligned_addr;
     addr_t intra_page_offset;
     size_t num_pages;
@@ -275,7 +276,7 @@ bool dump_memory_region(
     // * de-duplication - sometimes, different heuristics may want to dump the same piece of memory;
     //   unless there is a change in image base or contents, repeated memory dumps would get exactly
     //   the same file name
-    if (asprintf(&file, "%llx_%.16s", (unsigned long long) ctx->addr, chk_str) < 0)
+    if (asprintf(&file, "%llx_%.16s", (unsigned long long) dump_addr, chk_str) < 0)
         goto done;
 
     if (asprintf(&file_path, "%s/%s", plugin->memdump_dir, file) < 0)
@@ -289,7 +290,7 @@ bool dump_memory_region(
     if (asprintf(&metafile, "%s/memdump.%06d", plugin->memdump_dir, sequence_number) < 0)
         goto done;
 
-    save_file_metadata(info, metafile, file, len_bytes, ctx->addr, info->trap->name, reason, sequence_number, extras);
+    save_file_metadata(info, metafile, file, len_bytes, dump_addr, info->trap->name, reason, sequence_number, extras);
 
     ret = true;
 
@@ -300,7 +301,7 @@ printout:
         auto default_print = std::make_tuple(
                 keyval("DumpReason", fmt::Qstr(reason)),
                 keyval("DumpPID", fmt::Nval(info->attached_proc_data.pid)),
-                keyval("DumpAddr", fmt::Xval(ctx->addr, false)),
+                keyval("DumpAddr", fmt::Xval(dump_addr, false)),
                 keyval("DumpSize", fmt::Xval(len_bytes)),
                 keyval("DumpFilename", fmt::Qstr(display_file)),
                 keyval("DumpsCount", fmt::Nval(sequence_number))

--- a/src/plugins/memdump/memdump.cpp
+++ b/src/plugins/memdump/memdump.cpp
@@ -189,8 +189,6 @@ bool dump_memory_region(
 
     addr_t aligned_addr;
     addr_t intra_page_offset;
-    size_t aligned_len;
-    size_t len_remainder;
     size_t num_pages;
 
     GChecksum* checksum = nullptr;
@@ -213,16 +211,9 @@ bool dump_memory_region(
     aligned_addr = ctx->addr & ~(VMI_PS_4KB - 1);
     intra_page_offset = ctx->addr & (VMI_PS_4KB - 1);
 
-    aligned_len = len_bytes & ~(VMI_PS_4KB - 1);
-    len_remainder = len_bytes & (VMI_PS_4KB - 1);
-
-    if (len_remainder)
-    {
-        aligned_len += VMI_PS_4KB;
-    }
+    num_pages = (intra_page_offset + len_bytes + VMI_PS_4KB - 1) / VMI_PS_4KB;
 
     ctx->addr = aligned_addr;
-    num_pages = aligned_len / VMI_PS_4KB;
 
     access_ptrs = (void**)g_malloc(num_pages * sizeof(void*));
 


### PR DESCRIPTION
fixes an off by one error in calculating dump size when address is not page aligned (possible in NtWriteVirtualMemory and AssemblyNative::LoadImage hooks) and sum of taken size on first and last page is less or equal to pagesize

it needs to map both first and last page even if they don't sum to a full one, but it did `aligned_len += VMI_PS_4KB` which resulted in increasing num_pages by only one and not mapping the last page

also fixes the plugin logging the address of the first page as DumpAddr even if the dump started at an offset in the page