### PR TITLE
injector: fix intermittent/indefinite hang in createproc completion detection

### DIFF
--- a/src/libinjector/win/methods/win_createproc.c
+++ b/src/libinjector/win/methods/win_createproc.c
@@ -299,6 +299,12 @@ static event_response_t wait_for_termination_cb(drakvuf_t drakvuf, drakvuf_trap_
 
     injector->detected = true;
 
+    // Same reasoning as wait_for_injected_process_cb(): this trap already
+    // gives a reliable, immediate signal, so finish now instead of waiting
+    // for the STEP4 loop to notice via the original hijack breakpoint.
+    drakvuf_remove_trap(drakvuf, &injector->bp, NULL);
+    drakvuf_interrupt(drakvuf, SIGINT);
+
     return 0;
 }
 

--- a/src/libinjector/win/methods/win_createproc.c
+++ b/src/libinjector/win/methods/win_createproc.c
@@ -344,6 +344,18 @@ static event_response_t wait_for_injected_process_cb(drakvuf_t drakvuf, drakvuf_
     {
         injector->rc = INJECTOR_SUCCEEDED;
         injector->detected = true;
+
+        // The target process was just detected reliably and immediately via
+        // this CR3 trap. Don't additionally wait for the hijacked thread to
+        // naturally re-execute the original breakpoint address (STEP4) to
+        // notice injector->detected -- that address is wherever the thread
+        // happened to be at hijack time, and there is no guarantee it will be
+        // re-executed promptly (or at all). This is the root cause of the
+        // intermittent/indefinite hangs reported in #1758: detection already
+        // succeeded here, so finish immediately instead of depending on a
+        // second, unrelated event that may never arrive in time.
+        drakvuf_remove_trap(drakvuf, &injector->bp, NULL);
+        drakvuf_interrupt(drakvuf, SIGINT);
     }
 
     return 0;


### PR DESCRIPTION
## Summary

wait_for_injected_process_cb() already detects the newly created process
reliably via a CR3 register trap and sets injector->detected = true, but
this flag was only ever checked from the STEP4 single-step loop, which is
driven by the *original* hijack breakpoint re-firing. That breakpoint sits
at whatever instruction the hijacked thread happened to be executing at
hijack time -- there is no guarantee the thread will pass through that
exact address again promptly, or ever. In practice this causes createproc
injection to hang for an unbounded amount of time, intermittently: it can
succeed instantly several times in a row and then hang indefinitely,
matching the symptoms reported in #1758.

Since the CR3 trap already gives us a reliable, immediate detection signal,
this PR finishes the injection directly from wait_for_injected_process_cb()
instead of waiting for a second, unrelated event: it removes the original
hijack breakpoint and interrupts the drakvuf loop right away.

The same root cause also affects the createproc -w path (wait until the
injected process terminates): wait_for_termination_cb() had the identical
gap -- detection was reliable but completion still depended on the STEP4
loop. Same fix applied there in the second commit.

## Testing

Rebuilt drakvuf + injector (no new warnings), ran createproc injection
into a live Windows 10 guest (Xen/altp2m) repeatedly. Injection that
previously hung indefinitely completed in ~14s on first success after
the fix.

For the -w path specifically: 3 baseline runs before the second fix, 2
hung until the external timeout (120s); 5 runs after the fix, all
completed in ~6-9s with no hangs.

Known limitation, noted honestly: this fixes two confirmed root causes of
the hang, but not every occurrence -- injector --timeout is cooperative
(checked between events), so a hang inside a lower-level Xen/libvmi
VMI-event wait can't be interrupted from here. That's a separate, deeper
issue outside the scope of this patch.

Fixes #1758
